### PR TITLE
fix(backend): point kensa requirement at archive repo

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -71,4 +71,4 @@ authlib>=1.3.0
 pysaml2>=7.5.0
 
 # Kensa compliance engine
-kensa @ git+https://github.com/Hanalyx/kensa.git@v1.2.5
+kensa @ git+https://github.com/Hanalyx/kensa-archive.git@v1.2.5


### PR DESCRIPTION
## Summary

The Python `kensa` package's source repo moved. `Hanalyx/kensa` is now the Go
rebuild and is no longer pip-installable. The legacy Python package lives at
`Hanalyx/kensa-archive` at the same `v1.2.5` tag.

This one-line change in `backend/requirements.txt` updates the git URL so the
Python backend's pip install resolves again.

Unblocks Backend CI on PR #412 and PR #413.

## Scope

- Python backend only.
- No OpenWatch Go changes.
- No code changes outside `backend/requirements.txt`.

## Test plan

- [x] `git diff` shows only the one-line URL change
- [ ] CI: Backend Docker build / pip install succeeds against `kensa-archive` at `v1.2.5`
- [ ] No new Dependabot or secret-scan findings introduced