### PR TITLE
fix(ci): merge paginated gh api results in automated triage workflow

### DIFF
--- a/.github/workflows/automated-triage.yml
+++ b/.github/workflows/automated-triage.yml
@@ -37,10 +37,11 @@ jobs:
           echo "Fetching Dependabot alerts..."
 
           # Try to fetch alerts, handle 403 gracefully
+          # --paginate returns one JSON array per page; merge with jq -s 'add'
           if gh api /repos/${{ github.repository }}/dependabot/alerts \
             --paginate \
             --jq 'map(select(.state == "open"))' \
-            > dependabot_alerts.json 2>/dev/null; then
+            2>/dev/null | jq -s 'add // []' > dependabot_alerts.json; then
 
             ALERT_COUNT=$(jq 'length' dependabot_alerts.json 2>/dev/null || echo "0")
             echo "Found $ALERT_COUNT open Dependabot alerts"
@@ -180,10 +181,11 @@ jobs:
         id: fetch-alerts
         run: |
           echo "Fetching code scanning alerts..."
+          # --paginate returns one JSON array per page; merge with jq -s 'add'
           gh api /repos/${{ github.repository }}/code-scanning/alerts \
             --paginate \
             --jq 'map(select(.state == "open"))' \
-            > code_scanning_alerts.json
+            | jq -s 'add // []' > code_scanning_alerts.json
 
           ALERT_COUNT=$(jq 'length' code_scanning_alerts.json)
           echo "Found $ALERT_COUNT open code scanning alerts"


### PR DESCRIPTION
## Summary
- Fix `Automated Security & Dependency Triage` workflow failing on every scheduled run
- Merge paginated `gh api` results before processing with `jq`

## Problem
The `gh api --paginate` flag returns one JSON array per page. When written directly to a file, the result is multiple concatenated arrays (e.g., `[...][...][...]`), not a single merged array. This caused `jq 'length'` to output multiple numbers, with the last bare value written to `$GITHUB_OUTPUT`, producing:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '97'
```

This affected both the Dependabot alert fetch and Code Scanning alert fetch steps.

## Fix
Pipe `gh api --paginate` output through `jq -s 'add // []'` to merge all pages into a single flat array before writing to the output file. Applied to both fetch steps.

## Test plan
- [ ] Trigger workflow manually with `workflow_dispatch` to verify both jobs complete
- [ ] Verify `alert_count` output is a single integer
- [ ] Confirm downstream steps (Risk Assessment, Summary Report) execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)