### PR TITLE
fix(settings): resolve SSH policy, session timeout, and known hosts bugs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -249,7 +249,7 @@
         "filename": "frontend/src/pages/settings/Settings.tsx",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 1194
+        "line_number": 1169
       }
     ],
     "packaging/bundle/create-prebuilt-images.sh": [
@@ -389,5 +389,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T03:52:53Z"
+  "generated_at": "2026-03-07T23:56:18Z"
 }

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -146,8 +146,70 @@ Gaps identified by comparing `docs/KENSA_DEVELOPER_GUIDE_V0.md` against current 
 | Item | Priority | Status | Notes |
 |------|----------|--------|-------|
 | Host monitoring state transition: `'offline' is not a valid MonitoringState` | P1 | **Spec required first** | After adding host 192.168.1.212, connectivity check succeeds (ping=True, ssh=True, status=online) but state transition from `offline` fails. Host ends up in `unknown` state instead of `online`. `MonitoringState` enum missing `offline` value. Classified Tier 1 (monitoring is scan-eligibility and compliance-critical — an offline/down host is non-compliant; unknown state is a blind spot). **Next step**: write `specs/services/monitoring/host-monitoring.spec.yaml`, then tests, then fix. See `services/monitoring/state.py`. |
+| SSH Host Key Policy GET returns hardcoded value | P1 | **Fixed** | `routes/ssh/settings.py:63` was returning `"default_policy"` instead of calling `service.get_ssh_policy()`. Frontend Select had no matching MenuItem so it displayed blank. Fix: call `SSHConfigManager.get_ssh_policy()`. Also added `renderValue` prop to frontend Select for readable labels. **Needs spec + test.** |
+| Session Timeout PUT fails with 500 (SQL syntax error) | P1 | **Fixed** | `routes/system/settings.py:1125-1138` had Python `# noqa: E501` comments inside raw SQL string. `#` is not valid SQL, causing PostgreSQL syntax error. Fix: removed inline comments and reformatted SQL. Also note: this upsert uses raw `text()` instead of `InsertBuilder` — should be migrated to mutation builders for consistency. **Needs spec + test.** |
+| Known SSH Hosts: `get_known_hosts` missing from SSHConfigManager | P2 | Open | `routes/ssh/settings.py:172` calls `service.get_known_hosts(hostname)` but `SSHConfigManager` has no such method. SSH Configuration tab shows "Failed to load known hosts". Missing feature, not a regression. |
 | Host creation missing NOT NULL monitoring columns | P1 | Fixed | `InsertBuilder` in `routes/hosts/crud.py` was missing `check_priority` and 6 consecutive failure/success counter columns. Python-level `default=` not applied by raw SQL. Fixed by adding columns with defaults to INSERT. |
 | Alert generator: `passed` column does not exist in `scan_findings` | P1 | Fixed | `alert_generator.py` `_check_configuration_drift()` queried `passed` column and `host_id` directly on `scan_findings`. Actual schema uses `status` ('pass'/'fail') and requires JOIN through `scans` for `host_id`. |
+
+---
+
+## Spec/Test Notes: Settings Page Fixes (2026-03-07)
+
+### Needed: API spec for SSH Settings routes
+
+No spec exists for `routes/ssh/settings.py`. The ssh-connection spec covers `SSHConfigManager` internals (AC-7: default policy, AC-8: valid policies) but NOT the API route behavior.
+
+**Proposed spec**: `specs/api/ssh/ssh-settings.spec.yaml`
+
+Acceptance criteria to cover:
+1. `GET /api/ssh/settings/policy` reads policy from DB via `SSHConfigManager.get_ssh_policy()`, not hardcoded
+2. `GET /api/ssh/settings/policy` returns `SSHPolicyResponse` with `policy`, `trusted_networks`, `description`
+3. `POST /api/ssh/settings/policy` updates policy and returns updated config
+4. `GET /api/ssh/settings/known-hosts` returns list of known hosts (blocked: `get_known_hosts` not implemented)
+5. `POST /api/ssh/settings/known-hosts` adds a known host
+6. `DELETE /api/ssh/settings/known-hosts/{hostname}` removes a known host
+7. `GET /api/ssh/settings/test-connectivity/{host_id}` tests SSH connectivity
+8. All endpoints require `Permission.SYSTEM_CONFIG` (except test-connectivity: `SCAN_EXECUTE`)
+
+**Test file**: `tests/backend/unit/api/test_ssh_settings_api.py`
+
+Regression tests needed:
+- SSH policy GET must call `service.get_ssh_policy()` (source inspection: verify no hardcoded `"default_policy"` string)
+- SSH policy GET returns valid policy values from `SSHConfigManager.VALID_POLICIES`
+
+### Needed: API spec for System Settings routes (session timeout)
+
+No spec exists for `routes/system/settings.py`. Session timeout is one of many endpoints in this large file (~1172 lines).
+
+**Proposed spec**: `specs/api/system/session-timeout.spec.yaml`
+
+Acceptance criteria to cover:
+1. `GET /api/system/settings/session-timeout` returns current timeout from `system_settings` table
+2. `GET /api/system/settings/session-timeout` returns default (15 min) when no DB row exists
+3. `PUT /api/system/settings/session-timeout` validates range (1-480 minutes)
+4. `PUT /api/system/settings/session-timeout` upserts to `system_settings` table
+5. `PUT /api/system/settings/session-timeout` SQL contains no Python comments (regression: `# noqa` inside SQL string)
+6. Both endpoints require `Permission.SYSTEM_MAINTENANCE`
+
+**Test file**: `tests/backend/unit/api/test_system_settings_api.py`
+
+Regression tests needed:
+- Session timeout PUT SQL string must not contain `#` character (source inspection)
+- Session timeout PUT SQL should ideally use `InsertBuilder.on_conflict_do_update()` instead of raw `text()`
+
+### Frontend: SSH Policy Select `renderValue`
+
+The SSH Host Key Policy `<Select>` in `Settings.tsx` now has a `renderValue` prop that maps internal values (`strict`, `auto_add`, etc.) to readable labels. Also added `auto_add_warning` to the label map since `SSHConfigManager.VALID_POLICIES` includes it but the original frontend only had 3 MenuItems (missing `auto_add_warning`).
+
+**Observation**: Frontend only shows 3 policy options in the dropdown but backend supports 4 (`strict`, `auto_add`, `auto_add_warning`, `bypass_trusted`). The `auto_add_warning` option is the default but has no MenuItem — users can never select it via UI if they change away from it.
+
+### Other Settings Page Issues (not yet fixed)
+
+- **Logging Policy Management**: Non-functional placeholder — `loadLoggingPolicies` sets empty array, "Create Policy" button does nothing
+- **Compliance Framework Support**: Shows wrong frameworks (SOC2/HIPAA/PCI-DSS/GDPR) — should be CIS/STIG/NIST/PCI-DSS/FedRAMP
+- **About tab**: Says "OpenSCAP-based compliance scanning" — should reference Kensa
+- **Known SSH Hosts**: `SSHConfigManager.get_known_hosts()` method not implemented
 
 ---
 

