### PR TITLE
feat(compliance): Add adaptive compliance scheduler and system info collection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -265,7 +265,7 @@
         "filename": "frontend/src/pages/settings/Settings.tsx",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 1192
+        "line_number": 1196
       }
     ],
     "packaging/bundle/create-prebuilt-images.sh": [
@@ -430,5 +430,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-04T17:48:00Z"
+  "generated_at": "2026-02-10T03:59:54Z"
 }

--- a/backend/alembic/versions/20260209_2200_026_add_compliance_scheduler_tables.py
+++ b/backend/alembic/versions/20260209_2200_026_add_compliance_scheduler_tables.py
@@ -1,0 +1,321 @@
+"""Add compliance scheduler tables for adaptive compliance scanning
+
+Revision ID: 026_compliance_scheduler
+Revises: 025_host_monitoring_history
+Create Date: 2026-02-09
+
+Creates tables for the Adaptive Compliance Scheduler:
+- host_compliance_schedule: Per-host scheduling state and next scan time
+- compliance_scheduler_config: Global scheduler configuration (intervals, priorities)
+
+This enables automatic compliance scanning with state-based intervals (max 48 hours).
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# Revision identifiers
+revision = "026_compliance_scheduler"
+down_revision = "025_host_monitoring_history"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create compliance scheduler tables."""
+    conn = op.get_bind()
+
+    # 1. Create host_compliance_schedule table
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT FROM information_schema.tables " "WHERE table_name = 'host_compliance_schedule')"
+        )
+    )
+    if not result.scalar():
+        op.create_table(
+            "host_compliance_schedule",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "host_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("hosts.id", ondelete="CASCADE"),
+                nullable=False,
+                unique=True,
+            ),
+            # Current compliance state
+            sa.Column(
+                "compliance_score",
+                sa.Float,
+                nullable=True,
+            ),
+            sa.Column(
+                "compliance_state",
+                sa.String(20),
+                nullable=False,
+                server_default="unknown",
+            ),
+            sa.Column(
+                "has_critical_findings",
+                sa.Boolean,
+                nullable=False,
+                server_default="false",
+            ),
+            sa.Column(
+                "pass_count",
+                sa.Integer,
+                nullable=True,
+            ),
+            sa.Column(
+                "fail_count",
+                sa.Integer,
+                nullable=True,
+            ),
+            # Scheduling
+            sa.Column(
+                "current_interval_minutes",
+                sa.Integer,
+                nullable=False,
+                server_default="1440",  # 24 hours default
+            ),
+            sa.Column(
+                "next_scheduled_scan",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+            sa.Column(
+                "last_scan_completed",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+            sa.Column(
+                "last_scan_id",
+                postgresql.UUID(as_uuid=True),
+                nullable=True,
+            ),
+            # Maintenance mode
+            sa.Column(
+                "maintenance_mode",
+                sa.Boolean,
+                nullable=False,
+                server_default="false",
+            ),
+            sa.Column(
+                "maintenance_until",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+            # Scan priority (1-10, higher = more urgent)
+            sa.Column(
+                "scan_priority",
+                sa.Integer,
+                nullable=False,
+                server_default="5",
+            ),
+            # Failure tracking
+            sa.Column(
+                "consecutive_scan_failures",
+                sa.Integer,
+                nullable=False,
+                server_default="0",
+            ),
+            # Audit timestamps
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+        )
+
+        # Index for finding hosts due for scanning
+        op.create_index(
+            "ix_compliance_schedule_next_scan",
+            "host_compliance_schedule",
+            ["next_scheduled_scan"],
+            postgresql_where=sa.text("maintenance_mode = false"),
+        )
+
+        # Index for querying by compliance state
+        op.create_index(
+            "ix_compliance_schedule_state",
+            "host_compliance_schedule",
+            ["compliance_state"],
+        )
+
+        # Index for priority-based scanning
+        op.create_index(
+            "ix_compliance_schedule_priority",
+            "host_compliance_schedule",
+            ["scan_priority"],
+        )
+
+    # 2. Create compliance_scheduler_config table (singleton config)
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT FROM information_schema.tables " "WHERE table_name = 'compliance_scheduler_config')"
+        )
+    )
+    if not result.scalar():
+        op.create_table(
+            "compliance_scheduler_config",
+            sa.Column(
+                "id",
+                sa.Integer,
+                primary_key=True,
+            ),
+            sa.Column(
+                "enabled",
+                sa.Boolean,
+                nullable=False,
+                server_default="true",
+            ),
+            # Intervals in minutes for each compliance state
+            sa.Column(
+                "interval_compliant",
+                sa.Integer,
+                nullable=False,
+                server_default="1440",  # 24 hours
+            ),
+            sa.Column(
+                "interval_mostly_compliant",
+                sa.Integer,
+                nullable=False,
+                server_default="720",  # 12 hours
+            ),
+            sa.Column(
+                "interval_partial",
+                sa.Integer,
+                nullable=False,
+                server_default="360",  # 6 hours
+            ),
+            sa.Column(
+                "interval_low",
+                sa.Integer,
+                nullable=False,
+                server_default="120",  # 2 hours
+            ),
+            sa.Column(
+                "interval_critical",
+                sa.Integer,
+                nullable=False,
+                server_default="60",  # 1 hour
+            ),
+            sa.Column(
+                "interval_unknown",
+                sa.Integer,
+                nullable=False,
+                server_default="0",  # Immediate
+            ),
+            sa.Column(
+                "interval_maintenance",
+                sa.Integer,
+                nullable=False,
+                server_default="2880",  # 48 hours (max)
+            ),
+            # Maximum interval (enforced ceiling)
+            sa.Column(
+                "max_interval_minutes",
+                sa.Integer,
+                nullable=False,
+                server_default="2880",  # 48 hours
+            ),
+            # Priority levels (1-10, higher = more urgent)
+            sa.Column(
+                "priority_compliant",
+                sa.Integer,
+                nullable=False,
+                server_default="3",
+            ),
+            sa.Column(
+                "priority_mostly_compliant",
+                sa.Integer,
+                nullable=False,
+                server_default="4",
+            ),
+            sa.Column(
+                "priority_partial",
+                sa.Integer,
+                nullable=False,
+                server_default="6",
+            ),
+            sa.Column(
+                "priority_low",
+                sa.Integer,
+                nullable=False,
+                server_default="7",
+            ),
+            sa.Column(
+                "priority_critical",
+                sa.Integer,
+                nullable=False,
+                server_default="9",
+            ),
+            sa.Column(
+                "priority_unknown",
+                sa.Integer,
+                nullable=False,
+                server_default="10",
+            ),
+            sa.Column(
+                "priority_maintenance",
+                sa.Integer,
+                nullable=False,
+                server_default="1",
+            ),
+            # Concurrency and timeout settings
+            sa.Column(
+                "max_concurrent_scans",
+                sa.Integer,
+                nullable=False,
+                server_default="5",
+            ),
+            sa.Column(
+                "scan_timeout_seconds",
+                sa.Integer,
+                nullable=False,
+                server_default="600",  # 10 minutes
+            ),
+            # Audit
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            ),
+        )
+
+        # Insert default configuration (id=1)
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO compliance_scheduler_config (id)
+                VALUES (1)
+                ON CONFLICT (id) DO NOTHING
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    """Drop compliance scheduler tables."""
+    # Drop indexes first
+    op.drop_index("ix_compliance_schedule_priority", table_name="host_compliance_schedule")
+    op.drop_index("ix_compliance_schedule_state", table_name="host_compliance_schedule")
+    op.drop_index("ix_compliance_schedule_next_scan", table_name="host_compliance_schedule")
+
+    # Drop tables
+    op.drop_table("compliance_scheduler_config")
+    op.drop_table("host_compliance_schedule")

--- a/backend/alembic/versions/20260210_0100_027_add_host_system_info_table.py
+++ b/backend/alembic/versions/20260210_0100_027_add_host_system_info_table.py
@@ -1,0 +1,128 @@
+"""Add host_system_info table for detailed system information
+
+Revision ID: 027_host_system_info
+Revises: 026_compliance_scheduler
+Create Date: 2026-02-10
+
+Creates table for storing detailed host system information collected during scans:
+- Kernel version, CPU info, memory, SELinux status, firewall status
+- Historical tracking with updated_at timestamp
+- Rich OS version info (RHEL 9.4 vs just RHEL)
+
+Part of OpenWatch OS Transformation - Server Intelligence.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# Revision identifiers
+revision = "027_host_system_info"
+down_revision = "026_compliance_scheduler"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create host_system_info table."""
+    conn = op.get_bind()
+
+    # Check if table already exists
+    result = conn.execute(
+        sa.text("SELECT EXISTS (SELECT FROM information_schema.tables " "WHERE table_name = 'host_system_info')")
+    )
+    if not result.scalar():
+        op.create_table(
+            "host_system_info",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+            ),
+            sa.Column(
+                "host_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("hosts.id", ondelete="CASCADE"),
+                nullable=False,
+                unique=True,
+            ),
+            # OS Information
+            sa.Column("os_name", sa.String(255), nullable=True),  # Red Hat Enterprise Linux
+            sa.Column("os_version", sa.String(50), nullable=True),  # 9.4
+            sa.Column("os_version_full", sa.String(255), nullable=True),  # 9.4 (Plow)
+            sa.Column("os_pretty_name", sa.String(255), nullable=True),  # Red Hat Enterprise Linux 9.4 (Plow)
+            sa.Column("os_id", sa.String(50), nullable=True),  # rhel
+            sa.Column("os_id_like", sa.String(100), nullable=True),  # fedora
+            # Kernel Information
+            sa.Column("kernel_version", sa.String(100), nullable=True),  # 5.14.0-362.el9.x86_64
+            sa.Column("kernel_release", sa.String(100), nullable=True),  # 5.14.0-362.el9.x86_64
+            sa.Column("kernel_name", sa.String(50), nullable=True),  # Linux
+            # Hardware Information
+            sa.Column("architecture", sa.String(50), nullable=True),  # x86_64
+            sa.Column("cpu_model", sa.String(255), nullable=True),  # Intel(R) Xeon(R) CPU @ 2.30GHz
+            sa.Column("cpu_cores", sa.Integer, nullable=True),  # 4
+            sa.Column("cpu_threads", sa.Integer, nullable=True),  # 8
+            sa.Column("memory_total_mb", sa.Integer, nullable=True),  # 16384
+            sa.Column("memory_available_mb", sa.Integer, nullable=True),  # 8192
+            sa.Column("swap_total_mb", sa.Integer, nullable=True),  # 4096
+            # Disk Information
+            sa.Column("disk_total_gb", sa.Float, nullable=True),  # 100.0
+            sa.Column("disk_used_gb", sa.Float, nullable=True),  # 45.5
+            sa.Column("disk_free_gb", sa.Float, nullable=True),  # 54.5
+            # Security Status
+            sa.Column("selinux_status", sa.String(50), nullable=True),  # enforcing, permissive, disabled
+            sa.Column("selinux_mode", sa.String(50), nullable=True),  # targeted, mls, minimum
+            sa.Column("firewall_status", sa.String(50), nullable=True),  # active, inactive
+            sa.Column("firewall_service", sa.String(50), nullable=True),  # firewalld, iptables, nftables
+            # Network Information
+            sa.Column("hostname", sa.String(255), nullable=True),
+            sa.Column("fqdn", sa.String(255), nullable=True),
+            sa.Column("primary_ip", sa.String(45), nullable=True),  # IPv4 or IPv6
+            # System Uptime
+            sa.Column("uptime_seconds", sa.BigInteger, nullable=True),
+            sa.Column("boot_time", sa.DateTime(timezone=True), nullable=True),
+            # Timestamps
+            sa.Column(
+                "collected_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+                nullable=False,
+            ),
+        )
+
+        # Create index on host_id for lookups
+        op.create_index(
+            "ix_host_system_info_host_id",
+            "host_system_info",
+            ["host_id"],
+            unique=True,
+        )
+
+        # Create index on collected_at for time-based queries
+        op.create_index(
+            "ix_host_system_info_collected_at",
+            "host_system_info",
+            ["collected_at"],
+        )
+
+
+def downgrade() -> None:
+    """Drop host_system_info table."""
+    conn = op.get_bind()
+
+    # Check if table exists before dropping
+    result = conn.execute(
+        sa.text("SELECT EXISTS (SELECT FROM information_schema.tables " "WHERE table_name = 'host_system_info')")
+    )
+    if result.scalar():
+        op.drop_index("ix_host_system_info_collected_at", table_name="host_system_info")
+        op.drop_index("ix_host_system_info_host_id", table_name="host_system_info")
+        op.drop_table("host_system_info")

--- a/backend/app/routes/compliance/__init__.py
+++ b/backend/app/routes/compliance/__init__.py
@@ -53,6 +53,7 @@ try:
     from .owca import router as owca_router
     from .posture import router as posture_router
     from .remediation import router as remediation_router
+    from .scheduler import router as scheduler_router
 
     # Include sub-routers
     # Intelligence endpoints are at the root of /compliance (no additional prefix)
@@ -75,6 +76,9 @@ try:
 
     # Audit endpoints at /compliance/audit/* (Phase 6 Audit Queries)
     router.include_router(audit_router)
