### PR TITLE
chore(signing): narrow scope to OpenWatch-originated aggregate artifacts

### DIFF
--- a/backend/app/routes/signing/routes.py
+++ b/backend/app/routes/signing/routes.py
@@ -1,30 +1,40 @@
-"""Evidence signing API routes.
+"""Evidence signing API routes for OpenWatch-originated aggregate artifacts.
+
+Scope narrowed 2026-04-14 per Kensa↔OpenWatch coordination. Per-transaction
+envelope signing moved to Kensa (where the evidence originates). OpenWatch's
+signing layer now attests only to aggregate artifacts that OpenWatch itself
+produces — cross-host audit exports, quarterly posture reports, and the
+future State-of-Production report.
 
 Endpoints:
-    GET  /api/signing/public-keys            - List all public keys (no auth)
-    POST /api/signing/verify                 - Verify a signed bundle (no auth)
-    POST /api/transactions/{id}/sign         - Sign a transaction envelope (SECURITY_ADMIN+)
+    GET  /api/signing/public-keys   - List all public keys (no auth, for auditors)
+    POST /api/signing/verify        - Verify a signed aggregate bundle (no auth)
+
+    (REMOVED) POST /api/transactions/{id}/sign — per-transaction signing
+    moves to Kensa per KENSA_GO_DAY1_PLAN.md §8.2 and the Kensa team's
+    response §2.2. OpenWatch audit UIs display Kensa-signed envelopes via
+    kensa.api.Kensa.VerifyEnvelope() starting at Kensa Week 22.
 
 Security Notes:
     - public-keys and verify are unauthenticated so external auditors can
-      independently verify evidence bundles without OpenWatch credentials.
-    - The sign endpoint requires SECURITY_ADMIN or SUPER_ADMIN role.
+      independently verify OpenWatch-originated bundles without OpenWatch
+      credentials.
     - EncryptionService is loaded from app.state (initialised at startup).
