### PR TITLE
feat(frontend): persist host view preferences to localStorage

### DIFF
--- a/frontend/src/pages/hosts/hooks/useHostsPage.ts
+++ b/frontend/src/pages/hosts/hooks/useHostsPage.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTheme, type Theme } from '@mui/material';
 import { api } from '../../../services/api';
 import { adaptHosts, toUpdateHostRequest, type ApiHostResponse } from '../../../services/adapters';
+import { storageGet, storageSet, StorageKeys } from '../../../services/storage';
 import type { Host } from '../../../types/host';
 import { REFRESH_INTERVALS } from '../../../constants/refresh';
 import { validateSshKey } from '../../../utils/hostValidation';
@@ -167,9 +168,19 @@ export function useHostsPage(): UseHostsPageReturn {
   const [loading, setLoading] = useState(false);
   const [selectedHosts, setSelectedHosts] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    () => (storageGet(StorageKeys.HOSTS_VIEW_MODE) as ViewMode) || 'grid'
+  );
   const [filterMenuAnchor, setFilterMenuAnchor] = useState<null | HTMLElement>(null);
-  const [groupBy, setGroupBy] = useState<'all' | 'none' | 'group' | 'status' | 'compliance'>('all');
+  const [groupBy, setGroupBy] = useState<'all' | 'none' | 'group' | 'status' | 'compliance'>(
+    () =>
+      (storageGet(StorageKeys.HOSTS_GROUP_BY) as
+        | 'all'
+        | 'none'
+        | 'group'
+        | 'status'
+        | 'compliance') || 'all'
+  );
   const [bulkActionDialog, setBulkActionDialog] = useState(false);
   const [selectedBulkAction, setSelectedBulkAction] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<string[]>([]);
@@ -214,6 +225,15 @@ export function useHostsPage(): UseHostsPageReturn {
   const [editingAuthMethod, setEditingAuthMethod] = useState(false);
   const [deletingHost, setDeletingHost] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+
+  // Persist view preferences to localStorage
+  useEffect(() => {
+    storageSet(StorageKeys.HOSTS_VIEW_MODE, viewMode);
+  }, [viewMode]);
+
+  useEffect(() => {
+    storageSet(StorageKeys.HOSTS_GROUP_BY, groupBy);
+  }, [groupBy]);
 
   // Filter states - reserved for future advanced filtering features
   const [statusFilter] = useState<string[]>([]);

--- a/frontend/src/services/storage.ts
+++ b/frontend/src/services/storage.ts
@@ -17,6 +17,8 @@ export const StorageKeys = {
   THEME_MODE: 'themeMode',
   COMPLIANCE_RULES_VIEW_MODE: 'complianceRulesViewMode',
   SESSION_INACTIVITY_TIMEOUT: 'session_inactivity_timeout_minutes',
+  HOSTS_VIEW_MODE: 'hosts_view_mode',
+  HOSTS_GROUP_BY: 'hosts_group_by',
 } as const;
 
 export type StorageKey = (typeof StorageKeys)[keyof typeof StorageKeys];

--- a/specs/frontend/state-management.spec.yaml
+++ b/specs/frontend/state-management.spec.yaml
@@ -147,6 +147,15 @@ acceptance_criteria:
       MUST be replaced in both the store state and localStorage atomically
       within the same action.
 
+  - id: AC-11
+    description: >
+      Host list view preferences MUST be persisted to localStorage.
+      StorageKeys MUST include HOSTS_VIEW_MODE and HOSTS_GROUP_BY.
+      useHostsPage MUST initialize viewMode from storageGet(HOSTS_VIEW_MODE)
+      (default 'grid') and groupBy from storageGet(HOSTS_GROUP_BY) (default
+      'all'). Changes to viewMode or groupBy MUST be persisted via
+      storageSet so the user's preference is restored on next visit.
+
 ---
 
 # Changelog

--- a/tests/frontend/store/state-management.spec.test.ts
+++ b/tests/frontend/store/state-management.spec.test.ts
@@ -28,6 +28,8 @@ vi.mock('../../../frontend/src/services/storage', () => ({
     THEME_MODE: 'themeMode',
     COMPLIANCE_RULES_VIEW_MODE: 'complianceRulesViewMode',
     SESSION_INACTIVITY_TIMEOUT: 'session_inactivity_timeout_minutes',
+    HOSTS_VIEW_MODE: 'hosts_view_mode',
+    HOSTS_GROUP_BY: 'hosts_group_by',
   },
 }));
 
