### PR TITLE
refactor(frontend): extract sub-components from ScanDetail and Hosts

### DIFF
--- a/frontend/src/pages/hosts/Hosts.tsx
+++ b/frontend/src/pages/hosts/Hosts.tsx
@@ -5,13 +5,7 @@ import {
   Box,
   Typography,
   Button,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   LinearProgress,
-  Collapse,
   Menu,
   MenuItem,
   ListItemIcon,
@@ -26,22 +20,12 @@ import {
   Alert,
 } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import {
-  Add,
-  FilterList,
-  Computer,
-  Error as ErrorIcon,
-  Groups,
-  Download,
-  Security,
-  ExpandMore,
-  ChevronRight,
-  Scanner,
-  CloudUpload,
-} from '@mui/icons-material';
-import { StatCard, FilterToolbar } from '../../components/design-system';
+import { Add, FilterList, Groups, Download, Scanner, CloudUpload } from '@mui/icons-material';
+import { FilterToolbar } from '../../components/design-system';
 import { useHostsPage } from './hooks/useHostsPage';
-import HostCard from './components/HostCard';
+import HostStatCards from './components/HostStatCards';
+import HostGrid from './components/HostGrid';
+import HostConfirmDialogs from './components/HostConfirmDialogs';
 import EditHostDialog from './components/EditHostDialog';
 
 const Hosts: React.FC = () => {
@@ -137,65 +121,11 @@ const Hosts: React.FC = () => {
       </Box>
 
       {/* Header Statistics */}
-      <Box sx={{ mb: 4 }}>
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-            <StatCard
-              title={autoRefreshEnabled ? 'Hosts Online (Auto)' : 'Hosts Online'}
-              value={`${stats.online}/${stats.total}`}
-              color="primary"
-              icon={<Computer />}
-              trend={stats.online === stats.total ? 'up' : 'flat'}
-              trendValue={`${Math.round((stats.online / stats.total) * 100)}%`}
-            />
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-            <StatCard
-              title="Avg Compliance"
-              value={`${stats.avgCompliance}%`}
-              color={
-                stats.avgCompliance >= 90
-                  ? 'success'
-                  : stats.avgCompliance >= 75
-                    ? 'warning'
-                    : 'error'
-              }
-              icon={<Security />}
-              trend={stats.avgCompliance >= 85 ? 'up' : 'flat'}
-            />
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-            <StatCard
-              title="Critical Issues"
-              value={stats.criticalHosts}
-              color="error"
-              icon={<ErrorIcon />}
-              trend={stats.criticalHosts === 0 ? 'up' : 'down'}
-              subtitle={stats.criticalHosts === 0 ? 'All clear' : 'Needs attention'}
-            />
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-            <StatCard
-              title="Need Scanning"
-              value={stats.needsScanning}
-              color="warning"
-              icon={<Scanner />}
-              trend={stats.needsScanning === 0 ? 'up' : 'down'}
-              subtitle={stats.needsScanning === 0 ? 'Up to date' : 'Behind schedule'}
-            />
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
-            <StatCard
-              title="Quick Actions"
-              value="Add Host"
-              color="primary"
-              icon={<Add />}
-              onClick={() => navigate('/hosts/add-host')}
-              subtitle="Register new system"
-            />
-          </Grid>
-        </Grid>
-      </Box>
+      <HostStatCards
+        stats={stats}
+        autoRefreshEnabled={autoRefreshEnabled}
+        onAddHost={() => navigate('/hosts/add-host')}
+      />
 
       {/* Toolbar */}
       <Paper sx={{ mb: 3 }}>
@@ -269,95 +199,21 @@ const Hosts: React.FC = () => {
           </Grid>
         </Box>
       ) : (
-        <Box>
-          {/* Grouped View */}
-          {groupBy !== 'none' && Object.keys(processedHosts).length > 0 ? (
-            <Box>
-              {Object.entries(processedHosts).map(([groupName, groupHosts]) => (
-                <Box key={groupName} sx={{ mb: 4 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                    <Typography variant="h6" sx={{ flexGrow: 1 }}>
-                      {groupName} ({groupHosts.length})
-                    </Typography>
-                    <IconButton
-                      size="small"
-                      onClick={() =>
-                        setExpandedGroups((prev) =>
-                          prev.includes(groupName)
-                            ? prev.filter((g) => g !== groupName)
-                            : [...prev, groupName]
-                        )
-                      }
-                    >
-                      {expandedGroups.includes(groupName) ? <ExpandMore /> : <ChevronRight />}
-                    </IconButton>
-                  </Box>
-
-                  <Collapse in={expandedGroups.includes(groupName)}>
-                    <Grid container spacing={viewMode === 'compact' ? 2 : 3}>
-                      {groupHosts.map((host) => (
-                        <Grid
-                          size={
-                            viewMode === 'list'
-                              ? { xs: 12 }
-                              : viewMode === 'compact'
-                                ? { xs: 6, sm: 4, md: 2 }
-                                : { xs: 12, sm: 6, md: 3 }
-                          }
-                          key={host.id}
-                        >
-                          <HostCard
-                            host={host}
-                            viewMode={viewMode}
-                            selectedHosts={selectedHosts}
-                            navigate={navigate}
-                            handleSelectHost={handleSelectHost}
-                            handleQuickScanWithValidation={handleQuickScanWithValidation}
-                            handleEditHost={handleEditHost}
-                            handleDeleteHost={handleDeleteHost}
-                            checkHostStatus={checkHostStatus}
-                            setQuickScanDialog={setQuickScanDialog}
-                          />
-                        </Grid>
-                      ))}
-                    </Grid>
-                  </Collapse>
-                </Box>
-              ))}
-            </Box>
-          ) : (
-            /* Grid/List/Compact View */
-            <Grid container spacing={viewMode === 'compact' ? 2 : 3}>
-              {Object.values(processedHosts)
-                .flat()
-                .map((host) => (
-                  <Grid
-                    size={
-                      viewMode === 'list'
-                        ? { xs: 12 }
-                        : viewMode === 'compact'
-                          ? { xs: 6, sm: 4, md: 2 }
-                          : { xs: 12, sm: 6, md: 3 }
-                    }
-                    key={host.id}
-                  >
-                    <HostCard
-                      host={host}
-                      viewMode={viewMode}
-                      selectedHosts={selectedHosts}
-                      navigate={navigate}
-                      handleSelectHost={handleSelectHost}
-                      handleQuickScanWithValidation={handleQuickScanWithValidation}
-                      handleEditHost={handleEditHost}
-                      handleDeleteHost={handleDeleteHost}
-                      checkHostStatus={checkHostStatus}
-                      setQuickScanDialog={setQuickScanDialog}
-                    />
-                  </Grid>
-                ))}
-            </Grid>
-          )}
-        </Box>
+        <HostGrid
+          processedHosts={processedHosts}
+          groupBy={groupBy}
+          viewMode={viewMode}
+          expandedGroups={expandedGroups}
+          setExpandedGroups={setExpandedGroups}
+          selectedHosts={selectedHosts}
+          navigate={navigate}
+          handleSelectHost={handleSelectHost}
+          handleQuickScanWithValidation={handleQuickScanWithValidation}
+          handleEditHost={handleEditHost}
+          handleDeleteHost={handleDeleteHost}
+          checkHostStatus={checkHostStatus}
+          setQuickScanDialog={setQuickScanDialog}
+        />
       )}
 
       {/* Dialogs */}
@@ -370,31 +226,20 @@ const Hosts: React.FC = () => {
         }}
       />
 
-      <Dialog
-        open={deleteDialog.open}
-        onClose={() => setDeleteDialog({ open: false, host: null })}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Delete Host</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to delete <strong>{deleteDialog.host?.displayName}</strong>? This
-            action cannot be undone.
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button
-            onClick={() => setDeleteDialog({ open: false, host: null })}
-            disabled={deletingHost}
-          >
-            Cancel
-          </Button>
-          <Button onClick={confirmDelete} color="error" variant="contained" disabled={deletingHost}>
-            {deletingHost ? 'Deleting...' : 'Delete'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+      <HostConfirmDialogs
+        deleteDialog={deleteDialog}
+        setDeleteDialog={setDeleteDialog}
+        deletingHost={deletingHost}
+        confirmDelete={confirmDelete}
+        bulkActionDialog={bulkActionDialog}
+        setBulkActionDialog={setBulkActionDialog}
+        selectedBulkAction={selectedBulkAction}
+        selectedHostCount={selectedHosts.length}
+        executeBulkAction={executeBulkAction}
+        quickScanDialog={quickScanDialog}
+        setQuickScanDialog={setQuickScanDialog}
+        handleQuickScanWithValidation={handleQuickScanWithValidation}
+      />
 
       <EditHostDialog
         open={editDialog.open}
@@ -412,52 +257,6 @@ const Hosts: React.FC = () => {
         onAuthMethodChange={handleAuthMethodChange}
         onValidateSshKey={validateSshKeyForEdit}
       />
-
-      <Dialog
-        open={bulkActionDialog}
-        onClose={() => setBulkActionDialog(false)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Confirm Bulk Action</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Are you sure you want to perform <strong>{selectedBulkAction}</strong> on{' '}
-            {selectedHosts.length} selected hosts?
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setBulkActionDialog(false)}>Cancel</Button>
-          <Button onClick={executeBulkAction} variant="contained">
-            Confirm
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      <Dialog
-        open={quickScanDialog.open}
-        onClose={() => setQuickScanDialog({ open: false, host: null })}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Quick Scan</DialogTitle>
-        <DialogContent>
-          <Typography>
-            Start a compliance scan for <strong>{quickScanDialog.host?.displayName}</strong>?
-          </Typography>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setQuickScanDialog({ open: false, host: null })}>Cancel</Button>
-          <Button
-            variant="contained"
-            onClick={() =>
-              quickScanDialog.host && handleQuickScanWithValidation(quickScanDialog.host)
-            }
-          >
-            Start Scan
-          </Button>
-        </DialogActions>
-      </Dialog>
 
       {/* Filter Menu */}
       <Menu

--- a/frontend/src/pages/hosts/components/HostConfirmDialogs.tsx
+++ b/frontend/src/pages/hosts/components/HostConfirmDialogs.tsx
@@ -1,0 +1,126 @@
+/**
+ * Confirmation dialogs for host management actions.
+ *
+ * Contains Delete, Bulk Action, and Quick Scan confirmation dialogs.
+ */
+
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+} from '@mui/material';
+import type { Host } from '../../../types/host';
+
+interface HostConfirmDialogsProps {
+  deleteDialog: { open: boolean; host: Host | null };
+  setDeleteDialog: (val: { open: boolean; host: Host | null }) => void;
+  deletingHost: boolean;
+  confirmDelete: () => void;
+
+  bulkActionDialog: boolean;
+  setBulkActionDialog: (open: boolean) => void;
+  selectedBulkAction: string;
+  selectedHostCount: number;
+  executeBulkAction: () => void;
+
+  quickScanDialog: { open: boolean; host: Host | null };
+  setQuickScanDialog: (val: { open: boolean; host: Host | null }) => void;
+  handleQuickScanWithValidation: (host: Host) => Promise<void>;
+}
+
+const HostConfirmDialogs: React.FC<HostConfirmDialogsProps> = ({
+  deleteDialog,
+  setDeleteDialog,
+  deletingHost,
+  confirmDelete,
+  bulkActionDialog,
+  setBulkActionDialog,
+  selectedBulkAction,
+  selectedHostCount,
+  executeBulkAction,
+  quickScanDialog,
+  setQuickScanDialog,
+  handleQuickScanWithValidation,
+}) => {
+  return (
+    <>
+      <Dialog
+        open={deleteDialog.open}
+        onClose={() => setDeleteDialog({ open: false, host: null })}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Delete Host</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete <strong>{deleteDialog.host?.displayName}</strong>? This
+            action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeleteDialog({ open: false, host: null })}
+            disabled={deletingHost}
+          >
+            Cancel
+          </Button>
+          <Button onClick={confirmDelete} color="error" variant="contained" disabled={deletingHost}>
+            {deletingHost ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={bulkActionDialog}
+        onClose={() => setBulkActionDialog(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Confirm Bulk Action</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to perform <strong>{selectedBulkAction}</strong> on{' '}
+            {selectedHostCount} selected hosts?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setBulkActionDialog(false)}>Cancel</Button>
+          <Button onClick={executeBulkAction} variant="contained">
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={quickScanDialog.open}
+        onClose={() => setQuickScanDialog({ open: false, host: null })}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Quick Scan</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Start a compliance scan for <strong>{quickScanDialog.host?.displayName}</strong>?
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setQuickScanDialog({ open: false, host: null })}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={() =>
+              quickScanDialog.host && handleQuickScanWithValidation(quickScanDialog.host)
+            }
+          >
+            Start Scan
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default HostConfirmDialogs;

--- a/frontend/src/pages/hosts/components/HostGrid.tsx
+++ b/frontend/src/pages/hosts/components/HostGrid.tsx
@@ -1,0 +1,110 @@
+/**
+ * Host grid/list/compact view with optional grouping.
+ *
+ * Renders hosts as HostCards in the selected view mode (grid, list, compact).
+ * When groupBy is active, hosts are shown under collapsible group headers.
+ */
+
+import React from 'react';
+import { Box, Collapse, IconButton, Typography } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import { ExpandMore, ChevronRight } from '@mui/icons-material';
+import type { Host } from '../../../types/host';
+import type { ViewMode } from '../../../components/design-system';
+import HostCard from './HostCard';
+
+interface HostGridProps {
+  processedHosts: Record<string, Host[]>;
+  groupBy: string;
+  viewMode: ViewMode;
+  expandedGroups: string[];
+  setExpandedGroups: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedHosts: string[];
+  navigate: (path: string) => void;
+  handleSelectHost: (id: string) => void;
+  handleQuickScanWithValidation: (host: Host) => Promise<void>;
+  handleEditHost: (host: Host) => void;
+  handleDeleteHost: (host: Host) => void;
+  checkHostStatus: (hostId: string) => Promise<void>;
+  setQuickScanDialog: (val: { open: boolean; host: Host | null }) => void;
+}
+
+function getGridSize(viewMode: ViewMode) {
+  if (viewMode === 'list') return { xs: 12 as const };
+  if (viewMode === 'compact') return { xs: 6 as const, sm: 4 as const, md: 2 as const };
+  return { xs: 12 as const, sm: 6 as const, md: 3 as const };
+}
+
+const HostGrid: React.FC<HostGridProps> = ({
+  processedHosts,
+  groupBy,
+  viewMode,
+  expandedGroups,
+  setExpandedGroups,
+  selectedHosts,
+  navigate,
+  handleSelectHost,
+  handleQuickScanWithValidation,
+  handleEditHost,
+  handleDeleteHost,
+  checkHostStatus,
+  setQuickScanDialog,
+}) => {
+  const gridSize = getGridSize(viewMode);
+
+  const toggleGroup = (groupName: string) => {
+    setExpandedGroups((prev) =>
+      prev.includes(groupName) ? prev.filter((g) => g !== groupName) : [...prev, groupName]
+    );
+  };
+
+  const renderHostCard = (host: Host) => (
+    <Grid size={gridSize} key={host.id}>
+      <HostCard
+        host={host}
+        viewMode={viewMode}
+        selectedHosts={selectedHosts}
+        navigate={navigate}
+        handleSelectHost={handleSelectHost}
+        handleQuickScanWithValidation={handleQuickScanWithValidation}
+        handleEditHost={handleEditHost}
+        handleDeleteHost={handleDeleteHost}
+        checkHostStatus={checkHostStatus}
+        setQuickScanDialog={setQuickScanDialog}
+      />
+    </Grid>
+  );
+
+  if (groupBy !== 'none' && Object.keys(processedHosts).length > 0) {
+    return (
+      <Box>
+        {Object.entries(processedHosts).map(([groupName, groupHosts]) => (
+          <Box key={groupName} sx={{ mb: 4 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+              <Typography variant="h6" sx={{ flexGrow: 1 }}>
+                {groupName} ({groupHosts.length})
+              </Typography>
+              <IconButton size="small" onClick={() => toggleGroup(groupName)}>
+                {expandedGroups.includes(groupName) ? <ExpandMore /> : <ChevronRight />}
+              </IconButton>
+            </Box>
+
+            <Collapse in={expandedGroups.includes(groupName)}>
+              <Grid container spacing={viewMode === 'compact' ? 2 : 3}>
+                {groupHosts.map(renderHostCard)}
+              </Grid>
+            </Collapse>
+          </Box>
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <Grid container spacing={viewMode === 'compact' ? 2 : 3}>
+      {Object.values(processedHosts).flat().map(renderHostCard)}
+    </Grid>
+  );
+};
+
+export default HostGrid;

--- a/frontend/src/pages/hosts/components/HostStatCards.tsx
+++ b/frontend/src/pages/hosts/components/HostStatCards.tsx
@@ -1,0 +1,92 @@
+/**
+ * Host Management statistics cards.
+ *
+ * Displays online/total hosts, average compliance, critical issues,
+ * hosts needing scanning, and a quick-add action card.
+ */
+
+import React from 'react';
+import { Box } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import { Add, Computer, Error as ErrorIcon, Scanner, Security } from '@mui/icons-material';
+import { StatCard } from '../../../components/design-system';
+
+interface HostStats {
+  total: number;
+  online: number;
+  avgCompliance: number;
+  criticalHosts: number;
+  needsScanning: number;
+}
+
+interface HostStatCardsProps {
+  stats: HostStats;
+  autoRefreshEnabled: boolean;
+  onAddHost: () => void;
+}
+
+const HostStatCards: React.FC<HostStatCardsProps> = ({ stats, autoRefreshEnabled, onAddHost }) => {
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+          <StatCard
+            title={autoRefreshEnabled ? 'Hosts Online (Auto)' : 'Hosts Online'}
+            value={`${stats.online}/${stats.total}`}
+            color="primary"
+            icon={<Computer />}
+            trend={stats.online === stats.total ? 'up' : 'flat'}
+            trendValue={`${Math.round((stats.online / stats.total) * 100)}%`}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+          <StatCard
+            title="Avg Compliance"
+            value={`${stats.avgCompliance}%`}
+            color={
+              stats.avgCompliance >= 90
+                ? 'success'
+                : stats.avgCompliance >= 75
+                  ? 'warning'
+                  : 'error'
+            }
+            icon={<Security />}
+            trend={stats.avgCompliance >= 85 ? 'up' : 'flat'}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+          <StatCard
+            title="Critical Issues"
+            value={stats.criticalHosts}
+            color="error"
+            icon={<ErrorIcon />}
+            trend={stats.criticalHosts === 0 ? 'up' : 'down'}
+            subtitle={stats.criticalHosts === 0 ? 'All clear' : 'Needs attention'}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+          <StatCard
+            title="Need Scanning"
+            value={stats.needsScanning}
+            color="warning"
+            icon={<Scanner />}
+            trend={stats.needsScanning === 0 ? 'up' : 'down'}
+            subtitle={stats.needsScanning === 0 ? 'Up to date' : 'Behind schedule'}
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 2.4 }}>
+          <StatCard
+            title="Quick Actions"
+            value="Add Host"
+            color="primary"
+            icon={<Add />}
+            onClick={onAddHost}
+            subtitle="Register new system"
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default HostStatCards;

--- a/frontend/src/pages/scans/ScanDetail.tsx
+++ b/frontend/src/pages/scans/ScanDetail.tsx
@@ -26,28 +26,20 @@ import {
   Tab,
   Alert,
   CircularProgress,
-  Tooltip,
   Divider,
-  List,
-  ListItem,
   ListItemIcon,
   ListItemText,
   Menu,
   MenuItem,
   Snackbar,
-  Stack,
 } from '@mui/material';
-import Grid from '@mui/material/Grid';
 import {
   ArrowBack as ArrowBackIcon,
-  CheckCircle as CheckCircleIcon,
   GetApp as DownloadIcon,
-  Build as BuildIcon,
   MoreVert as MoreVertIcon,
   Refresh as RefreshIcon,
   PlayArrow as PlayArrowIcon,
   Print as PrintIcon,
-  FilterList as FilterIcon,
 } from '@mui/icons-material';
 import RemediationPanel from '../../components/remediation/RemediationPanel';
 
@@ -57,6 +49,8 @@ import { generateRemediationSteps } from './components/scanUtils';
 import ScanMetricsCards from './components/ScanMetricsCards';
 import ScanOverviewTab from './components/ScanOverviewTab';
 import ScanRulesTable from './components/ScanRulesTable';
+import ScanQuickActionBar from './components/ScanQuickActionBar';
+import ScanInformationTab from './components/ScanInformationTab';
 import { ScanRemediationDialog, ScanExportRuleDialog } from './components/ScanDialogs';
 
 // ---------------------------------------------------------------------------
@@ -219,76 +213,13 @@ const ScanDetail: React.FC = () => {
 
       {/* Quick Action Bar */}
       {scan.status === 'completed' && scan.results && (
-        <Paper
-          sx={{
-            p: 2,
-            mb: 3,
-            borderRadius: 2,
-            boxShadow: 2,
-            bgcolor: scan.results.failed_rules > 0 ? 'error.50' : 'success.50',
-          }}
-        >
-          <Stack direction="row" spacing={2} justifyContent="space-between" alignItems="center">
-            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-              {scan.results.failed_rules > 0 ? (
-                <>
-                  <Button
-                    variant="contained"
-                    color="error"
-                    size="large"
-                    startIcon={<BuildIcon />}
-                    onClick={() => setTabValue(3)}
-                  >
-                    Remediate {scan.results.failed_rules} Failed Rules
-                  </Button>
-                  <Button
-                    variant="outlined"
-                    color="error"
-                    startIcon={<FilterIcon />}
-                    onClick={() => setTabValue(1)}
-                  >
-                    View Failures
-                  </Button>
-                </>
-              ) : (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                  <CheckCircleIcon color="success" sx={{ fontSize: 40 }} />
-                  <Box>
-                    <Typography variant="h6" color="success.main" fontWeight="bold">
-                      All Checks Passed!
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      System is compliant with the selected profile
-                    </Typography>
-                  </Box>
-                </Box>
-              )}
-            </Box>
-
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Tooltip title="Export report">
-                <Button
-                  variant="outlined"
-                  startIcon={<DownloadIcon />}
-                  onClick={handleMenuOpen}
-                  size="medium"
-                >
-                  Export
-                </Button>
-              </Tooltip>
-              <Tooltip title="Run new scan with same configuration">
-                <Button
-                  variant="outlined"
-                  startIcon={<RefreshIcon />}
-                  onClick={handleRescan}
-                  size="medium"
-                >
-                  Rescan
-                </Button>
-              </Tooltip>
-            </Box>
-          </Stack>
-        </Paper>
+        <ScanQuickActionBar
+          failedRules={scan.results.failed_rules}
+          onViewFailures={() => setTabValue(1)}
+          onRemediate={() => setTabValue(3)}
+          onExport={handleMenuOpen}
+          onRescan={handleRescan}
+        />
       )}
 
       {/* Metrics Cards */}
@@ -383,92 +314,7 @@ const ScanDetail: React.FC = () => {
 
         {/* Tab 4: Scan Information */}
         <TabPanel value={tabValue} index={4}>
-          <Grid container spacing={3}>
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Typography variant="h6" gutterBottom>
-                Scan Configuration
-              </Typography>
-              <List>
-                <ListItem>
-                  <ListItemText primary="Scan Name" secondary={scan.name} />
-                </ListItem>
-                <ListItem>
-                  <ListItemText primary="Scan ID" secondary={scan.id} />
-                </ListItem>
-                <ListItem>
-                  <ListItemText primary="Profile ID" secondary={scan.profile_id} />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Started At"
-                    secondary={new Date(scan.started_at).toLocaleString()}
-                  />
-                </ListItem>
-                {scan.completed_at && (
-                  <ListItem>
-                    <ListItemText
-                      primary="Completed At"
-                      secondary={new Date(scan.completed_at).toLocaleString()}
-                    />
-                  </ListItem>
-                )}
-                <ListItem>
-                  <ListItemText
-                    primary="Duration"
-                    secondary={
-                      scan.completed_at
-                        ? `${Math.round((new Date(scan.completed_at).getTime() - new Date(scan.started_at).getTime()) / 1000)} seconds`
-                        : 'In progress...'
-                    }
-                  />
-                </ListItem>
-              </List>
-            </Grid>
-
-            <Grid size={{ xs: 12, md: 6 }}>
-              <Typography variant="h6" gutterBottom>
-                Technical Details
-              </Typography>
-              <List>
-                <ListItem>
-                  <ListItemText
-                    primary="Result File"
-                    secondary={scan.result_file || 'Not available'}
-                  />
-                </ListItem>
-                <ListItem>
-                  <ListItemText
-                    primary="Report File"
-                    secondary={scan.report_file || 'Not available'}
-                  />
-                </ListItem>
-                {scan.error_message && (
-                  <ListItem>
-                    <ListItemText
-                      primary="Error Message"
-                      secondary={scan.error_message}
-                      secondaryTypographyProps={{ color: 'error' }}
-                    />
-                  </ListItem>
-                )}
-              </List>
-
-              {scan.scan_options &&
-              typeof scan.scan_options === 'object' &&
-              Object.keys(scan.scan_options as Record<string, unknown>).length > 0 ? (
-                <>
-                  <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
-                    Scan Options
-                  </Typography>
-                  <Paper variant="outlined" sx={{ p: 2 }}>
-                    <pre style={{ margin: 0, overflow: 'auto' }}>
-                      {JSON.stringify(scan.scan_options, null, 2)}
-                    </pre>
-                  </Paper>
-                </>
-              ) : null}
-            </Grid>
-          </Grid>
+          <ScanInformationTab scan={scan} />
         </TabPanel>
       </Paper>
 

--- a/frontend/src/pages/scans/components/ScanInformationTab.tsx
+++ b/frontend/src/pages/scans/components/ScanInformationTab.tsx
@@ -1,0 +1,102 @@
+/**
+ * Scan Information tab content.
+ *
+ * Displays scan configuration details, technical details,
+ * and scan options in a two-column layout.
+ */
+
+import React from 'react';
+import { List, ListItem, ListItemText, Paper, Typography } from '@mui/material';
+import Grid from '@mui/material/Grid';
+import type { ScanDetails } from './scanTypes';
+
+interface ScanInformationTabProps {
+  scan: ScanDetails;
+}
+
+const ScanInformationTab: React.FC<ScanInformationTabProps> = ({ scan }) => {
+  return (
+    <Grid container spacing={3}>
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Typography variant="h6" gutterBottom>
+          Scan Configuration
+        </Typography>
+        <List>
+          <ListItem>
+            <ListItemText primary="Scan Name" secondary={scan.name} />
+          </ListItem>
+          <ListItem>
+            <ListItemText primary="Scan ID" secondary={scan.id} />
+          </ListItem>
+          <ListItem>
+            <ListItemText primary="Profile ID" secondary={scan.profile_id} />
+          </ListItem>
+          <ListItem>
+            <ListItemText
+              primary="Started At"
+              secondary={new Date(scan.started_at).toLocaleString()}
+            />
+          </ListItem>
+          {scan.completed_at && (
+            <ListItem>
+              <ListItemText
+                primary="Completed At"
+                secondary={new Date(scan.completed_at).toLocaleString()}
+              />
+            </ListItem>
+          )}
+          <ListItem>
+            <ListItemText
+              primary="Duration"
+              secondary={
+                scan.completed_at
+                  ? `${Math.round((new Date(scan.completed_at).getTime() - new Date(scan.started_at).getTime()) / 1000)} seconds`
+                  : 'In progress...'
+              }
+            />
+          </ListItem>
+        </List>
+      </Grid>
+
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Typography variant="h6" gutterBottom>
+          Technical Details
+        </Typography>
+        <List>
+          <ListItem>
+            <ListItemText primary="Result File" secondary={scan.result_file || 'Not available'} />
+          </ListItem>
+          <ListItem>
+            <ListItemText primary="Report File" secondary={scan.report_file || 'Not available'} />
+          </ListItem>
+          {scan.error_message && (
+            <ListItem>
+              <ListItemText
+                primary="Error Message"
+                secondary={scan.error_message}
+                secondaryTypographyProps={{ color: 'error' }}
+              />
+            </ListItem>
+          )}
+        </List>
+
+        {scan.scan_options &&
+        typeof scan.scan_options === 'object' &&
+        Object.keys(scan.scan_options as Record<string, unknown>).length > 0 ? (
+          <>
+            <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+              Scan Options
+            </Typography>
+            <Paper variant="outlined" sx={{ p: 2 }}>
+              <pre style={{ margin: 0, overflow: 'auto' }}>
+                {JSON.stringify(scan.scan_options, null, 2)}
+              </pre>
+            </Paper>
+          </>
+        ) : null}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ScanInformationTab;

--- a/frontend/src/pages/scans/components/ScanQuickActionBar.tsx
+++ b/frontend/src/pages/scans/components/ScanQuickActionBar.tsx
@@ -1,0 +1,102 @@
+/**
+ * Quick Action Bar for completed scans.
+ *
+ * Shows remediation/failure shortcuts when rules fail,
+ * or an "All Checks Passed" banner when compliant.
+ */
+
+import React from 'react';
+import { Box, Button, Paper, Stack, Tooltip, Typography } from '@mui/material';
+import {
+  CheckCircle as CheckCircleIcon,
+  GetApp as DownloadIcon,
+  Build as BuildIcon,
+  Refresh as RefreshIcon,
+  FilterList as FilterIcon,
+} from '@mui/icons-material';
+
+interface ScanQuickActionBarProps {
+  failedRules: number;
+  onViewFailures: () => void;
+  onRemediate: () => void;
+  onExport: (event: React.MouseEvent<HTMLElement>) => void;
+  onRescan: () => void;
+}
+
+const ScanQuickActionBar: React.FC<ScanQuickActionBarProps> = ({
+  failedRules,
+  onViewFailures,
+  onRemediate,
+  onExport,
+  onRescan,
+}) => {
+  return (
+    <Paper
+      sx={{
+        p: 2,
+        mb: 3,
+        borderRadius: 2,
+        boxShadow: 2,
+        bgcolor: failedRules > 0 ? 'error.50' : 'success.50',
+      }}
+    >
+      <Stack direction="row" spacing={2} justifyContent="space-between" alignItems="center">
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          {failedRules > 0 ? (
+            <>
+              <Button
+                variant="contained"
+                color="error"
+                size="large"
+                startIcon={<BuildIcon />}
+                onClick={onRemediate}
+              >
+                Remediate {failedRules} Failed Rules
+              </Button>
+              <Button
+                variant="outlined"
+                color="error"
+                startIcon={<FilterIcon />}
+                onClick={onViewFailures}
+              >
+                View Failures
+              </Button>
+            </>
+          ) : (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <CheckCircleIcon color="success" sx={{ fontSize: 40 }} />
+              <Box>
+                <Typography variant="h6" color="success.main" fontWeight="bold">
+                  All Checks Passed!
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  System is compliant with the selected profile
+                </Typography>
+              </Box>
+            </Box>
+          )}
+        </Box>
+
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Tooltip title="Export report">
+            <Button
+              variant="outlined"
+              startIcon={<DownloadIcon />}
+              onClick={onExport}
+              size="medium"
+            >
+              Export
+            </Button>
+          </Tooltip>
+          <Tooltip title="Run new scan with same configuration">
+            <Button variant="outlined" startIcon={<RefreshIcon />} onClick={onRescan} size="medium">
+              Rescan
+            </Button>
+          </Tooltip>
+        </Box>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default ScanQuickActionBar;


### PR DESCRIPTION
## Summary

- Extract 5 focused sub-components from two oversized page components to meet the <400 LOC target (E4/Phase 8F)
- **ScanDetail.tsx**: 536 → 382 LOC — extracted `ScanQuickActionBar` and `ScanInformationTab`
- **Hosts.tsx**: 559 → 365 LOC — extracted `HostStatCards`, `HostGrid`, and `HostConfirmDialogs`
- `AddHost.tsx` already at 97 LOC (completed in PR #343)

## Component Size Results

| Component | Before | After | Target |
|-----------|--------|-------|--------|
| ScanDetail.tsx | 536 | 382 | < 400 |
| Hosts.tsx | 559 | 365 | < 400 |
| AddHost.tsx | 97 | 97 | < 400 |

## Test plan

- [x] All 277 frontend tests pass
- [x] TypeScript type check clean (`tsc --noEmit`)
- [x] ESLint clean
- [x] Prettier formatted
- [x] No behavior changes — pure refactor extracting inline JSX to sub-components