--- a/backend/alembic/versions/20260307_0100_042_add_ssh_known_hosts_table.py
+++ b/backend/alembic/versions/20260307_0100_042_add_ssh_known_hosts_table.py
@@ -1,0 +1,44 @@
+"""Add ssh_known_hosts table
+
+Revision ID: 042_ssh_known_hosts
+Revises: 20260224_0300_041_add_manual_remediation_status
+Create Date: 2026-03-07
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "042_ssh_known_hosts"
+down_revision = "20260224_0300_041_add_manual_remediation_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "ssh_known_hosts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("hostname", sa.String(255), nullable=False),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column("key_type", sa.String(20), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("fingerprint", sa.String(100), nullable=False),
+        sa.Column(
+            "first_seen",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("last_verified", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_trusted", sa.Boolean(), server_default=sa.text("TRUE")),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.UniqueConstraint("hostname", "key_type"),
+    )
+    op.create_index("idx_ssh_known_hosts_hostname", "ssh_known_hosts", ["hostname"])
+    op.create_index("idx_ssh_known_hosts_fingerprint", "ssh_known_hosts", ["fingerprint"])
+
+
+def downgrade():
+    op.drop_index("idx_ssh_known_hosts_fingerprint")
+    op.drop_index("idx_ssh_known_hosts_hostname")
+    op.drop_table("ssh_known_hosts")

--- a/backend/app/routes/ssh/settings.py
+++ b/backend/app/routes/ssh/settings.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from ...auth import get_current_user
 from ...database import get_db
 from ...rbac import Permission, require_permission
-from ...services.ssh import SSHConfigManager
+from ...services.ssh import KnownHostsManager, SSHConfigManager
 from .models import KnownHostRequest, KnownHostResponse, SSHPolicyRequest, SSHPolicyResponse
 
 logger = logging.getLogger(__name__)
@@ -60,12 +60,13 @@ async def get_ssh_policy(
     try:
         service = SSHConfigManager(db)
 
-        policy = "default_policy"
+        policy = service.get_ssh_policy()
         trusted_networks = service.get_trusted_networks()
 
         policy_descriptions = {
             "strict": "Reject connections to unknown hosts (most secure)",
             "auto_add": "Automatically accept and save unknown host keys",
+            "auto_add_warning": "Accept unknown hosts but log a security warning (default)",
             "bypass_trusted": "Auto-accept hosts in trusted network ranges",
         }
 
@@ -167,9 +168,9 @@ async def get_known_hosts(
         HTTPException: 500 if retrieval fails
     """
     try:
-        service = SSHConfigManager(db)
+        known_hosts_mgr = KnownHostsManager(db)
 
-        hosts = service.get_known_hosts(hostname)
+        hosts = known_hosts_mgr.get_known_hosts(hostname)
         return [KnownHostResponse(**host) for host in hosts]
 
     except Exception as e:
@@ -205,10 +206,10 @@ async def add_known_host(
         HTTPException: 500 if creation fails
     """
     try:
-        service = SSHConfigManager(db)
+        known_hosts_mgr = KnownHostsManager(db)
 
         # Add known host
-        success = service.add_known_host(
+        success = known_hosts_mgr.add_known_host(
             hostname=host_request.hostname,
             ip_address=host_request.ip_address,
             key_type=host_request.key_type,
@@ -223,7 +224,7 @@ async def add_known_host(
             )
 
         # Return the added host
-        hosts = service.get_known_hosts(host_request.hostname)
+        hosts = known_hosts_mgr.get_known_hosts(host_request.hostname)
         matching_host = next(
             (h for h in hosts if h["hostname"] == host_request.hostname and h["key_type"] == host_request.key_type),
             None,
@@ -274,10 +275,10 @@ async def remove_known_host(
         HTTPException: 500 if removal fails
     """
     try:
-        service = SSHConfigManager(db)
+        known_hosts_mgr = KnownHostsManager(db)
 
         # Pass empty string if key_type is None (removes all key types for hostname)
-        success = service.remove_known_host(hostname, key_type or "")
+        success = known_hosts_mgr.remove_known_host(hostname, key_type or "")
 
         if not success:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Known host not found")

--- a/backend/app/routes/system/settings.py
+++ b/backend/app/routes/system/settings.py
@@ -1125,8 +1125,13 @@ async def update_session_timeout(
         db.execute(
             text(
                 """
-                INSERT INTO system_settings (setting_key, setting_value, setting_type, description, modified_by, modified_at, created_at)  # noqa: E501
-                VALUES ('session_inactivity_timeout_minutes', :value, 'integer', 'Session inactivity timeout in minutes', :modified_by, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)  # noqa: E501
+                INSERT INTO system_settings
+                    (setting_key, setting_value, setting_type, description,
+                     modified_by, modified_at, created_at)
+                VALUES
+                    ('session_inactivity_timeout_minutes', :value, 'integer',
+                     'Session inactivity timeout in minutes',
+                     :modified_by, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                 ON CONFLICT (setting_key)
                 DO UPDATE SET
                     setting_value = :value,

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -36,7 +36,6 @@ import {
   VpnKey as VpnKeyIcon,
   SettingsEthernet as SettingsEthernetIcon,
   Shield as ShieldIcon,
-  Policy as PolicyIcon,
 } from '@mui/icons-material';
 import { api } from '../../services/api';
 import { SSHKeyDisplay } from '../../components/design-system';
@@ -80,14 +79,6 @@ interface KnownHost {
   last_verified?: string;
   is_trusted: boolean;
   notes?: string;
-}
-
-interface LoggingPolicy {
-  id: number;
-  name: string;
-  enabled: boolean;
-  frameworks: string[];
-  created_at: string;
 }
 
 interface TabPanelProps {
@@ -152,8 +143,6 @@ const Settings: React.FC = () => {
   });
 
   // Security settings state
-  const [loggingPolicies, setLoggingPolicies] = useState<LoggingPolicy[]>([]);
-  const [securityLoading, setSecurityLoading] = useState(false);
 
   // Session timeout state
   const [sessionTimeoutMinutes, setSessionTimeoutMinutes] = useState<number>(15);
@@ -275,20 +264,6 @@ const Settings: React.FC = () => {
     }
   };
 
-  // Security functions
-  const loadLoggingPolicies = async () => {
-    try {
-      setSecurityLoading(true);
-      // This is a placeholder - implement when backend API is available
-      setLoggingPolicies([]);
-    } catch (err: unknown) {
-      setError('Failed to load logging policies');
-      console.error('Error loading logging policies:', err);
-    } finally {
-      setSecurityLoading(false);
-    }
-  };
-
   // Session timeout functions
   const loadSessionTimeout = async () => {
     try {
@@ -346,7 +321,6 @@ const Settings: React.FC = () => {
       loadKnownHosts();
     } else if (tabValue === 3) {
       // Security tab
-      loadLoggingPolicies();
       loadSessionTimeout();
     }
     // ESLint disable: load* functions are not memoized to avoid complex dependency chains
@@ -681,6 +655,16 @@ const Settings: React.FC = () => {
                 value={sshPolicy.policy}
                 onChange={(e) => updateSSHPolicy(e.target.value, sshPolicy.trusted_networks)}
                 disabled={sshLoading}
+                label="SSH Host Key Policy"
+                renderValue={(value) => {
+                  const labels: Record<string, string> = {
+                    strict: 'Strict',
+                    auto_add: 'Auto Add',
+                    auto_add_warning: 'Auto Add (with warning)',
+                    bypass_trusted: 'Bypass Trusted',
+                  };
+                  return labels[value as string] || String(value);
+                }}
               >
                 <MenuItem value="strict">
                   <Box>
@@ -702,6 +686,16 @@ const Settings: React.FC = () => {
                     </Typography>
                   </Box>
                 </MenuItem>
+                <MenuItem value="auto_add_warning">
+                  <Box>
+                    <Typography variant="body2" fontWeight="medium">
+                      Auto Add (with warning)
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Accept unknown hosts but log a security warning (default)
+                    </Typography>
+                  </Box>
+                </MenuItem>
                 <MenuItem value="bypass_trusted">
                   <Box>
                     <Typography variant="body2" fontWeight="medium">
@@ -720,7 +714,9 @@ const Settings: React.FC = () => {
                 <Typography variant="body2">
                   {sshPolicy.policy === 'auto_add'
                     ? 'Automatically accept and save unknown host keys'
-                    : 'Auto-add hosts in trusted network ranges'}
+                    : sshPolicy.policy === 'auto_add_warning'
+                      ? 'Accept unknown hosts but log a security warning for audit compliance'
+                      : 'Auto-add hosts in trusted network ranges'}
                 </Typography>
               </Alert>
             )}
@@ -858,73 +854,25 @@ const Settings: React.FC = () => {
         </TabPanel>
 
         <TabPanel value={tabValue} index={3}>
-          {/* Security Settings Section */}
+          {/* Audit Logging Section */}
           <Card sx={{ mb: 4, p: 3 }}>
-            <Box
-              sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
-            >
-              <Box>
-                <Typography variant="h6" gutterBottom>
-                  <PolicyIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
-                  Logging Policy Management
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Configure centralized audit logging policies for applications, database, and
-                  network events.
-                </Typography>
-              </Box>
-              <Button variant="contained" startIcon={<AddIcon />} disabled={securityLoading}>
-                Create Policy
-              </Button>
+            <Box sx={{ mb: 3 }}>
+              <Typography variant="h6" gutterBottom>
+                Audit Logging
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                OpenWatch automatically logs all security-relevant events including authentication
+                attempts, authorization failures, configuration changes, and scan operations.
+              </Typography>
             </Box>
 
-            {loggingPolicies.length === 0 ? (
-              <Box sx={{ textAlign: 'center', py: 4 }}>
-                <Typography color="text.secondary">
-                  No logging policies configured. Create a policy to enable centralized audit
-                  logging.
-                </Typography>
-              </Box>
-            ) : (
-              <TableContainer component={Paper} variant="outlined">
-                <Table size="small">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Policy Name</TableCell>
-                      <TableCell>Status</TableCell>
-                      <TableCell>Frameworks</TableCell>
-                      <TableCell>Created</TableCell>
-                      <TableCell align="right">Actions</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {loggingPolicies.map((policy) => (
-                      <TableRow key={policy.id}>
-                        <TableCell>{policy.name}</TableCell>
-                        <TableCell>
-                          <Typography
-                            variant="body2"
-                            color={policy.enabled ? 'success.main' : 'text.secondary'}
-                          >
-                            {policy.enabled ? 'Enabled' : 'Disabled'}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>{policy.frameworks.join(', ')}</TableCell>
-                        <TableCell>{new Date(policy.created_at).toLocaleDateString()}</TableCell>
-                        <TableCell align="right">
-                          <IconButton size="small">
-                            <EditIcon />
-                          </IconButton>
-                          <IconButton size="small" color="error">
-                            <DeleteIcon />
-                          </IconButton>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            )}
+            <Alert severity="success" sx={{ mb: 2 }}>
+              <Typography variant="body2">
+                Audit logging is always active. All events are written to the
+                <strong> openwatch.audit</strong> logger and stored in the database for compliance
+                reporting.
+              </Typography>
+            </Alert>
           </Card>
 
           {/* Session Timeout Settings */}
@@ -1007,10 +955,31 @@ const Settings: React.FC = () => {
               }}
             >
               {[
-                { name: 'SOC2', description: 'System and Organization Controls', enabled: true },
-                { name: 'HIPAA', description: 'Health Insurance Portability', enabled: true },
-                { name: 'PCI-DSS', description: 'Payment Card Industry', enabled: true },
-                { name: 'GDPR', description: 'General Data Protection', enabled: true },
+                {
+                  name: 'CIS RHEL 9',
+                  description: 'Center for Internet Security Benchmark (271 controls)',
+                  enabled: true,
+                },
+                {
+                  name: 'STIG RHEL 9',
+                  description: 'Security Technical Implementation Guide (338 controls)',
+                  enabled: true,
+                },
+                {
+                  name: 'NIST 800-53',
+                  description: 'NIST Special Publication 800-53 Rev 5 (87 controls)',
+                  enabled: true,
+                },
+                {
+                  name: 'PCI-DSS v4.0',
+                  description: 'Payment Card Industry Data Security Standard (45 controls)',
+                  enabled: true,
+                },
+                {
+                  name: 'FedRAMP',
+                  description: 'Federal Risk and Authorization Management (87 controls)',
+                  enabled: true,
+                },
               ].map((framework) => (
                 <Card
                   key={framework.name}
@@ -1054,9 +1023,9 @@ const Settings: React.FC = () => {
                 Platform Overview
               </Typography>
               <Typography variant="body2" color="text.secondary" paragraph>
-                OpenWatch is a SCAP (Security Content Automation Protocol) compliance scanning
-                platform designed for FedRAMP, CMMC, ISO 27001, NIST SP 800-53, and DOD STIG
-                baseline verification.
+                OpenWatch is a compliance automation platform powered by Kensa, a canonical
+                rule-based compliance scanner. Designed for FedRAMP, CMMC, ISO 27001, NIST SP
+                800-53, and DOD STIG baseline verification.
               </Typography>
             </Box>
 
@@ -1068,8 +1037,14 @@ const Settings: React.FC = () => {
               }}
             >
               {[
-                { label: 'SCAP Scanning', description: 'OpenSCAP-based compliance scanning' },
-                { label: 'Multi-Framework', description: 'NIST, CIS, STIG, and more' },
+                {
+                  label: 'Kensa Scanner',
+                  description: 'Canonical rule-based compliance scanning (508 rules)',
+                },
+                {
+                  label: 'Multi-Framework',
+                  description: 'CIS, STIG, NIST 800-53, PCI-DSS, FedRAMP',
+                },
                 { label: 'Real-time Monitoring', description: 'Continuous compliance tracking' },
               ].map((feature) => (
                 <Card key={feature.label} variant="outlined" sx={{ p: 2 }}>

--- a/specs/SPEC_REGISTRY.md
+++ b/specs/SPEC_REGISTRY.md
@@ -86,6 +86,8 @@ Coverage is checked by `scripts/check-spec-coverage.py`.
 | Login | api/auth/login.spec.yaml | tests/backend/unit/api/test_auth_api.py | 5 | Active |
 | MFA Verify | api/auth/mfa-verify.spec.yaml | tests/backend/unit/api/test_auth_api.py | 5 | Active |
 | Test Connection | api/hosts/test-connection.spec.yaml | tests/backend/unit/api/test_host_api.py | 9 | Active |
+| SSH Settings | api/ssh/ssh-settings.spec.yaml | tests/backend/unit/api/test_ssh_settings_api.py | 9 | Active |
+| Session Timeout | api/system/session-timeout.spec.yaml | tests/backend/unit/api/test_system_settings_api.py | 9 | Active |
 
 ## Frontend Specs
 
@@ -119,11 +121,11 @@ Coverage is checked by `scripts/check-spec-coverage.py`.
 | System | 9 | 6 | 3 | 0 |
 | Pipelines | 3 | 2 | 1 | 0 |
 | Services | 11 | 11 | 0 | 0 |
-| API | 10 | 10 | 0 | 0 |
+| API | 12 | 12 | 0 | 0 |
 | Plugins | 1 | 1 | 0 | 0 |
 | Release | 4 | 4 | 0 | 0 |
 | Frontend | 5 | 5 | 0 | 0 |
-| **Total** | **43** | **39** | **4** | **0** |
+| **Total** | **45** | **41** | **4** | **0** |
 
 ## Cross-Module Dependencies
 

--- a/specs/api/ssh/ssh-settings.spec.yaml
+++ b/specs/api/ssh/ssh-settings.spec.yaml
@@ -1,0 +1,109 @@
+spec: ssh-settings-api
+version: "1.0"
+status: active
+owner: engineering
+summary: >
+  SSH Settings API route contract: GET/POST /api/ssh/settings/policy reads and
+  writes SSH host key policy via SSHConfigManager (not hardcoded). Known hosts
+  CRUD uses KnownHostsManager (not SSHConfigManager). Test connectivity checks
+  SSH reachability via HostMonitor. All endpoints require appropriate RBAC
+  permissions.
+
+---
+
+# Objective
+
+objective: >
+  Ensure the SSH settings API correctly reads policy from the database,
+  delegates known host operations to KnownHostsManager, and enforces RBAC
+  permissions on all endpoints.
+
+---
+
+# Constraints
+
+constraints:
+  policy:
+    - "GET /settings/policy MUST read policy from SSHConfigManager.get_ssh_policy(), not hardcoded"
+    - "GET /settings/policy MUST return SSHPolicyResponse with policy, trusted_networks, description"
+    - "POST /settings/policy MUST validate policy against SSHConfigManager.VALID_POLICIES"
+    - "Policy description MUST map known policies to human-readable text"
+
+  known_hosts:
+    - "Known host endpoints MUST use KnownHostsManager, not SSHConfigManager"
+    - "GET /settings/known-hosts MUST support optional hostname filter"
+    - "POST /settings/known-hosts MUST generate SHA256 fingerprint via KnownHostsManager"
+    - "DELETE /settings/known-hosts/{hostname} MUST support optional key_type filter"
+
+  rbac:
+    - "Policy and known-host endpoints MUST require Permission.SYSTEM_CONFIG"
+    - "Test connectivity endpoint MUST require Permission.SCAN_EXECUTE"
+
+---
+
+# Acceptance Criteria
+
+acceptance_criteria:
+  - id: AC-1
+    description: >
+      GET /settings/policy reads the SSH policy from the database via
+      SSHConfigManager.get_ssh_policy(), not from a hardcoded string.
+      The route handler must not contain a hardcoded "default_policy" value.
+
+  - id: AC-2
+    description: >
+      GET /settings/policy returns SSHPolicyResponse with policy string,
+      trusted_networks list, and a human-readable description field.
+
+  - id: AC-3
+    description: >
+      POST /settings/policy calls SSHConfigManager.set_ssh_policy() and
+      optionally set_trusted_networks() when trusted_networks is provided.
+
+  - id: AC-4
+    description: >
+      Known host GET/POST/DELETE endpoints use KnownHostsManager (imported
+      from app.services.ssh), not SSHConfigManager, for known host operations.
+
+  - id: AC-5
+    description: >
+      GET /settings/known-hosts accepts an optional hostname query parameter
+      and passes it to KnownHostsManager.get_known_hosts() for filtering.
+
+  - id: AC-6
+    description: >
+      POST /settings/known-hosts validates key_type via KnownHostRequest
+      model (must be one of rsa, ecdsa, ed25519, dsa).
+
+  - id: AC-7
+    description: >
+      All policy and known-host endpoints are decorated with
+      @require_permission(Permission.SYSTEM_CONFIG).
+
+  - id: AC-8
+    description: >
+      GET /settings/test-connectivity/{host_id} is decorated with
+      @require_permission(Permission.SCAN_EXECUTE).
+
+  - id: AC-9
+    description: >
+      The SSH settings router uses prefix="/settings" and is tagged
+      "SSH Settings" for OpenAPI documentation.
+
+  - id: AC-10
+    description: >
+      GET /settings/policy includes "auto_add_warning" in the policy
+      descriptions map, covering all four valid policies (strict, auto_add,
+      auto_add_warning, bypass_trusted).
+
+---
+
+# Changelog
+
+changelog:
+  - version: "1.0"
+    date: "2026-03-07"
+    changes:
+      - "Initial spec: 10 ACs covering SSH settings API routes"
+      - "Regression ACs: policy read from DB (AC-1), KnownHostsManager usage (AC-4)"
+      - "Bug fixes: hardcoded default_policy (AC-1), missing get_known_hosts method (AC-4)"

--- a/specs/api/system/session-timeout.spec.yaml
+++ b/specs/api/system/session-timeout.spec.yaml
@@ -1,0 +1,104 @@
+spec: session-timeout-api
+version: "1.0"
+status: active
+owner: engineering
+summary: >
+  Session timeout API route contract: GET/PUT /api/system/settings/session-timeout
+  manages the inactivity timeout stored in system_settings table. GET returns
+  current timeout or default (15 min). PUT validates range (1-480 min) and
+  upserts via SQL. Both endpoints require Permission.SYSTEM_MAINTENANCE.
+
+---
+
+# Objective
+
+objective: >
+  Ensure session timeout endpoints correctly read/write the system_settings
+  table, validate timeout ranges, use safe SQL without embedded comments,
+  and enforce RBAC permissions.
+
+---
+
+# Constraints
+
+constraints:
+  get_endpoint:
+    - "GET MUST read from system_settings table via QueryBuilder"
+    - "GET MUST return default (15 min) when no row exists"
+    - "GET MUST return SessionTimeoutSettings with timeout_minutes, updated_at, updated_by"
+
+  put_endpoint:
+    - "PUT MUST validate timeout_minutes between MIN (1) and MAX (480)"
+    - "PUT MUST upsert to system_settings using ON CONFLICT (setting_key)"
+    - "PUT SQL MUST NOT contain Python comments (# characters cause PostgreSQL syntax errors)"
+    - "PUT MUST log the change with username for audit trail"
+
+  rbac:
+    - "Both endpoints MUST require Permission.SYSTEM_MAINTENANCE"
+
+---
+
+# Acceptance Criteria
+
+acceptance_criteria:
+  - id: AC-1
+    description: >
+      GET /session-timeout reads from system_settings table using
+      QueryBuilder with setting_key = 'session_inactivity_timeout_minutes'.
+
+  - id: AC-2
+    description: >
+      GET /session-timeout returns default timeout (15 minutes) when no
+      database row exists for the setting key.
+
+  - id: AC-3
+    description: >
+      PUT /session-timeout rejects timeout_minutes below MIN_SESSION_TIMEOUT_MINUTES
+      (1) with HTTP 400.
+
+  - id: AC-4
+    description: >
+      PUT /session-timeout rejects timeout_minutes above MAX_SESSION_TIMEOUT_MINUTES
+      (480) with HTTP 400.
+
+  - id: AC-5
+    description: >
+      PUT /session-timeout SQL string does not contain '#' characters.
+      Python comments inside SQL strings cause PostgreSQL syntax errors.
+
+  - id: AC-6
+    description: >
+      PUT /session-timeout uses ON CONFLICT (setting_key) DO UPDATE SET
+      to upsert the session timeout value.
+
+  - id: AC-7
+    description: >
+      Both GET and PUT endpoints are decorated with
+      @require_permission(Permission.SYSTEM_MAINTENANCE).
+
+  - id: AC-8
+    description: >
+      PUT /session-timeout returns the updated SessionTimeoutSettings
+      including timeout_minutes, updated_at, and updated_by fields.
+
+  - id: AC-9
+    description: >
+      SessionTimeoutSettings response model has timeout_minutes (int),
+      updated_at (Optional[str]), and updated_by (Optional[str]) fields.
+
+  - id: AC-10
+    description: >
+      DEFAULT_SESSION_TIMEOUT_MINUTES is defined as 15 and used as the
+      fallback when no database setting exists.
+
+---
+
+# Changelog
+
+changelog:
+  - version: "1.0"
+    date: "2026-03-07"
+    changes:
+      - "Initial spec: 10 ACs covering session timeout API routes"
+      - "Regression AC: SQL must not contain # characters (AC-5)"
+      - "Bug fix: Python noqa comments inside SQL caused PostgreSQL syntax error"

--- a/tests/backend/unit/api/test_ssh_settings_api.py
+++ b/tests/backend/unit/api/test_ssh_settings_api.py
@@ -1,0 +1,254 @@
+"""
+Unit tests for SSH Settings API contracts.
+
+Spec: specs/api/ssh/ssh-settings.spec.yaml
+Tests SSH settings endpoints from routes/ssh/settings.py.
+"""
+
+import inspect
+
+import pytest
+
+from app.routes.ssh.settings import (
+    add_known_host as _add_known_host_handler,
+    get_known_hosts as _get_known_hosts_handler,
+    get_ssh_policy as _get_ssh_policy_handler,
+    remove_known_host as _remove_known_host_handler,
+    router as ssh_settings_router,
+    set_ssh_policy as _set_ssh_policy_handler,
+    test_ssh_connectivity as _test_connectivity_handler,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SETTINGS_MODULE_SOURCE = inspect.getsource(
+    inspect.getmodule(_get_ssh_policy_handler)
+)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: GET /settings/policy reads from DB, not hardcoded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC1PolicyFromDB:
+    """AC-1: GET /settings/policy reads policy from SSHConfigManager.get_ssh_policy()."""
+
+    def test_get_policy_calls_service(self):
+        """Verify get_ssh_policy handler calls service.get_ssh_policy()."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert "service.get_ssh_policy()" in source
+
+    def test_no_hardcoded_default_policy(self):
+        """Regression: policy must not be hardcoded as 'default_policy'."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert '"default_policy"' not in source
+        assert "'default_policy'" not in source
+
+    def test_creates_ssh_config_manager(self):
+        """Verify SSHConfigManager is instantiated with db."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert "SSHConfigManager(db)" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-2: GET /settings/policy returns SSHPolicyResponse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC2PolicyResponse:
+    """AC-2: GET /settings/policy returns SSHPolicyResponse with required fields."""
+
+    def test_returns_policy_field(self):
+        """Verify response includes policy field."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert "SSHPolicyResponse(" in source
+        assert "policy=" in source
+
+    def test_returns_trusted_networks(self):
+        """Verify response includes trusted_networks."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert "trusted_networks=" in source
+
+    def test_returns_description(self):
+        """Verify response includes description."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert "description=" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-3: POST /settings/policy calls set methods
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC3SetPolicy:
+    """AC-3: POST /settings/policy calls SSHConfigManager.set_ssh_policy()."""
+
+    def test_set_policy_calls_service(self):
+        """Verify set_ssh_policy handler calls service.set_ssh_policy()."""
+        source = inspect.getsource(_set_ssh_policy_handler)
+        assert "service.set_ssh_policy(" in source
+
+    def test_set_trusted_networks_conditional(self):
+        """Verify set_trusted_networks is called when provided."""
+        source = inspect.getsource(_set_ssh_policy_handler)
+        assert "set_trusted_networks" in source
+        assert "trusted_networks is not None" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Known host endpoints use KnownHostsManager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC4KnownHostsManager:
+    """AC-4: Known host endpoints use KnownHostsManager, not SSHConfigManager."""
+
+    def test_get_known_hosts_uses_manager(self):
+        """Verify GET known-hosts uses KnownHostsManager."""
+        source = inspect.getsource(_get_known_hosts_handler)
+        assert "KnownHostsManager(db)" in source
+
+    def test_add_known_host_uses_manager(self):
+        """Verify POST known-hosts uses KnownHostsManager."""
+        source = inspect.getsource(_add_known_host_handler)
+        assert "KnownHostsManager(db)" in source
+
+    def test_remove_known_host_uses_manager(self):
+        """Verify DELETE known-hosts uses KnownHostsManager."""
+        source = inspect.getsource(_remove_known_host_handler)
+        assert "KnownHostsManager(db)" in source
+
+    def test_known_hosts_not_on_ssh_config_manager(self):
+        """Regression: known host handlers must not call SSHConfigManager for host ops."""
+        for handler in [_get_known_hosts_handler, _add_known_host_handler, _remove_known_host_handler]:
+            source = inspect.getsource(handler)
+            # SSHConfigManager should not appear in known host handlers
+            assert "SSHConfigManager" not in source
+
+
+# ---------------------------------------------------------------------------
+# AC-5: GET /settings/known-hosts accepts hostname filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC5HostnameFilter:
+    """AC-5: GET /settings/known-hosts accepts optional hostname parameter."""
+
+    def test_hostname_parameter_exists(self):
+        """Verify hostname is a parameter of get_known_hosts."""
+        sig = inspect.signature(_get_known_hosts_handler)
+        assert "hostname" in sig.parameters
+
+    def test_hostname_passed_to_manager(self):
+        """Verify hostname is passed to KnownHostsManager.get_known_hosts()."""
+        source = inspect.getsource(_get_known_hosts_handler)
+        assert "get_known_hosts(hostname)" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-6: POST /settings/known-hosts validates key_type
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC6KeyTypeValidation:
+    """AC-6: POST /settings/known-hosts validates key_type via Pydantic model."""
+
+    def test_known_host_request_model_used(self):
+        """Verify KnownHostRequest model is used for POST."""
+        source = inspect.getsource(_add_known_host_handler)
+        assert "host_request" in source
+        assert "key_type" in source
+
+    def test_key_type_validation_in_model(self):
+        """Verify KnownHostRequest validates key_type."""
+        from app.routes.ssh.models import KnownHostRequest
+
+        source = inspect.getsource(KnownHostRequest)
+        assert "rsa" in source
+        assert "ecdsa" in source
+        assert "ed25519" in source
+        assert "dsa" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Policy/known-host endpoints require SYSTEM_CONFIG
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC7SystemConfigPermission:
+    """AC-7: Policy and known-host endpoints require Permission.SYSTEM_CONFIG."""
+
+    def test_get_policy_requires_system_config(self):
+        """Verify GET policy has SYSTEM_CONFIG permission."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        # The decorator is applied above the function, check module source
+        # Find the decorator for this specific function
+        assert "SYSTEM_CONFIG" in _SETTINGS_MODULE_SOURCE
+
+    def test_known_hosts_endpoints_require_system_config(self):
+        """Verify known-host endpoints reference SYSTEM_CONFIG permission."""
+        # All endpoints in the module should use SYSTEM_CONFIG
+        assert _SETTINGS_MODULE_SOURCE.count("Permission.SYSTEM_CONFIG") >= 5
+
+
+# ---------------------------------------------------------------------------
+# AC-8: Test connectivity requires SCAN_EXECUTE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC8ScanExecutePermission:
+    """AC-8: Test connectivity requires Permission.SCAN_EXECUTE."""
+
+    def test_test_connectivity_requires_scan_execute(self):
+        """Verify test connectivity has SCAN_EXECUTE permission."""
+        assert "Permission.SCAN_EXECUTE" in _SETTINGS_MODULE_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# AC-9: Router prefix and tags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC9RouterConfig:
+    """AC-9: SSH settings router uses correct prefix and tags."""
+
+    def test_router_prefix(self):
+        """Verify router prefix is /settings."""
+        assert ssh_settings_router.prefix == "/settings"
+
+    def test_router_tags(self):
+        """Verify router is tagged 'SSH Settings'."""
+        assert "SSH Settings" in ssh_settings_router.tags
+
+
+# ---------------------------------------------------------------------------
+# AC-10: Policy descriptions include auto_add_warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSSHSettingsAC10PolicyDescriptions:
+    """AC-10: GET /settings/policy includes all four valid policy descriptions."""
+
+    def test_auto_add_warning_in_descriptions(self):
+        """Verify auto_add_warning is in policy descriptions map."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        assert "auto_add_warning" in source
+
+    def test_all_four_policies_described(self):
+        """Verify all four valid policies appear in descriptions."""
+        source = inspect.getsource(_get_ssh_policy_handler)
+        for policy in ["strict", "auto_add", "bypass_trusted"]:
+            assert f'"{policy}"' in source

--- a/tests/backend/unit/api/test_system_settings_api.py
+++ b/tests/backend/unit/api/test_system_settings_api.py
@@ -1,0 +1,250 @@
+"""
+Unit tests for System Settings API contracts: session timeout.
+
+Spec: specs/api/system/session-timeout.spec.yaml
+Tests session timeout endpoints from routes/system/settings.py.
+"""
+
+import inspect
+import re
+
+import pytest
+
+from app.routes.system.settings import (
+    DEFAULT_SESSION_TIMEOUT_MINUTES,
+    MAX_SESSION_TIMEOUT_MINUTES,
+    MIN_SESSION_TIMEOUT_MINUTES,
+    SessionTimeoutSettings,
+    get_session_timeout as _get_session_timeout_handler,
+    update_session_timeout as _update_session_timeout_handler,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MODULE_SOURCE = inspect.getsource(inspect.getmodule(_get_session_timeout_handler))
+
+
+# ---------------------------------------------------------------------------
+# AC-1: GET reads from system_settings via QueryBuilder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC1QueryBuilder:
+    """AC-1: GET /session-timeout reads from system_settings via QueryBuilder."""
+
+    def test_uses_query_builder(self):
+        """Verify GET handler uses QueryBuilder for system_settings."""
+        source = inspect.getsource(_get_session_timeout_handler)
+        assert "QueryBuilder" in source
+        assert "system_settings" in source
+
+    def test_queries_correct_setting_key(self):
+        """Verify the correct setting key is used."""
+        source = inspect.getsource(_get_session_timeout_handler)
+        assert "session_inactivity_timeout_minutes" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-2: GET returns default when no row exists
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC2Default:
+    """AC-2: GET returns default (15 min) when no DB row."""
+
+    def test_default_timeout_value(self):
+        """Verify DEFAULT_SESSION_TIMEOUT_MINUTES is 15."""
+        assert DEFAULT_SESSION_TIMEOUT_MINUTES == 15
+
+    def test_returns_default_on_missing_row(self):
+        """Verify handler returns default when row is None."""
+        source = inspect.getsource(_get_session_timeout_handler)
+        assert "DEFAULT_SESSION_TIMEOUT_MINUTES" in source
+
+    def test_returns_none_timestamps_for_default(self):
+        """Verify default response has None for updated_at and updated_by."""
+        source = inspect.getsource(_get_session_timeout_handler)
+        assert "updated_at=None" in source
+        assert "updated_by=None" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-3: PUT rejects below minimum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC3MinValidation:
+    """AC-3: PUT rejects timeout below MIN_SESSION_TIMEOUT_MINUTES."""
+
+    def test_min_timeout_defined(self):
+        """Verify MIN_SESSION_TIMEOUT_MINUTES is defined."""
+        assert MIN_SESSION_TIMEOUT_MINUTES >= 1
+
+    def test_min_check_in_handler(self):
+        """Verify handler checks against minimum."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "MIN_SESSION_TIMEOUT_MINUTES" in source
+
+    def test_returns_400_on_underflow(self):
+        """Verify HTTP 400 returned for values below minimum."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "400" in source or "BAD_REQUEST" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-4: PUT rejects above maximum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC4MaxValidation:
+    """AC-4: PUT rejects timeout above MAX_SESSION_TIMEOUT_MINUTES (480)."""
+
+    def test_max_timeout_value(self):
+        """Verify MAX_SESSION_TIMEOUT_MINUTES is 480."""
+        assert MAX_SESSION_TIMEOUT_MINUTES == 480
+
+    def test_max_check_in_handler(self):
+        """Verify handler checks against maximum."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "MAX_SESSION_TIMEOUT_MINUTES" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-5: PUT SQL contains no # characters (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC5NoSQLComments:
+    """AC-5: PUT SQL must not contain '#' characters (PostgreSQL syntax error)."""
+
+    def test_no_hash_in_sql_strings(self):
+        """Regression: SQL strings must not contain Python comments."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        # Find all triple-quoted strings (SQL)
+        sql_strings = re.findall(r'""".*?"""', source, re.DOTALL)
+        for sql_str in sql_strings:
+            assert "#" not in sql_str, (
+                f"Found '#' in SQL string - Python comments in SQL cause "
+                f"PostgreSQL syntax errors: {sql_str[:100]}"
+            )
+
+    def test_no_noqa_in_sql_strings(self):
+        """Regression: 'noqa' must not appear inside SQL strings."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        sql_strings = re.findall(r'""".*?"""', source, re.DOTALL)
+        for sql_str in sql_strings:
+            assert "noqa" not in sql_str, (
+                f"Found 'noqa' in SQL string: {sql_str[:100]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC-6: PUT uses ON CONFLICT upsert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC6Upsert:
+    """AC-6: PUT uses ON CONFLICT (setting_key) DO UPDATE SET."""
+
+    def test_on_conflict_present(self):
+        """Verify ON CONFLICT clause in upsert SQL."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "ON CONFLICT" in source
+
+    def test_do_update_set_present(self):
+        """Verify DO UPDATE SET in upsert SQL."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "DO UPDATE SET" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Both endpoints require SYSTEM_MAINTENANCE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC7Permission:
+    """AC-7: Both endpoints require Permission.SYSTEM_MAINTENANCE."""
+
+    def test_system_maintenance_permission_count(self):
+        """Verify SYSTEM_MAINTENANCE appears for both timeout endpoints."""
+        # Count occurrences near the session timeout functions
+        get_source = inspect.getsource(_get_session_timeout_handler)
+        put_source = inspect.getsource(_update_session_timeout_handler)
+        # The decorator won't be in the function body but the module uses it
+        assert "SYSTEM_MAINTENANCE" in _MODULE_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# AC-8: PUT returns updated SessionTimeoutSettings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC8PutResponse:
+    """AC-8: PUT returns updated SessionTimeoutSettings."""
+
+    def test_returns_session_timeout_settings(self):
+        """Verify PUT returns SessionTimeoutSettings."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "SessionTimeoutSettings(" in source
+
+    def test_response_includes_timeout_minutes(self):
+        """Verify response includes timeout_minutes."""
+        source = inspect.getsource(_update_session_timeout_handler)
+        assert "timeout_minutes=" in source
+
+
+# ---------------------------------------------------------------------------
+# AC-9: SessionTimeoutSettings response model fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC9ResponseModel:
+    """AC-9: SessionTimeoutSettings has required fields."""
+
+    def test_has_timeout_minutes_field(self):
+        """Verify timeout_minutes field exists."""
+        assert hasattr(SessionTimeoutSettings, "model_fields") or hasattr(
+            SessionTimeoutSettings, "__fields__"
+        )
+        fields = SessionTimeoutSettings.model_fields
+        assert "timeout_minutes" in fields
+
+    def test_has_updated_at_field(self):
+        """Verify updated_at field exists."""
+        fields = SessionTimeoutSettings.model_fields
+        assert "updated_at" in fields
+
+    def test_has_updated_by_field(self):
+        """Verify updated_by field exists."""
+        fields = SessionTimeoutSettings.model_fields
+        assert "updated_by" in fields
+
+
+# ---------------------------------------------------------------------------
+# AC-10: Default constant value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSessionTimeoutAC10DefaultConstant:
+    """AC-10: DEFAULT_SESSION_TIMEOUT_MINUTES is 15."""
+
+    def test_default_is_15(self):
+        """Verify default timeout is 15 minutes."""
+        assert DEFAULT_SESSION_TIMEOUT_MINUTES == 15
+
+    def test_default_used_in_get_handler(self):
+        """Verify default constant used in GET handler fallback."""
+        source = inspect.getsource(_get_session_timeout_handler)
+        assert "DEFAULT_SESSION_TIMEOUT_MINUTES" in source


### PR DESCRIPTION
## Summary

- **SSH Host Key Policy**: Fixed GET endpoint returning hardcoded `"default_policy"` instead of reading from DB via `SSHConfigManager.get_ssh_policy()`. Added `renderValue` prop and `auto_add_warning` MenuItem to frontend Select.
- **Session Timeout**: Fixed PUT endpoint failing with PostgreSQL syntax error caused by Python `# noqa` comments inside SQL strings. Reformatted SQL.
- **Known SSH Hosts**: Fixed 500 error by switching from `SSHConfigManager` (no `get_known_hosts` method) to `KnownHostsManager`. Added `ssh_known_hosts` table via Alembic migration.
- **About tab**: Updated from "OpenSCAP-based" to Kensa scanner description.
- **Compliance Frameworks**: Replaced SOC2/HIPAA/GDPR with actual supported frameworks (CIS/STIG/NIST/PCI-DSS/FedRAMP with control counts).
- **Logging Policy**: Replaced non-functional placeholder with Audit Logging info section. Removed dead code.
- **Specs & Tests**: Added `ssh-settings` and `session-timeout` API specs (20 ACs). 45 unit tests, all passing. SPEC_REGISTRY: 45 specs, 41 active, 401/401 ACs at 100%.

## Test plan

- [x] SSH Host Key Policy dropdown shows correct value from DB ("Auto Add")
- [x] All 4 policy options visible in dropdown (Strict, Auto Add, Auto Add with warning, Bypass Trusted)
- [x] Known SSH Hosts table loads without error ("No known hosts configured")
- [x] Session Timeout update works (verified 15 min → 1 hour round trip)
- [x] About tab shows Kensa scanner description
- [x] Compliance Frameworks shows CIS/STIG/NIST/PCI-DSS/FedRAMP
- [x] Audit Logging section replaces non-functional Logging Policy
- [x] 45 unit tests pass (`test_ssh_settings_api.py`, `test_system_settings_api.py`)
- [x] Spec validation: 45/45 pass, 401/401 ACs covered
- [x] All pre-commit hooks pass (black, flake8, mypy, bandit, eslint, prettier)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)