### PR TITLE
chore(transactions): reframe query API as interim over Kensa LogQuery

### DIFF
--- a/backend/app/routes/transactions/query.py
+++ b/backend/app/routes/transactions/query.py
@@ -8,6 +8,29 @@ and multi-value IN-clause filters.
 
 Spec: specs/api/transactions/transaction-query.spec.yaml
 
+# INTERIM IMPLEMENTATION (Kensa Go Week 22 convergence)
+# ====================================================
+# The HTTP surface of this endpoint (URL, request schema, response
+# envelope) is stable. Its implementation is INTERIM and migrates to
+# delegate into Kensa's Go api/ surface at Kensa Week 22:
+#
+#     Query()     -> kensa.api.Kensa.TransactionLog().Query(ctx, filter, page)
+#     Get(id)     -> kensa.api.Kensa.TransactionLog().Get(ctx, id)
+#     Aggregate() -> kensa.api.Kensa.TransactionLog().Aggregate(ctx, f, key)
+#
+# The current PostgreSQL-backed implementation reads the `transactions`
+# table that Python Kensa writes to today. At Week 22, swap the
+# implementation to call Kensa's Go LogQuery — endpoint callers see no
+# change. The PostgreSQL `transactions` table remains as a derived
+# multi-host aggregation cache through v1.0.0 (per Kensa Day-1 plan §13A).
+#
+# See also:
+#   - specs/api/transactions/transaction-query.spec.yaml (interim_implementation)
+#   - docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md
+#   - kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md §2.1
+#   - kensa/docs/KENSA_GO_DAY1_PLAN.md §3.5.1 LogQuery
+# ====================================================
+
 Design notes:
     Cursor format: base64(json({"started_at": ISO8601, "id": UUID})).
     Ordering: ORDER BY started_at DESC, id DESC. Cursor filter uses tuple

--- a/specs/api/transactions/transaction-query.spec.yaml
+++ b/specs/api/transactions/transaction-query.spec.yaml
@@ -1,13 +1,38 @@
 spec: transaction-query
-version: "1.0"
+version: "1.1"
 status: draft
 owner: engineering
 summary: >
   POST /api/transactions/query endpoint accepting a structured query DSL in
   the request body. Supports filtering, cursor-based pagination, and field
-  projection. Forms the foundation of the future Agent API and enables
-  historical posture queries (<500ms p95 target). Complements the existing
-  GET /api/transactions which remains for simple UI list views.
+  projection. Forms the HTTP surface that the OpenWatch UI and third-party
+  consumers call; its implementation converges onto Kensa Go
+  `api.Kensa.TransactionLog().Query()` at Kensa Week 22. Complements the
+  existing GET /api/transactions which remains for simple UI list views.
+
+# Interim-implementation annotation per Kensa↔OpenWatch coordination memo
+# (docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md and
+#  kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md §6.1).
+# The endpoint's URL and request/response schema are stable; the
+# implementation migrates at the convergence_week without breaking callers.
+interim_implementation:
+  delegates_to: kensa.api.Kensa.TransactionLog().Query
+  delegates_to_methods:
+    - LogQuery.Query (paginated filtered list)
+    - LogQuery.Get (single record with envelope)
+    - LogQuery.Aggregate (posture summaries by AggregateKey)
+  convergence_week: 22
+  kensa_plan_ref: kensa/docs/KENSA_GO_DAY1_PLAN.md §3.5.1 LogQuery
+  notes: |
+    Current PostgreSQL-backed implementation reads the `transactions` table
+    that Python Kensa (pre-Go-v1.0) writes to. At Kensa Go Week 22, the
+    implementation swaps to call into the Go `api/` surface; the
+    PostgreSQL table stays as a derived multi-host aggregation cache per
+    KENSA_GO_DAY1_PLAN.md §13A (survives through v1.0.0).
+
+    Kensa v1.1.0+ push-to-collector mode will let this cache become a
+    read-through instead of a client-side aggregator. No OpenWatch API
+    change required at that point.
 
 ---
 
@@ -124,6 +149,12 @@ out_of_scope:
 # Changelog
 
 changelog:
+  - version: "1.1"
+    date: "2026-04-14"
+    changes:
+      - "Add interim_implementation frontmatter per Kensa↔OpenWatch coordination"
+      - "Reframe summary to name Kensa.LogQuery as the convergence target"
+      - "No behavioral changes — endpoint URL, request schema, response schema unchanged"
   - version: "1.0"
     date: "2026-04-14"
     changes:


### PR DESCRIPTION
Direct follow-up to the Kensa↔OpenWatch coordination. One of three PRs the Kensa team explicitly asked to review (their response §6.2, item 2).

## Summary

PR #398 merged today adding \`POST /api/transactions/query\`. The endpoint's HTTP surface (URL, request schema, response envelope) is stable and correct. The **implementation** is interim — per the coordination memo and Kensa team response, it migrates to delegate into Kensa Go \`api.Kensa.TransactionLog().Query()\` at Kensa Week 22.

This PR adds the explicit convergence annotation so drift is visible at review time.

## Changes

- \`specs/api/transactions/transaction-query.spec.yaml\` → v1.1 with \`interim_implementation\` frontmatter naming:
  - \`delegates_to: kensa.api.Kensa.TransactionLog().Query\`
  - \`convergence_week: 22\`
  - \`kensa_plan_ref: kensa/docs/KENSA_GO_DAY1_PLAN.md §3.5.1 LogQuery\`
- \`backend/app/routes/transactions/query.py\` → module docstring gets a prominent \`INTERIM IMPLEMENTATION\` header pointing at the Kensa convergence target and the coordination docs

No behavioral changes. No endpoint surface changes. No test changes.

## Why this matters

Kensa team counter-asked (response §6.1):

> Every OpenWatch spec or interim implementation that will delegate to a Kensa \`api/\` method post-convergence should carry a frontmatter annotation.

This establishes the pattern. Future reviewers and Week-22-stakeholders can grep specs for \`interim_implementation:\` and verify nothing is stuck past its convergence week.

## Test plan

- [x] \`python3 scripts/validate-specs.py\` passes (95/95)
- [x] \`python3 scripts/check-spec-coverage.py --enforce-active\` passes (823/823)
- [ ] CI pipeline passes

## Related

- \`docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md\` (inbound memo)
- \`/home/rracine/hanalyx/kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md\` (Kensa response, §2.1 + §6.1)
- \`/home/rracine/hanalyx/kensa/docs/KENSA_GO_DAY1_PLAN.md\` §3.5.1 (convergence target)

Follow-up PRs in this same response-to-Kensa batch:
1. **This PR** — annotate #398 as interim ✅
2. Next — narrow signing scope to OpenWatch-originated artifacts (delete per-transaction signing endpoint)
3. Then — rewrite Q1-Q3 plan §6.2 and Phase 3 against Kensa \`api/\`