+
+    # Scheduler endpoints at /compliance/scheduler/* (OpenWatch OS)
+    router.include_router(scheduler_router)
 
     _modules_loaded = True
     logger.info("Compliance package: All modules loaded successfully")

--- a/backend/app/routes/compliance/scheduler.py
+++ b/backend/app/routes/compliance/scheduler.py
@@ -1,0 +1,455 @@
+"""
+Adaptive Compliance Scheduler API Routes
+
+Endpoints for managing the adaptive compliance scheduling system.
+Allows configuration of scan intervals, maintenance windows, and viewing scheduler status.
+
+Part of OpenWatch OS Transformation
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.auth import get_current_user
+from app.database import User, get_db
+from app.rbac import UserRole, require_role
+from app.services.compliance.compliance_scheduler import compliance_scheduler_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/scheduler",
+    tags=["compliance-scheduler"],
+)
+
+
+# =============================================================================
+# Request/Response Schemas
+# =============================================================================
+
+
+class SchedulerConfigUpdate(BaseModel):
+    """Request schema for updating scheduler configuration."""
+
+    enabled: Optional[bool] = None
+    # Intervals in minutes for each compliance state
+    interval_compliant: Optional[int] = Field(None, ge=60, le=2880)
+    interval_mostly_compliant: Optional[int] = Field(None, ge=30, le=2880)
+    interval_partial: Optional[int] = Field(None, ge=30, le=2880)
+    interval_low: Optional[int] = Field(None, ge=30, le=2880)
+    interval_critical: Optional[int] = Field(None, ge=15, le=2880)
+    interval_unknown: Optional[int] = Field(None, ge=0, le=2880)
+    # Concurrency settings
+    max_concurrent_scans: Optional[int] = Field(None, ge=1, le=20)
+    scan_timeout_seconds: Optional[int] = Field(None, ge=60, le=3600)
+
+
+class SchedulerConfigResponse(BaseModel):
+    """Response schema for scheduler configuration."""
+
+    enabled: bool
+    interval_compliant: int
+    interval_mostly_compliant: int
+    interval_partial: int
+    interval_low: int
+    interval_critical: int
+    interval_unknown: int
+    interval_maintenance: int
+    max_interval_minutes: int
+    priority_compliant: int
+    priority_mostly_compliant: int
+    priority_partial: int
+    priority_low: int
+    priority_critical: int
+    priority_unknown: int
+    priority_maintenance: int
+    max_concurrent_scans: int
+    scan_timeout_seconds: int
+
+
+class SchedulerStatusResponse(BaseModel):
+    """Response schema for scheduler status."""
+
+    enabled: bool
+    total_hosts: int
+    hosts_due: int
+    hosts_in_maintenance: int
+    by_compliance_state: Dict[str, int]
+    next_scheduled_scans: list
+
+
+class HostScheduleResponse(BaseModel):
+    """Response schema for host schedule details."""
+
+    host_id: str
+    hostname: str
+    compliance_score: Optional[float]
+    compliance_state: str
+    has_critical_findings: bool
+    pass_count: Optional[int]
+    fail_count: Optional[int]
+    current_interval_minutes: int
+    next_scheduled_scan: Optional[datetime]
+    last_scan_completed: Optional[datetime]
+    maintenance_mode: bool
+    maintenance_until: Optional[datetime]
+    scan_priority: int
+    consecutive_scan_failures: int
+
+
+class MaintenanceModeRequest(BaseModel):
+    """Request schema for setting maintenance mode."""
+
+    enabled: bool
+    duration_hours: Optional[int] = Field(None, ge=1, le=168)  # Max 1 week
+
+
+# =============================================================================
+# Scheduler Configuration Endpoints
+# =============================================================================
+
+
+@router.get("/config", response_model=SchedulerConfigResponse)
+@require_role(
+    [
+        UserRole.GUEST,
+        UserRole.AUDITOR,
+        UserRole.SECURITY_ANALYST,
+        UserRole.COMPLIANCE_OFFICER,
+        UserRole.SECURITY_ADMIN,
+        UserRole.SUPER_ADMIN,
+    ]
+)
+async def get_scheduler_config(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Get the current scheduler configuration.
+
+    Returns interval settings, priority levels, and concurrency limits.
+    """
+    try:
+        config = compliance_scheduler_service.get_config(db)
+
+        # Transform nested format to flat API format
+        return {
+            "enabled": config["enabled"],
+            "interval_compliant": config["intervals"]["compliant"],
+            "interval_mostly_compliant": config["intervals"]["mostly_compliant"],
+            "interval_partial": config["intervals"]["partial"],
+            "interval_low": config["intervals"]["low"],
+            "interval_critical": config["intervals"]["critical"],
+            "interval_unknown": config["intervals"]["unknown"],
+            "interval_maintenance": config["intervals"]["maintenance"],
+            "max_interval_minutes": config["max_interval_minutes"],
+            "priority_compliant": config["priorities"]["compliant"],
+            "priority_mostly_compliant": config["priorities"]["mostly_compliant"],
+            "priority_partial": config["priorities"]["partial"],
+            "priority_low": config["priorities"]["low"],
+            "priority_critical": config["priorities"]["critical"],
+            "priority_unknown": config["priorities"]["unknown"],
+            "priority_maintenance": config["priorities"]["maintenance"],
+            "max_concurrent_scans": config["max_concurrent_scans"],
+            "scan_timeout_seconds": config["scan_timeout_seconds"],
+        }
+    except Exception as e:
+        logger.error(f"Error getting scheduler config: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.put("/config", response_model=SchedulerConfigResponse)
+@require_role([UserRole.SECURITY_ADMIN, UserRole.SUPER_ADMIN])
+async def update_scheduler_config(
+    config: SchedulerConfigUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Update scheduler configuration.
+
+    Only provided fields will be updated. Requires ADMIN role.
+
+    - Intervals are in minutes (min 15, max 2880 = 48 hours)
+    - max_concurrent_scans: 1-20 concurrent scans
+    - scan_timeout_seconds: 60-3600 seconds
+    """
+    try:
+        # Filter out None values
+        flat_data = {k: v for k, v in config.model_dump().items() if v is not None}
+
+        if not flat_data:
+            raise HTTPException(status_code=400, detail="No fields to update")
+
+        # Transform flat format to nested format for service
+        intervals = {}
+        other_params = {}
+
+        for key, value in flat_data.items():
+            if key.startswith("interval_"):
+                state = key.replace("interval_", "")
+                intervals[state] = value
+            elif key == "enabled":
+                other_params["enabled"] = value
+            elif key == "max_concurrent_scans":
+                other_params["max_concurrent_scans"] = value
+            elif key == "scan_timeout_seconds":
+                other_params["scan_timeout_seconds"] = value
+
+        # Call service with transformed parameters
+        compliance_scheduler_service.update_config(
+            db,
+            enabled=other_params.get("enabled"),
+            intervals=intervals if intervals else None,
+            max_concurrent_scans=other_params.get("max_concurrent_scans"),
+            scan_timeout_seconds=other_params.get("scan_timeout_seconds"),
+        )
+
+        # Return updated config in flat format
+        return await get_scheduler_config(db=db, current_user=current_user)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating scheduler config: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/toggle")
+@require_role([UserRole.SECURITY_ADMIN, UserRole.SUPER_ADMIN])
+async def toggle_scheduler(
+    enabled: bool,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Enable or disable the compliance scheduler.
+
+    When disabled, no automatic compliance scans will be dispatched.
+    Manual scans can still be triggered.
+    """
+    try:
+        compliance_scheduler_service.update_config(db, {"enabled": enabled})
+        return {
+            "status": "ok",
+            "enabled": enabled,
+            "message": f"Compliance scheduler {'enabled' if enabled else 'disabled'}",
+        }
+    except Exception as e:
+        logger.error(f"Error toggling scheduler: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# =============================================================================
+# Scheduler Status Endpoints
+# =============================================================================
+
+
+@router.get("/status", response_model=SchedulerStatusResponse)
+@require_role(
+    [
+        UserRole.GUEST,
+        UserRole.AUDITOR,
+        UserRole.SECURITY_ANALYST,
+        UserRole.COMPLIANCE_OFFICER,
+        UserRole.SECURITY_ADMIN,
+        UserRole.SUPER_ADMIN,
+    ]
+)
+async def get_scheduler_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Get current scheduler status and statistics.
+
+    Returns host counts by compliance state and upcoming scans.
+    """
+    try:
+        status = compliance_scheduler_service.get_scheduler_status(db)
+        return status
+    except Exception as e:
+        logger.error(f"Error getting scheduler status: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/hosts-due")
+@require_role(
+    [
+        UserRole.GUEST,
+        UserRole.AUDITOR,
+        UserRole.SECURITY_ANALYST,
+        UserRole.COMPLIANCE_OFFICER,
+        UserRole.SECURITY_ADMIN,
+        UserRole.SUPER_ADMIN,
+    ]
+)
+async def get_hosts_due_for_scan(
+    limit: int = 10,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Get list of hosts that are due for scanning.
+
+    Returns hosts ordered by priority and scheduled time.
+    """
+    try:
+        hosts_due = compliance_scheduler_service.get_hosts_due_for_scan(db, limit=limit)
+        return {
+            "hosts_due": len(hosts_due),
+            "hosts": hosts_due,
+        }
+    except Exception as e:
+        logger.error(f"Error getting hosts due for scan: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# =============================================================================
+# Host Schedule Endpoints
+# =============================================================================
+
+
+@router.get("/hosts/{host_id}", response_model=HostScheduleResponse)
+@require_role(
+    [
+        UserRole.GUEST,
+        UserRole.AUDITOR,
+        UserRole.SECURITY_ANALYST,
+        UserRole.COMPLIANCE_OFFICER,
+        UserRole.SECURITY_ADMIN,
+        UserRole.SUPER_ADMIN,
+    ]
+)
+async def get_host_schedule(
+    host_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Get compliance schedule details for a specific host.
+
+    Returns current compliance state, next scan time, and schedule configuration.
+    """
+    try:
+        schedule = compliance_scheduler_service.get_host_schedule(db, host_id)
+        if not schedule:
+            raise HTTPException(status_code=404, detail=f"Schedule not found for host {host_id}")
+        return schedule
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting host schedule: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.put("/hosts/{host_id}/maintenance")
+@require_role([UserRole.SECURITY_ANALYST, UserRole.COMPLIANCE_OFFICER, UserRole.SECURITY_ADMIN, UserRole.SUPER_ADMIN])
+async def set_host_maintenance_mode(
+    host_id: UUID,
+    request: MaintenanceModeRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Set maintenance mode for a host.
+
+    When in maintenance mode, the host will not be automatically scanned.
+    Maintenance mode will automatically expire after the specified duration.
+    """
+    try:
+        maintenance_until = None
+        if request.enabled and request.duration_hours:
+            maintenance_until = datetime.now(timezone.utc) + timedelta(hours=request.duration_hours)
+
+        compliance_scheduler_service.set_host_maintenance_mode(
+            db,
+            host_id,
+            enabled=request.enabled,
+            maintenance_until=maintenance_until,
+        )
+
+        return {
+            "status": "ok",
+            "host_id": str(host_id),
+            "maintenance_mode": request.enabled,
+            "maintenance_until": maintenance_until.isoformat() if maintenance_until else None,
+        }
+    except Exception as e:
+        logger.error(f"Error setting maintenance mode: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/hosts/{host_id}/force-scan")
+@require_role([UserRole.SECURITY_ANALYST, UserRole.COMPLIANCE_OFFICER, UserRole.SECURITY_ADMIN, UserRole.SUPER_ADMIN])
+async def force_host_scan(
+    host_id: UUID,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Force an immediate compliance scan for a host.
+
+    This bypasses the normal schedule and queues a scan immediately.
+    The scan will be executed by the next available worker.
+    """
+    try:
+        from app.celery_app import celery_app
+
+        # Queue an immediate scan
+        task = celery_app.send_task(
+            "app.tasks.run_scheduled_aegis_scan",
+            args=[str(host_id), 10],  # Priority 10 = highest
+            priority=10,
+            queue="compliance_scanning",
+        )
+
+        return {
+            "status": "ok",
+            "message": f"Scan queued for host {host_id}",
+            "task_id": task.id,
+        }
+    except Exception as e:
+        logger.error(f"Error forcing host scan: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# =============================================================================
+# Initialization Endpoints
+# =============================================================================
+
+
+@router.post("/initialize")
+@require_role([UserRole.SECURITY_ADMIN, UserRole.SUPER_ADMIN])
+async def initialize_schedules(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Initialize compliance schedules for all hosts that don't have one.
+
+    This should be run after deploying the compliance scheduler to
+    bootstrap schedules for existing hosts.
+    """
+    try:
+        from app.celery_app import celery_app
+
+        # Queue the initialization task
+        task = celery_app.send_task(
+            "app.tasks.initialize_compliance_schedules",
+            queue="compliance_scanning",
+        )
+
+        return {
+            "status": "ok",
+            "message": "Schedule initialization queued",
+            "task_id": task.id,
+        }
+    except Exception as e:
+        logger.error(f"Error initializing schedules: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/services/auth/validation.py
+++ b/backend/app/services/auth/validation.py
@@ -530,7 +530,8 @@ def validate_credential_with_strict_policy(
                 if recommendations:
                     error_message += f". Recommendations: {'; '.join(recommendations[:2])}"
             else:
-                error_message = f"Credential validation failed (security level: {audit_result.get('overall_security_level', 'unknown')})"
+                security_level = audit_result.get("overall_security_level", "unknown")
+                error_message = f"Credential validation failed (security level: {security_level})"
         else:
             error_message = ""
 

--- a/backend/app/services/compliance/__init__.py
+++ b/backend/app/services/compliance/__init__.py
@@ -2,21 +2,24 @@
 Compliance Services Package
 
 Services for compliance posture management, temporal queries, drift detection,
-exception management, and audit queries.
+exception management, and adaptive compliance scheduling.
 
 Part of Phase 2: Temporal Compliance (Aegis Integration Plan)
 Part of Phase 3: Governance Primitives (Aegis Integration Plan)
-Part of Phase 6: Audit Queries (Aegis Integration Plan)
+OpenWatch OS: Adaptive Compliance Scheduler
 """
 
-from .audit_export import AuditExportService
-from .audit_query import AuditQueryService
+from .compliance_scheduler import ComplianceSchedulerService, compliance_scheduler_service
 from .exceptions import ExceptionService
 from .temporal import TemporalComplianceService
 
 __all__ = [
     "TemporalComplianceService",
     "ExceptionService",
-    "AuditQueryService",
-    "AuditExportService",
+    "ComplianceSchedulerService",
+    "compliance_scheduler_service",
 ]
+
+# Phase 6 Audit Queries - imports added when Phase 6 is complete
+# from .audit_export import AuditExportService
+# from .audit_query import AuditQueryService

--- a/backend/app/services/compliance/compliance_scheduler.py
+++ b/backend/app/services/compliance/compliance_scheduler.py
@@ -1,0 +1,819 @@
+"""
+Adaptive Compliance Scheduler Service
+
+This service manages the configuration and execution of the adaptive Celery-based
+compliance scanning scheduler. It uses compliance-state-based intervals to optimize
+resource usage while ensuring continuous compliance visibility.
+
+Architecture:
+- Celery Beat schedules periodic dispatcher task (every 2 minutes)
+- Dispatcher queries host_compliance_schedule WHERE next_scheduled_scan <= NOW()
+- Individual Aegis scan tasks dispatched with state-based priority
+- Results update compliance state and calculate next scan time (max 48 hours)
+
+Compliance States & Intervals:
+- unknown (new/never scanned): immediate scan (priority 10)
+- compliant (100%): 24 hours (priority 3)
+- mostly_compliant (80-99%): 12 hours (priority 4)
+- partial (50-79%): 6 hours (priority 6)
+- low (20-49%): 2 hours (priority 7)
+- critical (<20% or critical findings): 1 hour (priority 9)
+- maintenance: 48 hours or skip (priority 1)
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+class ComplianceSchedulerService:
+    """Service for managing adaptive compliance scanning scheduler"""
+
+    def __init__(self) -> None:
+        """Initialize compliance scheduler service with cache configuration."""
+        self._config_cache: Optional[Dict[str, Any]] = None
+        self._cache_timestamp: Optional[datetime] = None
+        self._cache_ttl_seconds = 60  # Cache config for 1 minute
+
+    def get_config(self, db: Session) -> Dict[str, Any]:
+        """
+        Get current scheduler configuration with caching.
+
+        Returns:
+            dict: Scheduler configuration with all intervals and settings
+        """
+        # Check cache validity
+        if self._config_cache and self._cache_timestamp:
+            cache_age = (datetime.now(timezone.utc) - self._cache_timestamp).total_seconds()
+            if cache_age < self._cache_ttl_seconds:
+                return self._config_cache
+
+        try:
+            result = db.execute(
+                text(
+                    """
+                SELECT
+                    enabled,
+                    interval_compliant,
+                    interval_mostly_compliant,
+                    interval_partial,
+                    interval_low,
+                    interval_critical,
+                    interval_unknown,
+                    interval_maintenance,
+                    max_interval_minutes,
+                    priority_compliant,
+                    priority_mostly_compliant,
+                    priority_partial,
+                    priority_low,
+                    priority_critical,
+                    priority_unknown,
+                    priority_maintenance,
+                    max_concurrent_scans,
+                    scan_timeout_seconds
+                FROM compliance_scheduler_config
+                WHERE id = 1
+            """
+                )
+            )
+
+            row = result.fetchone()
+            if not row:
+                return self._get_default_config()
+
+            config = {
+                "enabled": row.enabled,
+                "intervals": {
+                    "compliant": row.interval_compliant,
+                    "mostly_compliant": row.interval_mostly_compliant,
+                    "partial": row.interval_partial,
+                    "low": row.interval_low,
+                    "critical": row.interval_critical,
+                    "unknown": row.interval_unknown,
+                    "maintenance": row.interval_maintenance,
+                },
+                "max_interval_minutes": row.max_interval_minutes,
+                "priorities": {
+                    "compliant": row.priority_compliant,
+                    "mostly_compliant": row.priority_mostly_compliant,
+                    "partial": row.priority_partial,
+                    "low": row.priority_low,
+                    "critical": row.priority_critical,
+                    "unknown": row.priority_unknown,
+                    "maintenance": row.priority_maintenance,
+                },
+                "max_concurrent_scans": row.max_concurrent_scans,
+                "scan_timeout_seconds": row.scan_timeout_seconds,
+            }
+
+            # Update cache
+            self._config_cache = config
+            self._cache_timestamp = datetime.now(timezone.utc)
+
+            return config
+
+        except Exception as e:
+            logger.error(f"Error loading compliance scheduler config: {e}")
+            return self._get_default_config()
+
+    def update_config(
+        self,
+        db: Session,
+        enabled: Optional[bool] = None,
+        intervals: Optional[Dict[str, int]] = None,
+        max_concurrent_scans: Optional[int] = None,
+        scan_timeout_seconds: Optional[int] = None,
+        user_id: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Update scheduler configuration.
+
+        Args:
+            db: Database session
+            enabled: Enable/disable scheduler
+            intervals: Dict of state intervals (e.g., {'compliant': 1440, 'critical': 60})
+            max_concurrent_scans: Maximum concurrent scan tasks
+            scan_timeout_seconds: Timeout for individual scans
+            user_id: ID of user making the change
+
+        Returns:
+            dict: Updated configuration
+        """
+        try:
+            updates = []
+            params: Dict[str, Any] = {"updated_at": datetime.now(timezone.utc)}
+
+            if enabled is not None:
+                updates.append("enabled = :enabled")
+                params["enabled"] = enabled
+
+            if intervals:
+                interval_fields = [
+                    "compliant",
+                    "mostly_compliant",
+                    "partial",
+                    "low",
+                    "critical",
+                    "unknown",
+                    "maintenance",
+                ]
+                for field in interval_fields:
+                    if field in intervals:
+                        updates.append(f"interval_{field} = :interval_{field}")
+                        params[f"interval_{field}"] = intervals[field]
+
+            if max_concurrent_scans is not None:
+                updates.append("max_concurrent_scans = :max_concurrent_scans")
+                params["max_concurrent_scans"] = max_concurrent_scans
+
+            if scan_timeout_seconds is not None:
+                updates.append("scan_timeout_seconds = :scan_timeout_seconds")
+                params["scan_timeout_seconds"] = scan_timeout_seconds
+
+            if updates:
+                updates.append("updated_at = :updated_at")
+                query = f"UPDATE compliance_scheduler_config SET {', '.join(updates)} WHERE id = 1"
+                db.execute(text(query), params)
+                db.commit()
+
+                # Invalidate cache
+                self._config_cache = None
+                self._cache_timestamp = None
+
+                logger.info(f"Compliance scheduler config updated by user {user_id}")
+
+            return self.get_config(db)
+
+        except Exception as e:
+            logger.error(f"Error updating compliance scheduler config: {e}")
+            db.rollback()
+            raise
+
+    def get_compliance_state_from_score(self, score: Optional[float], has_critical: bool) -> str:
+        """
+        Determine compliance state from score and critical findings.
+
+        Args:
+            score: Compliance score (0-100) or None if never scanned
+            has_critical: Whether host has critical findings
+
+        Returns:
+            str: Compliance state (compliant, mostly_compliant, partial, low, critical, unknown)
+        """
+        if score is None:
+            return "unknown"
+
+        if has_critical:
+            return "critical"
+
+        if score >= 100:
+            return "compliant"
+        elif score >= 80:
+            return "mostly_compliant"
+        elif score >= 50:
+            return "partial"
+        elif score >= 20:
+            return "low"
+        else:
+            return "critical"
+
+    def get_interval_for_state(self, db: Session, state: str) -> int:
+        """
+        Get scan interval (in minutes) for a given compliance state.
+
+        Args:
+            db: Database session
+            state: Compliance state
+
+        Returns:
+            int: Scan interval in minutes (capped at max_interval_minutes)
+        """
+        config = self.get_config(db)
+        interval = config["intervals"].get(state.lower(), 1440)
+
+        # Enforce maximum interval (48 hours)
+        max_interval = config["max_interval_minutes"]
+        return min(interval, max_interval)
+
+    def get_priority_for_state(self, db: Session, state: str) -> int:
+        """
+        Get Celery queue priority for a given compliance state.
+
+        Args:
+            db: Database session
+            state: Compliance state
+
+        Returns:
+            int: Priority (1-10, higher = more urgent)
+        """
+        config = self.get_config(db)
+        return config["priorities"].get(state.lower(), 5)
+
+    def calculate_next_scan_time(self, db: Session, score: Optional[float], has_critical: bool) -> datetime:
+        """
+        Calculate next scan time based on compliance score and findings.
+
+        Args:
+            db: Database session
+            score: Current compliance score
+            has_critical: Whether host has critical findings
+
+        Returns:
+            datetime: Next scheduled scan time
+        """
+        state = self.get_compliance_state_from_score(score, has_critical)
+        interval_minutes = self.get_interval_for_state(db, state)
+
+        # Unknown state = immediate scan
+        if state == "unknown" or interval_minutes == 0:
+            return datetime.now(timezone.utc)
+
+        return datetime.now(timezone.utc) + timedelta(minutes=interval_minutes)
+
+    def get_hosts_due_for_scan(self, db: Session, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """
+        Get hosts that are due for compliance scanning.
+
+        Args:
+            db: Database session
+            limit: Maximum number of hosts to return
+
+        Returns:
+            List[dict]: Hosts due for scanning, ordered by priority and next_scheduled_scan
+        """
+        config = self.get_config(db)
+
+        if not config["enabled"]:
+            return []
+
+        if limit is None:
+            limit = config["max_concurrent_scans"]
+
+        try:
+            query = """
+                SELECT
+                    h.id as host_id,
+                    h.hostname,
+                    h.ip_address,
+                    h.status as host_status,
+                    hcs.compliance_score,
+                    hcs.compliance_state,
+                    hcs.has_critical_findings,
+                    hcs.next_scheduled_scan,
+                    hcs.scan_priority,
+                    hcs.maintenance_mode,
+                    hcs.last_scan_completed
+                FROM hosts h
+                LEFT JOIN host_compliance_schedule hcs ON h.id = hcs.host_id
+                WHERE h.is_active = true
+                  AND h.status != 'down'
+                  AND (hcs.maintenance_mode IS NULL OR hcs.maintenance_mode = false)
+                  AND (
+                    hcs.next_scheduled_scan IS NULL
+                    OR hcs.next_scheduled_scan <= :now
+                  )
+                ORDER BY
+                    COALESCE(hcs.scan_priority, 10) DESC,
+                    hcs.next_scheduled_scan ASC NULLS FIRST
+                LIMIT :limit
+            """
+
+            result = db.execute(text(query), {"now": datetime.now(timezone.utc), "limit": limit})
+
+            hosts = []
+            for row in result:
+                hosts.append(
+                    {
+                        "host_id": str(row.host_id),
+                        "hostname": row.hostname,
+                        "ip_address": row.ip_address,
+                        "host_status": row.host_status,
+                        "compliance_score": row.compliance_score,
+                        "compliance_state": row.compliance_state or "unknown",
+                        "has_critical_findings": row.has_critical_findings or False,
+                        "next_scheduled_scan": row.next_scheduled_scan,
+                        "scan_priority": row.scan_priority or 10,
+                        "last_scan_completed": row.last_scan_completed,
+                    }
+                )
+
+            return hosts
+
+        except Exception as e:
+            logger.error(f"Error getting hosts due for compliance scan: {e}")
+            return []
+
+    def update_host_schedule(
+        self,
+        db: Session,
+        host_id: UUID,
+        compliance_score: Optional[float],
+        has_critical_findings: bool,
+        pass_count: int,
+        fail_count: int,
+        scan_id: Optional[UUID] = None,
+    ) -> None:
+        """
+        Update a host's compliance schedule after a scan completes.
+
+        Args:
+            db: Database session
+            host_id: Host UUID
+            compliance_score: New compliance score
+            has_critical_findings: Whether scan found critical issues
+            pass_count: Number of passing rules
+            fail_count: Number of failing rules
+            scan_id: ID of the completed scan
+        """
+        try:
+            state = self.get_compliance_state_from_score(compliance_score, has_critical_findings)
+            priority = self.get_priority_for_state(db, state)
+            next_scan = self.calculate_next_scan_time(db, compliance_score, has_critical_findings)
+            interval = self.get_interval_for_state(db, state)
+
+            now = datetime.now(timezone.utc)
+
+            # Upsert: insert or update
+            query = """
+                INSERT INTO host_compliance_schedule (
+                    host_id, compliance_score, compliance_state,
+                    has_critical_findings, pass_count, fail_count,
+                    current_interval_minutes, next_scheduled_scan,
+                    last_scan_completed, last_scan_id, scan_priority,
+                    consecutive_scan_failures, updated_at
+                ) VALUES (
+                    :host_id, :score, :state,
+                    :has_critical, :pass_count, :fail_count,
+                    :interval, :next_scan,
+                    :now, :scan_id, :priority,
+                    0, :now
+                )
+                ON CONFLICT (host_id) DO UPDATE SET
+                    compliance_score = :score,
+                    compliance_state = :state,
+                    has_critical_findings = :has_critical,
+                    pass_count = :pass_count,
+                    fail_count = :fail_count,
+                    current_interval_minutes = :interval,
+                    next_scheduled_scan = :next_scan,
+                    last_scan_completed = :now,
+                    last_scan_id = :scan_id,
+                    scan_priority = :priority,
+                    consecutive_scan_failures = 0,
+                    updated_at = :now
+            """
+
+            db.execute(
+                text(query),
+                {
+                    "host_id": str(host_id),
+                    "score": compliance_score,
+                    "state": state,
+                    "has_critical": has_critical_findings,
+                    "pass_count": pass_count,
+                    "fail_count": fail_count,
+                    "interval": interval,
+                    "next_scan": next_scan,
+                    "now": now,
+                    "scan_id": str(scan_id) if scan_id else None,
+                    "priority": priority,
+                },
+            )
+            db.commit()
+
+            logger.info(
+                f"Updated compliance schedule for host {host_id}: "
+                f"score={compliance_score}, state={state}, next_scan={next_scan}"
+            )
+
+        except Exception as e:
+            logger.error(f"Error updating host compliance schedule: {e}")
+            db.rollback()
+            raise
+
+    def record_scan_failure(self, db: Session, host_id: UUID, error: str) -> None:
+        """
+        Record a scan failure and update next scan time.
+
+        Args:
+            db: Database session
+            host_id: Host UUID
+            error: Error message
+        """
+        try:
+            # Increment failure count and set retry time (5 minutes)
+            query = """
+                UPDATE host_compliance_schedule
+                SET consecutive_scan_failures = consecutive_scan_failures + 1,
+                    next_scheduled_scan = :next_scan,
+                    updated_at = :now
+                WHERE host_id = :host_id
+            """
+
+            db.execute(
+                text(query),
+                {
+                    "host_id": str(host_id),
+                    "next_scan": datetime.now(timezone.utc) + timedelta(minutes=5),
+                    "now": datetime.now(timezone.utc),
+                },
+            )
+            db.commit()
+
+            logger.warning(f"Recorded scan failure for host {host_id}: {error}")
+
+        except Exception as e:
+            logger.error(f"Error recording scan failure: {e}")
+            db.rollback()
+
+    def initialize_host_schedule(self, db: Session, host_id: UUID) -> None:
+        """
+        Initialize compliance schedule for a new host (immediate scan).
+
+        Args:
+            db: Database session
+            host_id: Host UUID
+        """
+        try:
+            query = """
+                INSERT INTO host_compliance_schedule (
+                    host_id, compliance_state, scan_priority,
+                    next_scheduled_scan, current_interval_minutes
+                ) VALUES (
+                    :host_id, 'unknown', 10,
+                    :now, 0
+                )
+                ON CONFLICT (host_id) DO NOTHING
+            """
+
+            db.execute(
+                text(query),
+                {"host_id": str(host_id), "now": datetime.now(timezone.utc)},
+            )
+            db.commit()
+
+            logger.info(f"Initialized compliance schedule for new host {host_id}")
+
+        except Exception as e:
+            logger.error(f"Error initializing host schedule: {e}")
+            db.rollback()
+
+    def set_maintenance_mode(
+        self,
+        db: Session,
+        host_id: UUID,
+        enabled: bool,
+        until: Optional[datetime] = None,
+    ) -> None:
+        """
+        Set maintenance mode for a host.
+
+        Args:
+            db: Database session
+            host_id: Host UUID
+            enabled: Enable or disable maintenance mode
+            until: When maintenance mode should automatically end
+        """
+        try:
+            query = """
+                UPDATE host_compliance_schedule
+                SET maintenance_mode = :enabled,
+                    maintenance_until = :until,
+                    updated_at = :now
+                WHERE host_id = :host_id
+            """
+
+            db.execute(
+                text(query),
+                {
+                    "host_id": str(host_id),
+                    "enabled": enabled,
+                    "until": until,
+                    "now": datetime.now(timezone.utc),
+                },
+            )
+            db.commit()
+
+            logger.info(f"Set maintenance mode for host {host_id}: enabled={enabled}, until={until}")
+
+        except Exception as e:
+            logger.error(f"Error setting maintenance mode: {e}")
+            db.rollback()
+            raise
+
+    def get_scheduler_stats(self, db: Session) -> Dict[str, Any]:
+        """
+        Get real-time scheduler statistics.
+
+        Returns:
+            dict: Stats including hosts per state, overdue scans, etc.
+        """
+        try:
+            # Get hosts by compliance state
+            state_result = db.execute(
+                text(
+                    """
+                SELECT
+                    COALESCE(hcs.compliance_state, 'unknown') as state,
+                    COUNT(*) as count
+                FROM hosts h
+                LEFT JOIN host_compliance_schedule hcs ON h.id = hcs.host_id
+                WHERE h.is_active = true
+                GROUP BY hcs.compliance_state
+            """
+                )
+            )
+
+            hosts_by_state = {row.state: row.count for row in state_result}
+
+            # Get overdue hosts
+            overdue_result = db.execute(
+                text(
+                    """
+                SELECT COUNT(*) as count
+                FROM host_compliance_schedule hcs
+                JOIN hosts h ON h.id = hcs.host_id
+                WHERE h.is_active = true
+                  AND hcs.maintenance_mode = false
+                  AND hcs.next_scheduled_scan < :now
+            """
+                ),
+                {"now": datetime.now(timezone.utc)},
+            )
+
+            overdue_count = overdue_result.fetchone().count
+
+            # Get next scan time
+            next_scan_result = db.execute(
+                text(
+                    """
+                SELECT MIN(hcs.next_scheduled_scan) as next_scan
+                FROM host_compliance_schedule hcs
+                JOIN hosts h ON h.id = hcs.host_id
+                WHERE h.is_active = true
+                  AND hcs.maintenance_mode = false
+                  AND hcs.next_scheduled_scan IS NOT NULL
+            """
+                )
+            )
+
+            next_scan_row = next_scan_result.fetchone()
+            next_scan = next_scan_row.next_scan if next_scan_row else None
+
+            # Get hosts in maintenance
+            maintenance_result = db.execute(
+                text(
+                    """
+                SELECT COUNT(*) as count
+                FROM host_compliance_schedule
+                WHERE maintenance_mode = true
+            """
+                )
+            )
+
+            maintenance_count = maintenance_result.fetchone().count
+
+            config = self.get_config(db)
+
+            return {
+                "enabled": config["enabled"],
+                "hosts_by_state": hosts_by_state,
+                "total_hosts": sum(hosts_by_state.values()),
+                "overdue_scans": overdue_count,
+                "in_maintenance": maintenance_count,
+                "next_scan_time": next_scan.isoformat() if next_scan else None,
+                "max_concurrent_scans": config["max_concurrent_scans"],
+                "max_interval_minutes": config["max_interval_minutes"],
+            }
+
+        except Exception as e:
+            logger.error(f"Error getting scheduler stats: {e}")
+            return {
+                "enabled": False,
+                "hosts_by_state": {},
+                "total_hosts": 0,
+                "overdue_scans": 0,
+                "in_maintenance": 0,
+                "next_scan_time": None,
+            }
+
+    def get_scheduler_status(self, db: Session) -> Dict[str, Any]:
+        """
+        Get current scheduler status including host counts and upcoming scans.
+
+        Returns:
+            dict: Status info for API response
+        """
+        try:
+            stats = self.get_scheduler_stats(db)
+            config = self.get_config(db)
+
+            # Get next scheduled scans
+            next_scans_result = db.execute(
+                text(
+                    """
+                SELECT
+                    h.id as host_id,
+                    h.hostname,
+                    hcs.compliance_state,
+                    hcs.next_scheduled_scan
+                FROM host_compliance_schedule hcs
+                JOIN hosts h ON h.id = hcs.host_id
+                WHERE h.is_active = true
+                  AND hcs.maintenance_mode = false
+                  AND hcs.next_scheduled_scan IS NOT NULL
+                ORDER BY hcs.next_scheduled_scan ASC
+                LIMIT 5
+            """
+                )
+            )
+
+            next_scans = [
+                {
+                    "host_id": str(row.host_id),
+                    "hostname": row.hostname,
+                    "compliance_state": row.compliance_state,
+                    "scheduled_for": row.next_scheduled_scan.isoformat() if row.next_scheduled_scan else None,
+                }
+                for row in next_scans_result
+            ]
+
+            return {
+                "enabled": config["enabled"],
+                "total_hosts": stats["total_hosts"],
+                "hosts_due": stats["overdue_scans"],
+                "hosts_in_maintenance": stats["in_maintenance"],
+                "by_compliance_state": stats["hosts_by_state"],
+                "next_scheduled_scans": next_scans,
+            }
+
+        except Exception as e:
+            logger.error(f"Error getting scheduler status: {e}")
+            return {
+                "enabled": False,
+                "total_hosts": 0,
+                "hosts_due": 0,
+                "hosts_in_maintenance": 0,
+                "by_compliance_state": {},
+                "next_scheduled_scans": [],
+            }
+
+    def get_host_schedule(self, db: Session, host_id: UUID) -> Optional[Dict[str, Any]]:
+        """
+        Get compliance schedule details for a specific host.
+
+        Args:
+            db: Database session
+            host_id: Host UUID
+
+        Returns:
+            dict: Schedule details or None if not found
+        """
+        try:
+            result = db.execute(
+                text(
+                    """
+                SELECT
+                    h.id as host_id,
+                    h.hostname,
+                    hcs.compliance_score,
+                    hcs.compliance_state,
+                    hcs.has_critical_findings,
+                    hcs.pass_count,
+                    hcs.fail_count,
+                    hcs.current_interval_minutes,
+                    hcs.next_scheduled_scan,
+                    hcs.last_scan_completed,
+                    hcs.maintenance_mode,
+                    hcs.maintenance_until,
+                    hcs.scan_priority,
+                    hcs.consecutive_scan_failures
+                FROM hosts h
+                LEFT JOIN host_compliance_schedule hcs ON h.id = hcs.host_id
+                WHERE h.id = :host_id
+            """
+                ),
+                {"host_id": str(host_id)},
+            )
+
+            row = result.fetchone()
+            if not row:
+                return None
+
+            return {
+                "host_id": str(row.host_id),
+                "hostname": row.hostname,
+                "compliance_score": row.compliance_score,
+                "compliance_state": row.compliance_state or "unknown",
+                "has_critical_findings": row.has_critical_findings or False,
+                "pass_count": row.pass_count,
+                "fail_count": row.fail_count,
+                "current_interval_minutes": row.current_interval_minutes or 1440,
+                "next_scheduled_scan": row.next_scheduled_scan,
+                "last_scan_completed": row.last_scan_completed,
+                "maintenance_mode": row.maintenance_mode or False,
+                "maintenance_until": row.maintenance_until,
+                "scan_priority": row.scan_priority or 5,
+                "consecutive_scan_failures": row.consecutive_scan_failures or 0,
+            }
+
+        except Exception as e:
+            logger.error(f"Error getting host schedule: {e}")
+            return None
+
+    def set_host_maintenance_mode(
+        self,
+        db: Session,
+        host_id: UUID,
+        enabled: bool,
+        maintenance_until: Optional[datetime] = None,
+    ) -> None:
+        """
+        Set maintenance mode for a host.
+
+        Alias for set_maintenance_mode with different parameter name.
+
+        Args:
+            db: Database session
+            host_id: Host UUID
+            enabled: Enable or disable maintenance mode
+            maintenance_until: When maintenance mode should automatically end
+        """
+        self.set_maintenance_mode(db, host_id, enabled, maintenance_until)
+
+    def _get_default_config(self) -> Dict[str, Any]:
+        """Get default configuration when database config is unavailable"""
+        return {
+            "enabled": True,
+            "intervals": {
+                "compliant": 1440,  # 24 hours
+                "mostly_compliant": 720,  # 12 hours
+                "partial": 360,  # 6 hours
+                "low": 120,  # 2 hours
+                "critical": 60,  # 1 hour
+                "unknown": 0,  # Immediate
+                "maintenance": 2880,  # 48 hours
+            },
+            "max_interval_minutes": 2880,  # 48 hours
+            "priorities": {
+                "compliant": 3,
+                "mostly_compliant": 4,
+                "partial": 6,
+                "low": 7,
+                "critical": 9,
+                "unknown": 10,
+                "maintenance": 1,
+            },
+            "max_concurrent_scans": 5,
+            "scan_timeout_seconds": 600,
+        }
+
+
+# Global service instance
+compliance_scheduler_service = ComplianceSchedulerService()

--- a/backend/app/services/system_info/__init__.py
+++ b/backend/app/services/system_info/__init__.py
@@ -1,0 +1,11 @@
+"""
+System Information Services Package
+
+Provides services for collecting and managing detailed host system information.
+
+Part of OpenWatch OS Transformation - Server Intelligence.
+"""
+
+from .collector import SystemInfo, SystemInfoCollector, SystemInfoService
+
+__all__ = ["SystemInfo", "SystemInfoCollector", "SystemInfoService"]

--- a/backend/app/services/system_info/collector.py
+++ b/backend/app/services/system_info/collector.py
@@ -1,0 +1,500 @@
+"""
+System Information Collector Service
+
+Collects detailed system information from remote hosts via SSH.
+Used during compliance scans to gather rich system data.
+
+Part of OpenWatch OS Transformation - Server Intelligence.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SystemInfo:
+    """Collected system information from a host."""
+
+    # OS Information
+    os_name: Optional[str] = None
+    os_version: Optional[str] = None
+    os_version_full: Optional[str] = None
+    os_pretty_name: Optional[str] = None
+    os_id: Optional[str] = None
+    os_id_like: Optional[str] = None
+
+    # Kernel Information
+    kernel_version: Optional[str] = None
+    kernel_release: Optional[str] = None
+    kernel_name: Optional[str] = None
+
+    # Hardware Information
+    architecture: Optional[str] = None
+    cpu_model: Optional[str] = None
+    cpu_cores: Optional[int] = None
+    cpu_threads: Optional[int] = None
+    memory_total_mb: Optional[int] = None
+    memory_available_mb: Optional[int] = None
+    swap_total_mb: Optional[int] = None
+
+    # Disk Information
+    disk_total_gb: Optional[float] = None
+    disk_used_gb: Optional[float] = None
+    disk_free_gb: Optional[float] = None
+
+    # Security Status
+    selinux_status: Optional[str] = None
+    selinux_mode: Optional[str] = None
+    firewall_status: Optional[str] = None
+    firewall_service: Optional[str] = None
+
+    # Network Information
+    hostname: Optional[str] = None
+    fqdn: Optional[str] = None
+    primary_ip: Optional[str] = None
+
+    # System Uptime
+    uptime_seconds: Optional[int] = None
+    boot_time: Optional[datetime] = None
+
+
+class SystemInfoCollector:
+    """Collects system information from remote hosts via SSH."""
+
+    def __init__(self, ssh_session: Any):
+        """
+        Initialize with an SSH session.
+
+        Args:
+            ssh_session: An SSH session object with run() method (Aegis SSHSession or similar)
+        """
+        self.ssh = ssh_session
+
+    def _run_command(self, command: str) -> Optional[str]:
+        """Run a command and return stdout, or None on error."""
+        try:
+            result = self.ssh.run(command)
+            if result.returncode == 0:
+                return result.stdout.strip()
+            return None
+        except Exception as e:
+            logger.debug(f"Command '{command}' failed: {e}")
+            return None
+
+    def collect(self) -> SystemInfo:
+        """
+        Collect all system information from the remote host.
+
+        Returns:
+            SystemInfo dataclass with collected data
+        """
+        info = SystemInfo()
+
+        # Collect OS information from /etc/os-release
+        self._collect_os_info(info)
+
+        # Collect kernel information
+        self._collect_kernel_info(info)
+
+        # Collect hardware information
+        self._collect_hardware_info(info)
+
+        # Collect disk information
+        self._collect_disk_info(info)
+
+        # Collect security status
+        self._collect_security_status(info)
+
+        # Collect network information
+        self._collect_network_info(info)
+
+        # Collect uptime
+        self._collect_uptime(info)
+
+        return info
+
+    def _collect_os_info(self, info: SystemInfo) -> None:
+        """Collect OS information from /etc/os-release."""
+        os_release = self._run_command("cat /etc/os-release 2>/dev/null")
+        if os_release:
+            # Parse key=value pairs
+            for line in os_release.split("\n"):
+                if "=" in line:
+                    key, value = line.split("=", 1)
+                    value = value.strip('"').strip("'")
+
+                    if key == "NAME":
+                        info.os_name = value
+                    elif key == "VERSION":
+                        info.os_version_full = value
+                    elif key == "VERSION_ID":
+                        info.os_version = value
+                    elif key == "PRETTY_NAME":
+                        info.os_pretty_name = value
+                    elif key == "ID":
+                        info.os_id = value
+                    elif key == "ID_LIKE":
+                        info.os_id_like = value
+
+    def _collect_kernel_info(self, info: SystemInfo) -> None:
+        """Collect kernel information using uname."""
+        info.kernel_name = self._run_command("uname -s")
+        info.kernel_release = self._run_command("uname -r")
+        info.kernel_version = self._run_command("uname -v")
+        info.architecture = self._run_command("uname -m")
+
+    def _collect_hardware_info(self, info: SystemInfo) -> None:
+        """Collect CPU and memory information."""
+        # CPU model from /proc/cpuinfo
+        cpu_info = self._run_command("grep 'model name' /proc/cpuinfo | head -1")
+        if cpu_info:
+            match = re.search(r"model name\s*:\s*(.+)", cpu_info)
+            if match:
+                info.cpu_model = match.group(1).strip()
+
+        # CPU cores (physical)
+        cores = self._run_command("grep -c '^processor' /proc/cpuinfo")
+        if cores:
+            try:
+                info.cpu_threads = int(cores)
+            except ValueError:
+                pass
+
+        # Physical cores (may be different from threads)
+        physical_cores = self._run_command("grep 'cpu cores' /proc/cpuinfo | head -1 | awk '{print $4}'")
+        if physical_cores:
+            try:
+                info.cpu_cores = int(physical_cores)
+            except ValueError:
+                # Fall back to threads count
+                info.cpu_cores = info.cpu_threads
+
+        # Memory information from /proc/meminfo
+        meminfo = self._run_command("cat /proc/meminfo")
+        if meminfo:
+            for line in meminfo.split("\n"):
+                if line.startswith("MemTotal:"):
+                    match = re.search(r"(\d+)", line)
+                    if match:
+                        info.memory_total_mb = int(match.group(1)) // 1024
+                elif line.startswith("MemAvailable:"):
+                    match = re.search(r"(\d+)", line)
+                    if match:
+                        info.memory_available_mb = int(match.group(1)) // 1024
+                elif line.startswith("SwapTotal:"):
+                    match = re.search(r"(\d+)", line)
+                    if match:
+                        info.swap_total_mb = int(match.group(1)) // 1024
+
+    def _collect_disk_info(self, info: SystemInfo) -> None:
+        """Collect disk usage for root filesystem."""
+        # Get disk usage for root partition
+        df_output = self._run_command("df -BG / | tail -1")
+        if df_output:
+            # Format: Filesystem Size Used Avail Use% Mounted
+            parts = df_output.split()
+            if len(parts) >= 4:
+                try:
+                    # Remove 'G' suffix and convert to float
+                    info.disk_total_gb = float(parts[1].rstrip("G"))
+                    info.disk_used_gb = float(parts[2].rstrip("G"))
+                    info.disk_free_gb = float(parts[3].rstrip("G"))
+                except (ValueError, IndexError):
+                    pass
+
+    def _collect_security_status(self, info: SystemInfo) -> None:
+        """Collect SELinux and firewall status."""
+        # SELinux status
+        selinux_status = self._run_command("getenforce 2>/dev/null")
+        if selinux_status:
+            info.selinux_status = selinux_status.lower()
+
+        # SELinux mode (targeted, mls, etc.)
+        selinux_config = self._run_command("grep '^SELINUXTYPE=' /etc/selinux/config 2>/dev/null")
+        if selinux_config:
+            match = re.search(r"SELINUXTYPE=(\w+)", selinux_config)
+            if match:
+                info.selinux_mode = match.group(1)
+
+        # Firewall status - try firewalld first
+        firewalld_status = self._run_command("systemctl is-active firewalld 2>/dev/null")
+        if firewalld_status == "active":
+            info.firewall_status = "active"
+            info.firewall_service = "firewalld"
+        else:
+            # Try iptables
+            iptables_rules = self._run_command("iptables -L -n 2>/dev/null | grep -c '^[A-Z]'")
+            if iptables_rules and int(iptables_rules) > 3:  # More than default chains
+                info.firewall_status = "active"
+                info.firewall_service = "iptables"
+            else:
+                # Try nftables
+                nft_rules = self._run_command("nft list tables 2>/dev/null | wc -l")
+                if nft_rules and int(nft_rules) > 0:
+                    info.firewall_status = "active"
+                    info.firewall_service = "nftables"
+                else:
+                    # Try ufw (Ubuntu)
+                    ufw_status = self._run_command("ufw status 2>/dev/null | head -1")
+                    if ufw_status and "active" in ufw_status.lower():
+                        info.firewall_status = "active"
+                        info.firewall_service = "ufw"
+                    else:
+                        info.firewall_status = "inactive"
+
+    def _collect_network_info(self, info: SystemInfo) -> None:
+        """Collect hostname and network information."""
+        info.hostname = self._run_command("hostname")
+        info.fqdn = self._run_command("hostname -f 2>/dev/null")
+
+        # Get primary IP (default route interface)
+        primary_ip = self._run_command("ip route get 1 2>/dev/null | head -1 | awk '{print $7}'")
+        if primary_ip:
+            info.primary_ip = primary_ip
+
+    def _collect_uptime(self, info: SystemInfo) -> None:
+        """Collect system uptime."""
+        uptime = self._run_command("cat /proc/uptime | awk '{print $1}'")
+        if uptime:
+            try:
+                info.uptime_seconds = int(float(uptime))
+                # Calculate boot time
+                info.boot_time = datetime.now(timezone.utc) - __import__("datetime").timedelta(
+                    seconds=info.uptime_seconds
+                )
+            except ValueError:
+                pass
+
+
+class SystemInfoService:
+    """Service for managing host system information in the database."""
+
+    def __init__(self, db: Session):
+        """Initialize with database session."""
+        self.db = db
+
+    def save_system_info(self, host_id: UUID, info: SystemInfo) -> None:
+        """
+        Save or update system information for a host.
+
+        Args:
+            host_id: The host UUID
+            info: SystemInfo dataclass with collected data
+        """
+        now = datetime.now(timezone.utc)
+
+        # Check if record exists
+        result = self.db.execute(
+            text("SELECT id FROM host_system_info WHERE host_id = :host_id"),
+            {"host_id": str(host_id)},
+        )
+        existing = result.fetchone()
+
+        if existing:
+            # Update existing record
+            self.db.execute(
+                text(
+                    """
+                    UPDATE host_system_info SET
+                        os_name = :os_name,
+                        os_version = :os_version,
+                        os_version_full = :os_version_full,
+                        os_pretty_name = :os_pretty_name,
+                        os_id = :os_id,
+                        os_id_like = :os_id_like,
+                        kernel_version = :kernel_version,
+                        kernel_release = :kernel_release,
+                        kernel_name = :kernel_name,
+                        architecture = :architecture,
+                        cpu_model = :cpu_model,
+                        cpu_cores = :cpu_cores,
+                        cpu_threads = :cpu_threads,
+                        memory_total_mb = :memory_total_mb,
+                        memory_available_mb = :memory_available_mb,
+                        swap_total_mb = :swap_total_mb,
+                        disk_total_gb = :disk_total_gb,
+                        disk_used_gb = :disk_used_gb,
+                        disk_free_gb = :disk_free_gb,
+                        selinux_status = :selinux_status,
+                        selinux_mode = :selinux_mode,
+                        firewall_status = :firewall_status,
+                        firewall_service = :firewall_service,
+                        hostname = :hostname,
+                        fqdn = :fqdn,
+                        primary_ip = :primary_ip,
+                        uptime_seconds = :uptime_seconds,
+                        boot_time = :boot_time,
+                        collected_at = :now,
+                        updated_at = :now
+                    WHERE host_id = :host_id
+                """
+                ),
+                {
+                    "host_id": str(host_id),
+                    "os_name": info.os_name,
+                    "os_version": info.os_version,
+                    "os_version_full": info.os_version_full,
+                    "os_pretty_name": info.os_pretty_name,
+                    "os_id": info.os_id,
+                    "os_id_like": info.os_id_like,
+                    "kernel_version": info.kernel_version,
+                    "kernel_release": info.kernel_release,
+                    "kernel_name": info.kernel_name,
+                    "architecture": info.architecture,
+                    "cpu_model": info.cpu_model,
+                    "cpu_cores": info.cpu_cores,
+                    "cpu_threads": info.cpu_threads,
+                    "memory_total_mb": info.memory_total_mb,
+                    "memory_available_mb": info.memory_available_mb,
+                    "swap_total_mb": info.swap_total_mb,
+                    "disk_total_gb": info.disk_total_gb,
+                    "disk_used_gb": info.disk_used_gb,
+                    "disk_free_gb": info.disk_free_gb,
+                    "selinux_status": info.selinux_status,
+                    "selinux_mode": info.selinux_mode,
+                    "firewall_status": info.firewall_status,
+                    "firewall_service": info.firewall_service,
+                    "hostname": info.hostname,
+                    "fqdn": info.fqdn,
+                    "primary_ip": info.primary_ip,
+                    "uptime_seconds": info.uptime_seconds,
+                    "boot_time": info.boot_time,
+                    "now": now,
+                },
+            )
+        else:
+            # Insert new record
+            self.db.execute(
+                text(
+                    """
+                    INSERT INTO host_system_info (
+                        host_id, os_name, os_version, os_version_full, os_pretty_name,
+                        os_id, os_id_like, kernel_version, kernel_release, kernel_name,
+                        architecture, cpu_model, cpu_cores, cpu_threads,
+                        memory_total_mb, memory_available_mb, swap_total_mb,
+                        disk_total_gb, disk_used_gb, disk_free_gb,
+                        selinux_status, selinux_mode, firewall_status, firewall_service,
+                        hostname, fqdn, primary_ip, uptime_seconds, boot_time,
+                        collected_at, updated_at
+                    ) VALUES (
+                        :host_id, :os_name, :os_version, :os_version_full, :os_pretty_name,
+                        :os_id, :os_id_like, :kernel_version, :kernel_release, :kernel_name,
+                        :architecture, :cpu_model, :cpu_cores, :cpu_threads,
+                        :memory_total_mb, :memory_available_mb, :swap_total_mb,
+                        :disk_total_gb, :disk_used_gb, :disk_free_gb,
+                        :selinux_status, :selinux_mode, :firewall_status, :firewall_service,
+                        :hostname, :fqdn, :primary_ip, :uptime_seconds, :boot_time,
+                        :now, :now
+                    )
+                """
+                ),
+                {
+                    "host_id": str(host_id),
+                    "os_name": info.os_name,
+                    "os_version": info.os_version,
+                    "os_version_full": info.os_version_full,
+                    "os_pretty_name": info.os_pretty_name,
+                    "os_id": info.os_id,
+                    "os_id_like": info.os_id_like,
+                    "kernel_version": info.kernel_version,
+                    "kernel_release": info.kernel_release,
+                    "kernel_name": info.kernel_name,
+                    "architecture": info.architecture,
+                    "cpu_model": info.cpu_model,
+                    "cpu_cores": info.cpu_cores,
+                    "cpu_threads": info.cpu_threads,
+                    "memory_total_mb": info.memory_total_mb,
+                    "memory_available_mb": info.memory_available_mb,
+                    "swap_total_mb": info.swap_total_mb,
+                    "disk_total_gb": info.disk_total_gb,
+                    "disk_used_gb": info.disk_used_gb,
+                    "disk_free_gb": info.disk_free_gb,
+                    "selinux_status": info.selinux_status,
+                    "selinux_mode": info.selinux_mode,
+                    "firewall_status": info.firewall_status,
+                    "firewall_service": info.firewall_service,
+                    "hostname": info.hostname,
+                    "fqdn": info.fqdn,
+                    "primary_ip": info.primary_ip,
+                    "uptime_seconds": info.uptime_seconds,
+                    "boot_time": info.boot_time,
+                    "now": now,
+                },
+            )
+
+        self.db.commit()
+        logger.info(f"Saved system info for host {host_id}")
+
+    def get_system_info(self, host_id: UUID) -> Optional[Dict[str, Any]]:
+        """
+        Get system information for a host.
+
+        Args:
+            host_id: The host UUID
+
+        Returns:
+            Dictionary with system info or None if not found
+        """
+        result = self.db.execute(
+            text(
+                """
+                SELECT
+                    os_name, os_version, os_version_full, os_pretty_name,
+                    os_id, os_id_like, kernel_version, kernel_release, kernel_name,
+                    architecture, cpu_model, cpu_cores, cpu_threads,
+                    memory_total_mb, memory_available_mb, swap_total_mb,
+                    disk_total_gb, disk_used_gb, disk_free_gb,
+                    selinux_status, selinux_mode, firewall_status, firewall_service,
+                    hostname, fqdn, primary_ip, uptime_seconds, boot_time,
+                    collected_at, updated_at
+                FROM host_system_info
+                WHERE host_id = :host_id
+            """
+            ),
+            {"host_id": str(host_id)},
+        )
+        row = result.fetchone()
+        if not row:
+            return None
+
+        return {
+            "os_name": row.os_name,
+            "os_version": row.os_version,
+            "os_version_full": row.os_version_full,
+            "os_pretty_name": row.os_pretty_name,
+            "os_id": row.os_id,
+            "os_id_like": row.os_id_like,
+            "kernel_version": row.kernel_version,
+            "kernel_release": row.kernel_release,
+            "kernel_name": row.kernel_name,
+            "architecture": row.architecture,
+            "cpu_model": row.cpu_model,
+            "cpu_cores": row.cpu_cores,
+            "cpu_threads": row.cpu_threads,
+            "memory_total_mb": row.memory_total_mb,
+            "memory_available_mb": row.memory_available_mb,
+            "swap_total_mb": row.swap_total_mb,
+            "disk_total_gb": row.disk_total_gb,
+            "disk_used_gb": row.disk_used_gb,
+            "disk_free_gb": row.disk_free_gb,
+            "selinux_status": row.selinux_status,
+            "selinux_mode": row.selinux_mode,
+            "firewall_status": row.firewall_status,
+            "firewall_service": row.firewall_service,
+            "hostname": row.hostname,
+            "fqdn": row.fqdn,
+            "primary_ip": row.primary_ip,
+            "uptime_seconds": row.uptime_seconds,
+            "boot_time": row.boot_time.isoformat() if row.boot_time else None,
+            "collected_at": row.collected_at.isoformat() if row.collected_at else None,
+            "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        }

--- a/backend/app/tasks/compliance_scheduler_tasks.py
+++ b/backend/app/tasks/compliance_scheduler_tasks.py
@@ -1,0 +1,385 @@
+"""
+Adaptive Compliance Scheduler Tasks for Celery Beat
+
+This module implements the dispatcher pattern for the adaptive compliance scanning scheduler.
+The dispatcher is called periodically by Celery Beat and queues individual Aegis scan tasks.
+
+Architecture:
+1. Celery Beat calls dispatch_compliance_scans() every 2 minutes
+2. Dispatcher queries host_compliance_schedule WHERE next_scheduled_scan <= NOW()
+3. Individual Aegis scan tasks dispatched with state-based priority
+4. Each task updates compliance state and calculates next_scheduled_scan (max 48 hours)
+
+This design ensures:
+- Continuous compliance visibility (max 48 hour interval)
+- Adaptive intervals (low-compliance hosts scanned more frequently)
+- Resource-aware (respects max_concurrent_scans limit)
+- Scalable to many hosts (distributed across time)
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+from uuid import UUID
+
+from app.celery_app import celery_app
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.dispatch_compliance_scans",
+    time_limit=120,
+    soft_time_limit=90,
+)
+def dispatch_compliance_scans(self: Any) -> Dict[str, Any]:
+    """
+    Dispatcher task that runs every 2 minutes via Celery Beat.
+
+    Queries hosts that are due for compliance scanning and dispatches
+    individual Aegis scan tasks with appropriate priorities.
+
+    Returns:
+        dict: Dispatch results including number of hosts dispatched
+    """
+    # Import here to avoid circular imports
+    from app.services.compliance.compliance_scheduler import compliance_scheduler_service
+
+    try:
+        logger.debug("Running compliance scan dispatcher...")
+
+        # Get database session
+        db = next(get_db())
+
+        try:
+            # Check if scheduler is enabled
+            config = compliance_scheduler_service.get_config(db)
+
+            if not config["enabled"]:
+                logger.debug("Compliance scheduler is disabled, skipping dispatch")
+                return {"status": "disabled", "hosts_dispatched": 0}
+
+            # Get hosts due for scanning (respects max_concurrent_scans)
+            hosts_due = compliance_scheduler_service.get_hosts_due_for_scan(db)
+
+            if not hosts_due:
+                logger.debug("No hosts due for compliance scanning")
+                return {"status": "ok", "hosts_dispatched": 0, "next_scan": "none due"}
+
+            # Dispatch individual scan tasks with priorities
+            dispatched_count = 0
+            for host in hosts_due:
+                try:
+                    priority = host["scan_priority"]
+
+                    # Dispatch individual Aegis scan task
+                    celery_app.send_task(
+                        "app.tasks.run_scheduled_aegis_scan",
+                        args=[host["host_id"], priority],
+                        priority=priority,
+                        queue="compliance_scanning",
+                    )
+
+                    dispatched_count += 1
+                    logger.debug(
+                        f"Dispatched compliance scan for {host['hostname']} "
+                        f"(state: {host['compliance_state']}, priority: {priority})"
+                    )
+
+                except Exception as dispatch_error:
+                    logger.error(f"Failed to dispatch scan for host {host['host_id']}: {dispatch_error}")
+
+            logger.info(f"Dispatched {dispatched_count} compliance scans")
+
+            return {
+                "status": "ok",
+                "hosts_dispatched": dispatched_count,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+
+        finally:
+            db.close()
+
+    except Exception as e:
+        logger.error(f"Error in compliance scan dispatcher: {e}")
+        return {"status": "error", "error": str(e), "hosts_dispatched": 0}
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.run_scheduled_aegis_scan",
+    time_limit=660,  # 11 minutes (scan timeout + buffer)
+    soft_time_limit=600,  # 10 minutes
+)
+def run_scheduled_aegis_scan(self: Any, host_id: str, priority: int = 5) -> Dict[str, Any]:
+    """
+    Execute an Aegis compliance scan for a host (scheduled by dispatcher).
+
+    This task is dispatched by the compliance scheduler when a host is due
+    for scanning. It runs the Aegis scan and updates the compliance schedule.
+
+    Args:
+        host_id: UUID of the host to scan
+        priority: Scan priority (1-10)
+
+    Returns:
+        dict: Scan results including compliance score
+    """
+    # Import here to avoid circular imports
+    from app.services.compliance.compliance_scheduler import compliance_scheduler_service
+
+    try:
+        logger.info(f"Starting scheduled Aegis scan for host {host_id}")
+
+        db = next(get_db())
+
+        try:
+            # Import Aegis scanner
+            try:
+                from app.plugins.aegis.scanner import AegisScanner
+
+                scanner = AegisScanner()
+            except ImportError:
+                logger.error("Aegis scanner not available")
+                compliance_scheduler_service.record_scan_failure(db, UUID(host_id), "Aegis scanner not available")
+                return {"status": "error", "error": "Aegis scanner not available"}
+
+            # Get host details
+            from sqlalchemy import text
+
+            result = db.execute(
+                text(
+                    """
+                    SELECT id, hostname, ip_address, port, username
+                    FROM hosts
+                    WHERE id = :host_id AND is_active = true
+                """
+                ),
+                {"host_id": host_id},
+            )
+            host = result.fetchone()
+
+            if not host:
+                logger.warning(f"Host {host_id} not found or inactive")
+                return {"status": "error", "error": "Host not found"}
+
+            # Run Aegis scan with system info collection
+            logger.info(f"Running Aegis scan on {host.hostname}")
+
+            import asyncio
+
+            async def run_scan():
+                """Initialize scanner and run scan with system info collection."""
+                await scanner.initialize()
+                return await scanner.scan(
+                    host_id=host_id,
+                    db=db,
+                    collect_system_info=True,
+                )
+
+            # Create event loop for async scan
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                scan_result = loop.run_until_complete(run_scan())
+            finally:
+                loop.close()
+
+            # Check if scan failed
+            if scan_result.get("status") == "error":
+                error_msg = scan_result.get("error", "Unknown error")
+                logger.error(f"Aegis scan failed for {host.hostname}: {error_msg}")
+                compliance_scheduler_service.record_scan_failure(db, UUID(host_id), error_msg)
+                return {"status": "error", "host_id": host_id, "error": error_msg}
+
+            # Extract results - Aegis returns 'passed' and 'failed', not 'pass_count'
+            compliance_score = scan_result.get("compliance_score", 0.0)
+            pass_count = scan_result.get("passed", 0)
+            fail_count = scan_result.get("failed", 0)
+
+            # Count critical findings from results list
+            results_list = scan_result.get("results", [])
+            critical_count = sum(
+                1 for r in results_list if not r.get("passed") and r.get("severity") in ["critical", "high"]
+            )
+
+            has_critical = critical_count > 0
+
+            # Save system info if collected
+            system_info = scan_result.get("system_info")
+            if system_info:
+                try:
+                    from app.services.system_info import SystemInfoService
+
+                    system_info_service = SystemInfoService(db)
+                    system_info_service.save_system_info(UUID(host_id), system_info)
+                    logger.debug(f"Saved system info for {host.hostname}")
+                except Exception as e:
+                    logger.warning(f"Failed to save system info: {e}")
+
+            # Update schedule with new compliance state
+            compliance_scheduler_service.update_host_schedule(
+                db=db,
+                host_id=UUID(host_id),
+                compliance_score=compliance_score,
+                has_critical_findings=has_critical,
+                pass_count=pass_count,
+                fail_count=fail_count,
+                scan_id=None,  # Aegis doesn't create a scan record
+            )
+
+            logger.info(
+                f"Completed scheduled scan for {host.hostname}: "
+                f"score={compliance_score}%, pass={pass_count}, fail={fail_count}"
+            )
+
+            return {
+                "status": "ok",
+                "host_id": host_id,
+                "hostname": host.hostname,
+                "compliance_score": compliance_score,
+                "pass_count": pass_count,
+                "fail_count": fail_count,
+                "has_critical": has_critical,
+                "critical_count": critical_count,
+                "system_info_collected": system_info is not None,
+            }
+
+        finally:
+            db.close()
+
+    except Exception as e:
+        logger.error(f"Error in scheduled Aegis scan for host {host_id}: {e}")
+
+        # Record failure
+        try:
+            db = next(get_db())
+            from app.services.compliance.compliance_scheduler import compliance_scheduler_service
+
+            compliance_scheduler_service.record_scan_failure(db, UUID(host_id), str(e))
+            db.close()
+        except Exception:
+            pass
+
+        return {"status": "error", "host_id": host_id, "error": str(e)}
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.initialize_compliance_schedules",
+    time_limit=300,
+    soft_time_limit=240,
+)
+def initialize_compliance_schedules(self: Any) -> Dict[str, Any]:
+    """
+    Initialize compliance schedules for all hosts that don't have one.
+
+    This task should be run once after deploying the compliance scheduler
+    to bootstrap schedules for existing hosts.
+
+    Returns:
+        dict: Number of hosts initialized
+    """
+    from sqlalchemy import text
+
+    from app.services.compliance.compliance_scheduler import compliance_scheduler_service
+
+    try:
+        logger.info("Initializing compliance schedules for existing hosts...")
+
+        db = next(get_db())
+
+        try:
+            # Find hosts without a schedule
+            result = db.execute(
+                text(
+                    """
+                    SELECT h.id
+                    FROM hosts h
+                    LEFT JOIN host_compliance_schedule hcs ON h.id = hcs.host_id
+                    WHERE h.is_active = true
+                      AND hcs.id IS NULL
+                """
+                )
+            )
+
+            hosts = result.fetchall()
+            initialized_count = 0
+
+            for host in hosts:
+                compliance_scheduler_service.initialize_host_schedule(db, host.id)
+                initialized_count += 1
+
+            logger.info(f"Initialized compliance schedules for {initialized_count} hosts")
+
+            return {
+                "status": "ok",
+                "hosts_initialized": initialized_count,
+            }
+
+        finally:
+            db.close()
+
+    except Exception as e:
+        logger.error(f"Error initializing compliance schedules: {e}")
+        return {"status": "error", "error": str(e)}
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.expire_compliance_maintenance",
+    time_limit=60,
+    soft_time_limit=45,
+)
+def expire_compliance_maintenance(self: Any) -> Dict[str, Any]:
+    """
+    Expire maintenance mode for hosts past their maintenance_until time.
+
+    This task runs hourly to automatically end maintenance windows.
+
+    Returns:
+        dict: Number of hosts expired
+    """
+    from sqlalchemy import text
+
+    try:
+        logger.debug("Checking for expired compliance maintenance windows...")
+
+        db = next(get_db())
+
+        try:
+            result = db.execute(
+                text(
+                    """
+                    UPDATE host_compliance_schedule
+                    SET maintenance_mode = false,
+                        maintenance_until = NULL,
+                        updated_at = :now
+                    WHERE maintenance_mode = true
+                      AND maintenance_until IS NOT NULL
+                      AND maintenance_until < :now
+                    RETURNING host_id
+                """
+                ),
+                {"now": datetime.now(timezone.utc)},
+            )
+
+            expired_hosts = result.fetchall()
+            db.commit()
+
+            if expired_hosts:
+                logger.info(f"Expired maintenance mode for {len(expired_hosts)} hosts")
+
+            return {
+                "status": "ok",
+                "hosts_expired": len(expired_hosts),
+            }
+
+        finally:
+            db.close()
+
+    except Exception as e:
+        logger.error(f"Error expiring maintenance windows: {e}")
+        return {"status": "error", "error": str(e)}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.backend
     container_name: openwatch-worker
-    command: ["python3", "-m", "celery", "-A", "app.celery_app", "worker", "--loglevel=info", "-Q", "default,scans,results,maintenance,monitoring,host_monitoring"]
+    command: ["python3", "-m", "celery", "-A", "app.celery_app", "worker", "--loglevel=info", "-Q", "default,scans,results,maintenance,monitoring,host_monitoring,health_monitoring,compliance_scanning"]
     environment:
       OPENWATCH_DATABASE_URL: postgresql://openwatch:${POSTGRES_PASSWORD}@database:5432/openwatch
       OPENWATCH_REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379

--- a/frontend/src/components/settings/ComplianceSchedulerSettings.tsx
+++ b/frontend/src/components/settings/ComplianceSchedulerSettings.tsx
@@ -1,0 +1,498 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Card,
+  Typography,
+  Switch,
+  FormControlLabel,
+  TextField,
+  Button,
+  Alert,
+  Chip,
+  Divider,
+  Collapse,
+  IconButton,
+  Tooltip,
+  LinearProgress,
+} from '@mui/material';
+import Grid from '@mui/material/Grid';
+import {
+  Security as SecurityIcon,
+  PlayArrow as PlayIcon,
+  Stop as StopIcon,
+  ExpandMore as ExpandMoreIcon,
+  ExpandLess as ExpandLessIcon,
+  Info as InfoIcon,
+} from '@mui/icons-material';
+import { api } from '../../services/api';
+
+interface SchedulerConfig {
+  enabled: boolean;
+  interval_compliant: number;
+  interval_mostly_compliant: number;
+  interval_partial: number;
+  interval_low: number;
+  interval_critical: number;
+  interval_unknown: number;
+  interval_maintenance: number;
+  max_interval_minutes: number;
+  priority_compliant: number;
+  priority_mostly_compliant: number;
+  priority_partial: number;
+  priority_low: number;
+  priority_critical: number;
+  priority_unknown: number;
+  priority_maintenance: number;
+  max_concurrent_scans: number;
+  scan_timeout_seconds: number;
+}
+
+interface SchedulerStatus {
+  enabled: boolean;
+  total_hosts: number;
+  hosts_due: number;
+  hosts_in_maintenance: number;
+  by_compliance_state: { [key: string]: number };
+  next_scheduled_scans: Array<{
+    host_id: string;
+    hostname: string;
+    compliance_state: string;
+    scheduled_for: string;
+  }>;
+}
+
+interface ComplianceSchedulerSettingsProps {
+  onSuccess?: (message: string) => void;
+  onError?: (message: string) => void;
+}
+
+const ComplianceSchedulerSettings: React.FC<ComplianceSchedulerSettingsProps> = ({
+  onSuccess,
+  onError,
+}) => {
+  const [config, setConfig] = useState<SchedulerConfig | null>(null);
+  const [status, setStatus] = useState<SchedulerStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [localConfig, setLocalConfig] = useState<Partial<SchedulerConfig>>({});
+
+  useEffect(() => {
+    loadConfig();
+    loadStatus();
+    // Refresh status every 30 seconds
+    const interval = setInterval(loadStatus, 30000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadConfig = async () => {
+    try {
+      setLoading(true);
+      const response = await api.get<SchedulerConfig>('/api/compliance/scheduler/config');
+      setConfig(response);
+      setLocalConfig({
+        interval_compliant: response.interval_compliant,
+        interval_mostly_compliant: response.interval_mostly_compliant,
+        interval_partial: response.interval_partial,
+        interval_low: response.interval_low,
+        interval_critical: response.interval_critical,
+        max_concurrent_scans: response.max_concurrent_scans,
+        scan_timeout_seconds: response.scan_timeout_seconds,
+      });
+    } catch (err) {
+      console.error('Error loading compliance scheduler config:', err);
+      onError?.('Failed to load compliance scheduler configuration');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadStatus = async () => {
+    try {
+      const response = await api.get<SchedulerStatus>('/api/compliance/scheduler/status');
+      setStatus(response);
+    } catch (err) {
+      console.error('Error loading compliance scheduler status:', err);
+    }
+  };
+
+  const toggleScheduler = async () => {
+    try {
+      setLoading(true);
+      const newEnabled = !config?.enabled;
+      await api.post(`/api/compliance/scheduler/toggle?enabled=${newEnabled}`);
+      onSuccess?.(newEnabled ? 'Compliance scheduler enabled' : 'Compliance scheduler disabled');
+      await loadConfig();
+      await loadStatus();
+    } catch (err) {
+      console.error('Error toggling compliance scheduler:', err);
+      onError?.('Failed to toggle compliance scheduler');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateConfig = async () => {
+    try {
+      setLoading(true);
+      await api.put('/api/compliance/scheduler/config', localConfig);
+      onSuccess?.('Compliance scheduler configuration updated');
+      await loadConfig();
+    } catch (err) {
+      console.error('Error updating compliance scheduler config:', err);
+      onError?.('Failed to update compliance scheduler configuration');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getStateColor = (state: string): string => {
+    const colors: { [key: string]: string } = {
+      compliant: '#4caf50',
+      mostly_compliant: '#8bc34a',
+      partial: '#ff9800',
+      low: '#ff5722',
+      critical: '#f44336',
+      unknown: '#9c27b0',
+      maintenance: '#2196f3',
+    };
+    return colors[state] || '#757575';
+  };
+
+  const getStateLabel = (state: string): string => {
+    const labels: { [key: string]: string } = {
+      compliant: 'Compliant (90%+)',
+      mostly_compliant: 'Mostly (70-89%)',
+      partial: 'Partial (50-69%)',
+      low: 'Low (20-49%)',
+      critical: 'Critical (<20%)',
+      unknown: 'Unknown',
+      maintenance: 'Maintenance',
+    };
+    return labels[state] || state;
+  };
+
+  const formatInterval = (minutes: number): string => {
+    if (minutes >= 1440) {
+      const hours = Math.round(minutes / 60);
+      return `${hours}h`;
+    } else if (minutes >= 60) {
+      const hours = Math.round(minutes / 60);
+      return `${hours}h`;
+    }
+    return `${minutes}m`;
+  };
+
+  if (!config) {
+    return <LinearProgress />;
+  }
+
+  return (
+    <Card sx={{ mb: 4, p: 3 }}>
+      {/* Header */}
+      <Box sx={{ mb: 3 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+          <Typography variant="h6">
+            <SecurityIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
+            Adaptive Compliance Scheduler
+          </Typography>
+          <Chip
+            label={config.enabled ? 'RUNNING' : 'STOPPED'}
+            color={config.enabled ? 'success' : 'default'}
+            size="small"
+          />
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          Automatic compliance scanning with adaptive intervals. Critical compliance hosts are
+          scanned more frequently than compliant hosts. Maximum interval: 48 hours.
+        </Typography>
+      </Box>
+
+      {/* Enable/Disable Toggle */}
+      <Box sx={{ mb: 3 }}>
+        <FormControlLabel
+          control={
+            <Switch checked={config.enabled} onChange={toggleScheduler} disabled={loading} />
+          }
+          label="Enable Automatic Compliance Scanning"
+        />
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={config.enabled ? <StopIcon /> : <PlayIcon />}
+          onClick={toggleScheduler}
+          disabled={loading}
+          sx={{ ml: 2 }}
+        >
+          {loading ? 'Updating...' : config.enabled ? 'Stop Scheduler' : 'Start Scheduler'}
+        </Button>
+      </Box>
+
+      {/* Compliance Distribution */}
+      {status && (
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Compliance Distribution ({status.total_hosts} hosts)
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+            {Object.entries(status.by_compliance_state).map(([state, count]) => (
+              <Chip
+                key={state}
+                label={`${getStateLabel(state).split(' ')[0]}: ${count}`}
+                size="small"
+                sx={{
+                  backgroundColor: getStateColor(state),
+                  color: 'white',
+                  fontWeight: 'medium',
+                }}
+              />
+            ))}
+          </Box>
+          {status.hosts_due > 0 && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              {status.hosts_due} host{status.hosts_due > 1 ? 's' : ''} due for compliance scanning
+            </Alert>
+          )}
+          {status.hosts_in_maintenance > 0 && (
+            <Typography variant="body2" color="text.secondary">
+              {status.hosts_in_maintenance} host{status.hosts_in_maintenance > 1 ? 's' : ''} in
+              maintenance mode
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Scan Intervals */}
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="subtitle2" gutterBottom>
+          Scan Intervals by Compliance State
+          <Tooltip title="How often to scan hosts based on their compliance score. Lower compliance = more frequent scans.">
+            <IconButton size="small" sx={{ ml: 0.5 }}>
+              <InfoIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Typography>
+        <Grid container spacing={2} sx={{ mt: 1 }}>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              label="Compliant (90%+)"
+              type="number"
+              size="small"
+              value={localConfig.interval_compliant || ''}
+              onChange={(e) =>
+                setLocalConfig({
+                  ...localConfig,
+                  interval_compliant: parseInt(e.target.value) || 60,
+                })
+              }
+              inputProps={{ min: 60, max: 2880 }}
+              helperText={`Current: ${formatInterval(config.interval_compliant)}`}
+              InputProps={{
+                endAdornment: <Typography variant="caption">min</Typography>,
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              label="Mostly Compliant (70-89%)"
+              type="number"
+              size="small"
+              value={localConfig.interval_mostly_compliant || ''}
+              onChange={(e) =>
+                setLocalConfig({
+                  ...localConfig,
+                  interval_mostly_compliant: parseInt(e.target.value) || 60,
+                })
+              }
+              inputProps={{ min: 30, max: 2880 }}
+              helperText={`Current: ${formatInterval(config.interval_mostly_compliant)}`}
+              InputProps={{
+                endAdornment: <Typography variant="caption">min</Typography>,
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              label="Partial (50-69%)"
+              type="number"
+              size="small"
+              value={localConfig.interval_partial || ''}
+              onChange={(e) =>
+                setLocalConfig({ ...localConfig, interval_partial: parseInt(e.target.value) || 60 })
+              }
+              inputProps={{ min: 30, max: 2880 }}
+              helperText={`Current: ${formatInterval(config.interval_partial)}`}
+              InputProps={{
+                endAdornment: <Typography variant="caption">min</Typography>,
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              label="Low (20-49%)"
+              type="number"
+              size="small"
+              value={localConfig.interval_low || ''}
+              onChange={(e) =>
+                setLocalConfig({ ...localConfig, interval_low: parseInt(e.target.value) || 60 })
+              }
+              inputProps={{ min: 30, max: 2880 }}
+              helperText={`Current: ${formatInterval(config.interval_low)}`}
+              InputProps={{
+                endAdornment: <Typography variant="caption">min</Typography>,
+              }}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+            <TextField
+              fullWidth
+              label="Critical (<20%)"
+              type="number"
+              size="small"
+              value={localConfig.interval_critical || ''}
+              onChange={(e) =>
+                setLocalConfig({
+                  ...localConfig,
+                  interval_critical: parseInt(e.target.value) || 60,
+                })
+              }
+              inputProps={{ min: 15, max: 2880 }}
+              helperText={`Current: ${formatInterval(config.interval_critical)}`}
+              InputProps={{
+                endAdornment: <Typography variant="caption">min</Typography>,
+              }}
+            />
+          </Grid>
+        </Grid>
+        <Box sx={{ mt: 2 }}>
+          <Button variant="contained" size="small" onClick={updateConfig} disabled={loading}>
+            Save Intervals
+          </Button>
+        </Box>
+      </Box>
+
+      <Divider sx={{ my: 3 }} />
+
+      {/* Advanced Settings */}
+      <Box>
+        <Button
+          size="small"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          endIcon={showAdvanced ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        >
+          Advanced Settings
+        </Button>
+        <Collapse in={showAdvanced}>
+          <Box sx={{ mt: 2 }}>
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <TextField
+                  fullWidth
+                  label="Max Concurrent Scans"
+                  type="number"
+                  size="small"
+                  value={localConfig.max_concurrent_scans || ''}
+                  onChange={(e) =>
+                    setLocalConfig({
+                      ...localConfig,
+                      max_concurrent_scans: parseInt(e.target.value) || 5,
+                    })
+                  }
+                  inputProps={{ min: 1, max: 20 }}
+                  helperText="1-20 concurrent scans (prevents resource exhaustion)"
+                />
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <TextField
+                  fullWidth
+                  label="Scan Timeout (seconds)"
+                  type="number"
+                  size="small"
+                  value={localConfig.scan_timeout_seconds || ''}
+                  onChange={(e) =>
+                    setLocalConfig({
+                      ...localConfig,
+                      scan_timeout_seconds: parseInt(e.target.value) || 600,
+                    })
+                  }
+                  inputProps={{ min: 60, max: 3600 }}
+                  helperText="60-3600 seconds per scan"
+                />
+              </Grid>
+            </Grid>
+            <Box sx={{ mt: 2 }}>
+              <Button variant="contained" size="small" onClick={updateConfig} disabled={loading}>
+                Save Advanced Settings
+              </Button>
+            </Box>
+          </Box>
+        </Collapse>
+      </Box>
+
+      {/* Next Scheduled Scans */}
+      {status && status.next_scheduled_scans && status.next_scheduled_scans.length > 0 && (
+        <>
+          <Divider sx={{ my: 3 }} />
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Next Scheduled Scans
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {status.next_scheduled_scans.slice(0, 5).map((scan) => (
+                <Box
+                  key={scan.host_id}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    p: 1,
+                    bgcolor: 'action.hover',
+                    borderRadius: 1,
+                  }}
+                >
+                  <Box>
+                    <Typography variant="body2" fontWeight="medium">
+                      {scan.hostname}
+                    </Typography>
+                    <Chip
+                      label={scan.compliance_state}
+                      size="small"
+                      sx={{
+                        backgroundColor: getStateColor(scan.compliance_state),
+                        color: 'white',
+                        height: 20,
+                        fontSize: '0.7rem',
+                      }}
+                    />
+                  </Box>
+                  <Typography variant="body2" color="text.secondary">
+                    {new Date(scan.scheduled_for).toLocaleString()}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        </>
+      )}
+
+      {/* Info Alert */}
+      <Alert severity="info" sx={{ mt: 3 }}>
+        <Typography variant="body2">
+          <strong>Adaptive Compliance Scanning:</strong> The scheduler automatically adjusts scan
+          frequency based on compliance score. Hosts with critical compliance issues are scanned
+          every {formatInterval(config.interval_critical)}, while compliant hosts are scanned every{' '}
+          {formatInterval(config.interval_compliant)}. All hosts are scanned at least every 48 hours
+          to ensure continuous visibility.
+        </Typography>
+      </Alert>
+    </Card>
+  );
+};
+
+export default ComplianceSchedulerSettings;

--- a/frontend/src/pages/hosts/HostDetail.tsx
+++ b/frontend/src/pages/hosts/HostDetail.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   CardContent,
   Chip,
-  Button,
   IconButton,
   Table,
   TableBody,
@@ -35,7 +34,6 @@ import {
   NetworkCheck as NetworkCheckIcon,
   Security as SecurityIcon,
   Assessment as AssessmentIcon,
-  PlayArrow as PlayArrowIcon,
   Visibility as VisibilityIcon,
   Schedule as ScheduleIcon,
   CheckCircle as CheckCircleIcon,
@@ -43,12 +41,10 @@ import {
   Info as InfoIcon,
   Settings as SettingsIcon,
   Terminal as TerminalIcon,
-  Flag as FlagIcon,
 } from '@mui/icons-material';
 import { StatusChip, ComplianceRing, SSHKeyDisplay } from '../../components/design-system';
 import type { StatusType } from '../../components/design-system/StatusChip';
 import HostTerminal from '../../components/terminal/HostTerminal';
-import BaselineEstablishDialog from '../../components/baselines/BaselineEstablishDialog';
 import ComplianceTrendChart from '../../components/baselines/ComplianceTrendChart';
 import { api } from '../../services/api';
 import { owcaService, type ComplianceScore as OWCAScore } from '../../services/owcaService';
@@ -165,7 +161,6 @@ const HostDetail: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [tabValue, setTabValue] = useState(0);
   const [deletingSSHKey, setDeletingSSHKey] = useState(false);
-  const [baselineDialogOpen, setBaselineDialogOpen] = useState(false);
   const [_owcaScore, setOwcaScore] = useState<OWCAScore | null>(null);
   const [complianceState, setComplianceState] = useState<ComplianceState | null>(null);
   const [complianceLoading, setComplianceLoading] = useState(true);
@@ -342,10 +337,6 @@ const HostDetail: React.FC = () => {
     }
   };
 
-  const handleStartScan = () => {
-    navigate('/scans/create', { state: { preselectedHostId: id } });
-  };
-
   const handleDeleteSSHKey = async () => {
     if (!host) return;
 
@@ -411,21 +402,13 @@ const HostDetail: React.FC = () => {
             {host.hostname} • {host.ip_address}
           </Typography>
         </Box>
-        <Button
-          variant="outlined"
-          startIcon={<FlagIcon />}
-          onClick={() => setBaselineDialogOpen(true)}
-          sx={{ mr: 1 }}
-        >
-          Establish Baseline
-        </Button>
-        <Button
-          variant="contained"
-          startIcon={runningScan ? <VisibilityIcon /> : <PlayArrowIcon />}
-          onClick={runningScan ? () => navigate(`/scans/${runningScan.id}`) : handleStartScan}
-        >
-          {runningScan ? 'View Running Scan' : 'Start New Scan'}
-        </Button>
+        {/* Manual scan buttons removed - compliance scans run automatically */}
+        <StatusChip
+          status={
+            host.status === 'online' ? 'online' : host.status === 'offline' ? 'offline' : 'unknown'
+          }
+          label={host.status || 'Unknown'}
+        />
       </Box>
 
       {/* Host Overview Cards */}
@@ -562,16 +545,7 @@ const HostDetail: React.FC = () => {
           </Box>
         ) : !complianceState || complianceState.total_rules === 0 ? (
           <Alert severity="info" sx={{ mb: 2 }}>
-            No Aegis compliance scan has been performed on this host yet.
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<PlayArrowIcon />}
-              onClick={handleStartScan}
-              sx={{ ml: 2 }}
-            >
-              Run Aegis Scan
-            </Button>
+            Awaiting first compliance scan. Scans run automatically based on the adaptive schedule.
           </Alert>
         ) : (
           <Box>
@@ -947,16 +921,8 @@ const HostDetail: React.FC = () => {
           </TableContainer>
         ) : (
           <Alert severity="info">
-            No scans have been performed on this host yet.
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<PlayArrowIcon />}
-              onClick={handleStartScan}
-              sx={{ ml: 2 }}
-            >
-              Start First Scan
-            </Button>
+            No scans have been performed on this host yet. Compliance scans run automatically based
+            on the adaptive schedule.
           </Alert>
         )}
 
@@ -1082,18 +1048,6 @@ const HostDetail: React.FC = () => {
           <HostTerminal hostId={host.id} hostname={host.hostname} ipAddress={host.ip_address} />
         </Box>
       </TabPanel>
-
-      {/* Baseline Establish Dialog */}
-      <BaselineEstablishDialog
-        open={baselineDialogOpen}
-        onClose={() => setBaselineDialogOpen(false)}
-        hostId={host.id}
-        hostname={host.hostname}
-        onBaselineEstablished={() => {
-          // Refresh scan data to show updated baseline status
-          fetchHostScans();
-        }}
-      />
     </Box>
   );
 };

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -43,6 +43,7 @@ import { SSHKeyDisplay } from '../../components/design-system';
 import { useSelector } from 'react-redux';
 import { type RootState } from '../../store';
 import AdaptiveSchedulerSettings from '../../components/settings/AdaptiveSchedulerSettings';
+import ComplianceSchedulerSettings from '../../components/settings/ComplianceSchedulerSettings';
 import OSDiscoverySettings from '../../components/settings/OSDiscoverySettings';
 import { VersionDisplay } from '../../components/common/VersionDisplay';
 
@@ -517,7 +518,10 @@ const Settings: React.FC = () => {
         </Box>
 
         <TabPanel value={tabValue} index={0}>
-          {/* Adaptive Scheduler Configuration Section */}
+          {/* Adaptive Compliance Scheduler Configuration Section */}
+          <ComplianceSchedulerSettings onSuccess={setSuccess} onError={setError} />
+
+          {/* Adaptive Host Monitoring Scheduler Configuration Section */}
           <AdaptiveSchedulerSettings onSuccess={setSuccess} onError={setError} />
 
           {/* OS Discovery Configuration Section */}


### PR DESCRIPTION
## Summary

OpenWatch OS Transformation - Phase 1: Auto-Scan Centric Architecture

This PR implements the foundation for transforming OpenWatch from a manual SCAP scanner into a Compliance Operating System with automatic, adaptive compliance scanning.

### Adaptive Compliance Scheduler
- Add `host_compliance_schedule` table for tracking scan intervals per host
- Implement `ComplianceSchedulerService` with state-based interval calculation
- Add Celery dispatcher task (runs every 2 minutes) to queue due hosts
- Create scheduler API endpoints for config, status, and control
- Add `ComplianceSchedulerSettings` component to Settings page
- Intervals adapt based on compliance score:
  - Critical (<20%): 1 hour
  - Low (20-49%): 2 hours
  - Partial (50-69%): 6 hours
  - Mostly Compliant (70-89%): 12 hours
  - Compliant (90%+): 24 hours
  - Maximum interval: 48 hours

### System Information Collection
- Add `host_system_info` table for detailed host data (30+ fields)
- Create `SystemInfoCollector` to gather OS, kernel, hardware, security info via SSH
- Integrate collection with Aegis scanner (collects during compliance scans)
- Add `GET /api/hosts/{host_id}/system-info` endpoint

### Host Detail Page Redesign
- Remove manual scan buttons (Start New Scan, Establish Baseline, Run Aegis Scan)
- Remove BaselineEstablishDialog component
- Update alerts to indicate scans run automatically
- Add host status chip to header

## Test plan

- [ ] Verify database migrations apply successfully
- [ ] Test compliance scheduler API endpoints (config, status, toggle)
- [ ] Verify Celery dispatcher queues hosts due for scanning
- [ ] Test system info collection during Aegis scans
- [ ] Verify system info API endpoint returns collected data
- [ ] Check Settings page displays ComplianceSchedulerSettings correctly
- [ ] Verify Host Detail page no longer shows manual scan buttons
- [ ] Test adaptive interval calculation for different compliance states

🤖 Generated with [Claude Code](https://claude.com/claude-code)