+
+See also:
+    - docs/SIGNING_SECURITY_REVIEW_2026-04-14.md (trust-layer boundary)
+    - docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md (§3.2)
+    - /home/rracine/hanalyx/kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md (§2.2)
 """
 
-import json
 import logging
 from typing import Any, Dict
-from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.auth import get_current_user
 from app.database import get_db
-from app.rbac import UserRole, require_role
 from app.services.signing import SignedBundle, SigningService
 
 logger = logging.getLogger(__name__)
@@ -52,7 +62,11 @@ class VerifyResponse(BaseModel):
 
 
 class SignedBundleResponse(BaseModel):
-    """Response body for a signed evidence bundle."""
+    """Response body for a signed OpenWatch-originated bundle.
+
+    Used by aggregate audit exports and quarterly posture reports. Not
+    used for per-transaction envelopes (those are Kensa-signed).
+    """
 
     envelope: Dict[str, Any]
     signature: str
@@ -116,68 +130,22 @@ async def verify_bundle(
 
 
 # ---------------------------------------------------------------------------
-# Protected endpoints
+# REMOVED: POST /api/transactions/{transaction_id}/sign
 # ---------------------------------------------------------------------------
-
-
-@require_role([UserRole.SECURITY_ADMIN, UserRole.SUPER_ADMIN])
-@router.post(
-    "/api/transactions/{transaction_id}/sign",
-    response_model=SignedBundleResponse,
-)
-async def sign_transaction(
-    transaction_id: UUID,
-    request: Request,
-    db: Session = Depends(get_db),
-    current_user: Dict[str, Any] = Depends(get_current_user),
-) -> SignedBundleResponse:
-    """Sign a transaction's evidence envelope with the active Ed25519 key.
-
-    Reads the transaction's evidence_envelope from the database and
-    produces a SignedBundle. Requires SECURITY_ADMIN or SUPER_ADMIN role.
-
-    Raises:
-        HTTPException 404: Transaction not found or has no evidence envelope.
-        HTTPException 400: No active signing key configured.
-    """
-    # Read transaction evidence_envelope
-    row = db.execute(
-        text("SELECT evidence_envelope " "FROM transactions " "WHERE id = :tid"),
-        {"tid": str(transaction_id)},
-    ).fetchone()
-
-    if not row:
-        raise HTTPException(status_code=404, detail="Transaction not found")
-
-    envelope = row.evidence_envelope
-    if envelope is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Transaction has no evidence envelope",
-        )
-
-    # Parse JSONB if returned as string
-    if isinstance(envelope, str):
-        try:
-            envelope = json.loads(envelope)
-        except (json.JSONDecodeError, ValueError):
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to parse evidence envelope",
-            )
-
-    signer = current_user.get("username", "openwatch")
-
-    service = _get_signing_service(request, db)
-    try:
-        bundle = service.sign_envelope(envelope, signer=signer)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-
-    return SignedBundleResponse(
-        envelope=bundle.envelope,
-        signature=bundle.signature,
-        key_id=bundle.key_id,
-        signed_at=bundle.signed_at,
-        signer=bundle.signer,
-    )
+#
+# Per-transaction envelope signing moved to Kensa on 2026-04-14 per the
+# Kensa↔OpenWatch coordination (docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md
+# §3.2; Kensa response §2.2). Kensa signs at evidence-capture time — the
+# auditor wants the Kensa attestation ("this execution happened on this
+# host"), not a later OpenWatch attestation ("OpenWatch stored this").
+#
+# At Kensa Go Week 22, OpenWatch audit UIs verify per-transaction envelopes
+# via kensa.api.Kensa.VerifyEnvelope() (KENSA_GO_DAY1_PLAN.md §3.5.4).
+# Until then, Python Kensa produces per-transaction signatures; OpenWatch
+# consumes them read-only.
+#
+# OpenWatch's signing path survives but is narrowed to aggregate artifacts
+# OpenWatch itself originates (audit exports, quarterly reports, future
+# State-of-Production report). See audit_export._generate_json for the
+# remaining legitimate signing call-site.
+# ---------------------------------------------------------------------------

--- a/backend/app/services/signing/signing_service.py
+++ b/backend/app/services/signing/signing_service.py
@@ -1,14 +1,38 @@
-"""Ed25519 evidence envelope signing and verification.
+"""Ed25519 signing for OpenWatch-originated aggregate artifacts.
 
-This module provides cryptographic signing of compliance evidence envelopes
-using Ed25519 keys. Signing keys are stored encrypted at rest via
-EncryptionService and support rotation without breaking verification of
-previously signed bundles.
+SCOPE NARROWED 2026-04-14 per Kensa↔OpenWatch coordination
+(docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md §3.2; Kensa response §2.2).
 
-Usage:
+This module signs **aggregate artifacts that OpenWatch itself produces** —
+cross-host audit exports, quarterly posture reports, the future State-of-
+Production report. It does NOT sign per-transaction evidence envelopes;
+those are Kensa-signed at evidence-capture time per
+KENSA_GO_DAY1_PLAN.md §8.2. OpenWatch audit UIs display Kensa's
+per-transaction signatures via kensa.api.Kensa.VerifyEnvelope() starting
+at Kensa Week 22.
+
+Trust-layer boundary::
+
+    +--------------------------------+   +---------------------------------+
+    | Kensa (per-transaction)        |   | OpenWatch (aggregate)           |
+    |                                |   |                                 |
+    | Signs: evidence envelope at    |   | Signs: audit export, quarterly  |
+    |   capture/execute time         |   |   posture report, State-of-     |
+    |                                |   |   Production release            |
+    | Attests: "This execution       |   | Attests: "OpenWatch aggregated  |
+    |   happened on this host at     |   |   this data from N hosts and    |
+    |   this time"                   |   |   produced this artifact"       |
+    +--------------------------------+   +---------------------------------+
+
+Signing keys are stored encrypted at rest via EncryptionService and
+support rotation without breaking verification of previously signed
+bundles.
+
+Usage (aggregate artifacts only)::
+
     service = SigningService(db, encryption_service=enc)
-    key_id = service.generate_key()
-    bundle = service.sign_envelope(envelope, signer="openwatch")
+    key_id = service.generate_key()  # once per deployment
+    bundle = service.sign_envelope(export_data, signer="openwatch")
     valid = service.verify(bundle)
 """
 

