### PR TITLE
feat: add test-connection endpoint and fix Add Host form authentication

### DIFF
--- a/backend/app/routes/hosts/crud.py
+++ b/backend/app/routes/hosts/crud.py
@@ -28,10 +28,11 @@ Architecture Notes:
 import logging
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.security import HTTPBearer
+from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -145,6 +146,189 @@ async def validate_credentials(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Validation failed: {str(e)}",
         )
+
+
+# =============================================================================
+# CONNECTION TEST (Ad-hoc, pre-creation)
+# =============================================================================
+
+
+class TestConnectionRequest(BaseModel):
+    """Request model for testing SSH connectivity before host creation."""
+
+    hostname: str
+    port: int = 22
+    username: Optional[str] = None
+    auth_method: str = "system_default"
+    ssh_key: Optional[str] = None
+    password: Optional[str] = None
+    timeout: int = 30
+
+
+@router.post("/test-connection")
+async def test_connection(
+    request: TestConnectionRequest,
+    db: Session = Depends(get_db),
+    current_user: Dict[str, Any] = Depends(get_current_user),
+) -> Dict[str, Any]:
+    """
+    Test SSH connectivity to a host before adding it.
+
+    Performs network reachability check (TCP socket) and optional SSH
+    authentication test using either provided credentials or system defaults.
+    """
+    import socket
+    import time as _time
+
+    start = _time.monotonic()
+    result: Dict[str, Any] = {
+        "success": False,
+        "network_connectivity": False,
+        "authentication": False,
+        "detected_os": "",
+        "detected_version": "",
+        "response_time_ms": 0,
+        "ssh_version": None,
+        "error": None,
+    }
+
+    # Step 1: TCP socket check
+    try:
+        sock = socket.create_connection(
+            (request.hostname, request.port),
+            timeout=min(request.timeout, 10),
+        )
+        result["network_connectivity"] = True
+        # Read SSH banner
+        try:
+            banner = sock.recv(256).decode("utf-8", errors="replace").strip()
+            if banner.startswith("SSH-"):
+                result["ssh_version"] = banner
+        except Exception:
+            pass
+        sock.close()
+    except (socket.timeout, OSError) as e:
+        elapsed = int((_time.monotonic() - start) * 1000)
+        result["response_time_ms"] = elapsed
+        result["error"] = f"Cannot reach {request.hostname}:{request.port} - {e}"
+        return result
+
+    # Step 2: SSH authentication test
+    try:
+        import paramiko
+
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        connect_kwargs: Dict[str, Any] = {
+            "hostname": request.hostname,
+            "port": request.port,
+            "timeout": min(request.timeout, 15),
+            "allow_agent": False,
+            "look_for_keys": False,
+        }
+
+        # Resolve credentials
+        username = request.username
+        if request.auth_method == "system_default":
+            # Load system default credential from unified_credentials table
+            cred_builder = (
+                QueryBuilder("unified_credentials")
+                .select("username", "encrypted_private_key", "encrypted_password", "auth_method")
+                .where("scope = :scope", "system", "scope")
+                .where("is_default = :is_default", True, "is_default")
+                .where("is_active = :is_active", True, "is_active")
+                .paginate(1, 1)
+            )
+            cred_query, cred_params = cred_builder.build()
+            cred_row = db.execute(text(cred_query), cred_params).fetchone()
+
+            if cred_row:
+                username = cred_row.username
+                # Decrypt the SSH key if present
+                if cred_row.encrypted_private_key:
+                    try:
+                        import base64
+
+                        from ...config import get_settings
+                        from ...encryption import EncryptionConfig, create_encryption_service
+
+                        settings = get_settings()
+                        enc_svc = create_encryption_service(master_key=settings.master_key, config=EncryptionConfig())
+                        # Stored as base64-encoded encrypted bytes
+                        raw = bytes(cred_row.encrypted_private_key)
+                        encrypted_bytes = base64.b64decode(raw)
+                        key_data = enc_svc.decrypt(encrypted_bytes).decode("utf-8")
+
+                        import io
+
+                        try:
+                            pkey = paramiko.RSAKey.from_private_key(io.StringIO(key_data))
+                        except paramiko.SSHException:
+                            try:
+                                pkey = paramiko.Ed25519Key.from_private_key(io.StringIO(key_data))
+                            except paramiko.SSHException:
+                                pkey = paramiko.ECDSAKey.from_private_key(io.StringIO(key_data))
+                        connect_kwargs["pkey"] = pkey
+                    except Exception as e:
+                        logger.warning(f"Failed to decrypt system credential key: {e}")
+                        result["error"] = "Failed to decrypt system default credentials"
+                        result["response_time_ms"] = int((_time.monotonic() - start) * 1000)
+                        return result
+            else:
+                result["error"] = "No system default credential configured"
+                result["response_time_ms"] = int((_time.monotonic() - start) * 1000)
+                return result
+        elif request.auth_method in ("ssh_key", "both") and request.ssh_key:
+            import io
+
+            try:
+                pkey = paramiko.RSAKey.from_private_key(io.StringIO(request.ssh_key))
+            except paramiko.SSHException:
+                try:
+                    pkey = paramiko.Ed25519Key.from_private_key(io.StringIO(request.ssh_key))
+                except paramiko.SSHException:
+                    pkey = paramiko.ECDSAKey.from_private_key(io.StringIO(request.ssh_key))
+            connect_kwargs["pkey"] = pkey
+            # For "both" mode, also include password as fallback
+            if request.auth_method == "both" and request.password:
+                connect_kwargs["password"] = request.password
+        elif request.auth_method == "password" and request.password:
+            connect_kwargs["password"] = request.password
+
+        if username:
+            connect_kwargs["username"] = username
+
+        ssh.connect(**connect_kwargs)
+        result["authentication"] = True
+
+        # Detect OS
+        try:
+            _, stdout, _ = ssh.exec_command(
+                "cat /etc/os-release 2>/dev/null | head -5",
+                timeout=5,
+            )
+            os_info = stdout.read().decode("utf-8", errors="replace")
+            for line in os_info.splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    result["detected_os"] = line.split("=", 1)[1].strip().strip('"')
+                elif line.startswith("VERSION_ID="):
+                    result["detected_version"] = line.split("=", 1)[1].strip().strip('"')
+        except Exception:
+            pass
+
+        ssh.close()
+        result["success"] = True
+
+    except paramiko.AuthenticationException as e:
+        result["error"] = f"Authentication failed: {e}"
+    except paramiko.SSHException as e:
+        result["error"] = f"SSH error: {e}"
+    except Exception as e:
+        result["error"] = f"Connection failed: {e}"
+
+    result["response_time_ms"] = int((_time.monotonic() - start) * 1000)
+    return result
 
 
 # =============================================================================

