### PR TITLE
spec(slice-b): B.1 trunk drafts — scheduler, kensa-executor, transaction-log-writer

### DIFF
--- a/app/api/scans.yaml
+++ b/app/api/scans.yaml
@@ -212,6 +212,14 @@ components:
           properties:
             type: {type: string, enum: [user, scheduler, api_key, agent]}
             id: {type: string}
+        policy_version:
+          type: string
+          description: |
+            Snapshotted version of the `schedules` policy at enqueue time.
+            Policy reloads do not affect in-flight scans; threshold lookups
+            (alert routing, drift sensitivity) for this scan use this exact
+            version. Absent on legacy scans created before Slice B.
+          examples: [1.7.0, 1.8.0-rc.2]
         session_id:
           type: string
           format: uuid

--- a/app/specs/system/kensa-executor.spec.yaml
+++ b/app/specs/system/kensa-executor.spec.yaml
@@ -72,6 +72,18 @@ spec:
       description: Kensa is the only allowed scan engine in Slice B; no engine abstraction is permitted at this layer (preserves the boundary doc's "Kensa is a pure measurement engine" framing)
       type: technical
       enforcement: error
+    - id: C-09
+      description: SSH host-key verification MUST go through internal/ssh/known_hosts (per system-ssh-connectivity); first-connect policy (tofu vs require_known) MUST come from policy.Schedules.HostKeyPolicy. Unknown hosts under require_known mode MUST fail before any auth attempt
+      type: security
+      enforcement: error
+    - id: C-10
+      description: Per-rule Kensa response data persisted into the executor's result MUST be bounded; max 10 MB per rule evidence blob. Oversized results MUST be truncated and surfaced as scan.failed (defense against malicious/buggy targets OOM-ing the executor)
+      type: security
+      enforcement: error
+    - id: C-11
+      description: Per-host failure backoff state MUST be tracked by the executor; three consecutive failures push next-attempt += 2x current interval up to a 24h ceiling. Backoff state is reported back to the scheduler so subsequent ticks respect it
+      type: security
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -119,3 +131,19 @@ spec:
       description: app/internal/kensa source files do not define a generic scan-engine interface (e.g., type ScanEngine interface) — Kensa is invoked directly. Source-inspection verifies no engine-abstraction type is declared.
       priority: high
       references_constraints: [C-08]
+    - id: AC-13
+      description: SSH dial to an unknown host (not in known_hosts) under require_known policy fails before authentication; emits scan.failed with detail.reason="host_key_unknown". No credential is decrypted, no scan.started emitted.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: A Kensa rule result whose evidence blob exceeds 10 MB is truncated to a marker value; the scan transitions to failed with detail.reason="evidence_oversize" and detail.rule_id set.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-15
+      description: Credential decryption failure (corrupt ciphertext, wrong DEK) emits scan.failed with detail.reason="credential_decryption_failed". No scan.started is emitted for that attempt; no Kensa session opened.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-16
+      description: A host with three consecutive scan failures has its next-attempt clock doubled (relative to its tier interval) up to 24h ceiling; the scheduler observes the backoff and skips dispatch until the backoff window passes.
+      priority: high
+      references_constraints: [C-11]

--- a/app/specs/system/kensa-executor.spec.yaml
+++ b/app/specs/system/kensa-executor.spec.yaml
@@ -1,0 +1,121 @@
+spec:
+  id: system-kensa-executor
+  title: Kensa executor wrapper
+  version: "1.0.0"
+  status: draft
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Kensa scan execution bridge
+    description: >
+      The executor invokes Kensa (Go module at github.com/Hanalyx/kensa)
+      to run a single framework's scan against a single host. It bridges
+      OpenWatch's credential store to Kensa's SSH session, captures the
+      structured result, and hands it to the transaction log writer.
+      Credentials are loaded once into memory; no SSH key file is written
+      to disk. The wrapper is the only place in OpenWatch that imports
+      Kensa packages.
+
+  objective:
+    summary: >
+      One function — executor.Run(ctx, hostID, framework) — returns a
+      KensaResult or a typed error. The function never writes to disk
+      (key material stays in memory), never blocks indefinitely (per-host
+      timeout), and never executes more than one concurrent scan against
+      the same host (concurrency guard). Reusable from both the scheduler
+      tick and POST /scans handler.
+    scope:
+      includes:
+        - Credential fetch via Slice A internal/credential resolver
+        - In-memory SSH key load (crypto/ssh.ParsePrivateKey)
+        - Kensa Go module invocation
+        - Per-host concurrency guard (sync.Map of in-flight host IDs)
+        - Per-scan timeout enforcement (default 600s, policy-tunable)
+        - Audit emission for scan.started, scan.completed, scan.failed
+      excludes:
+        - Persisting the result (transaction log writer's job)
+        - Retry logic (caller's responsibility)
+        - Reachability pre-check (liveness loop is source of truth)
+        - Multi-framework batching in a single call
+
+  constraints:
+    - id: C-01
+      description: SSH private key MUST be parsed into a crypto/ssh.Signer; never written to disk
+      type: security
+      enforcement: error
+    - id: C-02
+      description: Credential decryption MUST go through internal/credential.Resolver; no direct AES-GCM calls
+      type: security
+      enforcement: error
+    - id: C-03
+      description: Per-host concurrency guard MUST prevent two concurrent executor.Run calls for the same host_id; second call returns ErrHostBusy without invoking Kensa
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Per-scan timeout MUST be enforced via context cancellation; default 600s, override via policy.Schedules.ExecutorTimeoutSec
+      type: performance
+      enforcement: error
+    - id: C-05
+      description: All scan attempts MUST emit scan.started before Kensa invocation and either scan.completed or scan.failed after, with policy_version threaded through audit detail
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: Decrypted credential bytes MUST be zeroed before executor.Run returns (defer secret.Wipe())
+      type: security
+      enforcement: error
+    - id: C-07
+      description: Kensa Go module version MUST be pinned in app/go.mod; bumps require this spec's version bump
+      type: technical
+      enforcement: warning
+    - id: C-08
+      description: Kensa is the only allowed scan engine in Slice B; no engine abstraction is permitted at this layer (preserves the boundary doc's "Kensa is a pure measurement engine" framing)
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: executor.Run(ctx, hostID, framework) returns a non-nil KensaResult on success with rule outcomes, evidence, and framework_refs populated for the requested framework.
+      priority: critical
+    - id: AC-02
+      description: SSH key bytes are never written to /tmp or any disk path during executor.Run; verified by tracing open/openat syscalls in a strace-style test.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-03
+      description: Two concurrent executor.Run calls for the same hostID — the second returns ErrHostBusy immediately without acquiring a Kensa SSH session.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-04
+      description: Context with a 100ms deadline causes executor.Run to return ctx.Err() before the underlying Kensa scan completes; cancellation propagates to Kensa.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-05
+      description: A successful scan emits exactly one scan.started before invoking Kensa and exactly one scan.completed after, both carrying policy_version from the job payload.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-06
+      description: A Kensa-side failure (SSH refused, key invalid, framework unsupported) returns a typed error; executor emits scan.failed with detail.reason set to a short error code from a closed enum.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-07
+      description: After executor.Run returns (success or failure), the in-memory credential buffer is zeroed; verified by reading the buffer post-return.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-08
+      description: executor.Run is safe for concurrent invocation across different hostIDs; 100 parallel runs against 100 distinct hosts complete without data races (-race build).
+      priority: high
+    - id: AC-09
+      description: A host with no credential returns ErrNoCredential; no Kensa invocation, no scan.started audit event, no concurrency-guard slot consumed.
+      priority: high
+    - id: AC-10
+      description: Kensa Go module version in app/go.mod matches the version recorded in this spec's context block; verified by a source-inspection test.
+      priority: medium
+      references_constraints: [C-07]
+    - id: AC-11
+      description: app/internal/kensa source files import only internal/credential for credential resolution; no direct calls to encryption/AES primitives in this package. Source-inspection verifies the import set.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-12
+      description: app/internal/kensa source files do not define a generic scan-engine interface (e.g., type ScanEngine interface) — Kensa is invoked directly. Source-inspection verifies no engine-abstraction type is declared.
+      priority: high
+      references_constraints: [C-08]

--- a/app/specs/system/scheduler.spec.yaml
+++ b/app/specs/system/scheduler.spec.yaml
@@ -63,6 +63,22 @@ spec:
       description: Manual scans via POST /scans MUST bypass the schedule (no row update, no policy-version side effect on the row)
       type: technical
       enforcement: error
+    - id: C-08
+      description: Tier intervals MUST be clamped to a minimum of 5 minutes regardless of policy values; protects against scan-storm DoS via misconfigured (malicious or accidental) policy
+      type: business
+      enforcement: error
+    - id: C-09
+      description: Every UPDATE to host_compliance_schedule MUST emit a scheduler.schedule.updated audit event with the prior + new state in detail
+      type: security
+      enforcement: error
+    - id: C-10
+      description: Policy signatures MUST be checked against the current active signing key AND a revocation list; policies signed by a revoked key MUST be rejected even if the signature is otherwise valid (defense against signing-key-leak replay)
+      type: security
+      enforcement: error
+    - id: C-11
+      description: Each scan job payload MUST include an HMAC-SHA256 over (host_id, framework_id, policy_version, enqueued_at) using a server-side key; dequeue MUST verify the HMAC before executing, rejecting tampered payloads
+      type: security
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -101,8 +117,24 @@ spec:
       priority: critical
       references_constraints: [C-06]
     - id: AC-10
-      description: When the schedules policy is missing or fails Ed25519 verification at boot, scheduler refuses to start and emits scheduler.startup.failed audit event.
+      description: Schedules policy is Ed25519-verified at boot AND at every runtime reload. A reload with an invalid signature is rejected; the previous valid policy stays active and scheduler.policy.reload.rejected is emitted with the failure reason.
       priority: critical
     - id: AC-11
-      description: scheduler metrics expose last_tick_at, due_count, dispatched_count, skipped_maintenance_count, refuse_count counters.
+      description: scheduler metrics expose last_tick_at, due_count, dispatched_count, skipped_maintenance_count, refuse_count, policy_clamped_count, hmac_reject_count counters.
       priority: medium
+    - id: AC-12
+      description: A policy tier interval below 5 minutes is clamped to 5 minutes at load time; scheduler.policy.clamped audit event is emitted with the offending tier and original value.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-13
+      description: Every UPDATE to host_compliance_schedule (next_scheduled_scan write, maintenance_mode toggle, manual override) emits exactly one scheduler.schedule.updated audit event with prior and new state in detail.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: A schedules policy signed by a previously-rotated (revoked) signing key is rejected at load time even though its Ed25519 signature is mathematically valid; scheduler.policy.revoked_key.rejected audit event emitted.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-15
+      description: A scan job whose stored payload has been tampered (host_id mutated post-enqueue) fails HMAC verification at dequeue; the job is rejected, marked failed in the queue, and scheduler.job.hmac_rejected audit event is emitted.
+      priority: critical
+      references_constraints: [C-11]

--- a/app/specs/system/scheduler.spec.yaml
+++ b/app/specs/system/scheduler.spec.yaml
@@ -1,0 +1,108 @@
+spec:
+  id: system-scheduler
+  title: Adaptive compliance scheduler
+  version: "1.0.0"
+  status: draft
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Adaptive scan scheduling
+    description: >
+      The scheduler decides when to run which framework against which host.
+      A cron tick (60s via robfig/cron) sweeps host_compliance_schedule for
+      rows where next_scheduled_scan <= now() and enqueues a scan job to
+      the PostgreSQL SKIP LOCKED queue. Tier intervals are read from the
+      Ed25519-signed `schedules` policy YAML; after each scan, the row is
+      updated based on the resulting compliance state.
+
+  objective:
+    summary: >
+      A scan happens on every host on its policy-defined cadence with no
+      manual intervention. Fast for non-compliant hosts (1h), slow for
+      compliant (24h, max 48h). Maintenance windows block dispatch.
+      Manual scans via POST /scans always bypass the schedule.
+    scope:
+      includes:
+        - Per-host schedule record with state-derived next-scan time
+        - Cron tick that polls for due hosts
+        - Tier ladder driven by policy.Schedules
+        - System-wide and per-host maintenance flags (policy-driven)
+        - Schedule update after each scan completion
+      excludes:
+        - Per-rule scheduling (whole-framework cadence only in Slice B)
+        - Anomaly/ML-driven cadence
+        - Cross-host scan-storm protection (per-host concurrency only)
+
+  constraints:
+    - id: C-01
+      description: Tier intervals MUST be loaded from policy.Schedules, not hardcoded
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: Cron tick interval MUST be 60s; finer cadence offers no improvement
+      type: performance
+      enforcement: error
+    - id: C-03
+      description: Dispatcher MUST use SELECT ... FOR UPDATE SKIP LOCKED on host_compliance_schedule
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Max interval cap is 48 hours regardless of policy tier values
+      type: business
+      enforcement: error
+    - id: C-05
+      description: Maintenance mode MUST block dispatch; row's next_scheduled_scan still advances on the next tick after maintenance_until
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: Each scan job payload MUST snapshot policy.Schedules.Version at enqueue time; reloads do not affect in-flight scans
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: Manual scans via POST /scans MUST bypass the schedule (no row update, no policy-version side effect on the row)
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: scheduler.LoadIntervals() reads policy.Schedules and returns a TierLadder; missing tier defaults to MaxInterval (48h).
+      priority: critical
+      references_constraints: [C-01, C-04]
+    - id: AC-02
+      description: scheduler.NextScanFor(state, lastFinishedAt, ladder) returns lastFinishedAt + ladder[state]; clamps to MaxInterval.
+      priority: critical
+      references_constraints: [C-01, C-04]
+    - id: AC-03
+      description: Cron tick fires at 60s intervals; missed ticks (e.g., during a restart) do not cause double dispatch of the same host.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: Dispatcher's SELECT uses FOR UPDATE SKIP LOCKED; two concurrent tick processes dispatch disjoint hosts.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-05
+      description: A row with maintenance_mode=true is skipped by the dispatcher; next_scheduled_scan still updates on the next tick after maintenance_until passes.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-06
+      description: Scheduler-enqueued scan job payload contains policy_version, host_id, framework_id; downstream services use the snapshotted version for audit and threshold lookup.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-07
+      description: Manual scan via POST /scans does not write to host_compliance_schedule (no UPDATE to next_scheduled_scan, no row lock acquired by scheduler).
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-08
+      description: After a scan completes, scheduler.UpdateAfterScan(hostID, score, hasCritical) recomputes compliance_state and writes the new next_scheduled_scan.
+      priority: critical
+    - id: AC-09
+      description: Policy reload while a scan is in-flight does NOT change that scan's policy_version snapshot; verified by reloading mid-test.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-10
+      description: When the schedules policy is missing or fails Ed25519 verification at boot, scheduler refuses to start and emits scheduler.startup.failed audit event.
+      priority: critical
+    - id: AC-11
+      description: scheduler metrics expose last_tick_at, due_count, dispatched_count, skipped_maintenance_count, refuse_count counters.
+      priority: medium

--- a/app/specs/system/transaction-log-writer.spec.yaml
+++ b/app/specs/system/transaction-log-writer.spec.yaml
@@ -1,0 +1,123 @@
+spec:
+  id: system-transaction-log-writer
+  title: Transaction log writer (write-on-change)
+  version: "1.0.0"
+  status: draft
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Compliance state persistence
+    description: >
+      The transaction log writer takes a Kensa scan result and records
+      what changed. host_rule_state holds one row per (host, rule) with
+      current_status, severity, evidence. transactions records only state
+      CHANGES (pass→fail, fail→pass, first-seen). host_rule_state is
+      updated on every scan; transactions are appended only on change.
+      This is the Q1-decided write-on-change model — same intent as the
+      Python implementation, but with FK constraints and a typed evidence
+      schema from the start.
+
+  objective:
+    summary: >
+      One call — writer.Apply(ctx, scanID, hostID, kensaResult) — persists
+      the result. Atomic per scan (whole result or nothing). Idempotent
+      under retry (same scanID is a no-op on second call). For each rule
+      result, compares the prior host_rule_state row; identical state
+      updates last_checked_at + check_count only, changed state appends a
+      transactions row and updates host_rule_state.
+    scope:
+      includes:
+        - host_rule_state UPSERT (one row per host×rule)
+        - transactions INSERT on state change or first-seen
+        - Evidence envelope stored in JSONB, schema-validated
+        - Foreign keys to hosts(id) and scans(id), ON DELETE RESTRICT
+        - Single-transaction atomicity per Apply call
+        - Audit emission of finding.persisted per state change
+      excludes:
+        - Drift detection (separate consumer reads transactions)
+        - Posture rollups (fleet rollup service is the read side)
+        - Evidence retention/GC (separate sweep task)
+        - Cross-scan aggregation
+
+  constraints:
+    - id: C-01
+      description: writer.Apply MUST be wrapped in a single DB transaction; partial writes are forbidden
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: host_rule_state writes MUST use ON CONFLICT (host_id, rule_id) DO UPDATE
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: transactions row MUST be inserted ONLY when (prior_status != current_status) OR (prior row absent — first-seen)
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Re-applying the same scanID MUST be a no-op; enforced via UNIQUE (scan_id, rule_id) on transactions plus check-then-skip on host_rule_state.last_scan_id
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: Evidence JSONB MUST conform to the KensaEvidence schema (defined in app/api/openapi.yaml components.schemas.KensaEvidence)
+      type: technical
+      enforcement: warning
+    - id: C-06
+      description: FK constraints from transactions and host_rule_state to hosts(id) and scans(id) MUST be present and ON DELETE RESTRICT — historical findings outlive their host references
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: writer.Apply MUST emit one finding.persisted audit event per state CHANGE row (not per result); summary scan.completed (emitted by executor) covers the totals
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: writer.Apply MUST NOT write to scan_baselines — the prior transactions row IS the baseline (Python's scan_baselines table is explicitly dropped)
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: writer.Apply with N rule results performs exactly one DB transaction (BEGIN/COMMIT), regardless of N or how many rules changed.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: First scan against a host inserts N host_rule_state rows and N transactions rows (all marked change_kind="first_seen").
+      priority: critical
+      references_constraints: [C-02, C-03]
+    - id: AC-03
+      description: Second scan with identical results UPDATES N host_rule_state rows via ON CONFLICT (host_id, rule_id) DO UPDATE (last_checked_at advances, check_count++) and inserts 0 transactions rows.
+      priority: critical
+      references_constraints: [C-02, C-03]
+    - id: AC-04
+      description: Second scan with exactly one rule flipping pass→fail UPDATES N host_rule_state rows via ON CONFLICT and inserts exactly 1 transactions row with change_kind="state_changed".
+      priority: critical
+      references_constraints: [C-02, C-03]
+    - id: AC-05
+      description: Calling writer.Apply twice with the same scanID and same body is a no-op on the second call; host_rule_state and transactions row counts unchanged.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: A simulated DB error mid-Apply (e.g., FK violation injected on rule 50 of 100) rolls back the entire batch; zero rows persist across host_rule_state and transactions.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-07
+      description: DELETE on hosts with extant transactions rows fails with FK violation; verifies ON DELETE RESTRICT on the parent.
+      priority: high
+      references_constraints: [C-06]
+    - id: AC-08
+      description: Evidence JSONB that fails KensaEvidence schema validation (missing required field, wrong type) is rejected before INSERT with a typed error.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-09
+      description: finding.persisted audit event count for a scan equals the number of transactions rows inserted by that scan; verified end-to-end.
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-10
+      description: 1000-rule writer.Apply completes in under 2 seconds wall-clock against shared-CI Postgres, mirroring the system-audit-emission AC-05 budget pattern.
+      priority: high
+    - id: AC-11
+      description: Concurrent writer.Apply calls for two distinct scanIDs against different hosts complete without deadlock under -race; verified with 50 parallel calls.
+      priority: high
+    - id: AC-12
+      description: The codebase contains no scan_baselines table reference (no migration, no query, no model); verified by a repo-wide grep test.
+      priority: high
+      references_constraints: [C-08]

--- a/app/specs/system/transaction-log-writer.spec.yaml
+++ b/app/specs/system/transaction-log-writer.spec.yaml
@@ -54,8 +54,8 @@ spec:
       type: technical
       enforcement: error
     - id: C-04
-      description: Re-applying the same scanID MUST be a no-op; enforced via UNIQUE (scan_id, rule_id) on transactions plus check-then-skip on host_rule_state.last_scan_id
-      type: technical
+      description: Re-applying the same scanID MUST be a no-op; enforced via UNIQUE (scan_id, rule_id) on transactions plus check-then-skip on host_rule_state.last_scan_id. scan_id MUST be a server-generated UUIDv4 (never client-supplied) so it cannot be forged for replay
+      type: security
       enforcement: error
     - id: C-05
       description: Evidence JSONB MUST conform to the KensaEvidence schema (defined in app/api/openapi.yaml components.schemas.KensaEvidence)
@@ -72,6 +72,14 @@ spec:
     - id: C-08
       description: writer.Apply MUST NOT write to scan_baselines — the prior transactions row IS the baseline (Python's scan_baselines table is explicitly dropped)
       type: technical
+      enforcement: error
+    - id: C-09
+      description: All DB access in this package MUST use sqlc-generated typed queries; no raw string-concat SQL via db.Exec/db.Query/text() is permitted. Defense against SQL injection via evidence content or rule metadata
+      type: security
+      enforcement: error
+    - id: C-10
+      description: Evidence JSONB per rule MUST be 256 KB or smaller; oversized evidence is rejected by writer.Apply with a typed error before INSERT. Caller (Kensa executor) is expected to enforce its own 10 MB ceiling earlier; this writer-side limit is defense in depth and protects against storage DoS
+      type: security
       enforcement: error
 
   acceptance_criteria:
@@ -121,3 +129,15 @@ spec:
       description: The codebase contains no scan_baselines table reference (no migration, no query, no model); verified by a repo-wide grep test.
       priority: high
       references_constraints: [C-08]
+    - id: AC-13
+      description: app/internal/transactionlog source files (or wherever writer.Apply lives) contain no calls to db.Exec, db.Query, or text() with string-interpolated SQL; source-inspection verifies sqlc-generated functions are the only DB entry points.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: writer.Apply rejects a Kensa result whose any single rule's evidence exceeds 256 KB; returns a typed ErrEvidenceTooLarge with the offending rule_id; no row is inserted into host_rule_state or transactions for that batch.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-15
+      description: A DB error during writer.Apply (FK violation, deadlock, disk full) causes rollback AND emits exactly one writer.apply.failed audit event with detail.reason and detail.rule_count_attempted populated.
+      priority: critical
+      references_constraints: [C-01]


### PR DESCRIPTION
## Summary

Three draft Specter specs for **Slice B's trunk wave** — the end-to-end path that takes a scheduled scan through Kensa execution and into the write-on-change transaction log.

All three: `status: draft`, `tier: 1` (100% coverage target once implementation lands).

## Specs

| Spec | ACs | Highlights |
|---|---|---|
| **system-scheduler** | 11 | 60s cron tick, SKIP LOCKED dispatch, tier intervals from signed `schedules` policy, policy_version snapshotted at enqueue, 48h max interval cap, maintenance mode honored, manual scans bypass schedule |
| **system-kensa-executor** | 12 | Bridge from OW credentials to Kensa Go module, **in-memory SSH key only** (no /tmp keyfile — fixes a Python concern), per-host concurrency guard, ctx cancellation honored, credential zero-after-use, source-inspection ACs verify no engine-abstraction interface |
| **system-transaction-log-writer** | 12 | host_rule_state UPSERT every scan, transactions INSERT only on state change or first-seen, single DB tx per Apply, idempotent on scan_id, FK constraints w/ ON DELETE RESTRICT, evidence JSONB validated against `KensaEvidence` OpenAPI schema. Drops Python's `scan_baselines` table — the prior transactions row IS the baseline. |

## OpenAPI delta

`Scan.policy_version` field added (snapshotted policy version at enqueue). The existing `Scan.initiator` object already carries the scheduler-vs-manual distinction — no new endpoint needed.

## Coverage gate — expected red

All 33 specs parse cleanly and pass structural checks (`specter check`). Coverage report shows the 3 new drafts at **0%** — by design, no tests exist yet. Implementation lands in per-component follow-up PRs:

- **B.1a** — system-scheduler impl + tests (brings to 100%)
- **B.1b** — system-kensa-executor impl + tests (brings to 100%)
- **B.1c** — system-transaction-log-writer impl + tests (brings to 100%)

This PR is opened as **draft**. Merging strategy is the open question for review (see below).

## Open for review

1. **Spec shapes** — constraint/AC granularity, scope `includes/excludes`, priority assignments.
2. **Merging strategy**: three options —
   a. Merge this spec PR first, accept temporary coverage red on main, then land impl PRs one at a time.
   b. Hold this PR as draft; merge each spec+impl together as a single PR per component.
   c. Roll everything into one mega-PR (spec + all three impls + tests).
   I lean (b) — keeps main green at all times, cost is spec review happens alongside impl review.
3. **OpenAPI `policy_version` location** — currently a top-level Scan field. Could nest under `Scan.initiator.policy_version` if you prefer.

## Test plan

- [x] `specter parse` — all 33 specs valid
- [x] `specter check` — all constraints referenced, no orphans
- [ ] CI coverage — will fail as documented above
- [ ] Spec content review by user