--- a/docs/SIGNING_SECURITY_REVIEW_2026-04-14.md
+++ b/docs/SIGNING_SECURITY_REVIEW_2026-04-14.md
@@ -1,10 +1,40 @@
 # Evidence Signing Security Review
 
 **Date**: 2026-04-14
+**Last updated**: 2026-04-14 (scope narrow per Kensa↔OpenWatch coordination)
 **Scope**: `backend/app/services/signing/`, `backend/app/routes/signing/`, signing integration in `backend/app/services/compliance/audit_export.py`, schema migration `051_add_signing_keys.py`
 **Reviewer**: Automated (Bandit 1.9.4, Semgrep 239 rules) + manual code review
-**Spec**: `specs/services/signing/evidence-signing.spec.yaml` (8 ACs, active)
+**Spec**: `specs/services/signing/evidence-signing.spec.yaml` (9 ACs, active, **v2.0**)
 **Phase**: Phase 4 mandatory security review per `docs/OPENWATCH_Q1_Q3_PLAN.md` §"Security review gates"
+
+---
+
+## Scope narrow (2026-04-14)
+
+Per the Kensa↔OpenWatch coordination (`docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md` §3.2; Kensa team response §2.2), this review covered two trust layers that must not be conflated. The signing scope has been narrowed accordingly.
+
+### Trust-layer boundary
+
+| Layer | Who signs | What it attests | Storage |
+|---|---|---|---|
+| **Per-transaction evidence envelope** | **Kensa** (not OpenWatch) | "This execution happened on this host at this time" | Kensa SQLite store at capture time; envelope travels with the transaction log record |
+| **Aggregate audit export / quarterly posture report / State-of-Production release** | OpenWatch | "OpenWatch aggregated this data from N hosts and produced this artifact" | OpenWatch PostgreSQL; signed at export time by `SigningService` |
+
+### What was removed from OpenWatch
+
+- `POST /api/transactions/{id}/sign` endpoint — that surface belongs to Kensa per `KENSA_GO_DAY1_PLAN.md` §8.2
+- Any future per-transaction signing code path — OpenWatch does not attempt to co-sign what Kensa already signed
+
+### What remains in OpenWatch (covered by this review)
+
+- `SigningService.sign_envelope()` used **only** by `audit_export._generate_json()` and future aggregate-report services
+- `GET /api/signing/public-keys` — public key list so auditors can verify OpenWatch-signed aggregate bundles
+- `POST /api/signing/verify` — verification endpoint for OpenWatch-signed aggregate bundles
+- All five findings below remain valid for the narrowed scope
+
+### OpenWatch audit-UI verification of Kensa-signed envelopes
+
+At Kensa Week 22, OpenWatch audit UIs verify per-transaction envelopes via `kensa.api.Kensa.VerifyEnvelope()` (see `KENSA_GO_DAY1_PLAN.md` §3.5.4). OpenWatch does **not** maintain its own Kensa-envelope verification code path — Kensa owns that verification logic.
 
 ## Summary
 

--- a/specs/services/signing/evidence-signing.spec.yaml
+++ b/specs/services/signing/evidence-signing.spec.yaml
@@ -1,13 +1,35 @@
 spec: evidence-signing
-version: "1.0"
+version: "2.0"
 status: active
 owner: engineering
 summary: >