--- a/frontend/src/pages/hosts/AddHost.tsx
+++ b/frontend/src/pages/hosts/AddHost.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Box, Typography, IconButton, Paper, Card, CardContent } from '@mui/material';
-import Grid from '@mui/material/Grid';
-import { ArrowBack, Computer, Security, Schedule, Description } from '@mui/icons-material';
-import { StatCard } from '../../components/design-system';
+import { Box, Typography, IconButton } from '@mui/material';
+import { ArrowBack } from '@mui/icons-material';
 import { useAddHostForm } from './hooks/useAddHostForm';
 import { QuickAddHostForm } from './components/QuickAddHostForm';
 import { AdvancedAddHostForm } from './components/AdvancedAddHostForm';
@@ -51,46 +49,6 @@ const AddHost: React.FC = () => {
         </Typography>
       </Box>
 
-      {/* Quick Stats */}
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-          <StatCard
-            title="Total Hosts"
-            value="4"
-            icon={<Computer />}
-            color="primary"
-            subtitle="Currently managed"
-          />
-        </Grid>
-        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-          <StatCard
-            title="Available Profiles"
-            value="8"
-            icon={<Security />}
-            color="success"
-            subtitle="Compliance standards"
-          />
-        </Grid>
-        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-          <StatCard
-            title="Scan Queue"
-            value="2"
-            icon={<Schedule />}
-            color="warning"
-            subtitle="Pending scans"
-          />
-        </Grid>
-        <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-          <StatCard
-            title="Templates"
-            value="5"
-            icon={<Description />}
-            color="info"
-            subtitle="Saved configurations"
-          />
-        </Grid>
-      </Grid>
-
       {/* Main Form */}
       {quickMode ? (
         <QuickAddHostForm
@@ -132,75 +90,6 @@ const AddHost: React.FC = () => {
           onCancel={() => navigate('/hosts')}
         />
       )}
-
-      {/* Templates Section */}
-      <Paper sx={{ mt: 3, p: 3 }}>
-        <Typography variant="h6" gutterBottom>
-          Quick Start Templates
-        </Typography>
-        <Grid container spacing={2}>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card
-              variant="outlined"
-              sx={{ cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}
-            >
-              <CardContent>
-                <Typography variant="subtitle2" color="primary">
-                  Linux Web Server
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Ubuntu/RHEL with CIS Level 2
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card
-              variant="outlined"
-              sx={{ cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}
-            >
-              <CardContent>
-                <Typography variant="subtitle2" color="primary">
-                  Database Server
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  PostgreSQL/MySQL with STIG
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card
-              variant="outlined"
-              sx={{ cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}
-            >
-              <CardContent>
-                <Typography variant="subtitle2" color="primary">
-                  Container Host
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Docker/K8s with CIS Benchmark
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card
-              variant="outlined"
-              sx={{ cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}
-            >
-              <CardContent>
-                <Typography variant="subtitle2" color="primary">
-                  Windows Server
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Windows 2019/2022 with STIG
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
-      </Paper>
     </Box>
   );
 };

--- a/frontend/src/pages/hosts/components/QuickAddHostForm.tsx
+++ b/frontend/src/pages/hosts/components/QuickAddHostForm.tsx
@@ -194,22 +194,24 @@ export const QuickAddHostForm: React.FC<QuickAddHostFormProps> = ({
         </Box>
       </Grid>
 
-      <Grid size={{ xs: 12, md: 6 }}>
-        <TextField
-          fullWidth
-          label="Username"
-          value={formData.username}
-          onChange={(e) => onInputChange('username', e.target.value)}
-          placeholder="ubuntu"
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <AccountTree />
-              </InputAdornment>
-            ),
-          }}
-        />
-      </Grid>
+      {formData.authMethod !== 'system_default' && (
+        <Grid size={{ xs: 12, md: 6 }}>
+          <TextField
+            fullWidth
+            label="Username"
+            value={formData.username}
+            onChange={(e) => onInputChange('username', e.target.value)}
+            placeholder="root"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <AccountTree />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </Grid>
+      )}
 
       {formData.authMethod === 'password' && (
         <Grid size={{ xs: 12, md: 6 }}>
@@ -484,7 +486,11 @@ export const QuickAddHostForm: React.FC<QuickAddHostFormProps> = ({
             variant="outlined"
             onClick={onTestConnection}
             startIcon={testingConnection ? <LinearProgress /> : <NetworkCheck />}
-            disabled={testingConnection || !formData.hostname || !formData.username}
+            disabled={
+              testingConnection ||
+              !formData.hostname ||
+              (!formData.username && formData.authMethod !== 'system_default')
+            }
           >
             Test Connection
           </Button>
@@ -530,19 +536,16 @@ export const QuickAddHostForm: React.FC<QuickAddHostFormProps> = ({
                   {connectionTestResults.authentication ? '\u2713' : '\u2717'} Authentication
                   successful
                 </Typography>
-                <Typography variant="body2">
-                  {'\u2713'} Detected: {connectionTestResults.detectedOS}
-                  {connectionTestResults.detectedVersion &&
-                    ` ${connectionTestResults.detectedVersion}`}
-                </Typography>
+                {connectionTestResults.detectedOS && (
+                  <Typography variant="body2">
+                    {'\u2713'} Detected: {connectionTestResults.detectedOS}
+                    {connectionTestResults.detectedVersion &&
+                      ` ${connectionTestResults.detectedVersion}`}
+                  </Typography>
+                )}
                 {connectionTestResults.sshVersion && (
                   <Typography variant="body2">
                     {'\u2713'} SSH Version: {connectionTestResults.sshVersion}
-                  </Typography>
-                )}
-                {connectionTestResults.additionalInfo && (
-                  <Typography variant="body2" color="text.secondary">
-                    {connectionTestResults.additionalInfo}
                   </Typography>
                 )}
               </Box>

--- a/frontend/src/pages/hosts/hooks/useAddHostForm.ts
+++ b/frontend/src/pages/hosts/hooks/useAddHostForm.ts
@@ -23,7 +23,6 @@ export interface ConnectionTestResults {
   detectedVersion: string;
   responseTime: number;
   sshVersion?: string;
-  additionalInfo?: string;
   error?: string;
   errorCode?: number;
 }
@@ -224,7 +223,7 @@ export function useAddHostForm() {
       const testData = {
         hostname: formData.hostname || formData.ipAddress,
         port: parseInt(formData.port) || 22,
-        username: formData.username,
+        username: formData.username || undefined,
         auth_method: formData.authMethod,
         password:
           formData.authMethod === 'password' || formData.authMethod === 'both'
@@ -246,10 +245,11 @@ export function useAddHostForm() {
       );
 
       setTestingConnection(false);
-      setConnectionStatus('success');
 
       // Store the actual results for display via adapter
-      setConnectionTestResults(adaptConnectionTest(result));
+      const adapted = adaptConnectionTest(result);
+      setConnectionTestResults(adapted);
+      setConnectionStatus(adapted.success ? 'success' : 'failed');
     } catch (err) {
       // Type-safe error handling: check if error has message property
       console.error('Connection test failed:', err);
@@ -278,15 +278,18 @@ export function useAddHostForm() {
 
   const handleSubmit = async () => {
     try {
-      // Prepare host data for API
+      // Determine hostname and IP - use the single input for both fields
+      // The backend requires both; when user enters one value we use it for both
+      const hostValue = formData.hostname || formData.ipAddress;
+
       const hostData = {
-        hostname: formData.hostname || formData.ipAddress,
-        ip_address: formData.ipAddress || formData.hostname,
+        hostname: hostValue,
+        ip_address: hostValue,
         display_name: formData.displayName,
         operating_system:
           formData.operatingSystem === 'auto-detect' ? 'Unknown' : formData.operatingSystem,
-        port: formData.port,
-        username: formData.username,
+        port: parseInt(formData.port) || 22,
+        username: formData.username || undefined,
         auth_method: formData.authMethod,
         password:
           formData.authMethod === 'password' || formData.authMethod === 'both'
@@ -301,17 +304,22 @@ export function useAddHostForm() {
         owner: formData.owner,
       };
 
-      // Submitting new host configuration to API
-
-      // Make API call to create host
-      const newHost = await api.post('/api/hosts/', hostData);
-      // Host successfully created in database
-      void newHost; // Result logged for debugging
+      await api.post('/api/hosts/', hostData);
       navigate('/hosts');
     } catch (error) {
-      console.error('Error submitting host:', error);
-      // Fallback - still navigate for demo purposes
-      navigate('/hosts');
+      const err = error as { response?: { data?: { detail?: string } }; message?: string };
+      const message = err.response?.data?.detail || err.message || 'Failed to add host';
+      console.error('Error submitting host:', message);
+      setConnectionStatus('failed');
+      setConnectionTestResults({
+        success: false,
+        error: message,
+        networkConnectivity: false,
+        authentication: false,
+        detectedOS: '',
+        detectedVersion: '',
+        responseTime: 0,
+      });
     }
   };
 

--- a/frontend/src/services/adapters/hostAdapter.ts
+++ b/frontend/src/services/adapters/hostAdapter.ts
@@ -66,13 +66,14 @@ export interface ApiHostResponse {
 
 /** POST /api/hosts/test-connection response */
 export interface ApiConnectionTestResponse {
-  network_reachable?: boolean;
-  auth_successful?: boolean;
+  success?: boolean;
+  network_connectivity?: boolean;
+  authentication?: boolean;
   detected_os?: string;
-  os_version?: string;
+  detected_version?: string;
   response_time_ms?: number;
   ssh_version?: string;
-  additional_info?: string;
+  error?: string;
 }
 
 /** GET /api/system/credentials response item */
@@ -109,7 +110,6 @@ export interface ConnectionTestResult {
   detectedVersion: string;
   responseTime: number;
   sshVersion?: string;
-  additionalInfo?: string;
   error?: string;
   errorCode?: number;
 }
@@ -224,14 +224,14 @@ export function adaptHosts(hosts: ApiHostResponse[]): Host[] {
 /** Transform a connection test API response. */
 export function adaptConnectionTest(response: ApiConnectionTestResponse): ConnectionTestResult {
   return {
-    success: true,
-    networkConnectivity: response.network_reachable ?? true,
-    authentication: response.auth_successful ?? true,
-    detectedOS: response.detected_os || 'Unknown',
-    detectedVersion: response.os_version || '',
+    success: response.success ?? false,
+    networkConnectivity: response.network_connectivity ?? false,
+    authentication: response.authentication ?? false,
+    detectedOS: response.detected_os || '',
+    detectedVersion: response.detected_version || '',
     responseTime: response.response_time_ms || 0,
     sshVersion: response.ssh_version,
-    additionalInfo: response.additional_info,
+    error: response.error || undefined,
   };
 }
 

--- a/specs/SPEC_REGISTRY.md
+++ b/specs/SPEC_REGISTRY.md
@@ -85,6 +85,7 @@ Coverage is checked by `scripts/check-spec-coverage.py`.
 | Rollback | api/remediation/rollback.spec.yaml | tests/backend/unit/api/test_remediation_api.py | 5 | Active |
 | Login | api/auth/login.spec.yaml | tests/backend/unit/api/test_auth_api.py | 5 | Active |
 | MFA Verify | api/auth/mfa-verify.spec.yaml | tests/backend/unit/api/test_auth_api.py | 5 | Active |
+| Test Connection | api/hosts/test-connection.spec.yaml | tests/backend/unit/api/test_host_api.py | 9 | Active |
 
 ## Frontend Specs
 
@@ -94,6 +95,7 @@ Coverage is checked by `scripts/check-spec-coverage.py`.
 | Auth Flow | frontend/auth-flow.spec.yaml | tests/frontend/auth/auth-flow.spec.test.ts | 8 | Active |
 | Scan Workflow | frontend/scan-workflow.spec.yaml | tests/frontend/scans/scan-workflow.spec.test.ts | 8 | Active |
 | Host Detail Behavior | frontend/host-detail-behavior.spec.yaml | tests/frontend/hosts/host-detail.spec.test.ts | 8 | Active |
+| Add Host Form | frontend/add-host-form.spec.yaml | tests/frontend/hosts/add-host-form.spec.test.ts | 9 | Active |
 
 ## Plugin Specs
 
@@ -117,11 +119,11 @@ Coverage is checked by `scripts/check-spec-coverage.py`.
 | System | 9 | 6 | 3 | 0 |
 | Pipelines | 3 | 2 | 1 | 0 |
 | Services | 11 | 11 | 0 | 0 |
-| API | 9 | 9 | 0 | 0 |
+| API | 10 | 10 | 0 | 0 |
 | Plugins | 1 | 1 | 0 | 0 |
 | Release | 4 | 4 | 0 | 0 |
-| Frontend | 4 | 4 | 0 | 0 |
-| **Total** | **41** | **37** | **4** | **0** |
+| Frontend | 5 | 5 | 0 | 0 |
+| **Total** | **43** | **39** | **4** | **0** |
 
 ## Cross-Module Dependencies
 

--- a/specs/api/hosts/test-connection.spec.yaml
+++ b/specs/api/hosts/test-connection.spec.yaml
@@ -1,0 +1,113 @@
+spec: test-connection-api
+version: "1.0"
+status: active
+owner: engineering
+summary: >
+  POST /api/hosts/test-connection endpoint contract: accepts hostname, port,
+  auth_method, optional username/ssh_key/password. Performs TCP socket check
+  with SSH banner read, then SSH authentication via paramiko. Supports four
+  auth methods: system_default (decrypts credential from unified_credentials
+  table via base64 + AES-256-GCM), ssh_key (RSA/Ed25519/ECDSA), password,
+  and both (SSH key primary + password fallback). On successful SSH auth,
+  detects OS via /etc/os-release. Returns structured result with success,
+  network_connectivity, authentication, detected_os, detected_version,
+  response_time_ms, ssh_version, and error fields.
+
+---
+
+# Objective
+
+objective: >
+  Ensure the test-connection endpoint correctly validates SSH connectivity
+  before host creation, supports all four authentication methods, properly
+  decrypts system default credentials, detects remote OS, and returns
+  accurate structured results for frontend display.
+
+---
+
+# Constraints
+
+constraints:
+  network_check:
+    - "TCP socket check MUST use configurable timeout (capped at 10s)"
+    - "SSH banner MUST be read from socket if available"
+    - "Network failure MUST return early with network_connectivity=false"
+
+  authentication:
+    - "system_default MUST query unified_credentials with scope=system, is_default=true, is_active=true"
+    - "system_default MUST base64-decode then AES-256-GCM decrypt the encrypted_private_key"
+    - "ssh_key MUST try RSA, then Ed25519, then ECDSA key formats"
+    - "both mode MUST set both pkey and password in paramiko connect_kwargs"
+    - "password mode MUST only set password in connect_kwargs"
+
+  os_detection:
+    - "OS detection MUST parse /etc/os-release for PRETTY_NAME and VERSION_ID"
+    - "OS detection failure MUST NOT cause the overall test to fail"
+
+  response:
+    - "Response MUST include success, network_connectivity, authentication, detected_os, detected_version, response_time_ms"
+    - "Error responses MUST include error field with descriptive message"
+    - "Endpoint MUST return 200 for all outcomes (success or failure encoded in response body)"
+
+---
+
+# Acceptance Criteria
+
+acceptance_criteria:
+  - id: AC-1
+    description: >
+      POST /test-connection performs a TCP socket check to hostname:port
+      before attempting SSH authentication. If the socket fails, result
+      contains network_connectivity=false and an error message.
+
+  - id: AC-2
+    description: >
+      When auth_method is system_default, the endpoint queries
+      unified_credentials table filtering by scope=system, is_default=true,
+      is_active=true to resolve username and encrypted credentials.
+
+  - id: AC-3
+    description: >
+      System default credential decryption base64-decodes the
+      encrypted_private_key bytes, then decrypts via EncryptionService
+      (AES-256-GCM) using the application master_key.
+
+  - id: AC-4
+    description: >
+      SSH key parsing tries paramiko.RSAKey, then Ed25519Key, then
+      ECDSAKey from_private_key, supporting all three key formats.
+
+  - id: AC-5
+    description: >
+      When auth_method is "both", connect_kwargs MUST include both pkey
+      (SSH key) and password, enabling SSH key primary with password
+      fallback authentication.
+
+  - id: AC-6
+    description: >
+      On successful SSH authentication, the endpoint executes
+      "cat /etc/os-release" to detect PRETTY_NAME and VERSION_ID fields
+      for OS identification.
+
+  - id: AC-7
+    description: >
+      If no system default credential is found, the endpoint returns
+      error="No system default credential configured" without attempting
+      SSH connection.
+
+  - id: AC-8
+    description: >
+      The response always includes response_time_ms calculated from
+      request start to completion using monotonic clock.
+
+  - id: AC-9
+    description: >
+      SSH banner is captured from the initial TCP socket connection and
+      returned in the ssh_version field when the banner starts with "SSH-".
+
+  - id: AC-10
+    description: >
+      The TestConnectionRequest Pydantic model accepts hostname (required),
+      port (default 22), username (optional), auth_method (default
+      system_default), ssh_key (optional), password (optional), and
+      timeout (default 30).

--- a/specs/frontend/add-host-form.spec.yaml
+++ b/specs/frontend/add-host-form.spec.yaml
@@ -1,0 +1,126 @@
+spec: add-host-form
+version: "1.0"
+status: active
+owner: engineering
+summary: >
+  The Add Host page (Quick Add mode) MUST provide hostname/IP input,
+  display name, and four authentication methods: System Default, SSH Key,
+  Password, and SSH Key + Password (Fallback). System Default MUST hide
+  username and credential fields, showing system credential info instead.
+  Test Connection MUST call POST /api/hosts/test-connection and display
+  results faithfully (success/failure based on backend response.success).
+  The connection test adapter MUST map backend snake_case fields to
+  frontend camelCase without hardcoding success=true. The page MUST NOT
+  contain hardcoded statistics or non-functional template components.
+
+---
+
+# Objective
+
+objective: >
+  Ensure the Add Host form correctly handles all four authentication
+  methods with appropriate field visibility, sends properly structured
+  test-connection requests, displays accurate connection results from
+  the backend, and does not contain dead UI elements.
+
+---
+
+# Constraints
+
+constraints:
+  auth_methods:
+    - "System Default MUST hide Username and credential input fields"
+    - "System Default MUST show credential info (name, username, key type) from /api/system/credentials"
+    - "SSH Key MUST show Username and SSH Private Key textarea"
+    - "Password MUST show Username and Password fields"
+    - "SSH Key + Password (Fallback) MUST show Username, SSH Private Key, and Password fields"
+
+  test_connection:
+    - "Test Connection button MUST be disabled when hostname is empty"
+    - "Test Connection button MUST be disabled when username is empty AND auth_method is not system_default"
+    - "Test Connection MUST call POST /api/hosts/test-connection with correct auth_method value"
+    - "Connection status MUST reflect backend response.success (not hardcoded)"
+
+  adapter:
+    - "adaptConnectionTest MUST map network_connectivity, authentication, detected_os, detected_version from backend"
+    - "adaptConnectionTest MUST default success to false when field is missing"
+    - "adaptConnectionTest MUST NOT hardcode success=true"
+
+  form_cleanliness:
+    - "AddHost.tsx MUST NOT contain hardcoded StatCard components"
+    - "AddHost.tsx MUST NOT contain Quick Start Templates section"
+    - "Connection result display MUST only show 'Detected:' line when detected_os is non-empty"
+
+---
+
+# Acceptance Criteria
+
+acceptance_criteria:
+  - id: AC-1
+    description: >
+      When auth_method is system_default, the QuickAddHostForm MUST NOT
+      render a Username input field. The form MUST display system
+      credential info (credential name, username, key type) instead.
+
+  - id: AC-2
+    description: >
+      When auth_method is ssh_key, the form MUST render Username and
+      SSH Private Key textarea fields.
+
+  - id: AC-3
+    description: >
+      When auth_method is password, the form MUST render Username and
+      Password fields with a show/hide toggle.
+
+  - id: AC-4
+    description: >
+      When auth_method is both (SSH Key + Password Fallback), the form
+      MUST render Username, SSH Private Key (Primary), and Password
+      (Fallback) fields with an explanatory info banner.
+
+  - id: AC-5
+    description: >
+      The Test Connection button MUST be disabled when hostname is empty
+      OR when username is empty and auth_method is not system_default.
+
+  - id: AC-6
+    description: >
+      handleTestConnection sends auth_method=system_default with no
+      username/password/ssh_key when System Default is selected, allowing
+      the backend to resolve credentials.
+
+  - id: AC-7
+    description: >
+      The adaptConnectionTest adapter MUST map backend field
+      network_connectivity (not network_reachable), authentication (not
+      auth_successful), detected_version (not os_version) to their
+      camelCase frontend equivalents.
+
+  - id: AC-8
+    description: >
+      The adaptConnectionTest adapter MUST default success to false and
+      networkConnectivity/authentication to false when backend fields are
+      missing, never hardcoding optimistic defaults.
+
+  - id: AC-9
+    description: >
+      The connection status state MUST be set to 'failed' when the
+      adapted result has success=false, even when the HTTP response
+      is 200 OK.
+
+  - id: AC-10
+    description: >
+      AddHost.tsx MUST NOT contain StatCard components or Quick Start
+      Templates. The page MUST only render a header with back button
+      and the Quick/Advanced mode form toggle.
+
+  - id: AC-11
+    description: >
+      The connection result display MUST only show the "Detected:" line
+      when connectionTestResults.detectedOS is a non-empty string.
+
+  - id: AC-12
+    description: >
+      handleSubmit MUST NOT navigate to /hosts on error. On failure, it
+      MUST set connectionStatus to 'failed' and display the error message
+      in connectionTestResults.

--- a/tests/backend/unit/api/test_host_api.py
+++ b/tests/backend/unit/api/test_host_api.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for host API contracts: test-connection (POST /api/hosts/test-connection)
+behavioral contract.
+
+Spec: specs/api/hosts/test-connection.spec.yaml
+Tests test_connection endpoint from routes/hosts/crud.py.
+"""
+
+import inspect
+
+import pytest
+
+from app.routes.hosts.crud import TestConnectionRequest
+from app.routes.hosts.crud import test_connection as _test_connection_handler
+
+# ---------------------------------------------------------------------------
+# AC-1: TCP socket check before SSH authentication
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC1SocketCheck:
+    """AC-1: TCP socket check performed before SSH auth."""
+
+    def test_socket_create_connection_present(self):
+        """Verify socket.create_connection is used for TCP check."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "socket.create_connection" in source
+
+    def test_network_connectivity_set_on_success(self):
+        """Verify network_connectivity is set to True on socket success."""
+        source = inspect.getsource(_test_connection_handler)
+        assert 'result["network_connectivity"] = True' in source
+
+    def test_early_return_on_socket_failure(self):
+        """Verify early return with error when socket fails."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "socket.timeout" in source or "OSError" in source
+        assert "Cannot reach" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-2: system_default queries unified_credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC2SystemDefault:
+    """AC-2: system_default resolves from unified_credentials table."""
+
+    def test_queries_unified_credentials(self):
+        """Verify QueryBuilder targets unified_credentials table."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "unified_credentials" in source
+
+    def test_filters_scope_system(self):
+        """Verify scope=system filter applied."""
+        source = inspect.getsource(_test_connection_handler)
+        assert '"system"' in source or "'system'" in source
+        assert "scope" in source
+
+    def test_filters_is_default_true(self):
+        """Verify is_default=true filter applied."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "is_default" in source
+
+    def test_filters_is_active_true(self):
+        """Verify is_active=true filter applied."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "is_active" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-3: base64 decode + AES-256-GCM decryption
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC3Decryption:
+    """AC-3: Credential decryption uses base64 decode then AES-256-GCM."""
+
+    def test_base64_decode_present(self):
+        """Verify base64.b64decode is used before decryption."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "base64.b64decode" in source or "b64decode" in source
+
+    def test_encryption_service_used(self):
+        """Verify create_encryption_service is used for decryption."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "create_encryption_service" in source
+
+    def test_master_key_from_settings(self):
+        """Verify master_key is sourced from application settings."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "settings.master_key" in source
+
+    def test_decrypt_called(self):
+        """Verify enc_svc.decrypt is called on the encrypted bytes."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "enc_svc.decrypt" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-4: SSH key format support (RSA, Ed25519, ECDSA)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC4KeyFormats:
+    """AC-4: SSH key parsing supports RSA, Ed25519, and ECDSA."""
+
+    def test_rsa_key_support(self):
+        """Verify paramiko.RSAKey.from_private_key is tried."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "paramiko.RSAKey.from_private_key" in source
+
+    def test_ed25519_key_support(self):
+        """Verify paramiko.Ed25519Key.from_private_key is tried."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "paramiko.Ed25519Key.from_private_key" in source
+
+    def test_ecdsa_key_support(self):
+        """Verify paramiko.ECDSAKey.from_private_key is tried."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "paramiko.ECDSAKey.from_private_key" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-5: "both" mode sets pkey AND password
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC5BothMode:
+    """AC-5: both mode includes pkey and password in connect_kwargs."""
+
+    def test_both_mode_adds_password(self):
+        """Verify both mode explicitly adds password after setting pkey."""
+        source = inspect.getsource(_test_connection_handler)
+        assert 'auth_method == "both"' in source or "auth_method == 'both'" in source
+        # Verify password is set for both mode separately from the key
+        assert 'connect_kwargs["password"]' in source
+
+    def test_both_mode_not_elif_password(self):
+        """Verify password for both mode is not behind an elif that skips it."""
+        source = inspect.getsource(_test_connection_handler)
+        # After the ssh_key/both block, there should be a specific check
+        # for both mode to add password, not just elif password
+        lines = source.split("\n")
+        found_both_password = False
+        for line in lines:
+            if "both" in line and "password" in line and "connect_kwargs" not in line:
+                found_both_password = True
+                break
+        assert found_both_password, "Expected explicit both+password check"
+
+
+# ---------------------------------------------------------------------------
+# AC-6: OS detection via /etc/os-release
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC6OSDetection:
+    """AC-6: OS detection parses /etc/os-release."""
+
+    def test_os_release_command(self):
+        """Verify cat /etc/os-release is executed via SSH."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "/etc/os-release" in source
+
+    def test_pretty_name_parsed(self):
+        """Verify PRETTY_NAME field is extracted."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "PRETTY_NAME=" in source
+
+    def test_version_id_parsed(self):
+        """Verify VERSION_ID field is extracted."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "VERSION_ID=" in source
+
+    def test_os_detection_in_try_block(self):
+        """Verify OS detection failure does not cause overall failure."""
+        source = inspect.getsource(_test_connection_handler)
+        # The OS detection should be in its own try/except
+        detect_idx = source.find("/etc/os-release")
+        # There should be a try before it and except after it
+        preceding = source[:detect_idx]
+        assert "try:" in preceding.split("ssh.connect")[1]
+
+
+# ---------------------------------------------------------------------------
+# AC-7: No system default credential returns error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC7NoCredential:
+    """AC-7: Missing system default credential returns descriptive error."""
+
+    def test_no_credential_error_message(self):
+        """Verify error message when no system default credential found."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "No system default credential configured" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-8: Response includes response_time_ms
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC8ResponseTime:
+    """AC-8: Response includes response_time_ms from monotonic clock."""
+
+    def test_monotonic_clock_used(self):
+        """Verify monotonic clock is used for timing."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "monotonic" in source
+
+    def test_response_time_in_result(self):
+        """Verify response_time_ms is set in result dict."""
+        source = inspect.getsource(_test_connection_handler)
+        assert 'result["response_time_ms"]' in source
+
+
+# ---------------------------------------------------------------------------
+# AC-9: SSH banner captured from TCP socket
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC9SSHBanner:
+    """AC-9: SSH banner captured and returned in ssh_version."""
+
+    def test_banner_read_from_socket(self):
+        """Verify SSH banner is read from the socket."""
+        source = inspect.getsource(_test_connection_handler)
+        assert "sock.recv" in source
+
+    def test_banner_starts_with_ssh(self):
+        """Verify only SSH-prefixed banners are stored."""
+        source = inspect.getsource(_test_connection_handler)
+        assert 'startswith("SSH-")' in source
+
+    def test_ssh_version_stored(self):
+        """Verify banner is stored in ssh_version field."""
+        source = inspect.getsource(_test_connection_handler)
+        assert 'result["ssh_version"]' in source
+
+
+# ---------------------------------------------------------------------------
+# AC-10: TestConnectionRequest Pydantic model fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestConnectionAC10RequestModel:
+    """AC-10: TestConnectionRequest has correct fields and defaults."""
+
+    def test_hostname_required(self):
+        """Verify hostname is a required field."""
+        fields = TestConnectionRequest.model_fields
+        assert "hostname" in fields
+        assert fields["hostname"].is_required()
+
+    def test_port_default_22(self):
+        """Verify port defaults to 22."""
+        fields = TestConnectionRequest.model_fields
+        assert "port" in fields
+        assert fields["port"].default == 22
+
+    def test_auth_method_default_system_default(self):
+        """Verify auth_method defaults to system_default."""
+        fields = TestConnectionRequest.model_fields
+        assert "auth_method" in fields
+        assert fields["auth_method"].default == "system_default"
+
+    def test_username_optional(self):
+        """Verify username is optional."""
+        fields = TestConnectionRequest.model_fields
+        assert "username" in fields
+        assert not fields["username"].is_required()
+
+    def test_ssh_key_optional(self):
+        """Verify ssh_key is optional."""
+        fields = TestConnectionRequest.model_fields
+        assert "ssh_key" in fields
+        assert not fields["ssh_key"].is_required()
+
+    def test_password_optional(self):
+        """Verify password is optional."""
+        fields = TestConnectionRequest.model_fields
+        assert "password" in fields
+        assert not fields["password"].is_required()
+
+    def test_timeout_default_30(self):
+        """Verify timeout defaults to 30."""
+        fields = TestConnectionRequest.model_fields
+        assert "timeout" in fields
+        assert fields["timeout"].default == 30

--- a/tests/frontend/hosts/add-host-form.spec.test.ts
+++ b/tests/frontend/hosts/add-host-form.spec.test.ts
@@ -1,0 +1,261 @@
+// Spec: specs/frontend/add-host-form.spec.yaml
+/**
+ * Spec-enforcement tests for Add Host form behavior.
+ *
+ * Verifies auth method field visibility, test connection adapter accuracy,
+ * button disabled states, absence of dead UI elements, and error handling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SRC = path.resolve(__dirname, '../../../frontend/src');
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(SRC, relativePath), 'utf8');
+}
+
+const ADD_HOST = readSource('pages/hosts/AddHost.tsx');
+const QUICK_FORM = readSource('pages/hosts/components/QuickAddHostForm.tsx');
+const HOOK = readSource('pages/hosts/hooks/useAddHostForm.ts');
+const ADAPTER = readSource('services/adapters/hostAdapter.ts');
+
+// ---------------------------------------------------------------------------
+// AC-1: System Default hides Username field
+// ---------------------------------------------------------------------------
+
+describe('AC-1: System Default hides Username and credential fields', () => {
+  /**
+   * AC-1: When auth_method is system_default, QuickAddHostForm MUST NOT
+   * render a Username input field.
+   */
+
+  it('username field is conditionally hidden for system_default', () => {
+    // The form should check authMethod !== 'system_default' before rendering username
+    expect(QUICK_FORM).toContain("system_default");
+    // Username field should be wrapped in a conditional that excludes system_default
+    expect(QUICK_FORM).toMatch(/authMethod\s*!==\s*['"]system_default['"]/);
+  });
+
+  it('system credential info box is shown for system_default', () => {
+    expect(QUICK_FORM).toContain('Using System Default Credentials');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: SSH Key shows Username and SSH Private Key
+// ---------------------------------------------------------------------------
+
+describe('AC-2: SSH Key shows Username and SSH Private Key fields', () => {
+  it('SSH Private Key textarea is rendered for ssh_key method', () => {
+    expect(QUICK_FORM).toContain('SSH Private Key');
+  });
+
+  it('username field is rendered for ssh_key method', () => {
+    // Username renders for non-system_default methods
+    expect(QUICK_FORM).toContain('Username');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: Password shows Username and Password fields
+// ---------------------------------------------------------------------------
+
+describe('AC-3: Password shows Username and Password fields', () => {
+  it('password field is rendered for password method', () => {
+    expect(QUICK_FORM).toContain('Enter password for authentication');
+  });
+
+  it('password field has show/hide toggle', () => {
+    // Visibility toggle for password
+    expect(QUICK_FORM).toContain('showPassword') ;
+    expect(QUICK_FORM).toMatch(/Visibility(Off)?/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: Both mode shows Username, SSH Key, and Password
+// ---------------------------------------------------------------------------
+
+describe('AC-4: SSH Key + Password (Fallback) shows all three fields', () => {
+  it('info banner explains fallback behavior', () => {
+    expect(QUICK_FORM).toContain('SSH Key + Password Fallback');
+    expect(QUICK_FORM).toContain('automatically fallback to password');
+  });
+
+  it('SSH Private Key (Primary) label is shown for both mode', () => {
+    expect(QUICK_FORM).toContain('SSH Private Key (Primary)');
+  });
+
+  it('Password (Fallback) label is shown for both mode', () => {
+    expect(QUICK_FORM).toContain('Password (Fallback)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: Test Connection disabled states
+// ---------------------------------------------------------------------------
+
+describe('AC-5: Test Connection button disabled states', () => {
+  it('disabled when hostname is empty', () => {
+    expect(QUICK_FORM).toContain('!formData.hostname');
+  });
+
+  it('disabled when username is empty and not system_default', () => {
+    // Should check: !formData.username && formData.authMethod !== 'system_default'
+    expect(QUICK_FORM).toMatch(/!formData\.username.*system_default/s);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6: System Default sends no credentials to backend
+// ---------------------------------------------------------------------------
+
+describe('AC-6: System Default sends auth_method=system_default with no credentials', () => {
+  it('handleTestConnection sends auth_method from formData', () => {
+    expect(HOOK).toContain('auth_method: formData.authMethod');
+  });
+
+  it('password only sent for password or both methods', () => {
+    expect(HOOK).toContain("authMethod === 'password'");
+    expect(HOOK).toContain("authMethod === 'both'");
+  });
+
+  it('ssh_key only sent for ssh_key or both methods', () => {
+    expect(HOOK).toContain("authMethod === 'ssh_key'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7: Adapter maps correct backend field names
+// ---------------------------------------------------------------------------
+
+describe('AC-7: adaptConnectionTest maps correct backend field names', () => {
+  it('maps network_connectivity (not network_reachable)', () => {
+    expect(ADAPTER).toContain('response.network_connectivity');
+    expect(ADAPTER).not.toContain('response.network_reachable');
+  });
+
+  it('maps authentication (not auth_successful)', () => {
+    expect(ADAPTER).toContain('response.authentication');
+    expect(ADAPTER).not.toContain('response.auth_successful');
+  });
+
+  it('maps detected_version (not os_version)', () => {
+    expect(ADAPTER).toContain('response.detected_version');
+    expect(ADAPTER).not.toContain('response.os_version');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: Adapter defaults to false, not true
+// ---------------------------------------------------------------------------
+
+describe('AC-8: adaptConnectionTest defaults booleans to false', () => {
+  it('success defaults to false', () => {
+    expect(ADAPTER).toMatch(/response\.success\s*\?\?\s*false/);
+  });
+
+  it('networkConnectivity defaults to false', () => {
+    expect(ADAPTER).toMatch(/response\.network_connectivity\s*\?\?\s*false/);
+  });
+
+  it('authentication defaults to false', () => {
+    expect(ADAPTER).toMatch(/response\.authentication\s*\?\?\s*false/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9: Connection status reflects backend success field
+// ---------------------------------------------------------------------------
+
+describe('AC-9: Connection status set from adapted result.success', () => {
+  it('connectionStatus set based on adapted.success', () => {
+    expect(HOOK).toContain("adapted.success ? 'success' : 'failed'");
+  });
+
+  it('does not hardcode connectionStatus to success', () => {
+    // The hook should NOT set connectionStatus('success') unconditionally
+    // before checking the result
+    const lines = HOOK.split('\n');
+    const testConnSection = HOOK.substring(
+      HOOK.indexOf('handleTestConnection'),
+      HOOK.indexOf('handleSubmit')
+    );
+    // Should not have setConnectionStatus('success') without checking result
+    const unconditionalSuccess = testConnSection.match(
+      /setConnectionStatus\(['"]success['"]\)\s*;?\s*\n\s*\n\s*\/\//
+    );
+    expect(unconditionalSuccess).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-10: No StatCards or Quick Start Templates
+// ---------------------------------------------------------------------------
+
+describe('AC-10: AddHost.tsx has no dead UI elements', () => {
+  it('does not contain StatCard', () => {
+    expect(ADD_HOST).not.toContain('StatCard');
+  });
+
+  it('does not contain Quick Start Templates', () => {
+    expect(ADD_HOST).not.toContain('Quick Start');
+    expect(ADD_HOST).not.toContain('Template');
+  });
+
+  it('does not import Grid or Card from MUI', () => {
+    expect(ADD_HOST).not.toContain("import { Grid");
+    expect(ADD_HOST).not.toContain("Card,");
+    expect(ADD_HOST).not.toContain("CardContent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-11: Detected OS only shown when non-empty
+// ---------------------------------------------------------------------------
+
+describe('AC-11: Detected OS line only shown when detectedOS is non-empty', () => {
+  it('detectedOS display is conditionally rendered', () => {
+    // Should have a check like: connectionTestResults.detectedOS && (
+    expect(QUICK_FORM).toMatch(/connectionTestResults\.detectedOS\s*&&/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-12: handleSubmit does not navigate on error
+// ---------------------------------------------------------------------------
+
+describe('AC-12: handleSubmit shows error instead of navigating', () => {
+  it('catch block sets connectionStatus to failed', () => {
+    const submitSection = HOOK.substring(
+      HOOK.indexOf('handleSubmit'),
+      HOOK.indexOf('fetchSystemCredentials')
+    );
+    expect(submitSection).toContain("setConnectionStatus('failed')");
+  });
+
+  it('catch block sets connectionTestResults with error', () => {
+    const submitSection = HOOK.substring(
+      HOOK.indexOf('handleSubmit'),
+      HOOK.indexOf('fetchSystemCredentials')
+    );
+    expect(submitSection).toContain('setConnectionTestResults');
+    expect(submitSection).toContain('success: false');
+  });
+
+  it('navigate only called in try block (on success)', () => {
+    const submitSection = HOOK.substring(
+      HOOK.indexOf('handleSubmit'),
+      HOOK.indexOf('fetchSystemCredentials')
+    );
+    // navigate('/hosts') should only appear in try, not catch
+    const catchBlock = submitSection.substring(submitSection.indexOf('catch'));
+    expect(catchBlock).not.toContain("navigate('/hosts')");
+  });
+});

--- a/tests/frontend/services/adapters/hostAdapter.test.ts
+++ b/tests/frontend/services/adapters/hostAdapter.test.ts
@@ -156,10 +156,11 @@ describe('adaptHosts', () => {
 describe('adaptConnectionTest', () => {
   it('transforms a successful test response', () => {
     const api: ApiConnectionTestResponse = {
-      network_reachable: true,
-      auth_successful: true,
+      success: true,
+      network_connectivity: true,
+      authentication: true,
       detected_os: 'RHEL',
-      os_version: '9.2',
+      detected_version: '9.2',
       response_time_ms: 45,
       ssh_version: 'OpenSSH_8.7',
     };
@@ -175,9 +176,10 @@ describe('adaptConnectionTest', () => {
 
   it('applies defaults for missing fields', () => {
     const result = adaptConnectionTest({});
-    expect(result.networkConnectivity).toBe(true);
-    expect(result.authentication).toBe(true);
-    expect(result.detectedOS).toBe('Unknown');
+    expect(result.success).toBe(false);
+    expect(result.networkConnectivity).toBe(false);
+    expect(result.authentication).toBe(false);
+    expect(result.detectedOS).toBe('');
     expect(result.detectedVersion).toBe('');
     expect(result.responseTime).toBe(0);
   });


### PR DESCRIPTION
## Summary

- Add `POST /api/hosts/test-connection` endpoint for pre-creation SSH connectivity testing with support for all 4 auth methods (System Default, SSH Key, Password, SSH Key + Password Fallback)
- Fix Add Host form: hide username for System Default auth, fix adapter field mapping, remove dead StatCards/Templates, fix error handling
- Add 2 new behavioral specs (22 ACs) and 62 unit tests

## Changes

### Backend (`backend/app/routes/hosts/crud.py`)
- New `POST /test-connection` endpoint: TCP socket check + SSH banner read + paramiko auth + OS detection
- System default credential resolution from `unified_credentials` table (scope=system, is_default=true)
- Base64 decode + AES-256-GCM decryption of stored SSH keys via `EncryptionService`
- Support for RSA, Ed25519, ECDSA key formats
- Fix `both` auth mode to include password as fallback alongside SSH key (was `elif`, now explicit)
- OS detection via `/etc/os-release` parsing (PRETTY_NAME + VERSION_ID)

### Frontend
- **`AddHost.tsx`**: Remove hardcoded StatCards (Total Hosts: 4, Profiles: 8, etc.) and non-functional Quick Start Templates
- **`QuickAddHostForm.tsx`**: Hide Username field for System Default auth; conditionally show "Detected:" line only when OS detected
- **`useAddHostForm.ts`**: Check `adapted.success` before setting status (was hardcoded 'success'); fix `handleSubmit` to show errors instead of navigating away
- **`hostAdapter.ts`**: Fix `ApiConnectionTestResponse` interface to match actual backend fields (`network_connectivity` not `network_reachable`, `detected_version` not `os_version`); default booleans to `false` not `true`

### Specs & Tests
- **New spec**: `specs/api/hosts/test-connection.spec.yaml` (10 ACs, Active)
- **New spec**: `specs/frontend/add-host-form.spec.yaml` (12 ACs, Active)
- **New test**: `tests/backend/unit/api/test_host_api.py` (33 tests covering all 10 backend ACs)
- **New test**: `tests/frontend/hosts/add-host-form.spec.test.ts` (29 tests covering all 12 frontend ACs)
- **Updated**: `tests/frontend/services/adapters/hostAdapter.test.ts` (field name + default changes)
- **Updated**: `specs/SPEC_REGISTRY.md` (43 specs total, 39 Active)

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Frontend: 277/277 tests pass (29 new)
- [x] Backend: 33/33 new spec tests pass (in Docker container)
- [x] Spec validation: 43/43 specs pass schema validation
- [x] All pre-commit hooks pass (black, isort, flake8, mypy, bandit, eslint, prettier)
- [x] Manual browser test: System Default auth detects Ubuntu 24.04.3 LTS on 192.168.1.214
- [ ] CI pipeline validation

## Browser-verified behavior
- System Default: hides username, shows credential info, Test Connection detects OS
- SSH Key: shows username + key textarea
- Password: shows username + password with toggle
- SSH Key + Password (Fallback): shows all three fields with info banner