### PR TITLE
fix(ci): correct Docker action versions to latest valid releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,10 +621,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,7 +182,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.backend
@@ -194,7 +194,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.frontend

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.backend
@@ -114,7 +114,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.frontend


### PR DESCRIPTION
## Summary
- **ci.yml**: Reverts `docker/login-action@v4` → `@v3` and `docker/setup-buildx-action@v4` → `@v3` — v4 does not exist for either action, causing the "Build and Push Docker Images" job to fail on every CI run since commit `55c8f56`
- **deploy.yml, release.yml**: Updates `docker/build-push-action@v5` → `@v6` to align with ci.yml for consistency

All three workflows now use the same versions:
| Action | Version |
|--------|---------|
| `docker/setup-buildx-action` | `@v3` (latest: v3.12.0) |
| `docker/login-action` | `@v3` (latest: v3.7.0) |
| `docker/build-push-action` | `@v6` (latest: v6.18.0) |

## Test plan
- [ ] CI Pipeline passes with no "Build and Push Docker Images" failure
- [ ] All required checks (Backend CI, Frontend CI, Integration Tests, E2E Tests) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)