-  Workstream F1: Cryptographic signing of evidence envelopes using Ed25519 keys.
-  SigningService signs transaction evidence envelopes, producing SignedBundle
-  objects that can be independently verified. Signing keys are stored encrypted
-  at rest and support rotation without breaking verification of previously
-  signed bundles. Public keys are exposed via API for external verifiers.
+  Ed25519 signing for OpenWatch-originated aggregate artifacts (cross-host
+  audit exports, quarterly posture reports, State-of-Production releases).
+  Per-transaction evidence envelope signing moved to Kensa on 2026-04-14 —
+  see context below. SigningService signs aggregate artifacts, producing
+  SignedBundle objects that external auditors can independently verify.
+  Signing keys are stored encrypted at rest and support rotation without
+  breaking verification of previously signed bundles.
+
+# Context for the v2.0 scope narrow
+context:
+  scope_narrow_rationale: |
+    Per KENSA_GO_DAY1_PLAN.md §8.2 and the Kensa↔OpenWatch coordination
+    (docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md §3.2; Kensa response
+    §2.2), per-transaction evidence envelope signing moved to Kensa —
+    where the evidence originates. OpenWatch signing now covers only
+    aggregate artifacts OpenWatch itself produces.
+  trust_layer_boundary: |
+    Kensa signs: per-transaction evidence envelope at capture/execute time.
+      Attests: "This execution happened on this host at this time."
+    OpenWatch signs: aggregate audit exports, quarterly posture reports,
+      State-of-Production releases.
+      Attests: "OpenWatch aggregated this data from N hosts and produced
+      this artifact."
+  kensa_convergence: |
+    OpenWatch audit UIs verify per-transaction envelopes via
+    kensa.api.Kensa.VerifyEnvelope() starting at Kensa Week 22
+    (KENSA_GO_DAY1_PLAN.md §3.5.4).
 
 acceptance_criteria:
   - id: AC-1
@@ -17,34 +39,63 @@ acceptance_criteria:
 
   - id: AC-2
     description: >
-      SigningService.sign_envelope(envelope) returns a SignedBundle with
-      Ed25519 signature.
+      SigningService.sign_envelope(envelope) signs OpenWatch-originated
+      aggregate artifacts (audit exports, quarterly reports). Returns a
+      SignedBundle with Ed25519 signature.
 
   - id: AC-3
     description: >
-      SigningService.verify(bundle) validates signature against public key.
+      SigningService.verify(bundle) validates the signature of an
+      OpenWatch-originated signed bundle against the public key.
 
   - id: AC-4
     description: >
-      Key rotation: new key becomes active, old keys remain verifiable.
+      Key rotation: new key becomes active, old keys remain verifiable
+      so historical aggregate artifacts remain checkable.
 
   - id: AC-5
     description: >
-      GET /api/signing/public-keys returns all active and retired public keys.
+      GET /api/signing/public-keys returns all active and retired public
+      keys for external auditors verifying OpenWatch-originated bundles.
 
   - id: AC-6
     description: >
-      POST /api/transactions/{id}/sign signs a transaction's evidence envelope.
+      POST /api/signing/verify accepts an OpenWatch-signed bundle and
+      returns valid/invalid. Unauthenticated — external auditors do not
+      need OpenWatch credentials.
 
   - id: AC-7
     description: >
-      POST /api/signing/verify accepts a signed bundle and returns valid/invalid.
+      Signing keys are encrypted at rest via EncryptionService. Production
+      deploys that misconfigure EncryptionService hard-fail at
+      generate_key/sign_envelope unless OPENWATCH_SIGNING_DEV_MODE=true
+      (per SEC-SIGN-01 remediation in docs/SIGNING_SECURITY_REVIEW_2026-04-14.md).
 
   - id: AC-8
     description: >
-      Signing keys are encrypted at rest via EncryptionService.
+      Aggregate artifact callers (audit_export._generate_json) that invoke
+      signing write signed_bundle=null + signing_error to the produced
+      artifact on signing failure so the unsigned state is
+      machine-detectable (per SEC-SIGN-03 remediation).
+
+  - id: AC-9
+    description: >
+      Per-transaction signing is NOT in scope. Source inspection confirms
+      routes/signing/routes.py does not register a
+      POST /api/transactions/{id}/sign endpoint; that surface is
+      Kensa's per the v2.0 scope narrow.
 
 changelog:
