### PR TITLE
docs(plan): Kensa convergence addendum + rewrite §6.2 and §6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -868,6 +868,15 @@ docs/images/*
 # Security reviews and assessments (tracked in git for audit trail)
 !docs/OW_SECURITY_ASSESSMENT.md
 !docs/*_SECURITY_REVIEW_*.md
+# Planning documents (tracked in git so cross-team coordination docs can
+# reference them and so the Kensa↔OpenWatch convergence schedule is
+# reviewable)
+!docs/OPENWATCH_Q1_PLAN.md
+!docs/OPENWATCH_Q2_PLAN.md
+!docs/OPENWATCH_Q1_Q3_PLAN.md
+!docs/OPENWATCH_VISION.md
+!docs/OPENWATCH_VISION_STATUS.md
+!docs/KENSA_OPENWATCH_COORDINATION_*.md
 PRD/
 backend/docs/
 frontend/docs/

--- a/docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md
+++ b/docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md
@@ -1,0 +1,199 @@
+# Coordination Memo: OpenWatch ↔ Kensa Go Day-1
+
+**From:** OpenWatch team
+**To:** Kensa team
+**Date:** 2026-04-14
+**Subject:** Duplication review, integration commitments, and interface-freeze asks against `KENSA_GO_DAY1_PLAN.md`
+**Status:** Draft for review
+
+---
+
+## 1. What triggered this memo
+
+OpenWatch reviewed `kensa/docs/KENSA_GO_DAY1_PLAN.md` (the Go Day-1 build plan) on 2026-04-14 after recent OpenWatch Q3 work started diverging from the interfaces you've defined in §3.5 and §9. Four confirmed overlaps, one architectural misalignment, and two deferred OpenWatch phases that would build throwaway code if they proceed on current assumptions.
+
+We want to resolve all of this **before** your `api/` surface freezes at Week 1 and before OpenWatch's Phase 6.2 implementation starts.
+
+## 2. The posture OpenWatch is adopting
+
+Per `OPENWATCH_VISION.md`'s framing (git : GitHub :: Kensa : OpenWatch), OpenWatch commits to the following rules:
+
+| Rule | Consequence |
+|------|-------------|
+| Source of truth for per-transaction data lives in **Kensa's SQLite store**. | OpenWatch's PostgreSQL `transactions` table is demoted to a **derived cache/index**, not a parallel source of truth. |
+| Per-transaction cryptographic attestations are **signed by Kensa**. | OpenWatch's per-transaction signing path is deleted. OpenWatch keeps signing only for aggregate artifacts that OpenWatch itself originates (cross-host audit exports, quarterly posture reports, State-of-Production releases). |
+| Single-host execution semantics (Plan, Execute, Rollback, atomicity, capture) live in **Kensa**. | OpenWatch's Phase 6.2 "proactive remediation" rewrites from "OpenWatch generates a plan" to "OpenWatch wraps `Kensa.Plan` / `Kensa.Execute` with an approval-workflow UI." |
+| Event streams originate in **Kensa**. | OpenWatch's Heartbeat service subscribes to `Kensa.Subscribe(filter)` instead of polling PostgreSQL. |
+| OpenWatch codes against **Kensa's `api/` signatures from commit 1**. | `ErrNotYetImplemented` during the stub period is acceptable. Parallel implementations with the intent to "swap later" are not. |
+
+The short form: **OpenWatch is GitHub over Kensa's git.** We present, aggregate, orchestrate, collaborate. We do not re-implement what Kensa already does for a single host.
+
+## 3. Confirmed duplication and OpenWatch's resolution
+
+### 3.1 Transaction log query (Kensa §3.5.1 `LogQuery`)
+
+**Duplication:** OpenWatch merged PR #398 today adding `POST /api/transactions/query` with a DSL whose filter fields mirror your `LogFilter` struct (HostIDs, FleetIDs, RuleIDs, FrameworkRefs, Statuses, Since, Until). Our schema, pagination, and projection shapes were derived independently but the surface is effectively the same read-side contract.
+
+**OpenWatch resolution:**
+- Keep the HTTP endpoint URL and schema stable — it's what OpenWatch UI and any third-party customers will call
+- Refactor the implementation to delegate to `kensa.TransactionLog().Query()` once your Week 22 milestone lands
+- Interim (pre-Week 22): the endpoint queries the PostgreSQL cache (which the Python Kensa presently writes)
+- Spec and route file annotated with this "interim implementation" framing in a follow-up PR
+
+**Ask for Kensa:** see §5 interface questions.
+
+### 3.2 Per-transaction Ed25519 signing (Kensa §8.2)
+
+**Duplication:** OpenWatch merged PR #397 earlier today with `backend/app/services/signing/signing_service.py` + a `deployment_signing_keys` table + `POST /api/transactions/{id}/sign`. Your Go plan places Ed25519 signing at the point of evidence capture, which is the correct trust layer — the auditor needs Kensa's attestation ("this execution happened on this host"), not OpenWatch's ("OpenWatch stored this later").
+
+**OpenWatch resolution:**
+- Delete `POST /api/transactions/{id}/sign` — per-transaction signing becomes Kensa-only
+- Keep the `SigningService` class **but only for aggregate artifacts OpenWatch originates** — cross-host audit export bundles, quarterly posture snapshots, future State-of-Production report
+- Update `docs/SIGNING_SECURITY_REVIEW_2026-04-14.md` with an explicit trust-layer diagram
+- Bump `specs/services/signing/evidence-signing.spec.yaml` to version 2.0 with the narrowed scope
+
+**Ask for Kensa:** confirm that the signed envelope structure in §8.2 is exposed via the Go `api/` (we'll need to display the envelope + signature in OpenWatch's audit UI and verify it via `Kensa` on client request).
+
+### 3.3 Plan / Execute for remediation (Kensa §3.5.3 `Planner`, `Executor`)
+
+**Duplication (planned, not yet built):** OpenWatch's Q1-Q3 plan §6.2 "Proactive Remediation Workflow" specified *"Draft job is a remediation_jobs row with status=draft + the full proposed transaction plan (capture / apply / validate / rollback)"* — re-implementing your `Plan` type and Execute semantics.
+
+**OpenWatch resolution:**
+- Rewrite §6.2 before implementation starts. Revised architecture:
+  1. Drift event → OpenWatch calls `Kensa.Plan(host, rule)` → receives an opaque `Plan` blob
+  2. OpenWatch stores the blob in `remediation_jobs.kensa_plan` (JSONB) without interpreting it
+  3. ApprovalQueue UI renders the plan via a Kensa-provided preview formatter (not OpenWatch's own render)
+  4. On N-of-M approval (OpenWatch's approval-chain layer, §6.3), OpenWatch calls `Kensa.Execute(host, plan)`
+  5. `PlanStaleError` from Kensa surfaces as "re-plan required" in the UI
+- **Do not start 6.2 implementation** until your Week 24 milestone
+
+**Ask for Kensa:** does the `Plan` struct include a human-readable preview string or should OpenWatch render from the `ApplyStep` / `RollbackStep` structures directly? We'd prefer a Kensa-owned formatter (`Plan.Preview()` method or an `api` helper) so the display stays consistent with the CLI's preview.
+
+### 3.4 Event subscription for Heartbeat (Kensa §3.5.2 `EventSubscriber`)
+
+**Duplication (planned, not yet built):** OpenWatch's Phase 3 Heartbeat design called for a PostgreSQL-backed event stream generated by the OpenWatch scheduler/worker.
+
+**OpenWatch resolution:**
+- Rewrite Phase 3 before implementation starts. OpenWatch runs a long-lived consumer over `Kensa.Subscribe(EventFilter{...})`
+- OpenWatch owns: fleet-level aggregation, alert-routing policy, channel dispatch (Slack/email/webhook/Jira), deduplication, notification-rate-limiting
+- Kensa owns: the event stream itself
+
+**Ask for Kensa:** see §5.
+
+### 3.5 Transactions table as "canonical"
+
+**Architectural misalignment, not strict duplication:** OpenWatch's Q1 Phase 1 shipped a `transactions` + `host_rule_state` schema in PostgreSQL. With Kensa's SQLite store becoming the per-deployment source of truth, OpenWatch's PostgreSQL layer needs to be explicitly reframed.
+
+**OpenWatch resolution:**
+- Treat the PostgreSQL `transactions` table as a **multi-host aggregation cache** (not a source of truth). It survives because cross-fleet queries against N independent Kensa SQLite stores are too slow for UI response times
+- Add prominent comments to the ORM model and to `backend/app/tasks/kensa_scan_tasks.py` making this explicit
+- `transaction-log.spec.yaml` updated to bump version and reflect the cache-over-Kensa posture
+- Any conflict between PostgreSQL row and Kensa SQLite row: **Kensa wins** (cache invalidation path via `Subscribe` events)
+
+**Ask for Kensa:** confirm that `LogQuery.Query` + `LogQuery.Aggregate` can serve OpenWatch's multi-host aggregate needs at acceptable latency (<500ms p95 for historical posture queries on fleets of ~1000 hosts), or whether OpenWatch should maintain its own aggregation cache. If the former, OpenWatch drops the PostgreSQL `transactions` table entirely in a later phase.
+
+## 4. Work OpenWatch keeps as pure OpenWatch-layer (NON-duplicative)
+
+These are fleet/multi-user/multi-tenant concerns that have no analog in single-host Kensa. OpenWatch continues building them independently:
+
+| OpenWatch feature | Justification |
+|---|---|
+| Multi-approval chains + approval policies (Phase 6.3) | Orchestrating N approvers is orthogonal to `Kensa.Execute`. Same relationship as GitHub branch-protection rules to `git merge`. |
+| Fleet grouping + per-group policies (Phase 6.4) | Kensa has no concept of "a fleet". OpenWatch owns group membership, group-specific scan cadences, group approval policies. |
+| Public State-of-Production Rollback report (Phase 6.5) | Aggregated statistics across opt-in customers. Cross-tenant by definition. |
+| SSO federation (OIDC + SAML) | User authentication for OpenWatch; not a per-host concern. |
+| Notification channels (Slack, email, webhook, Jira) | Fan-out for Kensa events into organization-specific tooling. |
+| RBAC, audit logging of OpenWatch user actions, multi-tenant isolation | OpenWatch-specific. |
+| Adaptive scan scheduling across a fleet | OpenWatch decides *when* to call `Kensa.Scan` for each host. Kensa scans one host on demand. |
+| Audit export (aggregate CSV/JSON/PDF across hosts) + its Ed25519 signing | OpenWatch-originated artifact. |
+
+## 5. Interface review requests (before Week-1 freeze)
+
+We would value a review of the following interface shapes **before `api/` freezes**, because once semver locks you can't adjust without a major-version bump:
+
+### 5.1 `LogFilter` (§3.5.1)
+
+- Add `Phase []Phase` field? OpenWatch UI filters by phase (capture/apply/validate/commit/rollback).
+- Add `Severity []string` field? OpenWatch views filter by severity (critical/high/medium/low). Today inferred from `rule_id` — but that's expensive at query time.
+- Clarify `FrameworkRef` semantics: is it `(framework_id, control_id)` or an opaque string? OpenWatch filters by control path (`cis_rhel9_v2:5.2.3`).
+
+### 5.2 `AggregateKey` (§3.5.1)
+
+Please support at minimum:
+- `by_host`
+- `by_rule`
+- `by_framework_control`
+- `by_host_then_framework_control` (compliance-officer view: which control is failing on which host?)
+- `by_rule_then_status_over_time` (drift view: rule X's pass/fail ratio over week buckets)
+
+### 5.3 `EventFilter` (§3.5.2)
+
+- Can OpenWatch subscribe to `DeadmanTimerFired` **alone**? Our alert-routing needs to treat this as a critical-severity event regardless of other subscriptions.
+- Is `HeartbeatPulse` rate-limitable in the filter, or does the subscriber drop?
+
+### 5.4 `Plan` (§3.5.3)
+
+- Does `Plan` include a `Preview() string` or `Render() *PreviewDoc` method Kensa owns? OpenWatch would rather display Kensa's rendering than build a second renderer that drifts.
+- `PlanStaleError`: what granularity? (Same-host-any-change, or per-file drift?) OpenWatch's UX needs to say "re-plan because X changed," not just "re-plan."
+
+### 5.5 `TransactionRecord` (§3.5.1 `Get`)
+
+- Does it include the full evidence envelope or only its hash? OpenWatch's audit-export path embeds the envelope directly, so we'd need the full payload.
+
+### 5.6 Concurrency / rate limiting
+
+- Is `Kensa.Scan` / `Kensa.Transact` safe to call concurrently against the same host from different OpenWatch workers? OpenWatch's job queue may fan out.
+- Any per-host serialization you enforce, or is the caller responsible?
+
+## 6. Timing + coordination
+
+From your build sequence (§11):
+
+| Kensa milestone | OpenWatch action |
+|---|---|
+| **Week 1** — `api/` surface frozen with stubs | OpenWatch starts coding against signatures immediately. PR #398 spec annotated; signing narrowed; Q1-Q3 plan §6.2 and Phase 3 rewritten to target `api/`. |
+| **Week 22** — `LogQuery` real | OpenWatch swaps `POST /api/transactions/query` implementation from PostgreSQL to `Kensa.TransactionLog()`. |
+| **Week 24** — `Plan`/`Execute` real | OpenWatch starts §6.2 proactive-remediation implementation. |
+| **Week 25** — `Subscribe` real | OpenWatch cuts Heartbeat from PostgreSQL polling to Kensa event stream. |
+| **Week 26 (M5)** — all OpenWatch-facing APIs real | OpenWatch runs full integration test: Plan → Subscribe → Execute → Query. Target: parity with Python Kensa on a 50-rule corpus. |
+| **Week 40 (M7)** — Kensa Go v1.0.0 | OpenWatch is a pure consumer of Go Kensa. Python Kensa archived. |
+
+Concrete OpenWatch deliverables **this sprint** in direct response to this memo:
+
+1. PR: "docs: align signing scope to OpenWatch-originated artifacts only" (narrows `backend/app/services/signing/`, deletes per-transaction signing endpoint, updates review doc + spec)
+2. PR: "docs: rewrite Q1-Q3 plan §6.2 + Phase 3 against Kensa api/" (architecture-only, no code changes)
+3. PR: "chore(transactions): reframe query API as interim over Kensa LogQuery" (spec annotation + TODO comment in route; no behavior change)
+
+**Not in this sprint:** Phase 6.2 implementation (waits for Week 24) and Phase 3 Heartbeat (waits for Week 25). Phase 6.3 (multi-approval) and Phase 6.4 (fleet groups) remain scheduled — those are OpenWatch-layer and don't wait.
+
+## 7. Asks summary
+
+In priority order, what OpenWatch needs from Kensa team:
+
+1. **Confirm this memo's resolutions are what you expect.** Any of §3.1–3.5 where our resolution is wrong, flag now.
+2. **Review interface questions in §5** and adjust `api/` before Week-1 freeze.
+3. **Confirm the Week 1 `api/` stub strategy is real and imminent.** OpenWatch's roadmap assumes we can start coding against it in ~days, not ~months.
+4. **Coordinate on the evidence-envelope structure** so OpenWatch's audit UI and the CLI present the same thing.
+5. **Shared `kensa-spec` repo for rules/mappings/specs** (your §12.1) — confirm the submodule mechanics so OpenWatch's Kensa rule-reference UI doesn't diverge.
+
+## 8. Open questions
+
+These came up during the review and we want your input, not a pre-baked answer from us:
+
+- **Agent API** (your §3.5 intro says "future AI agents" are a consumer). Is the intent that OpenWatch *also* exposes an HTTP version of Kensa's API to external AI agents, or do agents talk to Kensa directly? This affects whether OpenWatch stands up an `/api/v2/agent` surface or not.
+- **Deadman-timer visibility.** Should OpenWatch's UI render a prominent warning when a deadman timer is armed on a host? (We think yes — operators need to know a rollback is scheduled.) What's the UX you envision?
+- **Multi-fleet transaction log.** If a transaction on host H_1 in fleet F_1 and another on host H_2 in fleet F_2 need cross-querying (e.g., "show me all remediations for CIS 5.2.3 across both fleets last week"), does `LogQuery` on a single Kensa instance answer this, or does OpenWatch federate across N Kensa instances?
+
+---
+
+**Response requested by:** Kensa team commit-1 timeline (please respond before you freeze `api/`).
+
+**Contacts:**
+- OpenWatch: engineering (CLAUDE.md collaborator reviewing this memo, human review pending)
+- Kensa: engineering
+
+**Related documents:**
+- `/home/rracine/hanalyx/kensa/docs/KENSA_GO_DAY1_PLAN.md`
+- `/home/rracine/hanalyx/openwatch/docs/OPENWATCH_VISION.md`
+- `/home/rracine/hanalyx/openwatch/docs/OPENWATCH_Q1_Q3_PLAN.md`
+- `/home/rracine/hanalyx/openwatch/docs/SIGNING_SECURITY_REVIEW_2026-04-14.md`

--- a/docs/OPENWATCH_Q1_PLAN.md
+++ b/docs/OPENWATCH_Q1_PLAN.md
@@ -1,0 +1,1009 @@
+# OpenWatch Q1 Implementation Plan
+
+**Date:** 2026-04-11
+**Window:** Weeks 1–12 (~3 months)
+**Parent:** [OPENWATCH_Q1_Q3_PLAN.md](OPENWATCH_Q1_Q3_PLAN.md)
+**Vision:** [OPENWATCH_VISION.md](OPENWATCH_VISION.md) § Quarter 1
+
+---
+
+## Q1 Goals (from vision)
+
+| Identity | Milestone |
+|---|---|
+| **Eye** | Refactor schema into `transactions` table (four-phase model). Ship transaction log as primary top-level UI. Per-transaction detail view. |
+| **Heartbeat** | Scheduled scans enabled by default on every host. Host liveness monitoring. Fleet-level health view. |
+| **Control Plane** | Slack + Jira integration (outbound alerts). SAML/OIDC SSO. |
+
+**Scope cut for Q1**: Jira moves to Q2 (bidirectional sync is non-trivial). Q1 control plane = SSO + Slack/email outbound only.
+
+**Not in Q1**: OSCAL export (deferred to Kensa), Ed25519 signing (Q2), per-host audit timeline API (Q2), proactive remediation workflow (Q3), multi-approval (Q3), fleet-group policies (Q3).
+
+---
+
+## Phasing
+
+Three parallel workstreams, 12 weeks total. Phase 1 (transaction log) is the critical path — everything else is important but not blocking.
+
+```
+Workstream A: Transaction Log         [weeks 1-12, critical path]
+Workstream B: Heartbeat Completion    [weeks 6-12, parallel]
+Workstream C: Control Plane           [weeks 6-12, parallel]
+```
+
+---
+
+## Workstream A — Transaction Log (weeks 1–12, critical path)
+
+### Week 1: Schema design + spec freeze
+
+**Deliverables:**
+- [ ] `specs/system/transaction-log.spec.yaml` (new, draft → review)
+- [ ] PRD epic opened: `PRD/epics/E7-TRANSACTION-LOG.md`
+- [ ] Design review with founding team (spec walkthrough, exit criteria agreement)
+- [ ] Schema decision: `transactions` table columns, index plan, FK rules, `tenant_id` nullable for Q6 groundwork
+- [ ] Customer survey: "what fields do you depend on in `/api/compliance/audit/exports` CSVs?"  — locks the export contract regression test
+
+**Artifacts:**
+- New spec: `system/transaction-log.spec.yaml` (15 ACs covering schema, write path, read path, backfill, migration rollback)
+- New test stub: `tests/backend/unit/system/test_transaction_log_spec.py` (skip-marked until code lands)
+
+### Week 2: Alembic migration + dual-write scaffold
+
+**Deliverables:**
+- [ ] Alembic migration `040_add_transactions_table.py` — create `transactions` table, indexes, FKs. Does NOT drop old tables.
+- [ ] `backend/app/models/transaction_models.py` — SQLAlchemy model for `Transaction`
+- [ ] `backend/app/repositories/transaction_repository.py` — new repository with `insert`, `get_by_id`, `list_by_host`, `query` methods
+- [ ] Modify `backend/app/tasks/kensa_scan_tasks.py` (write path lines 250–343) to dual-write: keep existing INSERTs into `scans`/`scan_results`/`scan_findings`, add parallel INSERT into `transactions` in the same DB transaction
+- [ ] Feature flag `OPENWATCH_DUAL_WRITE_TRANSACTIONS` (default `true` in dev, `false` in prod for rollback safety)
+
+**Spec coverage (transaction-log.spec.yaml):** AC-1 (table exists), AC-2 (dual-write on scan completion)
+
+### Week 3: Pre-state capture for read-only checks
+
+**Deliverables:**
+- [ ] Extend `backend/app/plugins/kensa/evidence.py:19-45` — `_evidence_to_dict` returns envelope shape with `phases.capture`, `phases.validate`, `phases.commit` populated (for read-only checks, capture == commit.post_state)
+- [ ] `evidence_envelope` JSONB column written for every transaction row
+- [ ] Schema versioning: `evidence_envelope.schema_version = "1.0"`, `kensa_version` captured
+
+**Spec coverage:** AC-3 (envelope schema v1.0), AC-4 (validate-phase fields), AC-5 (schema_version always set)
+
+### Week 4: Backfill task
+
+**Deliverables:**
+- [ ] `backend/app/tasks/transaction_backfill_tasks.py` — `backfill_transactions_from_scans` Celery task
+- [ ] Chunked at 10k rows, progress tracking in `backfill_progress` table
+- [ ] Resumable: if task dies mid-run, next invocation picks up from last checkpoint
+- [ ] Admin route: `POST /api/admin/transactions/backfill` (SUPER_ADMIN only)
+- [ ] Historical transactions have `phase=validate` only; pre/post-state is `null` for pre-refactor rows
+
+**Spec coverage:** AC-6 (backfill is idempotent), AC-7 (historical rows marked with schema_version=0.9)
+
+### Week 5: Service migration — read-only services first
+
+Migrate in dependency order from lowest-risk to highest:
+
+**Deliverables:**
+- [ ] `audit_query.py` reads from `transactions` via `TransactionRepository`
+- [ ] `temporal.py` `get_posture()` and `get_posture_history()` read from `transactions`
+- [ ] Benchmark: `get_posture(host_id, as_of)` p95 `<500ms` on 1M-row fixture database
+- [ ] Tests updated to source-inspect the new read path
+
+**Spec coverage:** AC-8 (audit query reads transactions), AC-9 (temporal queries meet 500ms SLA)
+
+### Week 6: Service migration — drift + alerts
+
+**Deliverables:**
+- [ ] `alert_generator.py` reads from `transactions`
+- [ ] `drift.py` routes source from `transactions`
+- [ ] `DriftDetectionService.detect_drift()` compares transaction aggregates (grouped by `host_id, started_at::date`) against baselines
+
+**Spec coverage:** AC-10 (drift uses transaction aggregates), AC-11 (alerts query transactions)
+
+### Week 7: Service migration — audit export (highest risk)
+
+**Deliverables:**
+- [ ] `audit_export.py` reads from `transactions`
+- [ ] **Critical regression test**: `tests/backend/integration/test_audit_export_parity.py` — runs export on a fixture scan against old schema, runs export against new schema, asserts byte-identical CSV/JSON output
+- [ ] Customer contract locked from week 1 survey
+- [ ] Fallback plan: feature flag `AUDIT_EXPORT_SOURCE=legacy|transactions` for instant rollback
+
+**Spec coverage:** AC-12 (export parity), AC-13 (fallback flag works)
+
+### Week 8: Service migration — routes + scan execution
+
+**Deliverables:**
+- [ ] `routes/scans/kensa.py`, `routes/scans/reports.py` — source from `transactions`
+- [ ] `routes/compliance/posture.py` — source from `transactions`
+- [ ] All integration tests in `tests/backend/integration/` passing against new read path
+- [ ] Old tables still dual-written (rollback path preserved)
+
+### Week 9: New `/api/transactions/*` endpoints
+
+**Deliverables:**
+- [ ] `backend/app/routes/transactions/crud.py` — new router
+  - `GET /api/transactions` — paginated list with filters (`host_id`, `status`, `framework`, `phase`, `rule_id`, `started_at` range, `initiator_type`)
+  - `GET /api/transactions/{id}` — single transaction, full envelope
+  - `GET /api/hosts/{host_id}/transactions` — per-host timeline (stub: paginated by `started_at DESC`, full filter surface in Q2)
+- [ ] `specs/api/transactions/transaction-crud.spec.yaml` (new, draft)
+- [ ] OpenAPI spec regenerated, Swagger docs updated
+
+### Week 10: Frontend — Transactions list + detail
+
+**Deliverables:**
+- [ ] `frontend/src/services/adapters/transactionAdapter.ts` — API client for `/api/transactions/*`
+- [ ] `frontend/src/pages/transactions/Transactions.tsx` — list page with filter bar (status, framework, date range, host)
+- [ ] `frontend/src/pages/transactions/TransactionDetail.tsx` — detail page with four tabs:
+  - **Execution**: phase timeline (capture → validate → commit) with durations
+  - **Evidence**: raw evidence envelope (pretty-printed JSON)
+  - **Controls**: framework mappings with control descriptions
+  - **Related**: other transactions for same host/rule
+- [ ] `scanAdapter.ts` becomes a thin re-export shim pointing at `transactionAdapter`
+- [ ] `specs/frontend/transactions-list.spec.yaml` (new, draft)
+- [ ] `specs/frontend/transaction-detail.spec.yaml` (new, draft)
+
+### Week 11: Navigation rename + Findings filter view
+
+**Deliverables:**
+- [ ] Top-nav **Scans → Transactions** (one-line change in `frontend/src/components/layout/Sidebar.tsx` or equivalent)
+- [ ] **Findings** becomes a preset filter on Transactions page: `status=fail`, no separate page
+- [ ] Old `/api/scans/*` endpoints gain `Deprecation` response header pointing at `/api/transactions/*`
+- [ ] `frontend/src/pages/scans/Scans.tsx` redirects to `/transactions` with a one-time notice
+- [ ] Update frontend specs: `scan-workflow.spec.yaml` → add AC for redirect behavior
+
+### Week 12: Exit criteria validation + spec promotion
+
+**Deliverables:**
+- [ ] All existing tests passing (no regressions)
+- [ ] Temporal query benchmark: p95 `<500ms` on production-sized fixture DB
+- [ ] Audit export parity test passing
+- [ ] `kensa_scan_tasks` duration regression: new dual-write adds `<10%` overhead vs baseline
+- [ ] `specs/system/transaction-log.spec.yaml` promoted **draft → active** (CI now enforces 100% AC coverage)
+- [ ] `specs/api/transactions/transaction-crud.spec.yaml` promoted **draft → active**
+- [ ] `specs/frontend/transactions-list.spec.yaml` promoted **draft → active**
+- [ ] `specs/frontend/transaction-detail.spec.yaml` promoted **draft → active**
+- [ ] Old tables still dual-written — **do not drop until Q2** (operational safety net)
+- [ ] Existing active specs updated with changelog entries (see "Spec Updates" below)
+
+---
+
+## Workstream B — Heartbeat Completion (weeks 6–12)
+
+Starts in week 6 when Workstream A has freed enough engineer attention.
+
+### Week 6: Auto-baseline on first scan
+
+**Current state:** `PostureSnapshot` model + daily snapshots shipped. `BaselineService` exists. No trigger on first scan.
+
+**Deliverables:**
+- [ ] Modify `kensa_scan_tasks.py` (end-of-scan hook): after successful scan, call `BaselineService.establish_baseline_if_missing(host_id, source_scan_id)`
+- [ ] Idempotent: no-ops if host already has `is_active=true` baseline
+- [ ] `specs/services/compliance/compliance-scheduler.spec.yaml` — add AC: "First successful scan MUST auto-establish baseline"
+
+### Weeks 7–8: Separate liveness ping
+
+**Current state:** Liveness inferred from `last_scan_completed`. At 6–24h scan cadence, signal is too slow for vision's 15-min detection target.
+
+**Deliverables:**
+- [ ] New Alembic migration `041_add_host_liveness.py` — `host_liveness` table: `host_id (PK)`, `last_ping_at`, `last_response_ms`, `reachability_status` (`reachable`/`unreachable`/`unknown`), `consecutive_failures`
+- [ ] `backend/app/models/host_liveness.py` — SQLAlchemy model
+- [ ] `backend/app/services/monitoring/liveness.py` — `LivenessService.ping_host(host_id)` opens a TCP connection to SSH port, records response time, updates row
+- [ ] `backend/app/tasks/liveness_tasks.py` — Celery Beat task `ping_all_managed_hosts`, schedule every 5 minutes
+- [ ] Alert dispatch: transition from `reachable → unreachable` triggers `HOST_UNREACHABLE` alert via `AlertService.create_alert()`
+- [ ] **New spec**: `specs/services/monitoring/host-liveness.spec.yaml` (draft)
+- [ ] Test stub: `tests/backend/unit/services/monitoring/test_host_liveness_spec.py`
+
+### Week 9: Maintenance mode UI
+
+**Current state:** Backend fully shipped at `compliance_scheduler.py:508-549`. Frontend absent.
+
+**Deliverables:**
+- [ ] Add "Maintenance Mode" toggle to `HostDetail.tsx` header — wired to `POST /api/hosts/{id}/schedule/maintenance`
+- [ ] Add column to `Hosts.tsx` list view showing maintenance state
+- [ ] Confirmation dialog: "Hosts in maintenance mode are not scanned and do not generate alerts. Continue?"
+- [ ] Update `specs/frontend/host-detail-behavior.spec.yaml` — add AC for maintenance mode toggle
+
+### Weeks 10–11: Fleet health "at a glance"
+
+**Current state:** `FleetHealthWidget.tsx` (336 LOC) shows status pie chart. Missing: drift count, failed scans count, liveness distinct from scan recency.
+
+**Deliverables:**
+- [ ] Extend `FleetHealthWidget.tsx` with three metric tiles:
+  - "**X / Y hosts reachable**" — from `host_liveness` (not scan_results)
+  - "**Z drift events** in last 24h"
+  - "**N failed scans** in last 24h"
+- [ ] New backend endpoint: `GET /api/fleet/health-summary` — single call returning all three metrics
+- [ ] Query goes against `transactions` table (Workstream A dependency — this is why B starts week 6, not week 1)
+- [ ] Update `specs/frontend/role-dashboards.spec.yaml` — add AC for fleet health summary
+
+### Week 12: Heartbeat exit validation
+
+**Deliverables:**
+- [ ] First-scan baseline established for new host in <1s
+- [ ] Liveness ping task running in production, p95 latency tracked
+- [ ] Fleet health widget loads in `<500ms`
+- [ ] `specs/services/monitoring/host-liveness.spec.yaml` promoted to active
+
+---
+
+## Workstream C — Control Plane Tier 1 (weeks 6–12)
+
+### Weeks 6–7: Notification dispatch foundation
+
+**Current state:** `AlertService` creates alert DB rows. `routes/integrations/webhooks.py` exists for generic webhooks but is not wired to alerts. No Slack, no email.
+
+**Deliverables:**
+- [ ] `backend/app/services/notifications/__init__.py` — new package
+- [ ] `backend/app/services/notifications/base.py` — `NotificationChannel` ABC: `async send(alert: Alert) -> DeliveryResult`
+- [ ] `backend/app/services/notifications/slack.py` — `SlackChannel` using `slack-sdk`, Block Kit message format
+- [ ] `backend/app/services/notifications/email.py` — `EmailChannel` using `aiosmtplib`, HTML template for alerts
+- [ ] `backend/app/services/notifications/webhook.py` — thin wrapper around existing webhook service
+- [ ] New table `notification_channels`: `id, tenant_id, channel_type, name, config_encrypted (JSONB), enabled`
+- [ ] `requirements.txt`: add `slack-sdk>=3.27.0`, `aiosmtplib>=3.0.0`
+- [ ] **New spec**: `specs/services/infrastructure/notification-channels.spec.yaml` (draft)
+- [ ] Test stub: `tests/backend/unit/services/infrastructure/test_notification_channels_spec.py`
+
+### Week 8: Alert → notification wiring
+
+**Deliverables:**
+- [ ] Modify `AlertService.create_alert()` — after DB insert, dispatch to all enabled channels via `NotificationDispatchService`
+- [ ] Dedupe via existing 60-min window (`alerts.py:137`)
+- [ ] Async dispatch: Celery task per channel per alert, failures logged but don't block alert creation
+- [ ] New endpoints in `routes/admin/notifications.py`:
+  - `GET /api/admin/notifications/channels` — list
+  - `POST /api/admin/notifications/channels` — create (SUPER_ADMIN)
+  - `POST /api/admin/notifications/channels/{id}/test` — send test notification
+- [ ] Frontend: `frontend/src/pages/admin/NotificationSettings.tsx` — admin-only page
+- [ ] Update `specs/services/compliance/alert-thresholds.spec.yaml` — add AC: "Alerts MUST dispatch to all enabled notification channels"
+
+### Weeks 9–11: SAML/OIDC SSO
+
+**Current state:** Zero groundwork. Local JWT auth, FIPS Argon2id/RS256 (both good). No federation library, no provider abstraction.
+
+**Deliverables week 9:**
+- [ ] Dependency evaluation: `authlib` (OIDC) + `python3-saml` vs `pysaml2` (SAML). **Decision by end of week 9**. Recommended: `authlib` for OIDC, `pysaml2` for SAML (pure Python, simpler RPM/DEB packaging)
+- [ ] `requirements.txt` updated with chosen libraries
+- [ ] Alembic migration `042_add_sso_providers.py`:
+  - `sso_providers` table: `id, provider_type (saml|oidc), name, config_encrypted (JSONB), enabled, created_at`
+  - `users` table: add `sso_provider_id (FK)`, `external_id (VARCHAR 255)`, `last_sso_login_at (TIMESTAMPTZ)`
+- [ ] **New spec**: `specs/services/auth/sso-federation.spec.yaml` (draft)
+- [ ] Test stub: `tests/backend/unit/services/auth/test_sso_federation_spec.py`
+
+**Deliverables week 10:**
+- [ ] `backend/app/services/auth/sso/__init__.py`
+- [ ] `backend/app/services/auth/sso/provider.py` — abstract `SSOProvider` with:
+  - `get_login_url(state: str, redirect_uri: str) -> str`
+  - `handle_callback(request_data: dict) -> SSOUserClaims`
+  - `map_claims_to_user(claims: SSOUserClaims) -> User` (creates or updates local user record)
+- [ ] `backend/app/services/auth/sso/oidc.py` — `OIDCProvider(SSOProvider)` using authlib
+- [ ] `backend/app/services/auth/sso/saml.py` — `SAMLProvider(SSOProvider)` using pysaml2
+- [ ] Claim-to-role mapping configurable per provider (stored in `sso_providers.config_encrypted`)
+- [ ] First-login creates local user linked via `external_id`; subsequent logins refresh claims
+
+**Deliverables week 11:**
+- [ ] Routes in `backend/app/routes/auth/sso.py`:
+  - `GET /api/auth/sso/providers` — list enabled providers for login screen (public)
+  - `GET /api/auth/sso/login?provider_id={id}` — redirect to IdP
+  - `GET /api/auth/sso/callback/oidc/{provider_id}` — OIDC callback
+  - `POST /api/auth/sso/callback/saml/{provider_id}` — SAML ACS endpoint
+- [ ] Admin CRUD in `backend/app/routes/admin/sso.py`:
+  - `POST /api/admin/sso/providers` — create
+  - `PUT /api/admin/sso/providers/{id}` — update
+  - `POST /api/admin/sso/providers/{id}/test` — test login flow
+- [ ] Frontend: login page `LoginPage.tsx` displays "Sign in with {Provider}" buttons for each enabled provider
+- [ ] Frontend admin page: `frontend/src/pages/admin/SSOSettings.tsx`
+- [ ] Integration tests:
+  - OIDC flow against a mock IdP (authlib supports local test IdPs)
+  - SAML flow against a mock IdP (pysaml2 ships with test fixtures)
+- [ ] **New spec**: `specs/api/auth/sso-routes.spec.yaml` (draft)
+- [ ] **Security review gate** — external review of SSO implementation before promotion to active
+
+### Week 12: Control Plane exit validation
+
+**Deliverables:**
+- [ ] Slack notification delivered end-to-end on a synthetic alert
+- [ ] Email notification delivered to configured SMTP
+- [ ] OIDC login flow works against Okta dev tenant (or Keycloak test instance)
+- [ ] SAML login flow works against AD FS test instance (or SimpleSAMLphp)
+- [ ] Security review sign-off
+- [ ] Specs promoted draft → active:
+  - `services/auth/sso-federation.spec.yaml`
+  - `services/infrastructure/notification-channels.spec.yaml`
+  - `api/auth/sso-routes.spec.yaml`
+
+---
+
+## Spec Updates
+
+### New specs (created as **draft**, promoted to **active** at week 12)
+
+| Spec | Location | Workstream | Week Active |
+|---|---|---|---|
+| transaction-log | `specs/system/transaction-log.spec.yaml` | A | 12 |
+| transaction-crud (API) | `specs/api/transactions/transaction-crud.spec.yaml` | A | 12 |
+| transactions-list (FE) | `specs/frontend/transactions-list.spec.yaml` | A | 12 |
+| transaction-detail (FE) | `specs/frontend/transaction-detail.spec.yaml` | A | 12 |
+| host-liveness | `specs/services/monitoring/host-liveness.spec.yaml` | B | 12 |
+| notification-channels | `specs/services/infrastructure/notification-channels.spec.yaml` | C | 12 |
+| sso-federation | `specs/services/auth/sso-federation.spec.yaml` | C | 12 |
+| sso-routes (API) | `specs/api/auth/sso-routes.spec.yaml` | C | 12 |
+
+### Existing specs that will change in Q1
+
+These specs keep their current ACs but gain new ones as Q1 features land. Each change is a version bump with a changelog entry in the YAML.
+
+| Spec | Change | Version Bump |
+|---|---|---|
+| `pipelines/scan-execution.spec.yaml` | Add AC: transactions row written alongside scan_findings | 1.2 → 1.3 |
+| `pipelines/drift-detection.spec.yaml` | Add AC: drift reads from transactions aggregates | 1.x → 1.y |
+| `services/compliance/temporal-compliance.spec.yaml` | Add AC: get_posture sources from transactions | bump |
+| `services/compliance/audit-query.spec.yaml` | Add AC: audit queries target transactions | bump |
+| `services/compliance/alert-thresholds.spec.yaml` | Add AC: alerts dispatch via notification channels | bump |
+| `services/compliance/compliance-scheduler.spec.yaml` | Add AC: first-scan auto-baseline | bump |
+| `api/scans/scan-results.spec.yaml` | Add AC: endpoint includes Deprecation header | bump |
+| `api/scans/scan-crud.spec.yaml` | Add AC: endpoint includes Deprecation header | bump |
+| `frontend/scan-workflow.spec.yaml` | Add AC: /scans redirects to /transactions | bump |
+| `frontend/scans-list.spec.yaml` | Add AC: Scans list redirects to Transactions | bump |
+| `frontend/host-detail-behavior.spec.yaml` | Add AC: maintenance mode toggle | bump |
+| `frontend/role-dashboards.spec.yaml` | Add AC: fleet health summary tiles | bump |
+
+### SPEC_REGISTRY update
+
+- Add 8 new specs to the registry in draft status during weeks 1–11
+- Bump totals: System 10→11, API 28→30, Frontend 13→15, Services 22→25, **Total 80→88**
+- After week 12 promotions: 88 Active, 0 Draft (matching current "only active" convention)
+
+---
+
+## Test Updates
+
+### New test files (stubs during weeks 1–11, fleshed out as code lands)
+
+Each new draft spec gets a matching test file with AC classes pre-scaffolded. Tests are skip-marked until the corresponding code lands. At week 12 promotion, all skip marks are removed and tests must pass.
+
+| Test File | Spec | Scaffold Week | Complete Week |
+|---|---|---|---|
+| `tests/backend/unit/system/test_transaction_log_spec.py` | transaction-log | 1 | 12 |
+| `tests/backend/unit/api/test_transaction_crud_spec.py` | transaction-crud | 9 | 12 |
+| `tests/frontend/transactions/transactions-list.spec.test.ts` | transactions-list | 10 | 12 |
+| `tests/frontend/transactions/transaction-detail.spec.test.ts` | transaction-detail | 10 | 12 |
+| `tests/backend/unit/services/monitoring/test_host_liveness_spec.py` | host-liveness | 7 | 12 |
+| `tests/backend/unit/services/infrastructure/test_notification_channels_spec.py` | notification-channels | 6 | 12 |
+| `tests/backend/unit/services/auth/test_sso_federation_spec.py` | sso-federation | 9 | 12 |
+| `tests/backend/unit/api/test_sso_routes_spec.py` | sso-routes | 11 | 12 |
+
+### Regression tests (critical — must ship before dependent feature)
+
+| Test | Purpose | Week |
+|---|---|---|
+| `tests/backend/integration/test_audit_export_parity.py` | Byte-identical CSV/JSON export across schema refactor | 7 |
+| `tests/backend/integration/test_temporal_query_perf.py` | p95 `<500ms` on 1M-row fixture | 5 |
+| `tests/backend/integration/test_scan_execution_dual_write.py` | Dual-write produces consistent rows in old + new tables | 2 |
+| `tests/backend/integration/test_transaction_backfill.py` | Backfill is idempotent and resumable | 4 |
+| `tests/backend/integration/test_sso_oidc_flow.py` | End-to-end OIDC against mock IdP | 11 |
+| `tests/backend/integration/test_sso_saml_flow.py` | End-to-end SAML against mock IdP | 11 |
+
+### Test marker conventions
+
+- `@pytest.mark.unit` — source-inspection tests (current project convention)
+- `@pytest.mark.integration` — database + full stack
+- `@pytest.mark.regression` — marks tests that pin existing behavior (audit export parity)
+- `@pytest.mark.slow` — performance benchmarks
+- `@pytest.mark.skip(reason="Q1: transaction log not yet implemented")` — skip-marked stubs during weeks 1–11
+
+---
+
+## Dependencies & risks
+
+### Dependency graph
+
+```
+week 1:  spec freeze (transaction-log)
+         ↓
+week 2:  Alembic migration + dual-write
+         ↓
+week 3:  pre-state capture (may require Kensa team coordination)
+         ↓
+week 4:  backfill task (independent)
+         ↓
+weeks 5-8: service migration (in risk order)
+         ↓
+week 9:  /api/transactions/* endpoints
+         ↓
+weeks 10-11: frontend
+         ↓
+week 12: exit validation + spec promotion
+
+Workstream B (weeks 6-12): depends on A's transactions table (for fleet health summary)
+Workstream C (weeks 6-12): independent of A, can start any time engineers free up
+```
+
+### Risks (ranked by severity)
+
+1. **Kensa team coordination on pre-state capture** (week 3). If Kensa needs changes to emit pre-state, it's an upstream PR on a different repo. **Mitigation:** open the conversation week 1; Phase 4 (Q2) is the real deadline for full envelope, so week 3 only needs read-only-check envelope shape.
+
+2. **Audit export contract drift** (week 7). Customer CSVs may depend on undocumented column order. **Mitigation:** week 1 customer survey, regression test from fixture file, feature flag rollback.
+
+3. **Temporal query performance on new schema** (week 5). 500ms SLA could fail if composite index `(host_id, started_at)` is mis-tuned. **Mitigation:** benchmark early, add covering indexes if needed, cold/warm cache test.
+
+4. **SAML library packaging** (weeks 9–10). `python3-saml` has C deps that complicate RPM/DEB. **Mitigation:** decide on `pysaml2` (pure Python) by end of week 9.
+
+5. **SSO security review delay** (week 12). External security review blocks promotion to active. **Mitigation:** schedule reviewer in week 9, deliver for review by week 11.
+
+6. **Large-deployment backfill** (week 4). Customers with millions of `scan_findings` rows will have multi-hour backfills. **Mitigation:** resumable chunked task, progress UI, Phase 2 UI can run on forward-only dual-written data without full backfill.
+
+---
+
+## Exit criteria (end of week 12)
+
+### Transaction Log (Workstream A)
+- [ ] `transactions` table in production, dual-written from every scan path
+- [ ] `/api/transactions/*` endpoints documented and live
+- [ ] Transaction list + detail pages shipped
+- [ ] Findings as filtered transaction view
+- [ ] Top-nav says **Transactions**; old `/api/scans/*` has `Deprecation` headers
+- [ ] Temporal query benchmark: p95 `<500ms`
+- [ ] Audit export parity regression passes
+- [ ] `kensa_scan_tasks` regression: dual-write adds `<10%` overhead
+- [ ] 4 new specs promoted to active; 10 existing specs updated with changelog
+
+### Heartbeat (Workstream B)
+- [ ] First-scan auto-baseline in production
+- [ ] `host_liveness` table + 5-min ping task running
+- [ ] Maintenance mode UI in Host Detail + Hosts list
+- [ ] Fleet health widget shows reachable/drift/failed tiles
+- [ ] 1 new spec promoted to active; 3 existing specs updated
+
+### Control Plane (Workstream C)
+- [ ] Slack notifications firing on synthetic alerts
+- [ ] Email notifications firing on synthetic alerts
+- [ ] OIDC login flow validated against real IdP (Okta/Keycloak)
+- [ ] SAML login flow validated against real IdP (AD FS/SimpleSAMLphp)
+- [ ] External security review sign-off on SSO
+- [ ] 3 new specs promoted to active; 1 existing spec updated
+
+### Cross-cutting
+- [ ] CI green: `validate-specs.py`, `check-spec-coverage.py --enforce-active`, `check-spec-changes.py`
+- [ ] Test coverage floor maintained (42%)
+- [ ] No regression in existing CI suite
+- [ ] PRD epic E7 closed; session handoff log updated
+- [ ] Old scan tables still written (rollback possible) — drop deferred to Q2
+
+---
+
+## PR decomposition (suggested)
+
+Small PRs, incremental commits. Each PR should pass CI independently.
+
+| PR | Contents | Reviewers | Week |
+|---|---|---|---|
+| 1 | `specs/system/transaction-log.spec.yaml` (draft) + test stub | founding engineer | 1 |
+| 2 | Alembic `040_add_transactions_table.py` + model + repository | backend | 2 |
+| 3 | Dual-write in `kensa_scan_tasks.py` + feature flag | backend | 2 |
+| 4 | Envelope shape in `kensa/evidence.py` | backend | 3 |
+| 5 | Backfill task + admin endpoint | backend | 4 |
+| 6 | `audit_query.py` migration | backend | 5 |
+| 7 | `temporal.py` migration + perf test | backend | 5 |
+| 8 | `alert_generator.py` + `drift.py` migration | backend | 6 |
+| 9 | `audit_export.py` migration + parity regression test | backend + security | 7 |
+| 10 | Routes migration | backend | 8 |
+| 11 | `/api/transactions/*` endpoints + spec + tests | backend | 9 |
+| 12 | `transactionAdapter.ts` + Transactions list page + spec | frontend | 10 |
+| 13 | Transaction detail page with four tabs + spec | frontend | 10 |
+| 14 | Nav rename + Findings filter + deprecation headers | frontend + backend | 11 |
+| 15 | Auto-baseline wiring | backend | 6 |
+| 16 | `host_liveness` table + ping task + spec | backend | 7–8 |
+| 17 | Maintenance mode UI | frontend | 9 |
+| 18 | Fleet health summary endpoint + widget extension | backend + frontend | 10–11 |
+| 19 | `notifications/` package + Slack + email + spec | backend | 6–7 |
+| 20 | Alert dispatch wiring + admin notification settings UI | backend + frontend | 8 |
+| 21 | SSO Alembic + models + abstract provider + spec | backend | 9 |
+| 22 | OIDC provider + routes + integration test | backend | 10 |
+| 23 | SAML provider + routes + integration test | backend | 10–11 |
+| 24 | SSO admin + login pages | frontend | 11 |
+| 25 | Spec promotions (draft → active) + SPEC_REGISTRY update | founding engineer | 12 |
+
+**~25 PRs over 12 weeks = ~2 PRs/week.** Realistic with 2 backend + 1 frontend engineer.
+
+---
+
+## Workstream D — Redis/Celery Migration (weeks 8–12)
+
+### Motivation
+
+OpenWatch uses <10% of Celery's features (no canvas, no rate limits, no chaining) and
+Redis only as a Celery broker + 3 small application caches (token blacklist, rule cache,
+SSO state). Eliminating both dependencies:
+- Removes 2 infrastructure services (Redis container, Celery Beat container)
+- Simplifies air-gapped RPM/DEB packaging (no Redis to bundle)
+- All state in one durable store (PostgreSQL WAL vs Redis in-memory)
+- Reduces Docker containers from 6 to 3 (backend, worker, db)
+
+### Scalability analysis
+
+PostgreSQL `SKIP LOCKED` handles ~5,000 dequeues/second. OpenWatch peak load:
+- 7 hosts: ~0.07 tasks/sec (trivial)
+- 700 hosts: ~2.6 tasks/sec (0.05% of capacity)
+- 7,000 hosts: ~25 tasks/sec (0.5% of capacity)
+- 70,000 hosts: ~250 tasks/sec (5% of capacity)
+
+The scaling wall is SSH scan execution (~60s per host), not task dispatch.
+
+### Phase D1: Job queue infrastructure (week 8)
+
+**Deliverables:**
+- [ ] Alembic migration: `job_queue` table (id, task_name, args JSONB, status, priority,
+      queue, scheduled_at, started_at, completed_at, result JSONB, error, retry_count,
+      max_retries, timeout_seconds, created_at)
+- [ ] Index: `(status, scheduled_at, queue, priority DESC)` for `SKIP LOCKED` polling
+- [ ] `backend/app/services/job_queue/service.py` — `JobQueueService` with:
+  - `enqueue(task_name, args, queue, priority, delay, max_retries, timeout)` → INSERT
+  - `dequeue(queue)` → SELECT FOR UPDATE SKIP LOCKED + UPDATE status=running
+  - `complete(job_id, result)` → UPDATE status=completed
+  - `fail(job_id, error, retry)` → UPDATE status=failed or re-enqueue with backoff
+  - `schedule_recurring(name, cron_expr, task_name, args, queue)` → recurring job config
+- [ ] `backend/app/services/job_queue/worker.py` — `Worker` class:
+  - Poll loop: `dequeue()` → dispatch to task registry → `complete()`/`fail()`
+  - Timeout enforcement via `signal.alarm()` (Unix) or threading timer
+  - Graceful shutdown on SIGTERM
+  - Configurable concurrency (thread pool or process pool)
+- [ ] `backend/app/services/job_queue/scheduler.py` — `Scheduler` class:
+  - Reads `recurring_jobs` table, INSERTs due jobs into `job_queue`
+  - Runs every 10 seconds in a loop
+  - Replaces Celery Beat entirely
+- [ ] New spec: `specs/system/job-queue.spec.yaml` (draft)
+- [ ] Test stubs
+
+### Phase D2: Task registry + adapter layer (week 9)
+
+**Deliverables:**
+- [ ] `backend/app/services/job_queue/registry.py` — maps task names to callables:
+  ```python
+  TASK_REGISTRY = {
+      "app.tasks.ping_all_managed_hosts": ping_all_managed_hosts,
+      "app.tasks.dispatch_compliance_scans": dispatch_compliance_scans,
+      ...
+  }
+  ```
+- [ ] Adapter: `enqueue()` wrapper that matches Celery's `.delay()` API for gradual migration:
+  ```python
+  # Drop-in replacement:
+  # Old: execute_kensa_scan_task.delay(scan_id=x, host_id=y)
+  # New: job_queue.enqueue("app.tasks.execute_kensa_scan", {"scan_id": x, "host_id": y})
+  ```
+- [ ] Migrate 2 simple tasks as proof of concept:
+  - `detect_stale_scans` (periodic, no retry, no dependencies)
+  - `cleanup_old_posture_snapshots` (periodic, no retry)
+- [ ] Both Celery and job_queue running side-by-side (feature flag `OPENWATCH_USE_PG_QUEUE`)
+
+### Phase D3: Replace Redis direct usage (week 10)
+
+**Deliverables:**
+- [ ] Token blacklist → PostgreSQL table `token_blacklist` (jti PK, expires_at):
+  - `is_blacklisted(jti)` → SELECT EXISTS
+  - `blacklist(jti, expires_at)` → INSERT
+  - Hourly cleanup: DELETE WHERE expires_at < NOW()
+  - No latency impact: blacklist check is on token refresh (not every request)
+- [ ] Rule cache → in-process `cachetools.TTLCache`:
+  - Kensa rules are static YAML loaded from disk
+  - No cross-process sharing needed (each worker loads its own copy)
+  - TTL 30 min matches current Redis TTL
+  - Eliminates Redis DB 2 entirely
+- [ ] SSO state → PostgreSQL table `sso_state` (state_token PK, provider_id, expires_at):
+  - 5-minute TTL, cleaned up by scheduler
+  - Low volume (<10 logins/hour)
+- [ ] Remove `redis` from `requirements.txt` imports in these modules
+
+### Phase D4: Migrate all tasks (week 11)
+
+**Deliverables:**
+- [ ] Migrate remaining 26 tasks from Celery to job_queue, in batches:
+  - Batch 1: Maintenance tasks (stale detection, cleanup, snapshots) — 5 tasks
+  - Batch 2: Monitoring tasks (host checks, liveness, OS discovery) — 5 tasks
+  - Batch 3: Compliance tasks (scheduler dispatch, scans, alerts) — 8 tasks
+  - Batch 4: On-demand tasks (remediation, exports, webhooks, backfill) — 8 tasks
+- [ ] Each batch: migrate, test, verify in running infrastructure before next batch
+- [ ] `recurring_jobs` table populated with all 8 Beat schedule entries
+- [ ] Feature flag `OPENWATCH_USE_PG_QUEUE=true` becomes default
+
+### Phase D5: Remove Celery + Redis (week 12)
+
+**Deliverables:**
+- [ ] Remove from `requirements.txt`: `celery`, `redis`, `kombu`, `flower`
+- [ ] Delete: `backend/app/celery_app.py`
+- [ ] Delete: `backend/app/services/auth/token_blacklist.py` (replaced)
+- [ ] Delete: `backend/app/services/rules/cache.py` (replaced)
+- [ ] Update `docker-compose.yml`:
+  - Remove `openwatch-redis` container
+  - Remove `openwatch-celery-beat` container
+  - Change `openwatch-worker` to run `python -m app.services.job_queue.worker`
+  - Result: 3 containers (backend, worker, db) instead of 6
+- [ ] Update `packaging/rpm/build-rpm.sh` and `packaging/deb/build-deb.sh`:
+  - Remove Redis dependency from package requirements
+  - Worker systemd service runs job_queue worker instead of Celery
+- [ ] Update health check endpoint to remove Redis health
+- [ ] Spec promotion: `job-queue.spec.yaml` draft → active
+- [ ] Integration test: full scan cycle with no Redis/Celery running
+
+### Phase D exit criteria
+
+- [ ] Zero Redis connections in the running system
+- [ ] Zero Celery imports in the codebase
+- [ ] All 28 tasks executing via job_queue
+- [ ] All 8 periodic schedules running via scheduler
+- [ ] Scan → transaction → alert → notification pipeline works end-to-end
+- [ ] Docker containers: backend, worker, db (3 total, down from 6)
+- [ ] RPM/DEB packages build without Redis dependency
+- [ ] `pg_queue.spec.yaml` active with 100% AC coverage
+
+### PR decomposition
+
+| PR | Contents | Week |
+|---|---|---|
+| 26 | job_queue table + service + worker + scheduler + spec | 8 |
+| 27 | Task registry + adapter + 2 proof-of-concept migrations | 9 |
+| 28 | Token blacklist → PG + rule cache → in-process + SSO state → PG | 10 |
+| 29 | Migrate tasks batch 1+2 (maintenance + monitoring) | 11 |
+| 30 | Migrate tasks batch 3+4 (compliance + on-demand) | 11 |
+| 31 | Remove Celery + Redis + docker-compose + packaging updates | 12 |
+
+**~6 PRs over 5 weeks.** Can overlap with Workstream A/B/C wrap-up.
+
+### Risks
+
+1. **Task timeout enforcement**: Celery uses OS signals (SIGTERM/SIGKILL) to enforce
+   time limits. The custom worker needs the same — `signal.alarm()` works on Unix but
+   not Windows. OpenWatch targets Linux only, so this is fine.
+
+2. **Concurrent worker scaling**: Celery's prefork pool is battle-tested. The custom
+   worker can use `concurrent.futures.ProcessPoolExecutor` for the same effect, but
+   needs testing under load.
+
+3. **Graceful shutdown**: Celery handles SIGTERM → warm shutdown → finish current task.
+   The custom worker needs the same signal handling.
+
+4. **Migration window**: During D2–D4, both Celery and job_queue run side-by-side.
+   This means Redis is still required until D5. Plan for a clean cutover.
+
+---
+
+**~31 PRs over 12 weeks = ~2.5 PRs/week.** Realistic with 2 backend + 1 frontend engineer.
+
+---
+
+## Workstream E — Dependency Minimization (3 tiers)
+
+OpenWatch targets air-gapped federal environments where every dependency is an attack
+surface, a licensing risk, and a packaging burden. This workstream systematically
+reduces the dependency tree across three tiers of increasing ambition.
+
+### Tier 1: Python dependency cleanup (Q1, weeks 10–12, alongside Workstream D)
+
+**Goal:** Consolidate redundant packages, remove dead dependencies. ~45 → ~30 packages.
+
+**Phase E1.1: Consolidate HTTP clients (week 10)**
+
+Three HTTP client libraries exist: `requests`, `httpx`, `aiohttp`. Only `httpx` is needed.
+
+- [ ] Audit all `import requests` callsites — migrate to `httpx`
+- [ ] Audit all `import aiohttp` callsites — migrate to `httpx` (supports async natively)
+- [ ] Remove from `requirements.txt`: `requests`, `aiohttp`
+- [ ] Keep: `httpx` (already used for webhooks and SSO)
+- [ ] Verify: Kensa does not import requests/aiohttp internally
+
+**Phase E1.2: Remove redundant schedulers (week 10)**
+
+Two scheduling libraries exist alongside Celery Beat: `APScheduler`, `schedule`.
+After Workstream D, all scheduling goes through the job_queue scheduler.
+
+- [ ] Audit all `import apscheduler` and `import schedule` callsites
+- [ ] Remove from `requirements.txt`: `APScheduler`, `schedule`
+- [ ] Verify no runtime usage remains
+
+**Phase E1.3: Remove dead SCAP/XML dependencies (week 11)**
+
+Kensa replaced OpenSCAP. The XML processing chain may be dead code.
+
+- [ ] Audit all `import lxml` and `import xmltodict` callsites
+- [ ] If only used in legacy SCAP result parsing (OpenSCAP pathway): remove
+- [ ] If used in active code (audit export PDF?): keep
+- [ ] Remove `Pillow` and `python-magic` if unused outside SCAP content import
+- [ ] Remove from `requirements.txt` any confirmed-dead packages
+
+**Phase E1.4: Frontend chart library consolidation (week 11)**
+
+Two charting libraries: `chart.js` + `react-chartjs-2` AND `recharts`.
+
+- [ ] Audit which components use which library
+- [ ] Consolidate to one (recommend `recharts` — more React-native, smaller bundle)
+- [ ] Remove the unused library from `package.json`
+
+**Phase E1.5: Remove Celery ecosystem (week 12, part of D5)**
+
+Handled by Workstream D. Removes: `celery`, `redis`, `kombu`, `amqp`, `flower`.
+
+**Tier 1 exit criteria:**
+- [ ] `requirements.txt` has ≤30 direct dependencies (down from ~45)
+- [ ] Zero redundant HTTP client libraries (httpx only)
+- [ ] Zero redundant scheduler libraries
+- [ ] Zero dead SCAP/XML dependencies (unless audit finds active usage)
+- [ ] Frontend `package.json` has one charting library
+
+**Tier 1 package inventory (target ~30):**
+
+| Category | Packages | Count |
+|---|---|---|
+| Core runtime | fastapi, uvicorn, starlette, python-multipart | 4 |
+| Database | SQLAlchemy, alembic, psycopg2-binary, asyncpg | 4 |
+| Validation | pydantic, pydantic-settings, email-validator | 3 |
+| Auth + crypto | PyJWT, passlib, argon2-cffi, cryptography, pyotp, qrcode | 6 |
+| SSH | paramiko | 1 |
+| HTTP client | httpx | 1 |
+| Notifications | aiosmtplib, slack-sdk | 2 |
+| SSO | authlib, pysaml2 | 2 |
+| Config | python-dotenv, PyYAML | 2 |
+| Monitoring | psutil | 1 |
+| Kensa | kensa (git) | 1 |
+| Observability | opentelemetry-api, opentelemetry-sdk, prometheus-client | 3 |
+| **Total** | | **~30** |
+
+**Removed (~15 packages):** celery, redis, kombu, amqp, requests, aiohttp, APScheduler,
+schedule, lxml, xmltodict, Pillow, python-magic, Jinja2 (if unused outside templates),
+aiofiles (if unused), chardet (if unused)
+
+---
+
+### Tier 2: FreeBSD 15.0 minimal containers (Q1, weeks 10–12) — ABANDONED 2026-04-14
+
+> **STATUS UPDATE:** Tier 2 is abandoned. Linux Docker hosts (developer machines
+> and GitHub Actions Linux runners) cannot execute FreeBSD OCI containers; that
+> requires OCI v1.3 with a FreeBSD-aware runtime, which only exists on FreeBSD
+> hosts. GitHub Actions does not provide FreeBSD runners. The maintenance cost
+> of self-hosted FreeBSD infrastructure was not justified by the image-size
+> reduction goal.
+>
+> All FreeBSD artifacts (Dockerfile.*.freebsd, docker-compose.freebsd.yml,
+> packaging/freebsd/) were removed on 2026-04-14. Containers remain on the
+> current Linux mix: UBI 9 (backend, worker), Alpine (db, frontend).
+>
+> The original Tier 2 plan is preserved below as historical record.
+
+**Goal:** Migrate all containers from the current 3-distro mix (Red Hat UBI 9, Debian,
+Alpine) to FreeBSD 15.0-RELEASE minimal. Eliminate package managers, shells, and
+unnecessary system libraries from production images. Reduce total image size from
+~600MB to ~200MB.
+
+**Platform:** FreeBSD 15.0-RELEASE (2025-12-02, supported until 2026-09-30, OCI spec v1.3 recognized).
+
+**Phase E2.1: FreeBSD base image (week 10)**
+
+Build a custom minimal FreeBSD 15.0 base image for OpenWatch:
+
+- [ ] Create `docker/Dockerfile.freebsd-base` — FreeBSD 15.0 minimal with:
+  - Python 3.12 (from FreeBSD ports/pkg)
+  - PostgreSQL 15 client libraries (libpq)
+  - OpenSSL 3.x with FIPS provider module
+  - openssh-portable (client only, for Kensa SSH)
+  - No X11, no docs, no games, no unnecessary ports
+- [ ] Target: base image ≤80MB
+- [ ] Verify all Python C extensions compile on FreeBSD:
+  - psycopg2 (libpq) — FreeBSD Tier 1 platform for PostgreSQL
+  - cryptography (OpenSSL) — FreeBSD uses OpenSSL from base or ports
+  - argon2-cffi (libargon2) — available in FreeBSD ports
+  - paramiko (no C deps, pure Python)
+- [ ] FIPS: Configure OpenSSL 3.x FIPS provider (`fips=yes` in openssl.cnf)
+
+**Phase E2.2: Backend on FreeBSD (week 10)**
+
+Replace `registry.access.redhat.com/ubi9/ubi:9.7` with FreeBSD 15.0:
+
+- [ ] `docker/Dockerfile.backend` — multi-stage:
+  - Stage 1: full FreeBSD 15.0 — install build deps, create venv, pip install
+  - Stage 2: FreeBSD 15.0 minimal — copy venv + app code, no build tools
+- [ ] `docker/Dockerfile.backend.dev` — full FreeBSD 15.0 with dev tools
+- [ ] Verify: all backend tests pass on FreeBSD
+- [ ] Verify: signal.alarm() works on FreeBSD (needed for job_queue worker timeouts)
+- [ ] Target: backend image ≤120MB (down from ~400MB)
+
+**Phase E2.3: Frontend serving on FreeBSD (week 11)**
+
+Replace `nginx:1.29.5-alpine` with FreeBSD Nginx or embedded serving:
+
+- [ ] Option A (recommended): Embed SPA in backend via FastAPI `StaticFiles` mount
+  - Eliminates frontend container entirely
+  - Backend serves both API (`:8000/api/*`) and SPA (`:8000/*`)
+  - Nginx remains as reverse proxy only (optional, can be on host)
+  - Container count: 3 → 2 (backend+SPA, worker, db)
+- [ ] Option B: Nginx on FreeBSD 15.0 minimal
+  - `docker/Dockerfile.frontend` — FreeBSD + nginx, no node/npm at runtime
+  - Multi-stage: node:20 builds SPA, FreeBSD serves it
+- [ ] Decision: Option A unless there's a specific reason for separate Nginx container
+
+**Phase E2.4: PostgreSQL on FreeBSD (week 11)**
+
+Replace `postgres:15.14-alpine` with FreeBSD PostgreSQL:
+
+- [ ] `docker/Dockerfile.db` — FreeBSD 15.0 + PostgreSQL 15 from ports
+- [ ] Minimal configuration: only en_US.UTF-8 locale, no unnecessary extensions
+- [ ] Data directory on volume mount (same as current)
+- [ ] Target: PostgreSQL image ≤80MB
+- [ ] Alternative: keep Alpine PostgreSQL if FreeBSD PostgreSQL image is significantly larger
+  (PostgreSQL is the same binary regardless of OS — the base matters less for DB)
+
+**Phase E2.5: Worker on FreeBSD (week 12)**
+
+- [ ] Worker Dockerfile inherits from the backend base (same Python + deps)
+- [ ] `ExecStart` changes from `celery worker` to `python -m app.services.job_queue.worker`
+  (handled by Workstream D)
+- [ ] Verify: concurrent.futures.ProcessPoolExecutor works on FreeBSD (it does — POSIX fork)
+
+**Phase E2.6: Native FreeBSD package (week 12)**
+
+- [ ] Create `packaging/freebsd/` directory
+- [ ] `packaging/freebsd/build-pkg.sh` — builds FreeBSD pkg package
+- [ ] Package installs to `/usr/local/openwatch/` (FreeBSD convention)
+- [ ] Systemd equivalent: FreeBSD rc.d scripts for openwatch-api and openwatch-worker
+- [ ] `packaging/freebsd/rc.d/openwatch_api` — rc.d service script
+- [ ] `packaging/freebsd/rc.d/openwatch_worker` — rc.d service script
+- [ ] PostgreSQL and Nginx managed by FreeBSD pkg (system packages)
+
+**Tier 2 exit criteria:**
+- [ ] All containers run on FreeBSD 15.0-RELEASE minimal
+- [ ] Zero Alpine, Debian, or Red Hat images in docker-compose.yml
+- [ ] Total image size ≤200MB (down from ~600MB)
+- [ ] FIPS: OpenSSL 3.x FIPS provider active on FreeBSD
+- [ ] All backend tests pass on FreeBSD
+- [ ] FreeBSD pkg package builds and installs correctly
+- [ ] 2-3 containers total (backend+SPA, worker, db)
+
+**Tier 2 container inventory (target):**
+
+| Container | Base | Size |
+|---|---|---|
+| backend (API + SPA) | FreeBSD 15.0 minimal + Python 3.12 | ~120MB |
+| worker | FreeBSD 15.0 minimal + Python 3.12 | ~120MB (shared base) |
+| db | FreeBSD 15.0 minimal + PostgreSQL 15 | ~80MB |
+| **Total** | | **~200MB** (with shared layers: ~150MB) |
+
+If Option A (embedded SPA): backend+worker share the same image, db is separate = **2 images**.
+
+**Native deployment (no containers):**
+
+| Platform | Package | Services |
+|---|---|---|
+| FreeBSD 15.0 | `openwatch-0.1.0.pkg` | rc.d: openwatch_api, openwatch_worker |
+| RHEL 9 / CentOS 9 | `openwatch-0.1.0.rpm` | systemd: openwatch-api, openwatch-worker |
+| Ubuntu 24.04 | `openwatch-0.1.0.deb` | systemd: openwatch-api, openwatch-worker |
+
+---
+
+### Tier 3: Compiled core (Q3+, if business requires)
+
+**Goal:** Rewrite performance-critical and dependency-heavy components in a compiled
+language (Go or Rust) to produce static binaries with zero runtime dependencies.
+This is a major architectural decision, not a cleanup task.
+
+**Rationale:** Python contributes ~150MB of runtime overhead (interpreter + stdlib +
+compiled extensions). A Go binary statically links against libpq and libssh2,
+producing a ~30MB executable with no runtime dependencies. For air-gapped federal
+deployments, "no runtime dependencies" is the ultimate packaging simplification.
+
+**Phase E3.1: Assess viability (Q3 week 1)**
+
+- [ ] Inventory which Python packages have Go/Rust equivalents:
+  - FastAPI → Go `net/http` + `chi`/`echo` (mature)
+  - SQLAlchemy → Go `sqlx` or `pgx` (mature)
+  - Paramiko → Go `golang.org/x/crypto/ssh` (mature)
+  - Pydantic → Go struct tags + validation (built-in)
+  - Celery → already replaced by PostgreSQL job queue
+- [ ] Assess Kensa compatibility: Kensa is Python. Options:
+  - Keep Kensa as Python subprocess invoked by Go binary
+  - Rewrite Kensa in Go (separate project decision)
+  - Use Go-Python bridge (cgo + embedded Python — adds complexity)
+- [ ] Decision gate: proceed only if Kensa team agrees on integration path
+- [ ] Kensa integration: **Keep Kensa as Python subprocess**
+  - Go binary invokes `python3 -m runner.engine` via subprocess, parses JSON output
+  - Zero changes to Kensa required
+  - Python becomes a single system dependency (alongside PostgreSQL)
+  - Whether Kensa eventually gets a Go port is a Kensa team decision driven by
+    Kensa's own community needs, NOT by OpenWatch's packaging preferences.
+    OpenWatch is a consumer of Kensa; proposing Kensa rewrite itself to suit
+    OpenWatch's binary size goals would invert the relationship.
+
+**Phase E3.2: Go API server prototype (Q3 weeks 2–6)**
+
+- [ ] Rewrite REST API layer in Go with identical endpoint contracts
+- [ ] Use `pgx` for PostgreSQL (no ORM — matches current SQL Builders pattern)
+- [ ] Use `golang.org/x/crypto/ssh` for SSH connections
+- [ ] Use Go's `crypto/tls` with BoringCrypto for FIPS (certificate #4407)
+- [ ] Embed frontend SPA as `embed.FS` — single binary serves API + SPA
+- [ ] Target: single `openwatch` binary, ~30MB, zero runtime dependencies
+
+**Phase E3.3: Worker in Go (Q3 weeks 4–8)**
+
+- [ ] Rewrite job_queue worker in Go
+- [ ] `SKIP LOCKED` polling with `pgx`
+- [ ] Task dispatch via function registry
+- [ ] Signal handling (SIGTERM graceful shutdown) built into Go runtime
+- [ ] SSH scan execution via `golang.org/x/crypto/ssh`
+
+**Tier 3 implications:**
+
+| Aspect | Python (current) | Go (Tier 3) |
+|---|---|---|
+| Binary size | ~150MB (runtime + venv) | ~30MB (static binary) |
+| Runtime deps | python3.12, libpq, libssl, ... | none (statically linked) |
+| Startup time | ~2-5 seconds | ~50ms |
+| Memory usage | ~100-200MB per process | ~20-50MB per process |
+| Deployment | install Python, create venv, pip install | copy one binary |
+| Kensa integration | native import | subprocess or rewrite |
+| Development speed | faster (Python) | slower (Go) |
+| Team skill requirement | Python | Go (new skill) |
+
+**Tier 3 exit criteria (if pursued):**
+- [ ] `openwatch` single binary serves API + SPA
+- [ ] `openwatch-worker` single binary runs job queue
+- [ ] RPM/DEB packages contain 2 binaries + config files (no Python, no venv)
+- [ ] Total installed size ≤100MB including Kensa rules
+- [ ] FIPS compliance via BoringCrypto (Go) or OpenSSL FIPS provider
+
+**Tier 3 is a Q3+ decision.** It depends on team capacity, Kensa integration path,
+and whether the packaging simplification justifies a full rewrite. Tiers 1 and 2
+deliver 80% of the dependency reduction at 20% of the effort.
+
+---
+
+### Dependency reduction roadmap
+
+```
+Current state (Q1 start):
+  Backend:    ~45 Python packages
+  Frontend:   ~30 npm packages
+  System:     6 deps (python, pg, redis, nginx, openssl, ssh)
+  Containers: 6 (3 distros: UBI9, Debian, Alpine)
+  Images:     ~600MB total
+  Platforms:  RPM (RHEL 9), DEB (Ubuntu 24.04)
+
+After Tier 1 + D (Q1 week 12):
+  Backend:    ~30 Python packages  (-33%)
+  Frontend:   ~28 npm packages     (-7%)
+  System:     4 deps               (-33%, no Redis)
+  Containers: 3-4 (still mixed distros)
+  Images:     ~500MB total
+
+After Tier 2 (Q1 week 12):
+  Backend:    ~30 Python packages  (same)
+  Frontend:   embedded in backend  (-100%, FastAPI StaticFiles)
+  System:     2 deps (python, pg)  (-67%, no Redis, no Nginx container)
+  Containers: 2-3 (all FreeBSD 15.0)
+  Images:     ~200MB total         (-67%)
+  Platforms:  FreeBSD pkg, RPM (RHEL 9), DEB (Ubuntu 24.04)
+
+After Tier 3 (Q3+ if pursued):
+  Backend:    0 Python packages    (Go binary)
+  Frontend:   embedded in binary   (embed.FS)
+  System:     1 dep (pg)           (-83%)
+  Containers: 2 (FreeBSD 15.0)
+  Images:     ~100MB total         (-83%)
+  Platforms:  FreeBSD pkg, RPM, DEB (single static binary for all)
+```
+
+---
+
+**~37 PRs total across all workstreams.** Tier 1 is part of Q1. Tier 2 is Q2.
+Tier 3 is a separate decision.
+
+---
+
+## Next steps
+
+1. **Walk this plan with founding team** — confirm Workstream A timing and parallelism assumption
+2. **Open PRD epic E7** in `PRD/epics/E7-TRANSACTION-LOG.md`
+3. **Customer survey** for audit export contract (week 1, blocking week 7)
+4. **Kensa team sync** on pre-state capture (week 1, blocking Q2)
+5. **Schedule security reviewer** for week 11 SSO review (week 9)
+6. **Draft specs committed** this week so the CI framework picks them up early
+7. **Redis/Celery migration** — Workstream D starts week 8 after transaction log stabilizes
+8. **Dependency cleanup** — Workstream E Tier 1 runs alongside D (weeks 10-12)
+9. **FIPS assessment** — determine if customers need CMVP certificate or just FIPS algorithms
+10. **BSD minimal** — all containers and native deployments will target BSD minimal base (decision made 2026-04-13)

--- a/docs/OPENWATCH_Q1_Q3_PLAN.md
+++ b/docs/OPENWATCH_Q1_Q3_PLAN.md
@@ -1,0 +1,712 @@
+# OpenWatch Q1–Q3 Implementation Plan
+
+**Date:** 2026-04-11
+**Last updated:** 2026-04-14 (Kensa Convergence Addendum)
+**Source:** Synthesis of codebase assessments against [OPENWATCH_VISION.md](OPENWATCH_VISION.md) Q1–Q3 milestones
+**Companion:** [OPENWATCH_VISION_STATUS.md](OPENWATCH_VISION_STATUS.md)
+
+**Scope note on OSCAL:** Per decision on 2026-04-11, OSCAL export is deferred — the feature belongs in Kensa first, then OpenWatch calls into it. This plan includes evidence envelope structure and Ed25519 signing (which are OpenWatch concerns) but omits OSCAL serialization.
+
+---
+
+## Kensa Convergence Addendum (2026-04-14)
+
+This addendum captures the coordination outcome between the OpenWatch team and the Kensa team on 2026-04-14. It supersedes sections of this plan that assumed OpenWatch would implement functionality the Kensa Go Day-1 plan (`kensa/docs/KENSA_GO_DAY1_PLAN.md`) now commits to providing through its `api/` surface.
+
+### The posture
+
+Per the `OPENWATCH_VISION.md` framing (git : GitHub :: Kensa : OpenWatch), **OpenWatch is a collaboration, aggregation, and orchestration layer over Kensa**. OpenWatch does not re-implement what Kensa already does for a single host.
+
+### What this changes in this plan
+
+| Plan section | Original assumption | Revised assumption |
+|---|---|---|
+| **§6.1 Transaction log query API** | OpenWatch builds and owns the read path against PostgreSQL `transactions` | Endpoint URL + schema owned by OpenWatch; implementation delegates to `kensa.api.Kensa.TransactionLog().Query()` at **Kensa Week 22**. Interim implementation annotated in `specs/api/transactions/transaction-query.spec.yaml` v1.1. |
+| **§6.2 Proactive remediation workflow** | OpenWatch generates the plan (capture/apply/validate/rollback) | OpenWatch wraps `Kensa.Plan` / `Kensa.Execute` with an approval-workflow UI. See revised §6.2 below. **Do not implement until Kensa Week 24.** |
+| **Phase 3.4 Fleet health** | Queries `transactions` table + `host_liveness` | Same queries; PostgreSQL `transactions` is now framed as a **derived multi-host aggregation cache over Kensa's SQLite store** per Kensa Day-1 plan §13A. Survives through Kensa v1.0.0. |
+| **Phase 3 Heartbeat (broadly)** | OpenWatch-internal event generation | OpenWatch subscribes to `Kensa.Subscribe(EventFilter{...})` at **Kensa Week 25** for transaction lifecycle events; OpenWatch still owns its own TCP liveness ping (§3.2 — distinct from Kensa's `HeartbeatPulse` and complementary). |
+| **Per-transaction Ed25519 signing** | OpenWatch signs transaction envelopes via `POST /api/transactions/{id}/sign` | **Removed from OpenWatch.** Kensa signs envelopes at capture/execute time. OpenWatch's `SigningService` narrows to aggregate artifacts it originates (audit exports, quarterly posture reports, State-of-Production release). See `specs/services/signing/evidence-signing.spec.yaml` v2.0. |
+
+### What this keeps unchanged
+
+These remain purely OpenWatch-layer concerns and ship on their original schedule:
+
+- SSO federation (Phase 3.6) — OIDC + SAML, purely user-auth concern
+- Notification dispatch (Phase 3.5) — Slack/email/webhook/Jira fan-out from `AlertService`
+- Adaptive scan scheduling — OpenWatch decides *when* to call `Kensa.Scan`
+- Multi-approval chains and approval policies (Phase 6.3)
+- Fleet grouping + per-group policies (Phase 6.4)
+- State-of-Production Rollback report (Phase 6.5) — cross-tenant aggregation
+- RBAC, audit logging of OpenWatch user actions, multi-tenant isolation
+- Audit-export generation and its Ed25519 signing (OpenWatch-originated artifact)
+
+### Kensa milestones OpenWatch converges onto
+
+| Kensa week | OpenWatch action |
+|---|---|
+| **Week 1** — `api/` surface frozen with stubs | OpenWatch codes against signatures immediately; stubs return `ErrNotYetImplemented` |
+| **Week 22** — `LogQuery` real | OpenWatch swaps `/api/transactions/query` from PostgreSQL to `Kensa.TransactionLog()` |
+| **Week 24** — `Plan`/`Execute` real | OpenWatch starts §6.2 implementation |
+| **Week 25** — `Subscribe` real | OpenWatch cuts Heartbeat (the event stream parts) from polling to subscription |
+| **Week 26 (M5)** — all OpenWatch-facing APIs real | Full integration test: Plan → Subscribe → Execute → Query |
+| **Week 40 (M7)** — Kensa Go v1.0.0 | OpenWatch is pure consumer; Python Kensa archived |
+
+### Convergence-annotation convention
+
+Every OpenWatch spec or interim implementation that delegates to a Kensa `api/` method post-convergence carries a frontmatter block:
+
+```yaml
+interim_implementation:
+  delegates_to: kensa.api.Kensa.TransactionLog().Query
+  convergence_week: 22
+  kensa_plan_ref: kensa/docs/KENSA_GO_DAY1_PLAN.md §3.5.1 LogQuery
+  notes: |
+    ...
+```
+
+This makes drift visible at review time. The pattern is established in `specs/api/transactions/transaction-query.spec.yaml` v1.1 (PR #399).
+
+### Related documents
+
+- `docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md` — the outbound memo from OpenWatch to Kensa
+- `/home/rracine/hanalyx/kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md` — Kensa team's response with accepted resolutions + interface decisions
+- `/home/rracine/hanalyx/kensa/docs/KENSA_GO_DAY1_PLAN.md` — Kensa's Day-1 build plan (updated 2026-04-14 §3.5 with interface refinements from OpenWatch's asks)
+
+---
+
+## Executive Summary
+
+The assessment confirms the vision doc's diagnosis: **OpenWatch's engine layer is strong, but the product-identity layer — the transaction log, Control Plane integrations, and signed evidence — is absent.** The single highest-leverage change is the Q1 transaction log refactor, because every subsequent milestone (per-host audit timeline, Agent API, historical posture, query API, signed bundles) assumes it exists.
+
+**Critical finding**: Kensa already captures the `validate` phase of the four-phase model in `scan_findings.evidence` JSONB. **Pre-state and post-state are not systematically captured.** The refactor is primarily (a) schema unification, (b) adding pre/post-state capture to `kensa_scan_tasks.py`, and (c) UI reorganization — NOT greenfield data modeling. The data mostly exists; it's in the wrong shape.
+
+**Second critical finding**: The compliance scheduler is more mature than the vision status suggested. Adaptive intervals (1h–48h based on compliance state) are shipped, Celery Beat dispatches every 2 minutes, per-host schedules live in `host_compliance_schedule`. The Heartbeat is **~60% there**; the gaps are auto-baseline-on-first-scan, a separate liveness ping (independent of scan cadence), and notification dispatch (Slack/email/webhook — the service layer exists, the channels don't).
+
+**Third critical finding**: The Control Plane has the biggest absolute gap. **Zero** SAML/OIDC groundwork. **No** multi-approval infrastructure (single-approver exceptions only). **No** Slack/Jira integrations (webhooks exist, but generic and outbound-only). Exception workflow has a complete backend API but **no frontend UI**. Scheduled-scan management has the same shape: backend ready, UI missing.
+
+---
+
+## Phasing
+
+The plan is organized into **6 phases over ~9 months**, mapping to Q1/Q2/Q3 milestones. Each phase is ~4–6 weeks. Phases 1–3 are Q1, phases 4–5 are Q2, phase 6 is Q3. Critical path is Phase 1 (transaction log schema) — everything else compounds on it.
+
+```
+Phase 1  (wks 1-6)   : Transaction log schema + write-path refactor   [Q1 — Eye]
+Phase 2  (wks 4-8)   : Transaction log UI + navigation rename         [Q1 — Eye]
+Phase 3  (wks 6-12)  : Heartbeat completion + Control Plane integrations Tier 1
+                       (SSO, Slack/email, auto-baseline, liveness ping) [Q1 — Heartbeat + CP]
+Phase 4  (wks 12-18) : Evidence envelope four-phase capture + Ed25519 signing
+                       + per-host timeline API + exception UI + scheduler UI [Q2]
+Phase 5  (wks 14-20) : Baseline auto-management + alert routing + Jira sync
+                       + retention policies                          [Q2]
+Phase 6  (wks 20-36) : Transaction log query API + proactive remediation workflow
+                       + multi-approval infrastructure + fleet-group policies
+                       + first "State of Production Rollback" report [Q3]
+```
+
+Phases overlap deliberately: while Phase 1's backend refactor is in flight, Phase 2's frontend work can start against the (versioned) new API; Phase 3 Control Plane work doesn't depend on transactions and starts in parallel.
+
+---
+
+## Phase 1: Transaction Log Schema & Write Path (weeks 1–6) — Q1
+
+**Why first:** Every Q2/Q3 deliverable (per-host timeline, query API, signed bundles, proactive remediation, Agent API) reads from the transaction log. Without the unified schema, later work either builds on shifting foundations or duplicates effort.
+
+**Current state (from assessment):**
+- 5 separate tables: `scans`, `scan_results`, `scan_findings`, `scan_baselines`, `scan_drift_events`
+- `scan_findings.evidence` (JSONB) already captures Kensa's validate-phase evidence (method, command, stdout, stderr, expected, actual, exit_code, timestamp)
+- `scan_findings.framework_refs` (JSONB) already stores rule-to-control mappings with GIN indexes
+- **Missing**: pre-state, post-state, four-phase-shaped envelope, initiator metadata, approval/rollback linkage
+- Write surface: `backend/app/tasks/kensa_scan_tasks.py:312-341` (single INSERT point for findings)
+
+### 1.1 New `transactions` table (week 1)
+
+Create a new Alembic migration adding a `transactions` table **alongside** the existing scan tables (do not drop old tables yet). Columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID (PK) | |
+| `host_id` | UUID (FK hosts.id) | |
+| `rule_id` | VARCHAR(255) | Kensa rule id; NULL for orchestration transactions |
+| `scan_id` | UUID (FK scans.id) | Legacy linkage during migration window |
+| `phase` | VARCHAR(16) | `capture` / `apply` / `validate` / `commit` / `rollback` |
+| `status` | VARCHAR(16) | `pass` / `fail` / `skipped` / `error` / `rolled_back` |
+| `severity` | VARCHAR(16) | |
+| `initiator_type` | VARCHAR(16) | `user` / `scheduler` / `drift_trigger` / `agent` |
+| `initiator_id` | VARCHAR(255) | user_id or service name |
+| `pre_state` | JSONB | System state before apply (nullable for read-only checks) |
+| `apply_plan` | JSONB | Handler + params that Kensa executed |
+| `validate_result` | JSONB | stdout, stderr, exit_code, expected, actual |
+| `post_state` | JSONB | System state after commit / restored state after rollback |
+| `evidence_envelope` | JSONB | Full structured envelope (see Phase 4) |
+| `framework_refs` | JSONB | `{cis-rhel9-v2.0.0: "5.1.12", stig-rhel9-v2r7: "V-257778"}` |
+| `baseline_id` | UUID (FK scan_baselines.id) | For drift comparison |
+| `remediation_job_id` | UUID | Links remediation transactions back to finding transaction |
+| `started_at` | TIMESTAMPTZ | |
+| `completed_at` | TIMESTAMPTZ | |
+| `duration_ms` | INTEGER | |
+| `tenant_id` | UUID | Nullable now; foundation for Q6 multi-tenancy |
+
+**Indexes:**
+- `(host_id, started_at DESC)` — primary per-host timeline query
+- `(scan_id)` — legacy join during migration
+- `(status, started_at)` — "all failures in last N hours" (alerts)
+- GIN on `framework_refs` — "all transactions satisfying NIST AC-2"
+- GIN on `evidence_envelope` — audit search
+- `(remediation_job_id)` — link remediation chains
+
+**Spec:** Create a new `specs/system/transaction-log.spec.yaml` (Active, owner: backend) as the authoritative contract for the four-phase model. This becomes a hard CI gate via existing `check-spec-coverage.py`.
+
+### 1.2 Dual-write from `kensa_scan_tasks.py` (week 2)
+
+Modify `backend/app/tasks/kensa_scan_tasks.py` (lines 250–343, the existing write path) to emit both old-schema rows AND new transaction rows on the same DB transaction. This gives us a reversible migration.
+
+**Capturing pre/post-state (the real new work):**
+- Kensa's current `Evidence.actual` field records post-validation state
+- `pre_state` is **not** captured today. Two options:
+  1. **Minimal**: for read-only compliance checks (the common case), pre_state == post_state (nothing changed), record once
+  2. **Full**: before Kensa applies a check, run a lightweight `capture_state` call via the same SSH session. Reuses Kensa's `detect_capabilities` mechanism but narrowed to the rule's target
+- **Recommendation**: ship Option 1 for read-only checks in Phase 1; extend to Option 2 for remediation transactions in Phase 4 (where pre/post genuinely differ)
+
+For **remediation** transactions (which already have richer data per migration `20260224_0100_039_add_remediation_evidence.py`), write a second transaction row with `phase=apply`/`commit`/`rollback` and link it to the original finding transaction via `remediation_job_id`.
+
+### 1.3 Shim read layer (weeks 2–3)
+
+Add a `TransactionRepository` in `backend/app/repositories/transaction_repository.py` that services will use going forward. For Phase 1, it reads from the new `transactions` table. Existing services (`DriftDetectionService`, `AlertGeneratorService`, `AuditQueryService`, `TemporalComplianceService`) stay on the old tables until Phase 2 migrates them one at a time.
+
+**Critical dependency map (from assessment) — these 14+ services read the old tables and must migrate:**
+
+- `services/compliance/temporal.py` — `get_posture()`, `detect_drift()`, `create_snapshot()` (historical queries)
+- `services/compliance/alert_generator.py` — severity threshold reads
+- `services/compliance/audit_query.py` — evidence search
+- `services/compliance/audit_export.py` — CSV/PDF/JSON exports (**highest risk** — customer-facing contract)
+- `services/compliance/exceptions.py` — finding suppression
+- `services/compliance/remediation.py` — job creation
+- `services/monitoring/drift.py` — drift monitoring
+- `services/baseline_service.py` — baseline management
+- `routes/scans/reports.py` — report generation
+- `routes/scans/kensa.py` — scan execution
+- `routes/compliance/drift.py` — drift API
+- `routes/compliance/posture.py` — posture API
+- `routes/compliance/audit.py` — audit API
+- `tasks/backfill_snapshot_rule_states.py` — snapshot backfill
+
+### 1.4 Backfill task (week 4)
+
+Celery task `backfill_transactions_from_scans` that reads all historical `scan_findings` rows and synthesizes transaction rows. Run in chunks of 10k rows with progress tracking. Transactions generated from historical data have `phase=validate` only (we can't reconstruct pre/post-state for rows that predate the refactor — this is fine; historical rows become immutable validate-only entries).
+
+### 1.5 Service migration (weeks 4–6)
+
+Migrate services off old tables to `TransactionRepository` one at a time, in order of risk:
+
+1. `audit_query.py` (read-only; low risk)
+2. `temporal.py` — `get_posture()` and `detect_drift()` — **most important because temporal compliance is a key differentiator**. Ensure `(host_id, started_at)` index query plans are <500ms
+3. `alert_generator.py`
+4. `audit_export.py` — **high risk**. Keep exports emitting the same CSV/JSON column contract; only the read source changes. Add a regression test that compares old vs new export bytes for a known fixture scan.
+5. `drift.py`, `posture.py` route layers
+6. `kensa.py` route layer
+
+**At end of Phase 1:** all services read from `transactions`, old tables still exist as write-through shadow tables (safe rollback), Phase 2 frontend work can begin.
+
+### 1.6 Risk mitigation
+
+From the assessment:
+- **Foreign key cascades**: `scan_findings.scan_id → scans.id ON DELETE CASCADE` could orphan transactions during the dual-write window. Add an explicit `ON DELETE` policy on `transactions.scan_id` (SET NULL, not CASCADE — we want transactions to survive scan deletion; they're the audit trail)
+- **Framework mapping consistency**: `RuleReferenceService` already syncs inline `references:` + mapping files into `framework_mappings`. Extend it to also sync into `transactions.framework_refs` on write (not retroactively — only on new transactions)
+- **Export schema stability**: regression test on fixture scan, as above
+
+### 1.7 Exit criteria
+
+- [ ] `transactions` table in production, dual-writing
+- [ ] All services migrated to `TransactionRepository`
+- [ ] `audit_export` regression test passes (byte-identical fixture export)
+- [ ] Temporal query benchmark: `<500ms` for "posture at date X for host Y"
+- [ ] `transaction-log.spec.yaml` Active with 100% AC coverage
+- [ ] Old tables still written to (rollback possible)
+- [ ] No performance regression on scan execution (`kensa_scan_tasks` duration within +10%)
+
+---
+
+## Phase 2: Transaction Log UI & Navigation (weeks 4–8) — Q1
+
+**Current state (from assessment):**
+- Frontend nav: Dashboard → Scans → Compliance (Drift, Exceptions, Alerts, Audit) → Reports
+- `frontend/src/pages/scans/Scans.tsx` + `ScanDetail.tsx` are the primary scan entry points
+- `frontend/src/services/adapters/scanAdapter.ts` is the API client
+- Role-based dashboards (PR #349) shipped; widgets are swappable per role
+
+### 2.1 New API surface (weeks 4–5)
+
+Create `/api/transactions/*` endpoints in `backend/app/routes/transactions/`:
+
+- `GET /api/transactions` — paginated list, filter by `host_id`, `status`, `framework`, `phase`, `initiator_type`, `started_at` range
+- `GET /api/transactions/{id}` — single transaction with full four-phase breakdown
+- `GET /api/transactions/{id}/evidence` — evidence envelope (prep for Phase 4 signing)
+- `GET /api/hosts/{host_id}/transactions` — per-host timeline (Q2 deliverable, stubbed in Phase 2, fully implemented in Phase 4)
+
+Old `/api/scans/*` endpoints stay live as shims (proxy to transactions repository) with `Deprecation` headers. Remove no earlier than Phase 6.
+
+### 2.2 Frontend refactor (weeks 5–8)
+
+- Rename top-nav **Scans** → **Transactions**
+- Create `frontend/src/pages/transactions/Transactions.tsx` (list) and `TransactionDetail.tsx` (detail)
+- Four tabs on TransactionDetail: **Execution** (four-phase timeline), **Evidence** (raw envelope), **Controls** (framework mappings), **Related** (other transactions for same host/rule)
+- Create `frontend/src/services/adapters/transactionAdapter.ts`; leave `scanAdapter.ts` as a thin re-export during deprecation
+- **Findings** becomes a filtered view: `Transactions` with `status=fail`; build `Findings.tsx` as a preset filter on the list page
+- **Reports** navigation unchanged; reports re-sourced from `TransactionRepository` (handled in Phase 1 service migration)
+
+### 2.3 Spec updates
+
+Update these specs (from the assessment) to reference the new `transactions` table and four-phase model:
+
+- `pipelines/scan-execution.spec.yaml`
+- `pipelines/drift-detection.spec.yaml`
+- `services/compliance/temporal-compliance.spec.yaml`
+- `services/compliance/audit-query.spec.yaml`
+- `services/compliance/compliance-scheduler.spec.yaml`
+- `api/scans/scan-results.spec.yaml`
+- `api/scans/scan-crud.spec.yaml`
+- `api/scans/scan-reports.spec.yaml`
+- `frontend/scan-workflow.spec.yaml`
+- `frontend/scans-list.spec.yaml`
+
+### 2.4 Exit criteria
+
+- [ ] `/api/transactions/*` live and documented in Swagger
+- [ ] Transactions list + detail pages shipped
+- [ ] Findings as filtered transaction view
+- [ ] Old `/api/scans/*` deprecation headers
+- [ ] 10 specs updated, CI coverage enforced
+- [ ] Manual QA: end-to-end flow (Kensa scan → transaction row → UI renders four phases)
+
+---
+
+## Phase 3: Heartbeat Completion + Control Plane Tier 1 (weeks 6–12) — Q1
+
+This phase runs in parallel with Phase 2 because it doesn't depend on the transaction log refactor.
+
+### 3.1 Heartbeat: auto-baseline on first scan (week 6)
+
+**Current state:** `PostureSnapshot` model exists; daily snapshots via `create_daily_posture_snapshots`. Manual snapshot creation via `TemporalComplianceService.create_snapshot()`. **No trigger on first scan.**
+
+Wire into `kensa_scan_tasks.py` (the same write path we're refactoring in Phase 1): after a successful scan, if `scan_baselines` has no `is_active=true` row for this host, create one via `BaselineService.establish_baseline(host_id, source_scan_id)`. Idempotent; safe to call on every scan.
+
+### 3.2 Heartbeat: liveness ping separate from scan cadence (weeks 6–7)
+
+**Current state:** "Liveness" = `last_scan_completed` timestamp. At the default 6h–24h scan cadence, liveness signal is too slow for the vision's "15-min detection" target.
+
+Add `host_liveness` table: `host_id, last_ping_at, last_response_ms, reachability_status (reachable/unreachable/unknown)`. New Celery Beat task `ping_managed_hosts` every 5 minutes — for each host, open a TCP connection to the SSH port and record response time. No auth, no command execution; it's a reachability check.
+
+Update `FleetHealthWidget.tsx` (already exists, 336 LOC) to show liveness distinct from scan recency.
+
+### 3.3 Heartbeat: maintenance mode UI (week 7)
+
+Backend exists (`compliance_scheduler.py:508-549`). Frontend needs a toggle in Host Detail + Host List pages. Small change, high user visibility.
+
+### 3.4 Heartbeat: fleet health "at a glance" (week 8)
+
+Extend Dashboard's existing fleet health section with:
+- "X hosts up / Y total"
+- "Z hosts with drift in last 24h"
+- "N failed scans in last 24h"
+
+Queries go against `transactions` table (Phase 1 exit criteria) + `host_liveness`.
+
+> **Revised 2026-04-14** per Kensa Convergence Addendum: the `transactions` PostgreSQL table is now framed as a **derived multi-host aggregation cache over Kensa's SQLite store** (Kensa Day-1 plan §13A). At Kensa Week 25, the event feed for drift counts switches from polling the PostgreSQL table to consuming `Kensa.Subscribe` with `EventKind=DriftDetected`. No API surface change for the frontend; just a backend implementation swap. The PostgreSQL cache survives through Kensa v1.0.0 because multi-fleet aggregation across N Kensa SQLite stores would be too slow to do at query time without a cache.
+
+### 3.5 Control Plane: notification dispatch (weeks 7–9)
+
+**Current state:** `AlertService` + alert thresholds shipped (PR #281). `alert_generator.py` creates alert rows in DB. **No outbound dispatch.** Generic webhook surface exists (`routes/integrations/webhooks.py`) but not wired to alerts.
+
+Create `backend/app/services/notifications/` package with:
+- `base.py` — abstract `NotificationChannel` interface
+- `slack.py` — uses `slack-sdk`, POST to incoming webhook URL with Block Kit formatting
+- `email.py` — SMTP via `aiosmtplib`, templated HTML
+- `webhook.py` — thin wrapper over existing webhook service for alert-specific events
+
+Wire `AlertService.create_alert()` to enqueue a notification task per configured channel. Dedupe via the existing 60-min window logic in `alerts.py:137`.
+
+**Jira is deferred to Phase 5.** Jira's bidirectional sync is a larger lift than Slack/email and isn't a Q1 blocker.
+
+### 3.6 Control Plane: SAML/OIDC SSO (weeks 8–12)
+
+**Current state (from assessment):** Zero groundwork. Local users + JWT only. FIPS-compliant Argon2id and RS256 JWT (good), but no federation.
+
+Add `authlib` to `requirements.txt` (authlib handles both OIDC and SAML2 and is actively maintained, FIPS-compatible).
+
+Create `backend/app/services/auth/sso/`:
+- `provider.py` — abstract `SSOProvider` with `get_login_url`, `handle_callback`, `map_claims_to_user`
+- `oidc.py` — `OIDCProvider` using authlib's OAuth2 client
+- `saml.py` — `SAMLProvider` using python3-saml (FedRAMP-approved library)
+
+Database:
+- `sso_providers` table: `id, tenant_id (nullable), provider_type, config (JSONB, encrypted), enabled`
+- Extend `users` table: `sso_provider_id`, `external_id`, `last_sso_login_at`
+
+Routes:
+- `GET /api/auth/sso/login?provider={id}` — redirect to IdP
+- `GET /api/auth/sso/callback/{provider_type}` — handle ACS (SAML) or token exchange (OIDC)
+- `GET /api/auth/sso/providers` — list configured providers for login screen
+- `POST /api/admin/sso/providers` — admin configures new IdP
+
+Claim mapping: `email → users.email`, `groups → users.role` (configurable mapping in provider config). First-login creates a local user record linked to `external_id`. Subsequent logins update claims.
+
+Frontend: extend login page to show "Login with SSO" buttons for configured providers. Small change; authlib does the heavy lifting.
+
+**Load-bearing because:** federal customers cannot buy OpenWatch without SSO. This is the most commercially-urgent item in Q1 after the transaction log.
+
+### 3.7 Exit criteria
+
+- [ ] First-scan baseline auto-established
+- [ ] `host_liveness` table + 5-minute ping task running
+- [ ] Maintenance mode toggle in Host Detail UI
+- [ ] Slack + email notifications firing on alerts
+- [ ] At least one OIDC provider (e.g., Okta dev tenant) and one SAML provider (e.g., AD FS test instance) successfully authenticating users
+- [ ] Deprecation headers on `/api/auth/login` for customers who need to migrate
+
+---
+
+## Phase 4: Evidence Envelope + Signing + Per-Host Timeline + UIs (weeks 12–18) — Q2
+
+### 4.1 Four-phase evidence capture (weeks 12–14)
+
+**Current state:** Kensa's `Evidence` dataclass captures the validate phase only (method, command, stdout, stderr, exit_code, expected, actual, timestamp). Pre/post-state missing.
+
+For compliance scans (read-only checks), Phase 1 established that `pre_state == post_state` is the common case. For Phase 4, add **explicit structured capture** even for read-only checks:
+
+```python
+evidence_envelope = {
+    "schema_version": "1.0",
+    "kensa_version": "1.2.5",
+    "phases": {
+        "capture": {"state": {...}, "at": "..."},
+        "apply": {"plan": {...}, "executed": False, "at": null},   # read-only
+        "validate": {"method": ..., "command": ..., "stdout": ..., "exit_code": ...},
+        "commit": {"status": "pass", "post_state": {...}, "at": "..."},
+        "rollback": null,
+    },
+    "framework_refs": {...},
+    "rule_metadata": {"id": ..., "title": ..., "severity": ...},
+    "host_context": {"host_id": ..., "os": ..., "arch": ...},
+}
+```
+
+For **remediation** transactions, all four phases populate. Extend `backend/app/plugins/kensa/evidence.py:19-45` (current `_evidence_to_dict`) to return this envelope shape. Coordinate with the Kensa team if upstream changes are needed — per the vision, OpenWatch is the fleet runtime, but if Kensa needs to emit pre-state, that's a Kensa PR.
+
+**Spec:** add AC for envelope schema to `specs/system/transaction-log.spec.yaml` (created in Phase 1).
+
+### 4.2 Ed25519 signing (weeks 13–15)
+
+**Current state (from assessment):** Greenfield. No Ed25519 code. `encryption/service.py` has AES-256-GCM; `auth.py` has RS256 JWT; no signing abstraction.
+
+Create `backend/app/services/signing/`:
+- `service.py` — `SigningService` with `sign_envelope(envelope: dict) -> SignedBundle` and `verify(bundle: SignedBundle) -> bool`
+- Uses `cryptography.hazmat.primitives.asymmetric.ed25519` (FIPS-compatible, already in deps)
+- Signing key stored per-deployment in `deployment_signing_keys` table (encrypted via existing `EncryptionService`)
+- Key rotation: new key becomes active, old keys remain verifiable; bundles record `key_id`
+
+Signed bundle format:
+```json
+{
+  "envelope": { ... },
+  "signature": "base64(ed25519-sig)",
+  "key_id": "uuid",
+  "signed_at": "ISO8601",
+  "signer": "openwatch@deployment-name"
+}
+```
+
+Public verification endpoint: `GET /api/signing/public-keys` returns all active + retired public keys so auditors can verify bundles offline.
+
+Documentation: publish `docs/EVIDENCE_VERIFICATION.md` with a standalone Python verification script (20 lines) that auditors can use without an OpenWatch install.
+
+### 4.3 Per-host transaction timeline (weeks 14–16)
+
+**Current state (from assessment):** `TemporalComplianceService.get_posture(host_id, as_of)` exists for point-in-time queries. No "all transactions for host X" timeline.
+
+API: `GET /api/hosts/{host_id}/transactions` with filters `phase`, `status`, `framework`, `rule_id`, date range, full-text search on evidence (using the GIN index on `transactions.evidence_envelope`). Paginated, cursor-based.
+
+Frontend: new tab on `HostDetail.tsx` — **Audit Timeline**. Reverse-chronological list of transactions, click-through to `TransactionDetail`. Export button → queues an audit export job for that host + date range.
+
+### 4.4 Exception workflow UI (weeks 15–17)
+
+**Current state (from assessment):** Backend complete at `routes/compliance/exceptions.py`. Zero frontend.
+
+Create `frontend/src/pages/compliance/Exceptions.tsx`:
+- List view (paginated, filter by status/rule/host)
+- Request form (justification, risk assessment, expiration date)
+- Approval workflow display (approver name, approved_at, justification)
+- "Escalate" button — re-routes to higher-role approver (requires Phase 6 multi-approval infra, so in Phase 4 it's a single-level escalation: analyst → officer/admin)
+- Button to kick off remediation from an excepted rule
+
+Backend change: add `approval_chain JSONB` to `ComplianceException` table for multi-approval groundwork (populated with single approver for now; Phase 6 extends to N approvers).
+
+### 4.5 Scheduled scan management UI (weeks 16–18)
+
+**Current state:** Backend complete at `routes/compliance/scheduler.py`. No frontend.
+
+Create `frontend/src/pages/scans/ScheduledScans.tsx`:
+- Current adaptive-interval config (the 1h/6h/12h/24h/48h tiers) with sliders
+- Per-host schedule table: `next_scheduled_scan`, `current_interval_minutes`, `maintenance_mode`
+- Preview: histogram of next 48h scans across the fleet
+- New backend endpoint `POST /api/compliance/scheduler/preview` that returns "given this config, here are the next 50 scheduled scans"
+
+### 4.6 Exit criteria
+
+- [ ] Evidence envelope schema v1.0 frozen and specced
+- [ ] Ed25519 signing service with key rotation
+- [ ] Per-host timeline API + Host Detail tab
+- [ ] Exception workflow UI shipped
+- [ ] Scheduled scan management UI shipped
+- [ ] `docs/EVIDENCE_VERIFICATION.md` + standalone verification script
+
+---
+
+## Phase 5: Baseline Auto-Mgmt, Alert Routing, Jira, Retention (weeks 14–20) — Q2
+
+Parallel to Phase 4.
+
+### 5.1 Baseline auto-management (weeks 14–15)
+
+**Current state (from assessment):** Baselines exist as `scan_baselines` rows; daily snapshots via `create_daily_posture_snapshots`. Auto-create on first scan lands in Phase 3. **Missing:** explicit "update baseline" API + rolling baselines for moving targets.
+
+- `POST /api/hosts/{host_id}/baseline/reset` — establish new baseline from most recent scan
+- `POST /api/hosts/{host_id}/baseline/promote` — promote current posture to baseline (after legitimate config change)
+- Rolling baseline: 7-day moving average for hosts marked `baseline_type=rolling_avg`
+- Frontend: button on HostDetail.tsx
+
+### 5.2 Alert routing rules (weeks 15–17)
+
+**Current state:** Alerts fire to a single default channel set. No per-severity routing.
+
+Add `alert_routing_rules` table: `id, severity, alert_type, channel_type, channel_config (JSONB), tenant_id`. Example rule: `CRITICAL + HOST_UNREACHABLE → pagerduty:oncall`.
+
+Extend `AlertService.create_alert()` dispatch loop to query routing rules and fan out to multiple channels. Add PagerDuty channel to `notifications/` package (alongside Slack/email from Phase 3).
+
+Frontend: `frontend/src/pages/compliance/AlertRoutingRules.tsx` — rule table, create/edit form.
+
+### 5.3 Jira bidirectional sync (weeks 16–19)
+
+Deferred from Phase 3 because bidirectional is nontrivial.
+
+- `backend/app/services/notifications/jira.py` — uses `jira` Python SDK
+- Outbound: drift events + failed transactions create Jira issues with evidence envelope attached
+- Inbound: Jira webhook → `POST /api/integrations/jira/webhook` → update OpenWatch exception or transaction state based on issue state transitions
+- Field mapping configurable per Jira project; first customer gets hardcoded mapping
+
+### 5.4 Retention policies (weeks 18–20)
+
+**Current state:** `audit_export.cleanup_expired_exports()` has 7-day retention. `scan_findings` has no TTL.
+
+Add `retention_policies` table: `tenant_id, resource_type, retention_days`. Enforce via `cleanup_old_transactions` Celery task that deletes `transactions` older than policy (default 365 days, configurable per fleet/tenant).
+
+**Critical:** before deletion, emit an "archive" signed bundle to configurable storage (S3 or filesystem). Retention deletion should NEVER be destructive of the audit trail — it moves transactions from hot storage to cold signed archives.
+
+### 5.5 Exit criteria
+
+- [ ] Baseline reset/promote APIs + UI
+- [ ] Alert routing rules + PagerDuty channel
+- [ ] Jira outbound + inbound (first customer mapping)
+- [ ] Retention policy CRUD + enforcement with signed archive emission
+
+---
+
+## Phase 6: Query API, Proactive Remediation, Multi-Approval, Groups, Report (weeks 20–36) — Q3
+
+### 6.1 Transaction log query API (weeks 20–23)
+
+> **REVISED 2026-04-14** per Kensa Convergence Addendum. The endpoint URL + schema + DSL shape are owned by OpenWatch (stable HTTP contract). The **implementation** converges onto Kensa's `api.Kensa.TransactionLog()` at Kensa Week 22. **First slice shipped 2026-04-14 as PR #398**; interim annotation added in PR #399.
+
+The read side we stubbed in Phase 2 becomes a first-class, documented, paginated, filterable HTTP API — which in turn is a thin wrapper over Kensa's `LogQuery` interface (Kensa Day-1 plan §3.5.1).
+
+- `POST /api/transactions/query` accepts a query DSL: filters (`host_id`, `fleet_id`, `date_range`, `status`, `phase`, `framework`, `rule_id`, `initiator_type`), sort, pagination cursor, projection (which fields to return) — **shipped in PR #398**
+- Response includes `total_count`, `next_cursor`, paginated results
+- Rate limits per API key — **deferred to follow-up PR** (listed in spec's `out_of_scope`)
+- OpenAPI spec published, versioned `v1`
+- **Target**: historical posture query (`"fleet X compliance state on 2026-03-15"`) in `<500ms` p95 (the vision's KPI) — **deferred to follow-up PR**
+
+At Kensa Week 22, the endpoint's implementation swaps:
+- Current: reads PostgreSQL `transactions` table (fed by Python Kensa)
+- Post-Week-22: delegates to `kensa.api.Kensa.TransactionLog().Query()` for single-deployment queries; PostgreSQL cache serves multi-fleet aggregate queries that span N Kensa deployments (per Kensa §13A federated-v1.0 / push-v1.1 sequencing).
+
+Spec: `specs/api/transactions/transaction-query.spec.yaml` v1.1 — carries the `interim_implementation:` frontmatter establishing the convergence pattern.
+
+### 6.2 Proactive remediation workflow (weeks 22–26)
+
+> **REVISED 2026-04-14** per Kensa Convergence Addendum. Original draft had OpenWatch generating the plan. Revised architecture: **OpenWatch wraps Kensa.Plan / Kensa.Execute with an approval-workflow UI.** Do not start implementation until Kensa Week 24 (when `Plan` / `Execute` land real).
+
+**Current state (from assessment):** `RemediationService.create_job()` exists with dry-run flag + license enforcement. **Missing:** auto-draft on drift, approval queue UI, integration with Kensa's Plan/Execute API.
+
+**Architecture (revised):**
+
+```
+Drift event detected (from Kensa.Subscribe event stream, Week 25)
+    ↓
+OpenWatch calls kensa.api.Kensa.Plan(host, rule)
+    ↓
+Returns an opaque Plan blob
+    ↓
+OpenWatch stores the blob in remediation_jobs.kensa_plan (JSONB) without interpreting it
+Row starts at status=draft with approval_chain metadata
+    ↓
+ApprovalQueue UI renders the plan via Kensa's plan.Preview(PreviewMarkdown)
+(canonical preview owned by Kensa — no OpenWatch-side plan rendering)
+    ↓
+Multi-approval chain (Phase 6.3) progresses draft → approved
+    ↓
+On full approval, OpenWatch calls kensa.api.Kensa.Execute(host, plan)
+    ↓
+If PlanStaleError returned: mark remediation_jobs.status=stale,
+  prompt for re-plan. The `StaleStepIndex` + `Field` + `Expected`/`Actual`
+  fields from Kensa drive the UX ("re-plan because step 2's config_set
+  of PermitRootLogin found value 'prohibit-password' but the plan
+  captured 'yes'")
+    ↓
+On success: update remediation_jobs.status=completed,
+  store Kensa's returned TransactionResult.TxnID
+    ↓
+Each state transition writes a transaction row to Kensa's log via Kensa's
+engine (not a separate OpenWatch-generated row)
+```
+
+**What OpenWatch owns:**
+- `remediation_jobs` table schema: `id, host_id, rule_id, kensa_plan (JSONB, opaque), approval_chain_id, status, created_at, approved_at, executed_at, kensa_txn_id (nullable, filled on success)`
+- Auto-draft triggering — when `DriftDetected` event arrives from `Kensa.Subscribe` with `drift_type=major`, call `Kensa.Plan` and persist the draft
+- ApprovalQueue UI (`frontend/src/pages/remediation/ApprovalQueue.tsx`) listing drafts, routing to detail view
+- Approval state machine (`draft → approved → executing → completed | failed | stale`)
+- Integration with the Phase 6.3 multi-approval chain
+- Re-plan UX when `PlanStaleError` surfaces
+
+**What OpenWatch does NOT own:**
+- The `Plan` struct internals — OpenWatch never looks inside the JSONB blob
+- The preview rendering — calls `plan.Preview(PreviewMarkdown)` which Kensa owns
+- The rollback plan derivation — part of Kensa's Plan
+- Staleness detection — Kensa's `PlanStaleError` is the authoritative signal
+- The actual execution semantics, capture logic, validation — all Kensa
+
+**Interim-implementation annotation** (to go on `specs/api/compliance/proactive-remediation.spec.yaml` when the spec is written):
+
+```yaml
+interim_implementation:
+  delegates_to:
+    - kensa.api.Kensa.Plan
+    - kensa.api.Kensa.Execute
+    - kensa.api.Kensa.Subscribe (for DriftDetected event)
+  convergence_week: 24
+  kensa_plan_ref: kensa/docs/KENSA_GO_DAY1_PLAN.md §3.5.3 Planner/Executor
+  notes: |
+    Do not implement until Kensa Week 24. Before that, OpenWatch codes
+    against api/ signatures returning ErrNotYetImplemented to validate
+    the integration shape.
+```
+
+**Blocking dependency:** Do not start until Kensa Week 24.
+
+### 6.3 Multi-approval infrastructure (weeks 24–28)
+
+**Current state (from assessment):** Single-approver only. No approval chains.
+
+- New `approval_policies` table: `resource_type, action, required_approvals, approver_roles, conditions (JSONB)`
+- Example policy: `transaction, execute, 2, [SECURITY_ADMIN], {"change_type": "grub_param"}`
+- `ApprovalService` evaluates policies on every state transition
+- Extend `ComplianceException.approval_chain` (introduced in Phase 4) to track N approvals
+- Audit each approval as a transaction row in the log (control-plane actions are themselves transactions — this is the vision's "audit log IS the transaction log" principle)
+
+### 6.4 Fleet grouping + per-group policies (weeks 26–30)
+
+**Current state:** Host groups exist as entities (`routes/host_groups/crud.py`). **No policies attached.**
+
+- New `group_compliance_policies` table: `group_id, scan_interval_override, approval_policy_id, drift_threshold_percent, auto_remediate_severities`
+- Extend `compliance_scheduler.py` to prefer group policy over default intervals
+- Extend `ApprovalService` to apply group-specific policies to hosts in that group
+- Frontend: Group Detail page gains a Policies tab
+
+### 6.5 First "State of Production Rollback" report (weeks 30–34)
+
+**Current state:** Zero. The report is the output, not the infrastructure.
+
+- `generate_production_rollback_report` task aggregates anonymized transaction log statistics across lighthouse customers (opt-in telemetry)
+- Metrics: rollback frequency by OS/framework, mean-time-to-remediate, drift types most commonly detected, most-failed rules
+- Output: public PDF + JSON datasets
+- Marketing deliverable, not a product feature — but the infrastructure (query API from 6.1, anonymized telemetry) feeds the Q5 "Agent API + aggregate dataset" milestone
+
+### 6.6 Exit criteria
+
+- [ ] `/api/transactions/query` with published OpenAPI spec
+- [ ] Proactive remediation draft → approval → execute flow
+- [ ] Multi-approval infrastructure with at least one 2-approval policy in production
+- [ ] Group compliance policies enforced by scheduler + approval service
+- [ ] First public "State of Production Rollback" report published
+
+---
+
+## Cross-Cutting Concerns
+
+### Testing strategy
+
+Every phase adds regression tests against the existing CI gate (42% coverage floor, 100% AC coverage for Active specs). Specific additions:
+
+- Phase 1: `test_transaction_backfill.py`, `test_audit_export_parity.py` (byte-identical export across schema change), `test_temporal_query_perf.py` (p95 < 500ms)
+- Phase 3: `test_sso_oidc_flow.py`, `test_sso_saml_flow.py` with mock IdP
+- Phase 4: `test_ed25519_signing.py`, `test_envelope_schema_v1.py`, `test_verification_script.py`
+- Phase 6: `test_transaction_query_dsl.py`, `test_approval_policy_evaluation.py`
+
+### Spec governance
+
+Every phase must land its spec updates in the same PR as the code change (existing `check-spec-changes.py` advisory becomes a hard block for new work). Phase 1 creates `specs/system/transaction-log.spec.yaml` which becomes the load-bearing contract for everything else.
+
+### Security review gates
+
+Three mandatory security reviews:
+- **End of Phase 1**: schema + write path (before transactions become canonical)
+- **End of Phase 3**: SSO (federation is a high-value attack surface)
+- **End of Phase 4**: signing (key management + verification)
+
+### Commercial gates
+
+- **End of Phase 3**: first customer can sign up with SSO — unblocks federal sales
+- **End of Phase 4**: first auditor can verify a signed bundle offline — unblocks the "signed evidence" trust moat
+- **End of Phase 6**: first "State of Production Rollback" report — unblocks the "canonical upstream" trust moat
+
+### Team shape
+
+Plan assumes ~2 backend engineers + 1 frontend engineer + founding engineer oversight. If headcount is smaller, Phase 3's SSO work and Phase 5's Jira sync are the first candidates to slip, in that order. **Do not slip Phase 1** — it blocks everything.
+
+---
+
+## What This Plan Does NOT Do
+
+Per vision doc "What OpenWatch Must Never Become" and the OSCAL deferral:
+
+- **No OSCAL export** — lands in Kensa first, OpenWatch calls into it later
+- **No third-party scanner ingestion** — we do not ingest Tenable/Qualys/Rapid7 findings
+- **No generic observability dashboards** — Heartbeat is about state, not metrics
+- **No cloud-posture features** — we manage Linux hosts, not AWS/Azure/GCP configurations
+- **No multi-tenancy exposure** — `tenant_id` columns land in Phase 1 but stay NULL / single-tenant until Q6
+- **No Agent API (write)** — Q5/Q6 work; Phase 6's query API is the read-only foundation
+
+---
+
+## Risks & Open Questions
+
+1. **Kensa team coordination on pre-state capture**: if capturing pre-state requires Kensa changes, the Phase 4 envelope work depends on a Kensa PR. **Mitigation**: start the conversation in week 1 of Phase 1; Phase 4 doesn't start until week 12, giving 11 weeks of lead time.
+
+2. **Audit export customer contract**: the Phase 1 regression test locks the CSV/JSON column contract, but customers may depend on undocumented column ordering. **Mitigation**: survey existing customers on audit export usage during Phase 1 week 1.
+
+3. **SAML library choice**: `python3-saml` has C dependencies that complicate RPM/DEB packaging. **Mitigation**: evaluate `pysaml2` as a pure-Python alternative in Phase 3 week 1.
+
+4. **Retention archive storage**: Phase 5.4 requires customer-side cold storage (S3 or filesystem). **Open question**: do we ship a default filesystem archive path, or require configuration?
+
+5. **Proactive remediation trust**: Phase 6.2's "auto-draft → human approve → execute" depends on the remediation job's dry-run accuracy. If drafts are consistently wrong, users disable the feature. **Mitigation**: ship dry-run preview UI before auto-draft; require users to opt into auto-draft per host.
+
+6. **Phase 1 backfill on large deployments**: customers with millions of `scan_findings` rows may have multi-hour backfills. **Mitigation**: chunked task with resumability, progress UI, and the ability to run Phase 2 UI work on dual-written (forward-only) data without full backfill.
+
+---
+
+## Next Steps
+
+1. **Walk this plan with founding team** — confirm phase ordering and Phase 3 parallelism assumption
+2. **Create spec `specs/system/transaction-log.spec.yaml`** as the first concrete Phase 1 deliverable
+3. **Open tracking epics** in PRD for each phase (E7–E12, following existing E0–E6 convention)
+4. **Schedule Kensa team sync** on pre-state capture requirements for Phase 4
+5. **Survey audit export customers** to lock the Phase 1 contract

--- a/docs/OPENWATCH_Q2_PLAN.md
+++ b/docs/OPENWATCH_Q2_PLAN.md
@@ -1,0 +1,319 @@
+# OpenWatch Q2 Implementation Plan
+
+**Date:** 2026-04-13
+**Window:** Months 4-6 (~12 weeks)
+**Parent:** [OPENWATCH_Q1_Q3_PLAN.md](OPENWATCH_Q1_Q3_PLAN.md)
+**Vision:** [OPENWATCH_VISION.md](OPENWATCH_VISION.md) Quarters 2-3
+**Predecessor:** [OPENWATCH_Q1_PLAN.md](OPENWATCH_Q1_PLAN.md) (completed 2026-04-13)
+
+---
+
+## Q1 Completed (foundation for Q2)
+
+Everything Q2 builds on was shipped in Q1:
+- Transaction log with write-on-change model (host_rule_state + transactions)
+- PostgreSQL job queue (Celery + Redis removed, 4 containers)
+- Notification channels (Slack, email, webhook)
+- SSO federation (OIDC + SAML)
+- Host liveness monitoring (5-min TCP ping)
+- FreeBSD 15.0 Dockerfiles + packaging skeleton
+- 86 specs, 762 ACs, 100% coverage
+
+---
+
+## Q2 Goals (from vision)
+
+| Identity | Milestone |
+|---|---|
+| **Eye** | Ed25519 signed evidence bundles. Per-host audit timeline. Transaction log retention policy. |
+| **Heartbeat** | Drift alerts via Slack/email/webhook. Baseline auto-management (reset/promote). |
+| **Control Plane** | Jira bidirectional sync. Scheduled scan management UI. Exception workflow UI. |
+| **Platform** | FreeBSD 15.0 container migration (test + validate). XCCDF/lxml removal. |
+
+**Scope note**: OSCAL export remains deferred to Kensa. Evidence signing is OpenWatch-side.
+
+---
+
+## Workstreams
+
+```
+Workstream F: Evidence Signing + Audit Timeline     [weeks 1-6]
+Workstream G: Control Plane UIs + Jira              [weeks 3-9]
+Workstream H: FreeBSD Validation + XCCDF Cleanup    [weeks 1-4]
+Workstream I: Baseline Mgmt + Retention Policies    [weeks 4-8]
+```
+
+---
+
+## Workstream F — Evidence Signing + Per-Host Audit Timeline (weeks 1-6)
+
+### F1: Ed25519 signing service (weeks 1-3)
+
+**Deliverables:**
+- [ ] `backend/app/services/signing/__init__.py`
+- [ ] `backend/app/services/signing/service.py` — `SigningService`:
+  - `sign_envelope(envelope: dict) -> SignedBundle`
+  - `verify(bundle: SignedBundle) -> bool`
+  - Uses `cryptography.hazmat.primitives.asymmetric.ed25519`
+- [ ] Alembic migration: `deployment_signing_keys` table (key_id, public_key, private_key_encrypted, active, created_at, rotated_at)
+- [ ] Key rotation: new key becomes active, old keys remain for verification
+- [ ] API: `GET /api/signing/public-keys` — returns all active + retired public keys
+- [ ] API: `POST /api/transactions/{id}/sign` — sign a transaction's evidence envelope
+- [ ] `docs/EVIDENCE_VERIFICATION.md` — standalone Python verification script (~20 lines)
+- [ ] Spec: `specs/services/signing/evidence-signing.spec.yaml`
+
+### F2: Per-host audit timeline (weeks 3-5)
+
+**Deliverables:**
+- [ ] `GET /api/hosts/{host_id}/transactions` — full filter surface (phase, status, framework, rule_id, date range)
+- [ ] Cursor-based pagination for large timelines
+- [ ] Full-text search on `evidence_envelope` via GIN index (already exists)
+- [ ] Frontend: new tab on HostDetail — **Audit Timeline**
+  - Reverse-chronological list of transactions
+  - Click-through to TransactionDetail
+  - Export button → queues audit export for that host + date range
+- [ ] Spec: update `api/hosts/host-crud.spec.yaml` with timeline AC
+
+### F3: Signed evidence export (weeks 5-6)
+
+**Deliverables:**
+- [ ] Extend audit export (CSV/JSON/PDF) to include Ed25519 signature
+- [ ] Export includes `signed_bundle` with envelope + signature + key_id
+- [ ] Verification endpoint: `POST /api/signing/verify` accepts a bundle, returns valid/invalid
+- [ ] Frontend: "Download Signed Evidence" button on TransactionDetail page
+
+---
+
+## Workstream G — Control Plane UIs + Jira (weeks 3-9)
+
+### G1: Exception workflow UI (weeks 3-5)
+
+**Current state:** Backend complete at `routes/compliance/exceptions.py`. Zero frontend.
+
+**Deliverables:**
+- [ ] `frontend/src/pages/compliance/Exceptions.tsx` — list view (paginated, filter by status/rule/host)
+- [ ] Exception request form (justification, risk assessment, expiration date)
+- [ ] Approval workflow display (approver name, approved_at, justification)
+- [ ] Escalate button (routes to higher-role approver)
+- [ ] Re-remediation button (kick off remediation for excepted rule)
+- [ ] Nav item: "Exceptions" under Compliance
+
+### G2: Scheduled scan management UI (weeks 4-6)
+
+**Current state:** Backend complete at `routes/compliance/scheduler.py`. No frontend.
+
+**Deliverables:**
+- [ ] `frontend/src/pages/scans/ScheduledScans.tsx` — adaptive interval config with sliders
+- [ ] Per-host schedule table: next_scheduled_scan, current_interval, maintenance_mode
+- [ ] Preview histogram: "next 48h scans across the fleet"
+- [ ] New backend endpoint: `POST /api/compliance/scheduler/preview`
+
+### G3: Jira bidirectional sync (weeks 5-9)
+
+**Deliverables:**
+- [ ] `backend/app/services/notifications/jira.py` — uses `jira` Python SDK (add to requirements.txt)
+- [ ] Outbound: drift events + failed transactions create Jira issues with evidence
+- [ ] Inbound: `POST /api/integrations/jira/webhook` — Jira webhook receiver
+  - Issue state transitions update OpenWatch exception or transaction state
+- [ ] Field mapping configurable per Jira project
+- [ ] Admin UI: Jira integration settings (project, field mapping, webhook URL)
+- [ ] Spec: `specs/services/infrastructure/jira-sync.spec.yaml`
+
+---
+
+## Workstream H — FreeBSD Validation + XCCDF Cleanup (weeks 1-4)
+
+> **STATUS UPDATE (2026-04-14):** H1 and H3 (the FreeBSD items) are
+> **abandoned**. No path forward — Linux Docker hosts cannot run FreeBSD OCI
+> containers, GitHub Actions has no FreeBSD runners, and the native pkg
+> deliverable did not justify maintaining the container fork. All FreeBSD
+> artifacts removed. **H2 (XCCDF/lxml removal) shipped as planned.**
+> See `docs/OPENWATCH_VISION_STATUS.md` for the platform decision details.
+
+### H1: FreeBSD container testing (weeks 1-2) — ABANDONED
+
+**Deliverables:**
+- [ ] Test `docker-compose.freebsd.yml` with FreeBSD 15.0 images
+- [ ] Verify all Python C extensions compile: psycopg2, cryptography, argon2-cffi
+- [ ] Verify job queue worker runs correctly on FreeBSD
+- [ ] Verify SSH connections (Paramiko) work from FreeBSD containers
+- [ ] Fix any FreeBSD-specific issues (paths, package names, signal handling)
+- [ ] CI: add FreeBSD container build job to `.github/workflows/ci.yml`
+
+### H2: XCCDF/lxml removal (weeks 2-4)
+
+**From backlog (P2):** `owca/extraction/xccdf_parser.py` imports lxml at module level via `owca/__init__.py`. Legacy OpenSCAP path.
+
+**Deliverables:**
+- [ ] Make XCCDF parser import conditional (lazy import, not at module level)
+- [ ] Verify OWCA works without lxml when XCCDF parser is not called
+- [ ] If XCCDF parser is never called in the Kensa-only path: remove it entirely
+- [ ] Remove `lxml` from `requirements.txt` if no active code paths use it
+- [ ] Audit: verify no other module imports lxml
+
+### H3: FreeBSD native package testing (weeks 3-4) — ABANDONED
+
+**Deliverables:**
+- [ ] Test `packaging/freebsd/build-pkg.sh` on FreeBSD 15.0
+- [ ] Verify rc.d scripts start/stop services correctly
+- [ ] Test upgrade path: install pkg, upgrade pkg
+- [ ] Document any FreeBSD-specific configuration in `docs/guides/`
+
+---
+
+## Workstream I — Baseline Management + Retention (weeks 4-8)
+
+### I1: Baseline auto-management (weeks 4-5)
+
+**Current state:** Auto-baseline on first scan shipped (Q1). Missing: explicit reset/promote API.
+
+**Deliverables:**
+- [ ] `POST /api/hosts/{host_id}/baseline/reset` — establish new baseline from most recent scan
+- [ ] `POST /api/hosts/{host_id}/baseline/promote` — promote current posture to baseline
+- [ ] Rolling baseline: 7-day moving average for hosts marked `baseline_type=rolling_avg`
+- [ ] Frontend: "Reset Baseline" / "Promote to Baseline" buttons on HostDetail
+
+### I2: Alert routing rules (weeks 5-7)
+
+**Deliverables:**
+- [ ] `alert_routing_rules` table: severity, alert_type, channel_type, channel_config
+- [ ] Example: `CRITICAL + HOST_UNREACHABLE → pagerduty:oncall`
+- [ ] Extend `AlertService.create_alert()` to fan out per routing rule
+- [ ] PagerDuty channel: `backend/app/services/notifications/pagerduty.py`
+- [ ] Frontend: `frontend/src/pages/compliance/AlertRoutingRules.tsx`
+- [ ] Add `python-pagerduty` to requirements.txt
+
+### I3: Transaction log retention policies (weeks 6-8)
+
+**Deliverables:**
+- [ ] `retention_policies` table: tenant_id, resource_type, retention_days
+- [ ] Default: 365 days for transactions, 30 days for host_rule_state check history
+- [ ] `cleanup_old_transactions` job queue task (registered in recurring_jobs)
+- [ ] Before deletion: emit signed archive bundle to configurable storage (filesystem)
+- [ ] Admin API: `GET/PUT /api/admin/retention` — view/update retention config
+- [ ] Frontend: retention settings in admin page
+
+---
+
+## Exit Criteria (end of Q2)
+
+### Evidence (Workstream F)
+- [ ] Ed25519 signing service with key rotation
+- [ ] Per-host audit timeline with full filter/export surface
+- [ ] Signed evidence exports downloadable from UI
+- [ ] `docs/EVIDENCE_VERIFICATION.md` with standalone verification script
+
+### Control Plane (Workstream G)
+- [ ] Exception workflow UI shipped
+- [ ] Scheduled scan management UI shipped
+- [ ] Jira bidirectional sync (outbound + inbound webhook)
+
+### Platform (Workstream H)
+- [ ] FreeBSD 15.0 containers tested and validated
+- [ ] XCCDF/lxml dependency removed (or made conditional)
+- [ ] FreeBSD pkg package tested
+
+### Heartbeat (Workstream I)
+- [ ] Baseline reset/promote API + UI
+- [ ] Alert routing rules with PagerDuty channel
+- [ ] Transaction retention policy enforced with signed archives
+
+---
+
+## Dependencies and Risks
+
+1. **Kensa team coordination** (F1): If evidence signing requires Kensa to emit different data, that's an upstream PR. Current envelope shape may be sufficient.
+
+2. **Jira SDK packaging** (G3): `jira` Python SDK adds a dependency. Evaluate size vs value. Alternative: raw REST calls to Jira API (no SDK needed).
+
+3. **FreeBSD container availability** (H1): FreeBSD 15.0 OCI images are on Docker Hub but may have quirks with specific Python C extensions. Test early.
+
+4. **lxml removal risk** (H2): OWCA module-level import means removing lxml breaks import chain. Must be lazy-loaded first.
+
+5. **PagerDuty pricing** (I2): PagerDuty integration requires customers to have PagerDuty accounts. May not be relevant for all deployments.
+
+---
+
+## PR Decomposition
+
+| PR | Contents | Workstream | Week |
+|---|---|---|---|
+| 1 | Signing service + migration + spec | F1 | 1-2 |
+| 2 | Signing API endpoints + verification docs | F1 | 2-3 |
+| 3 | Per-host audit timeline API + frontend tab | F2 | 3-5 |
+| 4 | Signed evidence export + download button | F3 | 5-6 |
+| 5 | Exception workflow UI | G1 | 3-5 |
+| 6 | Scheduled scan management UI + preview API | G2 | 4-6 |
+| 7 | Jira service + outbound + inbound webhook | G3 | 5-8 |
+| 8 | Jira admin UI | G3 | 8-9 |
+| 9 | FreeBSD container validation + CI | H1 | 1-2 |
+| 10 | XCCDF lazy import / removal | H2 | 2-4 |
+| 11 | FreeBSD pkg testing | H3 | 3-4 |
+| 12 | Baseline reset/promote API + UI | I1 | 4-5 |
+| 13 | Alert routing rules + PagerDuty | I2 | 5-7 |
+| 14 | Retention policies + signed archives | I3 | 6-8 |
+
+**~14 PRs over 9 weeks.**
+
+---
+
+## Q2 Specs Plan
+
+### New draft specs (8 total, created at Q2 kickoff)
+
+| Spec | Location | Workstream | ACs | Test Stub |
+|------|----------|------------|-----|-----------|
+| evidence-signing | services/signing/ | F1 | 8 | test_evidence_signing_spec.py |
+| jira-sync | services/infrastructure/ | G3 | 8 | test_jira_sync_spec.py |
+| baseline-management | services/compliance/ | I1 | 5 | test_baseline_management_spec.py |
+| alert-routing | services/compliance/ | I2 | 6 | test_alert_routing_spec.py |
+| retention-policy | services/compliance/ | I3 | 6 | test_retention_policy_spec.py |
+| exception-workflow (FE) | frontend/ | G1 | 7 | exception-workflow.spec.test.ts |
+| scheduled-scans (FE) | frontend/ | G2 | 5 | scheduled-scans.spec.test.ts |
+| host-audit-timeline (FE) | frontend/ | F2 | 5 | host-audit-timeline.spec.test.ts |
+
+### Existing specs to update in Q2
+
+| Spec | Change | Version Bump |
+|------|--------|-------------|
+| api/hosts/host-crud.spec.yaml | Add AC: per-host transaction timeline endpoint | bump |
+| services/compliance/alert-thresholds.spec.yaml | Add AC: alert routing rules dispatch | bump |
+| frontend/host-detail-behavior.spec.yaml | Add AC: audit timeline tab | bump |
+
+### SPEC_REGISTRY after Q2 kickoff
+
+- Total: 94 specs (80 Active, 14 Draft)
+- System: 13 (10 Active, 3 Q1 Draft)
+- Services: 29 (21 Active, 3 Q1 Draft, 5 Q2 Draft)
+- Frontend: 16 (13 Active, 3 Q2 Draft)
+- All others unchanged
+
+### Promotion schedule
+
+- **Q2 week 4**: Promote Q1 draft specs (6) to active once CI validates
+- **Q2 week 9**: Promote Q2 draft specs as features ship
+
+---
+
+## Carries from Q1
+
+These Q1 items carry into Q2 as operational gates:
+
+| Item | Status | Q2 action |
+|---|---|---|
+| SSO security review | Checklist documented, Bandit/Semgrep clean | Complete internal review or engage external reviewer |
+| Spec promotions (6 draft → active) | Code landed, tests skip-marked | Unskip tests in CI Docker environment, promote |
+| Liveness ping port detection | P2 backlog | Fix: read SSH port from host credential config |
+| XCCDF/lxml removal | P2 backlog | Workstream H2 |
+
+---
+
+## Q3 Preview (from Q1-Q3 plan)
+
+Q3 focuses on:
+- **Transaction log query API** (REST, filters, pagination) — foundation for Agent API
+- **Proactive remediation workflow** (drift → draft remediation → human approve → execute)
+- **Multi-approval infrastructure** (2-human approval for sensitive transactions)
+- **Fleet grouping + per-group policies** (scan cadence, approval, drift thresholds)
+- **Tier 3 decision gate** (Go rewrite viability + Kensa integration path)
+- **First "State of Production Rollback" public report**

--- a/docs/OPENWATCH_VISION.md
+++ b/docs/OPENWATCH_VISION.md
@@ -1,0 +1,314 @@
+# OpenWatch Vision
+
+**Status:** Founding document, draft v1
+**Companion documents:**
+- `KENSA_VISION.md` — the transactional primitive OpenWatch is built on
+- `HANALYX_MISSION_AND_ROADMAP.md` — company mission and 18-month trust roadmap
+- `HANALYX_18_MONTH_STRATEGY.md` — tactical strategy and 90-day plan
+- `AI_DEFENSIBILITY.md` — why Hanalyx becomes more valuable as AI improves
+
+---
+
+## What OpenWatch Is
+
+**OpenWatch is the fleet eye, the heartbeat, and the control plane for Kensa.**
+
+Kensa is a passive primitive. It acts only when invoked. It remembers nothing across runs. It knows how to capture, apply, validate, and roll back — but it does not know when to do so, which hosts to do it on, or what happened yesterday. Left alone, Kensa does nothing.
+
+OpenWatch is what turns Kensa from a CLI tool into continuous, proactive, observable infrastructure. It decides when Kensa runs. It remembers every transaction Kensa has ever executed. It notices when today differs from yesterday. It alerts humans to drift. It orchestrates transactions across fleets. It provides the audit trail. It is where the passive primitive becomes an active system.
+
+**Kensa is the transaction. OpenWatch is the fleet that runs on it.**
+
+---
+
+## The Frame: git is to GitHub as Kensa is to OpenWatch
+
+The cleanest mental model for how Kensa and OpenWatch relate is git and GitHub. The pattern repeats because it is correct for a whole class of products.
+
+| git | Kensa | GitHub | OpenWatch |
+|---|---|---|---|
+| Open-source plumbing | Open-source plumbing | Hosted porcelain | On-prem or hosted porcelain |
+| Local, stateless | Local, stateless | Stateful, persistent | Stateful, persistent |
+| Powerful primitive | Powerful primitive | Multiplies git's value | Multiplies Kensa's value |
+| Used by developers who know it | Used by compliance engineers who know it | Where most users actually work | Where most users actually work |
+| Credibility-bearing | Credibility-bearing | Revenue-bearing | Revenue-bearing |
+| Can be used alone | Can be used alone | Cannot exist without git | Cannot exist without Kensa |
+| Most people don't use it alone | Most people won't use it alone | — | — |
+
+git without GitHub is a programmer's tool. GitHub without git is a dashboard with nothing underneath. They need each other, they reinforce each other, and they divide labor cleanly: one is the open primitive that earns trust through auditability, the other is the product people actually pay for.
+
+Kensa and OpenWatch should be thought of the same way. **Kensa must remain open source, visible, auditable, and community-facing — because credibility demands it and because it is the primitive that defines the category. OpenWatch must become continuous, proactive, and transactional — because it is where value is delivered to customers and where revenue lives.**
+
+This is the architecture of a successful open-core company. It is not an accident that GitHub, GitLab, Grafana, MongoDB, Elastic, Sentry, and HashiCorp all run versions of this pattern. It works because it resolves the central tension in selling infrastructure software: customers need the engine to be transparent, and the company needs the product to be ownable.
+
+---
+
+## The Three Identities of OpenWatch
+
+OpenWatch has three architectural identities. Each one corresponds to a specific customer need and a specific part of the codebase. The three together define what OpenWatch is for.
+
+### 1. The Eye
+
+**OpenWatch is the continuous, comprehensive view of the transactional state of every Linux host under management.** Every change Kensa has ever captured, applied, validated, committed, or rolled back — on every host, across every fleet — is visible here. Nothing is lost. Nothing is invisible. If it happened on a managed host, OpenWatch saw it and recorded it.
+
+The Eye is the component that makes the product trustworthy. You cannot sell "every change is auditable" unless you have a system that actually captures and retains every change in a queryable form. The Eye is that system.
+
+This identity is delivered by the **transaction log** — the primary data structure of OpenWatch, the thing customers look at first, the thing auditors export from, and the thing AI agents will eventually read and write against.
+
+### 2. The Heartbeat
+
+**OpenWatch is continuously and proactively aware of every host's state — not just when a human asks.** The heartbeat runs whether a human is watching or not. It scans hosts on a schedule. It detects drift from baseline. It raises alerts when something changes. It tracks host liveness, reachability, and responsiveness. It is the difference between a tool that answers questions and a tool that tells you when you need to ask one.
+
+The heartbeat is how OpenWatch earns the "continuous compliance" and "continuous state assurance" claims that federal continuous monitoring requires and that commercial SREs intuitively want. It is also the component that makes the Eye's data current — without a heartbeat, the Eye is a photograph, not a live feed.
+
+### 3. The Control Plane
+
+**OpenWatch is where humans and (eventually) AI agents issue instructions to the fleet.** A human who wants to apply a change across 500 hosts describes it in OpenWatch, reviews the preview (what will be captured, what will be applied, what validation will run, what rollback will occur on failure), approves, and OpenWatch orchestrates the transaction across the fleet. The result flows back into the transaction log.
+
+This identity is what turns OpenWatch from a dashboard into infrastructure. A dashboard is something you look at. A control plane is something you operate through. The difference is the difference between Grafana and Kubernetes.
+
+The Control Plane is also the surface that the eventual AI-agent use case will consume. An agent in 2027 or 2028 that wants to apply a change to production does not talk to Kensa directly. It talks to OpenWatch's Control Plane API, which enforces authorization, records intent, captures the transaction, and provides the audit trail. Humans approve; agents operate; OpenWatch mediates.
+
+---
+
+## The Core Architectural Commitment
+
+Every feature in OpenWatch must serve one or more of the three identities above. Features that do not serve any of them do not ship.
+
+Concretely:
+
+- **Scan scheduling** → Heartbeat
+- **Drift detection** → Heartbeat → Eye
+- **Transaction log UI** → Eye
+- **Evidence export (OSCAL, signed bundles)** → Eye
+- **Exception workflow** → Control Plane
+- **Multi-host orchestration** → Control Plane
+- **RBAC, SSO, audit log** → Control Plane
+- **API for programmatic access** → Control Plane (future: agents)
+- **Alerting and notification** → Heartbeat → Control Plane
+- **Host health / liveness monitoring** → Heartbeat
+- **Historical posture queries** → Eye
+- **Baseline management** → Heartbeat → Eye
+
+Features that do not fit this model — third-party scanner ingestion, cloud provider integrations that aggregate foreign findings, CI/CD security scanning, generic observability dashboards — do not ship. They expand OpenWatch's scope at the cost of its identity. OpenWatch is not a compliance aggregator. It is the Eye, the Heartbeat, and the Control Plane for Kensa transactions.
+
+---
+
+## The Transaction Log as Primary Interface
+
+The most important architectural decision in the next six months is to make the **transaction log** the primary interface of OpenWatch, replacing the current organization around "scans," "findings," and "reports."
+
+### What the transaction log contains
+
+Every entry is a Kensa transaction with:
+
+- **Timestamp and duration**
+- **Host and fleet context**
+- **Initiator** (human user, scheduled job, drift trigger, AI agent)
+- **Pre-state capture** — the exact state of the system before the change
+- **Change applied** — the specific remediation handler and parameters
+- **Validation result** — did the change produce the intended effect
+- **Commit or rollback decision**
+- **Post-state** — the exact state of the system after commit, or restored pre-state after rollback
+- **Evidence envelope** — structured, signable, exportable to OSCAL
+- **Framework mappings** — which compliance controls this transaction satisfies (CIS, STIG, NIST, etc.) — as metadata, not as the primary organizing principle
+
+### Why this reframing matters
+
+- **One data model serves three audiences.** SREs see "what changed." Compliance officers see "what was remediated." Auditors see "the evidence trail." All three views come from the same log; only the filter and the UI differ.
+- **It maps 1:1 to the Kensa vision.** Kensa's four phases (capture, apply, validate, commit-or-rollback) are exactly the fields of a transaction log entry. No impedance mismatch between the engine and the product.
+- **It is the right surface for the AI-agent future.** When an agent needs to apply a change, it writes a transaction intent to the log. When it needs to understand fleet state, it reads the log. The log is the API.
+- **It differentiates from every other compliance tool.** No competitor organizes around transactions. They all organize around findings (scanner mindset) or controls (GRC mindset). The transaction log is a category-defining UI, not just a rename.
+
+### What this replaces
+
+- The current "Scans" top-level navigation becomes "Transactions."
+- "Findings" becomes a filtered view of the transaction log (transactions with status = fail).
+- "Reports" becomes exports generated from the transaction log.
+- "Compliance status" becomes aggregate queries against the transaction log over time ranges.
+- The database schema is refactored to treat `scans` + `scan_results` + `scan_findings` as a single `transactions` table, with the existing fields reorganized around the four-phase model.
+
+This is the single highest-leverage change to OpenWatch in the next six months. It is mostly a data-model refactor and UI reorganization, not new feature work. It pays for itself by making every subsequent feature simpler to build.
+
+---
+
+## What OpenWatch Must Never Become
+
+As important as naming what OpenWatch is: naming what it is not, so scope creep does not dilute the identity.
+
+- **OpenWatch is not a compliance aggregator.** It does not ingest findings from Tenable, Qualys, Rapid7, OpenSCAP, or any other scanner. It records Kensa transactions. Customers who want a compliance aggregator should buy a compliance aggregator.
+- **OpenWatch is not a GRC platform.** It does not track policies, manage SOC 2 evidence collection, or produce organization-wide compliance dashboards across non-Linux systems. Drata, Vanta, and Secureframe exist for that. OpenWatch is focused on the Linux transactional layer.
+- **OpenWatch is not an observability tool.** It does not replace Datadog, Grafana, Prometheus, or New Relic. It tells you what changed, not what is happening. The heartbeat is about state, not about metrics and logs.
+- **OpenWatch is not a configuration management system.** Customers should still use Ansible, Chef, Puppet, or Salt for day-to-day provisioning. OpenWatch is where those changes become transactional and auditable — not where they originate.
+- **OpenWatch is not a multi-cloud security posture management tool.** It does not talk to AWS Security Hub, Azure Defender, or GCP SCC. It manages Linux hosts directly. Cloud-native posture management is a different market with different competitors and Hanalyx does not play there.
+- **OpenWatch is not a scanner without Kensa.** Every transaction runs through the Kensa primitive. There is no parallel scanning path. The architectural commitment is that Kensa is the only engine underneath.
+
+Each of these constraints is load-bearing. Violating any one of them dilutes the identity of the product and pushes it toward being a generic compliance platform — a space where we cannot compete and would not want to.
+
+---
+
+## 12–18 Month Milestones
+
+These milestones are organized around the three identities. They connect directly to the trust moats in `HANALYX_MISSION_AND_ROADMAP.md` — every milestone serves at least one moat.
+
+### Quarter 1 (Months 0–3): Transaction log reframing and heartbeat foundations
+
+**The Eye**
+- [ ] Refactor database schema: unify `scans`, `scan_results`, `scan_findings`, `scan_baselines`, `scan_drift_events` around a single `transactions` table with the four-phase model (capture, apply, validate, commit/rollback).
+- [ ] Ship the transaction log as the primary top-level UI in OpenWatch. Replace "Scans" / "Findings" / "Reports" navigation with "Transactions."
+- [ ] Implement per-transaction detail view: full pre-state, apply, validate, commit/rollback, post-state, evidence envelope, framework mappings as metadata.
+
+**The Heartbeat**
+- [ ] Scheduled scans enabled by default on every onboarded host. Remove the opt-in barrier.
+- [ ] Host liveness monitoring: last-seen timestamp, reachability check, response time tracking on every managed host.
+- [ ] Fleet-level health view: all hosts up, last scan successful, drift events in the last 24 hours visible at a glance.
+
+**The Control Plane**
+- [ ] Slack + Jira integration (outbound alerts and bidirectional ticket sync for drift events and failed transactions).
+- [ ] SAML/OIDC SSO — required for enterprise and federal sales.
+
+**Moat connection:** Track Record (Eye makes the log auditable from day one), Community (clean data model is foundation for community rule contributions).
+
+---
+
+### Quarter 2 (Months 3–6): Evidence export and auditor-grade outputs
+
+**The Eye**
+- [ ] OSCAL export from the transaction log. Every transaction in the log can be exported as an OSCAL-formatted evidence bundle.
+- [ ] Signed evidence bundles using Ed25519. Signing key managed per deployment, with published verification instructions.
+- [ ] Per-host audit timeline view: every transaction that has ever touched this host, with filter, search, and export.
+- [ ] Transaction log retention policy, configurable per fleet.
+
+**The Heartbeat**
+- [ ] Drift detection running automatically on every scheduled scan, with no configuration required.
+- [ ] First-class drift alert notifications via Slack, email, and webhook.
+- [ ] Baseline auto-management: first scan establishes baseline, subsequent scans measured against it, baseline can be explicitly updated.
+
+**The Control Plane**
+- [ ] Scheduled scan management UI: when, how often, which rules, which hosts, with a clear preview of what each scheduled scan will do.
+- [ ] Exception workflow UI for the transaction log: mark a transaction as accepted (risk acknowledged), escalate, or request re-remediation.
+
+**Moat connection:** Auditor Relationships (OSCAL + signed bundles are the concrete artifacts we will brief auditors on), Liability (the signed evidence is what makes the production SLA defensible).
+
+---
+
+### Quarter 3 (Months 6–9): Proactive remediation and control plane maturity
+
+**The Eye**
+- [ ] Query API for the transaction log: REST endpoint that accepts filters (host, fleet, date range, status, mechanism, framework) and returns paginated transactions. This is the foundation of both the advanced UI and the future agent API.
+- [ ] Historical posture queries: "what was fleet X's compliance state on date Y?" answered in under 500ms from the transaction log.
+- [ ] First public **"State of Production Rollback"** report generated from anonymized aggregate transaction log data across lighthouse customers.
+
+**The Heartbeat**
+- [ ] **Proactive remediation workflow:** when drift is detected, OpenWatch automatically drafts a proposed remediation transaction (capture plan, apply plan, validation plan, rollback plan) and raises it to a human for approval. One-click approve → transaction runs → result flows back into the log.
+- [ ] Alert routing rules: different drift severities go to different channels (Slack, email, PagerDuty, ticketing).
+- [ ] Heartbeat performance: every managed host scanned at least every 6 hours by default, with per-host override.
+
+**The Control Plane**
+- [ ] RBAC with role-based approval requirements: certain transactions (e.g., grub parameter changes) require two-human approval before execution.
+- [ ] Fleet grouping and per-group policy: different hosts can have different scan cadences, different approval requirements, different drift thresholds.
+- [ ] First batch of user-contributed rules merged from the open-source community (tied to Kensa community work).
+
+**Moat connection:** Track Record (proactive remediation is where customers see the closed-loop story in action), Canonical Upstream (public report establishes Hanalyx as the authority on production rollback statistics).
+
+---
+
+### Quarter 4 (Months 9–12): FedRAMP-ready continuous monitoring
+
+**The Eye**
+- [ ] Continuous monitoring reporting that meets federal ConMon requirements: rolling 30-day posture, POA&M integration, continuous compliance dashboards, monthly evidence packages.
+- [ ] Per-framework filtered views of the transaction log: "show me all transactions that satisfy NIST 800-53 AC-2 over the last 90 days."
+- [ ] Export integration with FedRAMP continuous monitoring tooling.
+
+**The Heartbeat**
+- [ ] SLO tracking: uptime of OpenWatch itself, time-to-detect drift, time-to-alert, time-to-remediate. Publicly visible on an internal status page first, then externally.
+- [ ] Alerting integrations: PagerDuty, Opsgenie, Microsoft Teams (in addition to existing Slack/email/webhook).
+
+**The Control Plane**
+- [ ] Audit log for every Control Plane action: who approved what, when, from where, with what justification. The audit log is itself a set of transactions in the transaction log.
+- [ ] First signed **production SLA** offered to paying customers, backed by the transaction log as evidence.
+- [ ] First federal customer successfully passing a continuous monitoring review with OpenWatch as the ConMon system.
+
+**Moat connection:** FedRAMP (continuous monitoring is one of the largest control families), Liability (SLA backed by transaction log), Auditor Relationships (first auditor success story).
+
+---
+
+### Quarter 5 (Months 12–15): The agent API surface and hosted control plane
+
+**The Eye**
+- [ ] Read-only **Agent API**: authenticated, rate-limited, OpenAPI-specified interface that lets an authorized AI agent query the transaction log, read fleet state, and subscribe to drift events. Not write-enabled yet.
+- [ ] Anonymized aggregate telemetry (opt-in) from customer deployments feeding the first cross-customer benchmark dataset.
+
+**The Heartbeat**
+- [ ] Multi-region heartbeat: OpenWatch can monitor hosts across geographic regions with appropriate latency and reliability guarantees.
+- [ ] Graceful degradation: if OpenWatch loses contact with a host, the Heartbeat explicitly distinguishes "host is down" from "host is unreachable from OpenWatch" and alerts accordingly.
+
+**The Control Plane**
+- [ ] **First hybrid deployment:** on-prem Kensa agent pushing signed transaction bundles to a Hanalyx-hosted OpenWatch control plane, as an opt-in upgrade for existing customers. Single-tenant at first.
+- [ ] Formal API versioning and deprecation policy for the Control Plane API.
+- [ ] First non-founder engineering hire (if hiring timing allows) focused on the Control Plane surface.
+
+**Moat connection:** Canonical Upstream (agent API positions OpenWatch as infrastructure, not a tool), Track Record (hybrid deployment is the beginning of the long-term SaaS option).
+
+---
+
+### Quarter 6 (Months 15–18): Write-enabled agent API and multi-tenant readiness
+
+**The Eye**
+- [ ] Public transaction log schema specification, versioned and stable. Third parties can build tools against it.
+- [ ] Second **"State of Production Rollback"** report with year-over-year trends.
+
+**The Heartbeat**
+- [ ] Heartbeat performance SLA: drift detected within 15 minutes of occurrence on any managed host by default.
+- [ ] Predictive heartbeat: OpenWatch flags hosts whose behavior is diverging from the fleet norm before an explicit drift event fires.
+
+**The Control Plane**
+- [ ] **Write-enabled Agent API:** an authorized AI agent can propose a transaction, which lands in the approval queue for human review. Approved transactions execute through Kensa and flow back into the log. This is the first version of the "AI agents + humans operating the fleet together" vision.
+- [ ] **Multi-tenancy groundwork:** `tenant_id` / `org_id` columns on all relevant tables, row-level security policies, tenant-aware RBAC. Not yet exposed to customers; this is the technical foundation for the potential commercial SaaS wedge at month 18+.
+- [ ] Decision point on the commercial SaaS wedge: based on federal ARR, community traction, and agent API interest, decide whether to launch a separate commercial brand on top of the multi-tenant foundation.
+
+**Moat connection:** Canonical Upstream (agent API makes OpenWatch the reference integration point for AI infrastructure), FedRAMP (authorization should land around this time — the multi-tenant groundwork is what makes a hosted FedRAMP offering possible).
+
+---
+
+## KPIs
+
+Measured monthly, reviewed quarterly.
+
+**The Eye**
+- Transactions per month (cumulative across customers)
+- Percentage of transactions with complete evidence envelopes (target: 100%)
+- Time to query the transaction log for a typical historical posture question (target: under 500ms)
+- Evidence exports generated per month
+
+**The Heartbeat**
+- Percentage of managed hosts scanned in the last 24 hours (target: 99%+)
+- Median time from drift event to human alert (target: under 15 minutes)
+- False positive rate on drift alerts (target: decreasing over time)
+- Host liveness coverage: percentage of managed hosts with current liveness data
+
+**The Control Plane**
+- Active users per customer per month
+- Transactions initiated from the Control Plane (human-initiated) vs the Heartbeat (automatic) — the ratio tells us how proactive the product has become
+- Approval latency: median time from proposed transaction to human approval
+- API requests per month (once the Agent API is live)
+
+---
+
+## The One-Line Version
+
+**OpenWatch is the Eye, the Heartbeat, and the Control Plane for Kensa. Kensa is the transaction; OpenWatch is the fleet that runs on it.**
+
+---
+
+## The OpenWatch Landing Page Hero
+
+> ### OpenWatch is the fleet eye, the heartbeat, and the control plane for Kensa.
+>
+> Continuous visibility into every transactional change across your Linux fleet. Proactive drift detection. Auditor-grade evidence, automatically. One transaction log for humans, compliance teams, auditors, and eventually the AI agents that will operate production alongside them.
+>
+> *Kensa is the transaction. OpenWatch is the fleet that runs on it.*
+
+---
+
+*End of document.*

--- a/docs/OPENWATCH_VISION_STATUS.md
+++ b/docs/OPENWATCH_VISION_STATUS.md
@@ -1,0 +1,36 @@
+# OpenWatch vs. Vision Milestones — Status Check
+
+**Date:** 2026-04-13 (updated)
+**Source:** Assessment against [OPENWATCH_VISION.md](OPENWATCH_VISION.md) Q1–Q3 milestones
+
+---
+
+## Platform Decision: Linux Containers (FreeBSD evaluated, dropped 2026-04-14)
+
+OpenWatch ships on Linux containers with native RPM and DEB packages for
+air-gapped deployment.
+
+- Container base: Red Hat UBI 9 (backend, worker), Alpine (db, frontend)
+- FIPS: OpenSSL 3.x FIPS provider module (portable, not tied to Red Hat)
+- Native packages: RPM (CentOS Stream 9) and DEB (Ubuntu 24.04)
+
+### Why FreeBSD was evaluated and dropped
+
+A FreeBSD 15.0 minimal container target was scoped in early 2026-04 as part of
+the Workstream E dependency-minimization story. The Dockerfiles, compose file,
+and pkg packaging skeleton were drafted and merged. Validation revealed there
+is no practical path forward:
+
+- Standard Linux Docker hosts (including all developer machines and GitHub
+  Actions Linux runners) cannot execute FreeBSD OCI containers — that requires
+  OCI v1.3 with a FreeBSD-aware runtime, which only exists on FreeBSD hosts
+- GitHub Actions does not provide FreeBSD runners; self-hosted FreeBSD runners
+  would need to be procured and maintained
+- The native FreeBSD pkg deliverable can serve air-gapped FreeBSD operators
+  without requiring containerized FreeBSD at all, but H3 alone did not justify
+  the maintenance cost of the container fork
+
+All FreeBSD artifacts (Dockerfile.*.freebsd, docker-compose.freebsd.yml,
+packaging/freebsd/) were removed on 2026-04-14.
+
+---


### PR DESCRIPTION
Third and final PR in the Kensa↔OpenWatch coordination batch (#399, #400, this one). The Kensa team explicitly asked to review this one (their response §6.2, item 3).

## Summary

Updates the Q1-Q3 plan to reflect the 2026-04-14 architectural commitments. Also first-time-tracks the planning docs so cross-team coordination can reference them.

## Changes

### \`.gitignore\`

Whitelist planning docs + coordination memos:
- \`docs/OPENWATCH_Q1_PLAN.md\`
- \`docs/OPENWATCH_Q2_PLAN.md\`
- \`docs/OPENWATCH_Q1_Q3_PLAN.md\` (the primary doc this PR rewrites)
- \`docs/OPENWATCH_VISION.md\`
- \`docs/OPENWATCH_VISION_STATUS.md\`
- \`docs/KENSA_OPENWATCH_COORDINATION_*.md\`

### \`docs/OPENWATCH_Q1_Q3_PLAN.md\` — the substantive rewrite

**New: top-level Kensa Convergence Addendum (2026-04-14)** documenting:
- The "GitHub over Kensa's git" posture from OPENWATCH_VISION.md
- Section-by-section table of what changes under the addendum
- What stays purely OpenWatch-layer (SSO, notifications, 6.3 multi-approval, 6.4 fleet groups, 6.5 public report)
- Kensa milestone convergence table (Week 1, 22, 24, 25, 26, 40)
- The \`interim_implementation:\` frontmatter convention (established in PR #399)

**Rewritten: §6.1 Transaction Log Query API**
- Endpoint URL + schema stable
- Implementation swaps to \`kensa.api.Kensa.TransactionLog()\` at Kensa Week 22
- Notes that first slice shipped as PR #398, interim-annotated in PR #399
- Rate limiting + <500ms p95 target deferred to follow-up PR

**Rewritten: §6.2 Proactive Remediation Workflow**
- Original draft: "OpenWatch generates the plan"
- Revised: "OpenWatch wraps \`Kensa.Plan\` / \`Kensa.Execute\` with an approval-workflow UI"
- Detailed architecture diagram (drift event → Kensa.Plan → opaque blob in remediation_jobs.kensa_plan → ApprovalQueue UI → Kensa.Execute → PlanStaleError handling)
- Ownership split: OpenWatch owns workflow, Kensa owns plan/execute semantics
- **Blocking dependency**: do not start until Kensa Week 24
- Includes the \`interim_implementation:\` block to carry on the spec when written

**Updated: §3.4 Fleet health**
- PostgreSQL \`transactions\` table reframed as derived multi-host aggregation cache over Kensa's SQLite store
- Event feed for drift counts switches from polling PostgreSQL to \`Kensa.Subscribe\` at Week 25
- No frontend API surface change

### \`docs/KENSA_OPENWATCH_COORDINATION_2026-04-14.md\`

Newly tracked. The outbound coordination memo becomes a first-class committed artifact so:
- The Kensa team's response (at \`kensa/docs/KENSA_OPENWATCH_RESPONSE_2026-04-14.md\`) can reference this by git sha
- Future engineers have the coordination trail in-repo
- The weekly sync (Kensa response §5.2 item 7) has a concrete anchor

### Other tracked-for-first-time plan docs

\`OPENWATCH_Q1_PLAN.md\`, \`Q2_PLAN.md\`, \`VISION.md\`, \`VISION_STATUS.md\` — newly tracked. Earlier session edits (FreeBSD removal markers) already in the local copies and committed as-is.

## No code changes

This is the plan-doc counterpart to:
1. ✅ PR #399 — reframe transaction query API as interim
2. ✅ PR #400 — narrow signing scope to OpenWatch-originated artifacts
3. 🔄 **This PR** — rewrite Q1-Q3 plan §6.2 + §3.4 + add Kensa Convergence Addendum

## What OpenWatch does NOT commit to in this PR

These remain open per the Kensa response §8 (items for follow-up):
- Authorization model for \`CancelDeadman\` (who can cancel an armed timer)
- Key rotation policy display UX for rotated-key warnings
- Collector schema for v1.1.0 push mode (joint design)

## Test plan

- [x] All specs still validate (\`scripts/validate-specs.py\`: 95/95)
- [x] Spec coverage still 100% (\`check-spec-coverage.py --enforce-active\`: 823/823)
- [x] No code paths modified
- [ ] CI passes
- [ ] Kensa team reviews within their 48-hour response SLA (counter-ask §6.2)