@@ -419,5 +421,48 @@ describe('AC-10: refreshTokenSuccess updates store and localStorage', () => {
     resetAuthStore({ error: 'previous error' });
     act(() => useAuthStore.getState().refreshTokenSuccess({ token: 'new-tok', expiresIn: 3600 }));
     expect(useAuthStore.getState().error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-11: Host view preferences persisted to localStorage
+// ---------------------------------------------------------------------------
+
+describe('AC-11: Host view preferences persisted to localStorage', () => {
+  /**
+   * AC-11: StorageKeys MUST include HOSTS_VIEW_MODE and HOSTS_GROUP_BY.
+   * useHostsPage MUST initialize viewMode from storageGet(HOSTS_VIEW_MODE)
+   * (default 'grid') and groupBy from storageGet(HOSTS_GROUP_BY) (default
+   * 'all'). Changes MUST be persisted via storageSet.
+   */
+
+  it('StorageKeys includes HOSTS_VIEW_MODE', () => {
+    const storageSource = readSource('services/storage.ts');
+    expect(storageSource).toContain('HOSTS_VIEW_MODE');
+  });
+
+  it('StorageKeys includes HOSTS_GROUP_BY', () => {
+    const storageSource = readSource('services/storage.ts');
+    expect(storageSource).toContain('HOSTS_GROUP_BY');
+  });
+
+  it('useHostsPage reads viewMode from localStorage via storageGet(HOSTS_VIEW_MODE)', () => {
+    const hookSource = readSource('pages/hosts/hooks/useHostsPage.ts');
+    expect(hookSource).toContain('storageGet(StorageKeys.HOSTS_VIEW_MODE)');
+  });
+
+  it('useHostsPage reads groupBy from localStorage via storageGet(HOSTS_GROUP_BY)', () => {
+    const hookSource = readSource('pages/hosts/hooks/useHostsPage.ts');
+    expect(hookSource).toContain('storageGet(StorageKeys.HOSTS_GROUP_BY)');
+  });
+
+  it('useHostsPage persists viewMode changes via storageSet(HOSTS_VIEW_MODE)', () => {
+    const hookSource = readSource('pages/hosts/hooks/useHostsPage.ts');
+    expect(hookSource).toContain('storageSet(StorageKeys.HOSTS_VIEW_MODE');
+  });
+
+  it('useHostsPage persists groupBy changes via storageSet(HOSTS_GROUP_BY)', () => {
+    const hookSource = readSource('pages/hosts/hooks/useHostsPage.ts');
+    expect(hookSource).toContain('storageSet(StorageKeys.HOSTS_GROUP_BY');
   });
 });


### PR DESCRIPTION
## Summary
- Add `HOSTS_VIEW_MODE` and `HOSTS_GROUP_BY` to `StorageKeys` in `storage.ts`
- `useHostsPage` hook now initializes `viewMode` and `groupBy` from localStorage (defaults: `'grid'` and `'all'`)
- Changes to either preference are persisted via `useEffect` so the user's selection is restored on next visit
- Add AC-11 to `state-management.spec.yaml` (v2.0) covering the persistence contract
- Add 6 source-inspection tests for AC-11 in `state-management.spec.test.ts`

## Changed files
- `frontend/src/services/storage.ts` — 2 new StorageKeys
- `frontend/src/pages/hosts/hooks/useHostsPage.ts` — lazy init + persistence effects
- `specs/frontend/state-management.spec.yaml` — AC-11 added
- `tests/frontend/store/state-management.spec.test.ts` — 6 new tests (57 total, all passing)

## Test plan
- [x] All 57 state-management spec tests pass (`npx vitest run`)
- [x] Pre-commit hooks pass (ESLint, Prettier, commitlint, detect-secrets)
- [ ] CI passes (Backend CI, Frontend CI, E2E Tests)