+  - version: "2.0"
+    date: "2026-04-14"
+    changes:
+      - "BREAKING: scope narrowed to OpenWatch-originated aggregate artifacts"
+      - "Per-transaction signing endpoint removed; that surface moves to Kensa"
+      - "AC-6 retitled: now refers to /api/signing/verify (was POST /api/transactions/{id}/sign)"
+      - "AC-9 added: per-transaction signing explicitly out of scope (Kensa's domain)"
+      - "AC-7 expanded with the SEC-SIGN-01 dev-mode gate"
+      - "AC-8 expanded with the SEC-SIGN-03 machine-detectable unsigned state"
+      - "context: block documents the trust-layer boundary and Kensa convergence"
   - version: "1.0"
     date: "2026-04-11"
     changes:

--- a/tests/backend/unit/services/signing/test_evidence_signing_spec.py
+++ b/tests/backend/unit/services/signing/test_evidence_signing_spec.py
@@ -113,18 +113,12 @@ class TestAC5PublicKeysEndpoint:
 
 
 @pytest.mark.unit
-class TestAC6SignTransactionEndpoint:
-    """AC-6: POST /api/transactions/{id}/sign signs a transaction's evidence envelope."""
+class TestAC6VerifyEndpoint:
+    """AC-6: POST /api/signing/verify accepts OpenWatch-signed bundles.
 
-    def test_sign_transaction_route_exists(self):
-        """Route for POST /api/transactions/{id}/sign is registered."""
-        source = _read_route_source()
-        assert "sign" in source
-
-
-@pytest.mark.unit
-class TestAC7VerifyEndpoint:
-    """AC-7: POST /api/signing/verify accepts a signed bundle and returns valid/invalid."""
+    (Spec v2.0 scope narrow: the former AC-6 per-transaction signing
+    endpoint was removed; verification is the relevant public endpoint now.)
+    """
 
     def test_verify_route_exists(self):
         """Route for POST /api/signing/verify is registered."""
@@ -133,8 +127,8 @@ class TestAC7VerifyEndpoint:
 
 
 @pytest.mark.unit
-class TestAC8KeysEncryptedAtRest:
-    """AC-8: Signing keys are encrypted at rest via EncryptionService."""
+class TestAC7KeysEncryptedAtRest:
+    """AC-7: Signing keys are encrypted at rest via EncryptionService."""
 
     def test_encryption_service_used(self):
         """SigningService source references EncryptionService."""
@@ -161,3 +155,43 @@ class TestAC8KeysEncryptedAtRest:
         # nor dev mode is present.
         assert "RuntimeError" in source
         assert "_dev_mode_enabled" in source
+
+
+@pytest.mark.unit
+class TestAC8AggregateSigningFailureDetectable:
+    """AC-8: Aggregate signing failure is machine-detectable in the artifact."""
+
+    def test_audit_export_writes_explicit_null_on_sign_failure(self):
+        """audit_export writes signed_bundle=null + signing_error on failure.
+
+        Regression for SEC-SIGN-03 (silent signing failure on export).
+        """
+        import app.services.compliance.audit_export as mod
+
+        source = inspect.getsource(mod)
+        assert 'export_data["signed_bundle"] = None' in source
+        assert "signing_error" in source
+
+
+@pytest.mark.unit
+class TestAC9PerTransactionSigningRemoved:
+    """AC-9: Per-transaction signing is NOT in OpenWatch's scope.
+
+    Scope narrowed 2026-04-14: per-transaction signing moved to Kensa.
+    OpenWatch signs only aggregate artifacts it originates.
+    """
+
+    def test_routes_do_not_register_per_transaction_sign_endpoint(self):
+        """routes/signing/routes.py must not register POST /api/transactions/{id}/sign."""
+        source = _read_route_source()
+        # The endpoint must not be registered
+        assert "/api/transactions/{transaction_id}/sign" not in source
+        # Nor the handler function name
+        assert "def sign_transaction" not in source
+
+    def test_module_docstring_documents_kensa_boundary(self):
+        """routes/signing/routes.py module docstring must document the boundary."""
+        source = _read_route_source()
+        # Name the coordination doc that establishes the boundary
+        assert "Kensa" in source
+        assert "aggregate" in source.lower()


### PR DESCRIPTION
Direct action from the Kensa↔OpenWatch coordination. One of three PRs Kensa team explicitly asked to review (their response §6.2, item 1).

## Summary

Per-transaction evidence envelope signing moves to Kensa — where the evidence originates. OpenWatch's signing layer narrows to **aggregate artifacts OpenWatch itself originates** (audit exports, quarterly posture reports, State-of-Production releases).

## Trust-layer boundary (established in this PR)

| Layer | Who signs | What it attests |
|---|---|---|
| **Per-transaction evidence envelope** | **Kensa** | "This execution happened on this host at this time" |
| **Aggregate audit export / quarterly report / State-of-Production** | OpenWatch | "OpenWatch aggregated this data from N hosts and produced this artifact" |

At Kensa Week 22, OpenWatch audit UIs verify per-transaction envelopes via \`kensa.api.Kensa.VerifyEnvelope()\` — OpenWatch does not maintain its own Kensa-envelope verification code.

## Changes

| File | Change |
|---|---|
| \`backend/app/routes/signing/routes.py\` | **Remove** \`POST /api/transactions/{id}/sign\` endpoint + handler. Module docstring documents the boundary. |
| \`backend/app/services/signing/signing_service.py\` | Module docstring rewritten with trust-layer diagram and "aggregate artifacts only" statement. |
| \`specs/services/signing/evidence-signing.spec.yaml\` | **v2.0** scope narrow (see changelog). AC-6 retitled; AC-9 added; AC-7/AC-8 expanded with SEC-SIGN-01/-03 guarantees; \`context:\` block documents rationale. |
| \`tests/backend/unit/services/signing/test_evidence_signing_spec.py\` | AC-9 added enforcing endpoint is gone + module docstring names the boundary. AC-8 tightened. |
| \`docs/SIGNING_SECURITY_REVIEW_2026-04-14.md\` | New "Scope narrow" section at top. Former review findings (SEC-SIGN-01/-02/-03 fixed in #397; -04/-05 open as #395/#396) still valid for the narrowed scope. |

## What survives (covered by this review)

- \`SigningService.sign_envelope()\` — called **only** by \`audit_export._generate_json()\` and future aggregate-report services
- \`GET /api/signing/public-keys\` — public key list for auditors verifying OpenWatch-signed bundles
- \`POST /api/signing/verify\` — verification endpoint for OpenWatch-signed bundles

## What was removed

- \`POST /api/transactions/{id}/sign\` — that surface belongs to Kensa per KENSA_GO_DAY1_PLAN.md §8.2

## Test plan

- [x] \`validate-specs.py\` passes (95/95)
- [x] \`check-spec-coverage.py --enforce-active\` passes (**824/824**, +1 for AC-9)
- [x] Existing signing tests updated; new AC-9 test enforces endpoint is gone
- [x] black + flake8 clean
- [ ] CI pipeline passes

## Related

- \`docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md\` §3.2 (the ask)
- \`/home/rracine/hanalyx/kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md\` §2.2 (Kensa acceptance)
- \`/home/rracine/hanalyx/kensa/docs/KENSA_GO_DAY1_PLAN.md\` §8.2 (per-transaction signing at capture time)
- PR #399 (sibling: interim annotation on transaction query endpoint)
- PR for Q1-Q3 plan rewrite (forthcoming, §6.2 + Phase 3)

## Sequencing

This is PR 2 of 3 in the Kensa-coordination batch:
1. ✅ PR #399 — reframe transaction query API as interim
2. 🔄 **This PR** — narrow signing scope
3. ⏭ Next — rewrite Q1-Q3 plan §6.2 and Phase 3