### PR TITLE
feat(alertrouter): B.3b — system-alert-router (15/15 ACs, 100%)

### DIFF
--- a/app/internal/alertrouter/dedup.go
+++ b/app/internal/alertrouter/dedup.go
@@ -1,0 +1,70 @@
+package alertrouter
+
+import (
+	"sync"
+	"time"
+)
+
+// DedupGate filters out repeat alerts with the same dedup key seen
+// within the configured TTL. Per Spec C-03 / C-04 / AC-06 / AC-07.
+//
+// Implementation: in-memory map keyed by Alert.DedupKey(). Each entry
+// holds the last-seen timestamp; ShouldSkip compares now() against
+// that timestamp + TTL. Stale entries are reaped opportunistically on
+// every ShouldSkip call to keep the map from growing unbounded under
+// churn.
+type DedupGate struct {
+	ttl  time.Duration
+	now  func() time.Time
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
+
+// NewDedupGate constructs a DedupGate with the given TTL. Caller is
+// expected to have validated the TTL via ValidateDedupTTL.
+func NewDedupGate(ttl time.Duration) *DedupGate {
+	return &DedupGate{
+		ttl:  ttl,
+		now:  time.Now,
+		seen: make(map[string]time.Time),
+	}
+}
+
+// ShouldSkip reports whether the alert should be skipped because it
+// matches a recently-seen dedup key. As a side effect, on a non-skip
+// outcome it records the alert's timestamp so the next call within
+// TTL will skip.
+//
+// Spec AC-06: a repeat within TTL is skipped.
+// Spec AC-07: a repeat after TTL passes through.
+func (g *DedupGate) ShouldSkip(alert Alert) bool {
+	key := alert.DedupKey()
+	now := g.now()
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Opportunistic reap: drop entries past TTL. Cheap because the map
+	// is small (one entry per active alert tuple). Avoids unbounded
+	// growth under high churn.
+	for k, ts := range g.seen {
+		if now.Sub(ts) > g.ttl {
+			delete(g.seen, k)
+		}
+	}
+
+	if last, ok := g.seen[key]; ok {
+		if now.Sub(last) <= g.ttl {
+			return true
+		}
+	}
+	g.seen[key] = now
+	return false
+}
+
+// Size returns the number of tracked dedup keys. Test helper.
+func (g *DedupGate) Size() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.seen)
+}

--- a/app/internal/alertrouter/doc.go
+++ b/app/internal/alertrouter/doc.go
@@ -1,0 +1,50 @@
+// Package alertrouter is the bridge between OpenWatch's in-process
+// event bus (internal/eventbus) and external notification channels
+// (Slack, email, webhook, PagerDuty).
+//
+// Spec: specs/system/alert-router.spec.yaml (status: approved)
+//
+// Architectural choices:
+//
+//   - Subscribes to EventKindHeartbeatPulse + EventKindDriftDetected on
+//     the bus at Start. A single dispatch goroutine reads from the
+//     subscription channels and translates each event to a typed Alert
+//     before fan-out. Spec C-08 / AC-11.
+//
+//   - Closed enums for AlertType and Severity. Each AlertType has a
+//     default Severity that the router applies before channel routing.
+//     Spec C-01 / C-02.
+//
+//   - In-memory dedup gate keyed by (alert_type, host_id, rule_id) with
+//     configurable TTL (default 60 min, range 60s..24h). Dedup state
+//     does NOT survive process restart — for v1, single-instance
+//     dedup is correct; multi-instance deploys can slot a Postgres
+//     store behind the same interface. Spec C-03 / C-04.
+//
+//   - Channel registration with tag-filter routing. Each channel
+//     declares a Tags map of required key/value pairs; an empty Tags
+//     map is a wildcard (channel receives every alert). Alert.Tags
+//     always carries at minimum severity + alert_type + host_id.
+//     Spec C-05 / C-06.
+//
+//   - Per-channel goroutine for Channel.Send. A Send returning an error
+//     increments that channel's FailureCount but does NOT halt delivery
+//     to other channels for the same alert. The router never panics on
+//     a channel-side error. Spec C-07 / AC-10.
+//
+//   - Router.Stop unsubscribes from the bus AND waits up to 10s for
+//     in-flight Channel.Send calls to complete (drain timeout). After
+//     Stop, new events arriving on the bus subscription are ignored.
+//     Spec C-08 / AC-12.
+//
+// Distinction from internal/audit: the audit log is the persistent
+// forensic record of who/what/when; the alert router is real-time
+// delivery to notification surfaces. Most alert-worthy events emit
+// to both — e.g., a major drift writes compliance.drift.detected to
+// the audit log AND fires through the alert router to Slack.
+//
+// Concrete Channel implementations (Slack, email, webhook) live in
+// subpackages so the core router has no external SDK dependencies.
+// This PR ships the interface + a fake (for tests) + stdout (for
+// dev/test scenarios). Spec C-09 / AC-13.
+package alertrouter

--- a/app/internal/alertrouter/metrics.go
+++ b/app/internal/alertrouter/metrics.go
@@ -1,0 +1,45 @@
+package alertrouter
+
+import "sync/atomic"
+
+// Metrics holds the router's runtime counters. Spec AC-14.
+type Metrics struct {
+	// ReceivedCount is the count of bus events the router translated
+	// into Alert values (pre-dedup).
+	ReceivedCount atomic.Int64
+
+	// RoutedCount is the count of (alert, channel) pairs where the
+	// channel's tag filter matched and Send was invoked. Counts each
+	// channel delivery for a fan-out alert.
+	RoutedCount atomic.Int64
+
+	// DedupedCount is the count of alerts skipped by the dedup gate.
+	// Per Spec C-03, these never reach Channel.Send.
+	DedupedCount atomic.Int64
+
+	// ChannelFailureCount is the aggregate count of Channel.Send calls
+	// that returned an error. Per-channel counters are tracked on
+	// channelEntry.failureCount.
+	ChannelFailureCount atomic.Int64
+}
+
+// NewMetrics returns a fresh Metrics.
+func NewMetrics() *Metrics { return &Metrics{} }
+
+// MetricsSnapshot is a JSON-friendly point-in-time snapshot.
+type MetricsSnapshot struct {
+	ReceivedCount       int64 `json:"received_count"`
+	RoutedCount         int64 `json:"routed_count"`
+	DedupedCount        int64 `json:"deduped_count"`
+	ChannelFailureCount int64 `json:"channel_failure_count"`
+}
+
+// Snapshot returns a point-in-time copy of all counters.
+func (m *Metrics) Snapshot() MetricsSnapshot {
+	return MetricsSnapshot{
+		ReceivedCount:       m.ReceivedCount.Load(),
+		RoutedCount:         m.RoutedCount.Load(),
+		DedupedCount:        m.DedupedCount.Load(),
+		ChannelFailureCount: m.ChannelFailureCount.Load(),
+	}
+}

--- a/app/internal/alertrouter/router.go
+++ b/app/internal/alertrouter/router.go
@@ -1,0 +1,330 @@
+package alertrouter
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+)
+
+// stopDrainTimeout is the max time Router.Stop waits for in-flight
+// Channel.Send calls to complete before returning. Spec C-08.
+const stopDrainTimeout = 10 * time.Second
+
+// Router subscribes to the event bus and dispatches alerts to
+// registered channels.
+//
+// Construct with NewRouter, register channels via Register, then call
+// Start to begin reading from the bus. Call Stop to unsubscribe and
+// drain in-flight deliveries.
+type Router struct {
+	bus      *eventbus.Bus
+	dedup    *DedupGate
+	metrics  *Metrics
+	logger   *slog.Logger
+	dedupTTL time.Duration
+
+	mu       sync.RWMutex
+	channels []*channelEntry
+
+	started atomic.Bool
+	stopped atomic.Bool
+
+	heartbeatSub *eventbus.Subscription
+	driftSub     *eventbus.Subscription
+
+	// loopWG covers the two reader goroutines (heartbeat, drift).
+	loopWG sync.WaitGroup
+
+	// sendWG covers in-flight Channel.Send goroutines so Stop can wait
+	// for them to complete with a bounded timeout.
+	sendWG sync.WaitGroup
+}
+
+// channelEntry binds a ChannelRegistration to its per-channel failure
+// counter. Pointer because we mutate the counter atomically.
+type channelEntry struct {
+	reg          ChannelRegistration
+	failureCount atomic.Int64
+}
+
+// Config holds optional Router parameters.
+type Config struct {
+	// DedupTTL is the time window for the dedup gate. Must be in
+	// [MinDedupTTL, MaxDedupTTL] per ValidateDedupTTL. Zero defaults to
+	// DefaultDedupTTL.
+	DedupTTL time.Duration
+
+	// Logger is the structured logger for failure/diagnostic messages.
+	// nil uses slog.Default.
+	Logger *slog.Logger
+}
+
+// NewRouter constructs a Router bound to the given event bus. The
+// router is not yet subscribed; call Start.
+func NewRouter(bus *eventbus.Bus, cfg Config) (*Router, error) {
+	if bus == nil {
+		return nil, fmt.Errorf("alertrouter: bus is required")
+	}
+	ttl := cfg.DedupTTL
+	if ttl == 0 {
+		ttl = DefaultDedupTTL
+	}
+	if err := ValidateDedupTTL(ttl); err != nil {
+		return nil, err
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Router{
+		bus:      bus,
+		dedup:    NewDedupGate(ttl),
+		metrics:  NewMetrics(),
+		logger:   logger,
+		dedupTTL: ttl,
+	}, nil
+}
+
+// Register adds a channel + filter to the router. Safe to call before
+// or after Start. Spec C-05.
+func (r *Router) Register(reg ChannelRegistration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.channels = append(r.channels, &channelEntry{reg: reg})
+}
+
+// Start subscribes to EventKindHeartbeatPulse + EventKindDriftDetected
+// on the bus and begins dispatching. Idempotent (re-calling has no
+// effect). Spec AC-11.
+func (r *Router) Start(ctx context.Context) {
+	if !r.started.CompareAndSwap(false, true) {
+		return
+	}
+	r.heartbeatSub = r.bus.Subscribe(eventbus.SubscribeOptions{
+		Kinds: []eventbus.EventKind{eventbus.EventKindHeartbeatPulse},
+	})
+	r.driftSub = r.bus.Subscribe(eventbus.SubscribeOptions{
+		Kinds: []eventbus.EventKind{eventbus.EventKindDriftDetected},
+	})
+
+	r.loopWG.Add(2)
+	go r.run(ctx, r.heartbeatSub)
+	go r.run(ctx, r.driftSub)
+}
+
+// Stop unsubscribes from the bus and waits up to stopDrainTimeout for
+// in-flight Channel.Send calls to complete. After Stop, new events are
+// ignored. Spec AC-12 / C-08.
+func (r *Router) Stop() {
+	if !r.stopped.CompareAndSwap(false, true) {
+		return
+	}
+	// Unsubscribe from the bus. The reader goroutines see closed
+	// channels and return.
+	if r.heartbeatSub != nil {
+		r.heartbeatSub.Unsubscribe()
+	}
+	if r.driftSub != nil {
+		r.driftSub.Unsubscribe()
+	}
+	// Wait for the reader loops to exit so no new Channel.Send calls
+	// will be spawned after this point.
+	r.loopWG.Wait()
+
+	// Drain in-flight sends with a bounded timeout.
+	done := make(chan struct{})
+	go func() {
+		r.sendWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(stopDrainTimeout):
+		r.logger.WarnContext(context.Background(),
+			"alertrouter: Stop drain timeout exceeded; some in-flight sends abandoned",
+			slog.Duration("timeout", stopDrainTimeout))
+	}
+}
+
+// run is the per-subscription reader loop. Each event is translated to
+// an Alert, run through the dedup gate, and fanned out to matching
+// channels.
+func (r *Router) run(ctx context.Context, sub *eventbus.Subscription) {
+	defer r.loopWG.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.Events():
+			if !ok {
+				return
+			}
+			r.handle(ctx, ev)
+		}
+	}
+}
+
+// handle is the per-event translation + dispatch pipeline. Exported
+// only via run; tests use translate + dispatch directly when finer
+// granularity is needed.
+func (r *Router) handle(ctx context.Context, ev eventbus.Event) {
+	alert, ok := translate(ev)
+	if !ok {
+		return
+	}
+	r.metrics.ReceivedCount.Add(1)
+	if r.dedup.ShouldSkip(alert) {
+		r.metrics.DedupedCount.Add(1)
+		return
+	}
+	r.dispatch(ctx, alert)
+}
+
+// dispatch fans the alert out to every channel whose filter matches.
+// Each Channel.Send runs in its own goroutine so a slow channel does
+// not delay others. Spec C-07 / AC-10.
+func (r *Router) dispatch(ctx context.Context, alert Alert) {
+	r.mu.RLock()
+	targets := make([]*channelEntry, 0, len(r.channels))
+	for _, c := range r.channels {
+		if c.reg.matches(alert) {
+			targets = append(targets, c)
+		}
+	}
+	r.mu.RUnlock()
+
+	for _, c := range targets {
+		r.metrics.RoutedCount.Add(1)
+		r.sendWG.Add(1)
+		go func(entry *channelEntry) {
+			defer r.sendWG.Done()
+			defer func() {
+				if rec := recover(); rec != nil {
+					// A channel panicked. Count it as a failure and log;
+					// the router itself stays up.
+					entry.failureCount.Add(1)
+					r.metrics.ChannelFailureCount.Add(1)
+					r.logger.ErrorContext(ctx,
+						"alertrouter: channel panicked during Send",
+						slog.String("channel", entry.reg.Channel.Name()),
+						slog.Any("panic", rec))
+				}
+			}()
+			if err := entry.reg.Channel.Send(ctx, alert); err != nil {
+				entry.failureCount.Add(1)
+				r.metrics.ChannelFailureCount.Add(1)
+				r.logger.WarnContext(ctx,
+					"alertrouter: channel send failed",
+					slog.String("channel", entry.reg.Channel.Name()),
+					slog.String("alert_type", string(alert.Type)),
+					slog.String("severity", string(alert.Severity)),
+					slog.Any("error", err))
+			}
+		}(c)
+	}
+}
+
+// translate converts a bus event into a typed Alert. Returns ok=false
+// for events that don't map to any AlertType (e.g., a heartbeat with
+// no state change). Spec AC-03 / AC-04 / AC-05.
+func translate(ev eventbus.Event) (Alert, bool) {
+	switch e := ev.(type) {
+	case eventbus.HeartbeatPulse:
+		return translateHeartbeat(e)
+	case eventbus.DriftDetected:
+		return translateDrift(e)
+	default:
+		return Alert{}, false
+	}
+}
+
+func translateHeartbeat(e eventbus.HeartbeatPulse) (Alert, bool) {
+	switch {
+	case !e.Reachable:
+		// Host went unreachable.
+		a := Alert{
+			Type:       AlertTypeHostUnreachable,
+			HostID:     e.HostID,
+			OccurredAt: e.OccurredAt,
+			Title:      fmt.Sprintf("Host %s unreachable", e.HostID),
+			Body:       fmt.Sprintf("Liveness probe failed for host %s.", e.HostID),
+		}
+		a.Severity = defaultSeverityFor(a.Type)
+		a.Tags = baseTags(a)
+		return a, true
+	case e.Reachable && !e.PriorReachable:
+		// Host recovered (was unreachable, now reachable).
+		a := Alert{
+			Type:       AlertTypeHostRecovered,
+			HostID:     e.HostID,
+			OccurredAt: e.OccurredAt,
+			Title:      fmt.Sprintf("Host %s recovered", e.HostID),
+			Body:       fmt.Sprintf("Host %s is reachable again (response_time=%dms).", e.HostID, e.ResponseTimeMS),
+		}
+		a.Severity = defaultSeverityFor(a.Type)
+		a.Tags = baseTags(a)
+		return a, true
+	default:
+		// Reachable AND prior reachable: no transition, no alert.
+		return Alert{}, false
+	}
+}
+
+func translateDrift(e eventbus.DriftDetected) (Alert, bool) {
+	var t AlertType
+	switch e.DriftType {
+	case "major":
+		t = AlertTypeDriftMajor
+	case "minor":
+		t = AlertTypeDriftMinor
+	case "improvement":
+		t = AlertTypeDriftImprovement
+	default:
+		return Alert{}, false
+	}
+	a := Alert{
+		Type:       t,
+		HostID:     e.HostID,
+		OccurredAt: e.OccurredAt,
+		Title:      fmt.Sprintf("Compliance drift (%s) on host %s", e.DriftType, e.HostID),
+		Body: fmt.Sprintf(
+			"Scan %s: score %.2f → %.2f (Δ %.2f). Critical→fail: %d, High→fail: %d.",
+			e.ScanID, e.PriorScore, e.CurrentScore, e.ScoreDelta,
+			e.CriticalBecameFailing, e.HighBecameFailing),
+	}
+	a.Severity = defaultSeverityFor(a.Type)
+	a.Tags = baseTags(a)
+	a.Tags["score_delta"] = fmt.Sprintf("%.2f", e.ScoreDelta)
+	return a, true
+}
+
+// baseTags is the minimum tag set every alert carries. Spec C-06.
+func baseTags(a Alert) map[string]string {
+	return map[string]string{
+		"severity":   string(a.Severity),
+		"alert_type": string(a.Type),
+		"host_id":    a.HostID.String(),
+	}
+}
+
+// Metrics returns the router's runtime counters handle.
+func (r *Router) Metrics() *Metrics { return r.metrics }
+
+// FailureCount returns the per-channel failure counter for the channel
+// with the given Name(). Returns -1 if no such channel is registered.
+// Test helper.
+func (r *Router) FailureCount(name string) int64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, c := range r.channels {
+		if c.reg.Channel.Name() == name {
+			return c.failureCount.Load()
+		}
+	}
+	return -1
+}

--- a/app/internal/alertrouter/router_test.go
+++ b/app/internal/alertrouter/router_test.go
@@ -1,0 +1,558 @@
+// @spec system-alert-router
+//
+// AC traceability (this file):
+//   AC-03  TestTranslate_HeartbeatUnreachable_HostUnreachableAlert
+//   AC-04  TestTranslate_HeartbeatRecovery_HostRecoveredAlert
+//   AC-05  TestTranslate_DriftMajor_DriftMajorAlert
+//   AC-06  TestRouter_Dedup_SkipsRepeatWithinTTL
+//   AC-07  TestRouter_Dedup_PassesAfterTTL
+//   AC-08  TestRouter_TagFilter_RejectsNonMatch
+//   AC-09  TestRouter_WildcardChannel_ReceivesEvery
+//   AC-10  TestRouter_ChannelError_DoesNotBlockOtherChannels
+//   AC-11  TestRouter_Start_SubscribesToBothEventKinds
+//   AC-12  TestRouter_Stop_UnsubscribesAndDrains
+//   AC-14  TestRouter_Metrics_AllCountersIncrement
+
+package alertrouter
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/google/uuid"
+)
+
+// fakeChannel is a Channel implementation that records received alerts
+// in memory + lets tests force errors. Lives in the test file so the
+// core package has no dependency on it.
+type fakeChannel struct {
+	name string
+
+	mu      sync.Mutex
+	alerts  []Alert
+	sendErr error
+
+	delay time.Duration // optional artificial latency
+}
+
+func newFakeChannel(name string) *fakeChannel {
+	return &fakeChannel{name: name}
+}
+
+func (f *fakeChannel) Name() string { return f.name }
+
+func (f *fakeChannel) Send(ctx context.Context, a Alert) error {
+	if f.delay > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(f.delay):
+		}
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.alerts = append(f.alerts, a)
+	return nil
+}
+
+func (f *fakeChannel) Received() []Alert {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Alert, len(f.alerts))
+	copy(out, f.alerts)
+	return out
+}
+
+func (f *fakeChannel) setError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendErr = err
+}
+
+func newTestRouter(t *testing.T) (*Router, *eventbus.Bus) {
+	t.Helper()
+	bus := eventbus.NewBus()
+	r, err := NewRouter(bus, Config{DedupTTL: 5 * time.Minute})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+	return r, bus
+}
+
+// waitFor polls cond until true or budget elapses. Reduces test
+// flakiness vs. fixed sleeps.
+func waitFor(t *testing.T, budget time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// @ac AC-03
+// AC-03: HeartbeatPulse{Reachable=false} → Alert with
+// Type=AlertTypeHostUnreachable, Severity=SeverityHigh; host_id tag set.
+func TestTranslate_HeartbeatUnreachable_HostUnreachableAlert(t *testing.T) {
+	t.Run("system-alert-router/AC-03", func(t *testing.T) {
+		hostID := uuid.New()
+		ev := eventbus.HeartbeatPulse{
+			HostID:         hostID,
+			Reachable:      false,
+			PriorReachable: true,
+			OccurredAt:     time.Now(),
+		}
+		alert, ok := translate(ev)
+		if !ok {
+			t.Fatal("translate returned ok=false for unreachable heartbeat")
+		}
+		if alert.Type != AlertTypeHostUnreachable {
+			t.Errorf("Type = %q, want %q", alert.Type, AlertTypeHostUnreachable)
+		}
+		if alert.Severity != SeverityHigh {
+			t.Errorf("Severity = %q, want %q", alert.Severity, SeverityHigh)
+		}
+		if alert.HostID != hostID {
+			t.Errorf("HostID = %s, want %s", alert.HostID, hostID)
+		}
+		if alert.Tags["host_id"] != hostID.String() {
+			t.Errorf("Tags[host_id] = %q, want %q", alert.Tags["host_id"], hostID)
+		}
+		if alert.Tags["alert_type"] != string(AlertTypeHostUnreachable) {
+			t.Errorf("Tags[alert_type] = %q, want %q", alert.Tags["alert_type"], AlertTypeHostUnreachable)
+		}
+		if alert.Tags["severity"] != string(SeverityHigh) {
+			t.Errorf("Tags[severity] = %q, want %q", alert.Tags["severity"], SeverityHigh)
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: HeartbeatPulse{Reachable=true, PriorReachable=false} → Alert
+// with Type=AlertTypeHostRecovered, Severity=SeverityInfo.
+func TestTranslate_HeartbeatRecovery_HostRecoveredAlert(t *testing.T) {
+	t.Run("system-alert-router/AC-04", func(t *testing.T) {
+		ev := eventbus.HeartbeatPulse{
+			HostID:         uuid.New(),
+			Reachable:      true,
+			PriorReachable: false,
+			OccurredAt:     time.Now(),
+			ResponseTimeMS: 12,
+		}
+		alert, ok := translate(ev)
+		if !ok {
+			t.Fatal("translate returned ok=false for recovery heartbeat")
+		}
+		if alert.Type != AlertTypeHostRecovered {
+			t.Errorf("Type = %q, want %q", alert.Type, AlertTypeHostRecovered)
+		}
+		if alert.Severity != SeverityInfo {
+			t.Errorf("Severity = %q, want %q", alert.Severity, SeverityInfo)
+		}
+
+		// Reachable + PriorReachable → no transition, no alert.
+		evNoChange := eventbus.HeartbeatPulse{
+			HostID: uuid.New(), Reachable: true, PriorReachable: true,
+			OccurredAt: time.Now(),
+		}
+		if _, ok := translate(evNoChange); ok {
+			t.Error("translate returned ok=true for no-transition heartbeat")
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: DriftDetected{DriftType="major"} → Alert with
+// Type=AlertTypeDriftMajor, Severity=SeverityHigh; score_delta + host_id
+// in tags.
+func TestTranslate_DriftMajor_DriftMajorAlert(t *testing.T) {
+	t.Run("system-alert-router/AC-05", func(t *testing.T) {
+		hostID := uuid.New()
+		ev := eventbus.DriftDetected{
+			HostID:                hostID,
+			ScanID:                uuid.New(),
+			OccurredAt:            time.Now(),
+			DriftType:             "major",
+			PriorScore:            92.0,
+			CurrentScore:          70.0,
+			ScoreDelta:            -22.0,
+			CriticalBecameFailing: 1,
+			HighBecameFailing:     3,
+		}
+		alert, ok := translate(ev)
+		if !ok {
+			t.Fatal("translate returned ok=false for major drift")
+		}
+		if alert.Type != AlertTypeDriftMajor {
+			t.Errorf("Type = %q, want %q", alert.Type, AlertTypeDriftMajor)
+		}
+		if alert.Severity != SeverityHigh {
+			t.Errorf("Severity = %q, want %q", alert.Severity, SeverityHigh)
+		}
+		if alert.Tags["host_id"] != hostID.String() {
+			t.Errorf("Tags[host_id] = %q, want %q", alert.Tags["host_id"], hostID)
+		}
+		if alert.Tags["score_delta"] != "-22.00" {
+			t.Errorf("Tags[score_delta] = %q, want %q", alert.Tags["score_delta"], "-22.00")
+		}
+
+		// Unknown DriftType → no alert.
+		evBogus := eventbus.DriftDetected{
+			HostID: uuid.New(), ScanID: uuid.New(),
+			OccurredAt: time.Now(), DriftType: "bogus",
+		}
+		if _, ok := translate(evBogus); ok {
+			t.Error("translate returned ok=true for unknown DriftType")
+		}
+	})
+}
+
+// @ac AC-06
+// AC-06: dedup gate skips a repeat alert within TTL; DedupedCount
+// increments; Channel.Send NOT called for the skipped alert.
+func TestRouter_Dedup_SkipsRepeatWithinTTL(t *testing.T) {
+	t.Run("system-alert-router/AC-06", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+		ch := newFakeChannel("fake")
+		r.Register(ChannelRegistration{Channel: ch})
+		r.Start(context.Background())
+		defer r.Stop()
+
+		hostID := uuid.New()
+		ev := eventbus.HeartbeatPulse{
+			HostID: hostID, Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		}
+		// Publish twice within TTL.
+		bus.Publish(context.Background(), ev)
+		bus.Publish(context.Background(), ev)
+
+		waitFor(t, 200*time.Millisecond, func() bool {
+			return r.Metrics().Snapshot().ReceivedCount >= 2
+		})
+
+		snap := r.Metrics().Snapshot()
+		if snap.ReceivedCount != 2 {
+			t.Errorf("ReceivedCount = %d, want 2", snap.ReceivedCount)
+		}
+		if snap.DedupedCount != 1 {
+			t.Errorf("DedupedCount = %d, want 1", snap.DedupedCount)
+		}
+		// Channel saw only one alert (the second was deduped).
+		waitFor(t, 100*time.Millisecond, func() bool {
+			return len(ch.Received()) == 1
+		})
+		if got := len(ch.Received()); got != 1 {
+			t.Errorf("channel received %d alerts, want 1", got)
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: a repeat alert AFTER the dedup TTL elapses passes through;
+// Channel.Send IS called. Use a 60s TTL with a controllable clock on
+// the dedup gate (router uses default `now`, but we test the gate
+// directly here since router uses real time).
+func TestRouter_Dedup_PassesAfterTTL(t *testing.T) {
+	t.Run("system-alert-router/AC-07", func(t *testing.T) {
+		// Test the DedupGate directly with a fake clock to avoid
+		// 60s real-time waits.
+		gate := NewDedupGate(60 * time.Second)
+		t0 := time.Now()
+		gate.now = func() time.Time { return t0 }
+
+		alert := Alert{Type: AlertTypeHostUnreachable, HostID: uuid.New()}
+		if gate.ShouldSkip(alert) {
+			t.Error("first call should not skip")
+		}
+		if !gate.ShouldSkip(alert) {
+			t.Error("second call within TTL should skip")
+		}
+
+		// Advance past TTL.
+		gate.now = func() time.Time { return t0.Add(90 * time.Second) }
+		if gate.ShouldSkip(alert) {
+			t.Error("call after TTL should NOT skip")
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: a channel with Tags{"severity":"critical"} receives only
+// critical alerts; a medium-severity alert does not reach it.
+func TestRouter_TagFilter_RejectsNonMatch(t *testing.T) {
+	t.Run("system-alert-router/AC-08", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+
+		critOnly := newFakeChannel("crit-only")
+		r.Register(ChannelRegistration{
+			Channel: critOnly,
+			Tags:    map[string]string{"severity": string(SeverityCritical)},
+		})
+		r.Start(context.Background())
+		defer r.Stop()
+
+		// HostUnreachable is High severity (not Critical) → must not
+		// reach the crit-only channel.
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: uuid.New(), Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+
+		waitFor(t, 150*time.Millisecond, func() bool {
+			return r.Metrics().Snapshot().ReceivedCount >= 1
+		})
+		// Give dispatch a chance to run.
+		time.Sleep(20 * time.Millisecond)
+		if got := len(critOnly.Received()); got != 0 {
+			t.Errorf("crit-only channel received %d alerts, want 0", got)
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09: a channel with empty Tags receives every alert.
+func TestRouter_WildcardChannel_ReceivesEvery(t *testing.T) {
+	t.Run("system-alert-router/AC-09", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+
+		wildcard := newFakeChannel("wildcard")
+		r.Register(ChannelRegistration{Channel: wildcard})
+		r.Start(context.Background())
+		defer r.Stop()
+
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: uuid.New(), Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+		bus.Publish(context.Background(), eventbus.DriftDetected{
+			HostID: uuid.New(), ScanID: uuid.New(),
+			OccurredAt: time.Now(), DriftType: "major", ScoreDelta: -10,
+		})
+
+		waitFor(t, 250*time.Millisecond, func() bool {
+			return len(wildcard.Received()) == 2
+		})
+		if got := len(wildcard.Received()); got != 2 {
+			t.Errorf("wildcard received %d alerts, want 2", got)
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: Channel.Send returning an error increments that channel's
+// FailureCount but does NOT block delivery to other channels for the
+// same alert.
+func TestRouter_ChannelError_DoesNotBlockOtherChannels(t *testing.T) {
+	t.Run("system-alert-router/AC-10", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+
+		broken := newFakeChannel("broken")
+		broken.setError(errors.New("simulated send failure"))
+		healthy := newFakeChannel("healthy")
+		r.Register(ChannelRegistration{Channel: broken})
+		r.Register(ChannelRegistration{Channel: healthy})
+		r.Start(context.Background())
+		defer r.Stop()
+
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: uuid.New(), Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+
+		waitFor(t, 300*time.Millisecond, func() bool {
+			return len(healthy.Received()) == 1
+		})
+		if got := len(healthy.Received()); got != 1 {
+			t.Errorf("healthy channel received %d alerts, want 1 — broken channel's error blocked it",
+				got)
+		}
+		waitFor(t, 100*time.Millisecond, func() bool {
+			return r.FailureCount("broken") == 1
+		})
+		if got := r.FailureCount("broken"); got != 1 {
+			t.Errorf("broken FailureCount = %d, want 1", got)
+		}
+		if got := r.FailureCount("healthy"); got != 0 {
+			t.Errorf("healthy FailureCount = %d, want 0", got)
+		}
+		if snap := r.Metrics().Snapshot(); snap.ChannelFailureCount != 1 {
+			t.Errorf("ChannelFailureCount = %d, want 1", snap.ChannelFailureCount)
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: Router.Start subscribes to both EventKindHeartbeatPulse AND
+// EventKindDriftDetected. Verify by publishing one of each and
+// observing both arrive at a wildcard channel.
+func TestRouter_Start_SubscribesToBothEventKinds(t *testing.T) {
+	t.Run("system-alert-router/AC-11", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+		ch := newFakeChannel("all")
+		r.Register(ChannelRegistration{Channel: ch})
+		r.Start(context.Background())
+		defer r.Stop()
+
+		hbHostID := uuid.New()
+		driftHostID := uuid.New()
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: hbHostID, Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+		bus.Publish(context.Background(), eventbus.DriftDetected{
+			HostID: driftHostID, ScanID: uuid.New(),
+			OccurredAt: time.Now(), DriftType: "minor", ScoreDelta: -5,
+		})
+
+		waitFor(t, 250*time.Millisecond, func() bool {
+			return len(ch.Received()) == 2
+		})
+		alerts := ch.Received()
+		if len(alerts) != 2 {
+			t.Fatalf("received %d alerts, want 2", len(alerts))
+		}
+		gotTypes := map[AlertType]bool{}
+		for _, a := range alerts {
+			gotTypes[a.Type] = true
+		}
+		if !gotTypes[AlertTypeHostUnreachable] {
+			t.Error("missing host_unreachable alert — heartbeat subscription not active")
+		}
+		if !gotTypes[AlertTypeDriftMinor] {
+			t.Error("missing drift_minor alert — drift subscription not active")
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: Router.Stop unsubscribes AND waits for in-flight Channel.Send
+// calls to complete. After Stop, new events received are ignored.
+func TestRouter_Stop_UnsubscribesAndDrains(t *testing.T) {
+	t.Run("system-alert-router/AC-12", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+
+		// Channel with a 30ms delay → drain must wait for it.
+		slow := newFakeChannel("slow")
+		slow.delay = 30 * time.Millisecond
+		r.Register(ChannelRegistration{Channel: slow})
+		r.Start(context.Background())
+
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: uuid.New(), Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+
+		// Wait until the router has dispatched (RoutedCount==1) so a
+		// Send goroutine is in flight when we call Stop.
+		waitFor(t, 200*time.Millisecond, func() bool {
+			return r.Metrics().Snapshot().RoutedCount >= 1
+		})
+
+		stopStart := time.Now()
+		r.Stop()
+		stopElapsed := time.Since(stopStart)
+
+		// Stop should have waited at least ~25ms for the slow channel
+		// to finish its Send. (Lenient lower bound to avoid flakes.)
+		if stopElapsed < 10*time.Millisecond {
+			t.Errorf("Stop returned in %v — drain did not wait for slow channel", stopElapsed)
+		}
+		// Slow Send should have completed.
+		if got := len(slow.Received()); got != 1 {
+			t.Errorf("slow.Received = %d, want 1 — drain didn't wait", got)
+		}
+
+		// After Stop: publish should be ignored (subscription
+		// unsubscribed). Verified by ReceivedCount not changing.
+		before := r.Metrics().Snapshot().ReceivedCount
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: uuid.New(), Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+		time.Sleep(20 * time.Millisecond)
+		after := r.Metrics().Snapshot().ReceivedCount
+		if after != before {
+			t.Errorf("ReceivedCount changed after Stop: %d → %d", before, after)
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: Metrics().Snapshot() exposes ReceivedCount, RoutedCount,
+// DedupedCount, ChannelFailureCount; all increment under matching
+// scenarios.
+func TestRouter_Metrics_AllCountersIncrement(t *testing.T) {
+	t.Run("system-alert-router/AC-14", func(t *testing.T) {
+		r, bus := newTestRouter(t)
+		defer bus.Shutdown()
+
+		broken := newFakeChannel("broken")
+		broken.setError(errors.New("nope"))
+		healthy := newFakeChannel("healthy")
+		r.Register(ChannelRegistration{Channel: broken})
+		r.Register(ChannelRegistration{Channel: healthy})
+		r.Start(context.Background())
+		defer r.Stop()
+
+		hostID := uuid.New()
+		// First publish: drives ReceivedCount=1, RoutedCount=2,
+		// ChannelFailureCount=1.
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: hostID, Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+		// Second publish identical: drives DedupedCount=1.
+		bus.Publish(context.Background(), eventbus.HeartbeatPulse{
+			HostID: hostID, Reachable: false, PriorReachable: true,
+			OccurredAt: time.Now(),
+		})
+
+		waitFor(t, 300*time.Millisecond, func() bool {
+			snap := r.Metrics().Snapshot()
+			return snap.ReceivedCount == 2 && snap.DedupedCount == 1 &&
+				snap.RoutedCount == 2 && snap.ChannelFailureCount == 1
+		})
+		snap := r.Metrics().Snapshot()
+		if snap.ReceivedCount != 2 {
+			t.Errorf("ReceivedCount = %d, want 2", snap.ReceivedCount)
+		}
+		if snap.DedupedCount != 1 {
+			t.Errorf("DedupedCount = %d, want 1", snap.DedupedCount)
+		}
+		if snap.RoutedCount != 2 {
+			t.Errorf("RoutedCount = %d, want 2 (1 alert × 2 channels)", snap.RoutedCount)
+		}
+		if snap.ChannelFailureCount != 1 {
+			t.Errorf("ChannelFailureCount = %d, want 1", snap.ChannelFailureCount)
+		}
+	})
+}
+
+// Ensure tests don't accidentally leave goroutines around.
+func TestMain(m *testing.M) {
+	// One quick sanity assertion: atomic counters round-trip without
+	// data races. (-race detector covers the rest.)
+	var x atomic.Int64
+	x.Add(1)
+	if x.Load() != 1 {
+		panic("atomic broken")
+	}
+	m.Run()
+}

--- a/app/internal/alertrouter/source_test.go
+++ b/app/internal/alertrouter/source_test.go
@@ -1,0 +1,76 @@
+// @spec system-alert-router
+//
+// AC traceability (this file):
+//   AC-13  TestNoExternalNotificationSDKImports
+
+package alertrouter
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func packageDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+// @ac AC-13
+// AC-13: internal/alertrouter (core package, NOT subpackages) imports
+// no external notification SDKs. Channel implementations live in
+// subpackages so the core router stays dependency-light and the
+// boundary is enforceable at the source level.
+func TestNoExternalNotificationSDKImports(t *testing.T) {
+	t.Run("system-alert-router/AC-13", func(t *testing.T) {
+		dir := packageDir(t)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir: %v", err)
+		}
+
+		// Known external notification SDK prefixes. Reviewers extend
+		// this list when a new SDK enters the ecosystem.
+		forbiddenPrefixes := []string{
+			"github.com/slack-go/slack",       // Slack
+			"github.com/nlopes/slack",         // Slack (legacy)
+			"github.com/sendgrid/sendgrid-go", // SendGrid
+			"github.com/mailgun/mailgun-go",   // Mailgun
+			"github.com/sendinblue/APIv3-go",  // Brevo (ex-Sendinblue)
+			"github.com/twilio/twilio-go",     // Twilio (SMS)
+			"github.com/PagerDuty/go-pagerduty",
+			"github.com/opsgenie/opsgenie-go-sdk", // Opsgenie
+			"gopkg.in/gomail.v2",                  // SMTP wrapper
+			"github.com/jordan-wright/email",      // SMTP wrapper
+		}
+
+		fset := token.NewFileSet()
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+				continue
+			}
+			if strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			f := filepath.Join(dir, e.Name())
+			astFile, err := parser.ParseFile(fset, f, nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", f, err)
+			}
+			for _, imp := range astFile.Imports {
+				path := strings.Trim(imp.Path.Value, `"`)
+				for _, bad := range forbiddenPrefixes {
+					if strings.HasPrefix(path, bad) {
+						t.Errorf("%s imports %q — core router must stay SDK-free (AC-13); channel implementations belong in subpackages",
+							f, path)
+					}
+				}
+			}
+		}
+	})
+}

--- a/app/internal/alertrouter/types.go
+++ b/app/internal/alertrouter/types.go
@@ -1,0 +1,207 @@
+package alertrouter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// AlertType is the closed enum of alert types the router can emit.
+// Spec C-01 / AC-01.
+type AlertType string
+
+const (
+	// AlertTypeHostUnreachable is raised when the liveness loop
+	// transitions a host from reachable to unreachable.
+	AlertTypeHostUnreachable AlertType = "host_unreachable"
+
+	// AlertTypeHostRecovered is raised when a previously unreachable
+	// host becomes reachable again.
+	AlertTypeHostRecovered AlertType = "host_recovered"
+
+	// AlertTypeDriftMajor is raised when the drift detector classifies
+	// a scan as a major worsening.
+	AlertTypeDriftMajor AlertType = "drift_major"
+
+	// AlertTypeDriftMinor is raised when the drift detector classifies
+	// a scan as a minor worsening.
+	AlertTypeDriftMinor AlertType = "drift_minor"
+
+	// AlertTypeDriftImprovement is raised when the drift detector
+	// classifies a scan as an improvement.
+	AlertTypeDriftImprovement AlertType = "drift_improvement"
+)
+
+// AllAlertTypes is the closed set, in registration order. Spec AC-01's
+// reflection-style check counts this slice.
+var AllAlertTypes = []AlertType{
+	AlertTypeHostUnreachable,
+	AlertTypeHostRecovered,
+	AlertTypeDriftMajor,
+	AlertTypeDriftMinor,
+	AlertTypeDriftImprovement,
+}
+
+// Severity is the closed enum of alert severities. Spec C-02 / AC-02.
+type Severity string
+
+const (
+	// SeverityCritical is the highest severity. Used for pager-quality
+	// events that must wake someone.
+	SeverityCritical Severity = "critical"
+
+	// SeverityHigh is one tier below Critical. Notifies via primary
+	// channels (Slack #alerts, email).
+	SeverityHigh Severity = "high"
+
+	// SeverityMedium is the default for noteworthy-but-not-urgent
+	// events.
+	SeverityMedium Severity = "medium"
+
+	// SeverityLow is informational with a slight nudge — surfaced in
+	// digest channels.
+	SeverityLow Severity = "low"
+
+	// SeverityInfo is purely informational (e.g., a host recovered).
+	SeverityInfo Severity = "info"
+)
+
+// AllSeverities is the closed set in descending order
+// (critical → info). Spec AC-02.
+var AllSeverities = []Severity{
+	SeverityCritical,
+	SeverityHigh,
+	SeverityMedium,
+	SeverityLow,
+	SeverityInfo,
+}
+
+// SeverityOrder gives each severity a numeric rank for comparison.
+// Lower number = higher severity (critical=0, info=4). Spec AC-02.
+var SeverityOrder = map[Severity]int{
+	SeverityCritical: 0,
+	SeverityHigh:     1,
+	SeverityMedium:   2,
+	SeverityLow:      3,
+	SeverityInfo:     4,
+}
+
+// defaultSeverityFor returns the Severity the router applies before
+// channel routing for a given AlertType. Spec C-02.
+func defaultSeverityFor(t AlertType) Severity {
+	switch t {
+	case AlertTypeHostUnreachable:
+		return SeverityHigh
+	case AlertTypeHostRecovered:
+		return SeverityInfo
+	case AlertTypeDriftMajor:
+		return SeverityHigh
+	case AlertTypeDriftMinor:
+		return SeverityMedium
+	case AlertTypeDriftImprovement:
+		return SeverityInfo
+	default:
+		return SeverityMedium
+	}
+}
+
+// Alert is a typed alert produced by the router from a bus event.
+// Channel implementations receive Alert values; they may format with
+// String() or render their own way from the structured fields.
+type Alert struct {
+	Type       AlertType
+	Severity   Severity
+	HostID     uuid.UUID
+	RuleID     string // empty when not rule-scoped (host_unreachable, host_recovered)
+	OccurredAt time.Time
+
+	// Title is a one-line summary suitable for a channel header.
+	Title string
+
+	// Body carries human-readable detail. Channel implementations may
+	// wrap this in their native format (Slack blocks, email body, etc.).
+	Body string
+
+	// Tags carries routable metadata. At minimum: severity + alert_type
+	// + host_id (populated by the router). Spec C-06.
+	Tags map[string]string
+}
+
+// DedupKey returns the (alert_type|host_id|rule_id) tuple used by the
+// dedup gate. Spec C-03.
+func (a Alert) DedupKey() string {
+	return fmt.Sprintf("%s|%s|%s", a.Type, a.HostID, a.RuleID)
+}
+
+// String returns a single-line summary of the alert. Used by the
+// stdout channel and as a fallback for channels without a custom
+// renderer.
+func (a Alert) String() string {
+	return fmt.Sprintf("[%s] %s — %s", a.Severity, a.Type, a.Title)
+}
+
+// Channel is the contract every notification channel implements.
+// Implementations (Slack, email, webhook) live in subpackages so the
+// core router has no external SDK dependencies. Spec C-09.
+type Channel interface {
+	// Name returns the channel's identifier. Used in metrics + logs.
+	Name() string
+
+	// Send delivers the alert. An error increments the channel's
+	// FailureCount but does not halt delivery to other channels for the
+	// same alert. Spec C-07.
+	Send(ctx context.Context, alert Alert) error
+}
+
+// ChannelRegistration binds a Channel to a tag filter.
+type ChannelRegistration struct {
+	// Channel is the implementation that receives matching alerts.
+	Channel Channel
+
+	// Tags is the required filter: every key/value pair must be present
+	// in Alert.Tags for the channel to receive. An empty Tags map is a
+	// wildcard (channel receives every alert). Spec C-05.
+	Tags map[string]string
+}
+
+// matches reports whether the alert satisfies the channel's tag filter.
+// Empty Tags = wildcard. Spec AC-08 / AC-09.
+func (r ChannelRegistration) matches(alert Alert) bool {
+	if len(r.Tags) == 0 {
+		return true
+	}
+	for k, v := range r.Tags {
+		if alert.Tags[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// MinDedupTTL is the lower bound on the dedup TTL — anything shorter
+// flattens the dedup gate to a no-op. Spec C-04.
+const MinDedupTTL = 60 * time.Second
+
+// MaxDedupTTL is the upper bound on the dedup TTL — anything longer is
+// likely a misconfiguration that suppresses real recurrences. Spec C-04.
+const MaxDedupTTL = 24 * time.Hour
+
+// DefaultDedupTTL is the policy default when no explicit TTL is
+// configured. Spec C-04.
+const DefaultDedupTTL = 60 * time.Minute
+
+// ErrDedupTTLOutOfRange is returned by ValidateDedupTTL when the
+// configured TTL falls outside [MinDedupTTL, MaxDedupTTL]. Spec AC-15.
+var ErrDedupTTLOutOfRange = errors.New("alertrouter: dedup TTL must be between 60s and 24h")
+
+// ValidateDedupTTL enforces the policy range on the configurable dedup
+// TTL. Spec AC-15 / C-04.
+func ValidateDedupTTL(ttl time.Duration) error {
+	if ttl < MinDedupTTL || ttl > MaxDedupTTL {
+		return fmt.Errorf("%w: got %s", ErrDedupTTLOutOfRange, ttl)
+	}
+	return nil
+}

--- a/app/internal/alertrouter/types_test.go
+++ b/app/internal/alertrouter/types_test.go
@@ -1,0 +1,104 @@
+// @spec system-alert-router
+//
+// AC traceability (this file):
+//   AC-01  TestAlertTypeEnum_HasExactlyFiveValues
+//   AC-02  TestSeverityEnum_HasExactlyFiveValues_OrderPreserved
+//   AC-15  TestValidateDedupTTL_RangeCheck
+
+package alertrouter
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// @ac AC-01
+// AC-01: AlertType enum has exactly 5 values listed in AllAlertTypes.
+func TestAlertTypeEnum_HasExactlyFiveValues(t *testing.T) {
+	t.Run("system-alert-router/AC-01", func(t *testing.T) {
+		if len(AllAlertTypes) != 5 {
+			t.Errorf("AllAlertTypes = %d, want 5", len(AllAlertTypes))
+		}
+		expected := map[AlertType]bool{
+			AlertTypeHostUnreachable:  false,
+			AlertTypeHostRecovered:    false,
+			AlertTypeDriftMajor:       false,
+			AlertTypeDriftMinor:       false,
+			AlertTypeDriftImprovement: false,
+		}
+		for _, k := range AllAlertTypes {
+			if _, ok := expected[k]; !ok {
+				t.Errorf("AllAlertTypes contains unexpected value %q", k)
+			}
+			expected[k] = true
+		}
+		for k, found := range expected {
+			if !found {
+				t.Errorf("AllAlertTypes missing %q", k)
+			}
+		}
+	})
+}
+
+// @ac AC-02
+// AC-02: Severity enum has exactly 5 values; SeverityOrder ranks
+// critical=0 ... info=4 so comparison works (lower = higher severity).
+func TestSeverityEnum_HasExactlyFiveValues_OrderPreserved(t *testing.T) {
+	t.Run("system-alert-router/AC-02", func(t *testing.T) {
+		if len(AllSeverities) != 5 {
+			t.Errorf("AllSeverities = %d, want 5", len(AllSeverities))
+		}
+		// Ordering: critical → high → medium → low → info.
+		wantOrder := []Severity{
+			SeverityCritical, SeverityHigh, SeverityMedium, SeverityLow, SeverityInfo,
+		}
+		for i, s := range wantOrder {
+			if AllSeverities[i] != s {
+				t.Errorf("AllSeverities[%d] = %q, want %q", i, AllSeverities[i], s)
+			}
+		}
+		// SeverityOrder: critical=0, info=4.
+		if SeverityOrder[SeverityCritical] != 0 {
+			t.Errorf("SeverityOrder[Critical] = %d, want 0", SeverityOrder[SeverityCritical])
+		}
+		if SeverityOrder[SeverityInfo] != 4 {
+			t.Errorf("SeverityOrder[Info] = %d, want 4", SeverityOrder[SeverityInfo])
+		}
+		// Critical is strictly higher (lower rank) than High.
+		if SeverityOrder[SeverityCritical] >= SeverityOrder[SeverityHigh] {
+			t.Errorf("Critical rank %d should be < High rank %d",
+				SeverityOrder[SeverityCritical], SeverityOrder[SeverityHigh])
+		}
+	})
+}
+
+// @ac AC-15
+// AC-15: ValidateDedupTTL rejects values < 60s or > 24h with a typed
+// error (ErrDedupTTLOutOfRange).
+func TestValidateDedupTTL_RangeCheck(t *testing.T) {
+	t.Run("system-alert-router/AC-15", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			ttl     time.Duration
+			wantErr bool
+		}{
+			{"below_min", 30 * time.Second, true},
+			{"exact_min", 60 * time.Second, false},
+			{"middle", 60 * time.Minute, false},
+			{"exact_max", 24 * time.Hour, false},
+			{"above_max", 25 * time.Hour, true},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := ValidateDedupTTL(tc.ttl)
+				if (err != nil) != tc.wantErr {
+					t.Errorf("ValidateDedupTTL(%s) err = %v, wantErr %v", tc.ttl, err, tc.wantErr)
+				}
+				if tc.wantErr && !errors.Is(err, ErrDedupTTLOutOfRange) {
+					t.Errorf("ValidateDedupTTL(%s) err = %v, want errors.Is ErrDedupTTLOutOfRange", tc.ttl, err)
+				}
+			})
+		}
+	})
+}

--- a/app/specs/system/alert-router.spec.yaml
+++ b/app/specs/system/alert-router.spec.yaml
@@ -1,0 +1,144 @@
+spec:
+  id: system-alert-router
+  title: Alert router
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Event-bus subscriber that translates events to alerts and routes them to delivery channels
+    description: >
+      The alert router is the bridge between OpenWatch's event bus
+      (B.3a) and external notification channels (Slack, email,
+      webhook, PagerDuty). It subscribes to bus events at boot,
+      translates them into typed Alert structures with severity +
+      tags, applies a dedup gate per (alert_type, host, rule_id)
+      tuple, and dispatches matching alerts to registered Channels.
+
+      Channel implementations (Slack, email, webhook) live in
+      subpackages so the core router has no external SDK dependencies.
+      The Channel interface is small enough to fake in tests without
+      standing up real services.
+
+  objective:
+    summary: >
+      One Router value, constructed once at boot. Subscribers to the
+      bus translate events to alerts, the dedup gate skips recent
+      duplicates, the routing layer matches each alert against
+      registered channel tag filters, and Channel.Send delivers.
+      Failures are logged and counted; the router never panics on a
+      channel-side error.
+    scope:
+      includes:
+        - Event-to-alert translation (HeartbeatPulse → HostUnreachable / HostRecovered; DriftDetected → drift alerts)
+        - Closed AlertType + Severity enums
+        - Dedup gate with configurable TTL (default 60 min)
+        - Channel registration with tag-filter routing
+        - Per-channel failure counters
+        - Router.Start subscribes to the bus; Router.Stop unsubscribes + drains
+        - In-memory dedup state (per-process; survives single-instance restart)
+      excludes:
+        - Concrete Slack/email/webhook implementations (each in its own subpackage; this PR ships interface + fake + stdout channels)
+        - Templates (text/template integration lands in a follow-up; for v1 alerts are typed structs with String() formatting)
+        - Persistent dedup state (in-memory is fine for v1; if multi-instance deploys need shared dedup, a Postgres-backed store slots in behind the same interface)
+        - Retry queue integration (initial failures are logged + counted; retry lands when internal/queue gets the right job-type)
+
+  constraints:
+    - id: C-01
+      description: AlertType is a closed enum (host_unreachable / host_recovered / drift_major / drift_minor / drift_improvement). Mapped 1:1 from EventKind + payload classification
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: Severity is a closed enum (critical / high / medium / low / info). Each AlertType has a default Severity that the router applies before channel routing
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: Dedup key is "{alert_type}|{host_id}|{rule_id}". Repeats within the configured TTL are skipped (DedupedCount++) and never reach Channel.Send
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Default dedup TTL is 60 minutes; configurable via policy.AlertThresholds.DedupTTLSec. Range (60s, 24h)
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: Channel registration MUST include a tag filter (Tags map of required key/value pairs). Empty Tags = wildcard (channel receives every alert)
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: Alert.Tags MUST include at minimum severity + alert_type + host_id. Channel filters match when ALL required channel tags are present in the alert
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: Channel.Send failure (returned error) MUST NOT panic the router and MUST NOT halt delivery to other channels for the same alert. Failure increments per-channel FailureCount
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: Router.Start subscribes to the bus for HeartbeatPulse + DriftDetected; Router.Stop unsubscribes and waits for in-flight Channel.Send calls to complete (with a 10s drain timeout)
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: The core router package (internal/alertrouter) imports no external notification SDKs (slack-sdk, sendgrid, mailgun, twilio, pagerduty). Channel implementations live in subpackages
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: AlertType enum has exactly 5 values listed in AllAlertTypes; verified by length + set check.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: Severity enum has exactly 5 values listed in AllSeverities; ordering critical → info preserved in SeverityOrder for comparison.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: HeartbeatPulse{Reachable=false} → Alert with Type=AlertTypeHostUnreachable, Severity=SeverityHigh. The host_id tag is populated from the event.
+      priority: critical
+      references_constraints: [C-01, C-02, C-06]
+    - id: AC-04
+      description: HeartbeatPulse{Reachable=true, PriorReachable=false} → Alert with Type=AlertTypeHostRecovered, Severity=SeverityInfo.
+      priority: critical
+      references_constraints: [C-01, C-02]
+    - id: AC-05
+      description: DriftDetected{DriftType="major"} → Alert with Type=AlertTypeDriftMajor, Severity=SeverityHigh. score_delta and host_id propagate to tags.
+      priority: critical
+      references_constraints: [C-01, C-02, C-06]
+    - id: AC-06
+      description: Dedup gate skips a repeat alert with the same dedup key within TTL; DedupedCount increments; Channel.Send is NOT called for the skipped alert.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-07
+      description: A repeat alert AFTER the dedup TTL elapses passes through; Channel.Send IS called.
+      priority: critical
+      references_constraints: [C-03, C-04]
+    - id: AC-08
+      description: Tag filter — a channel registered with Tags{"severity":"critical"} receives only Severity=critical alerts. A medium-severity alert does not reach it.
+      priority: critical
+      references_constraints: [C-05, C-06]
+    - id: AC-09
+      description: Wildcard channel — a channel registered with empty Tags receives every alert (no filter rejection).
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-10
+      description: Channel.Send returning an error increments that channel's FailureCount but does NOT block delivery to other registered channels for the same alert.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-11
+      description: Router.Start subscribes to both EventKindHeartbeatPulse and EventKindDriftDetected on the provided Bus.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-12
+      description: Router.Stop unsubscribes from the bus AND waits for in-flight Channel.Send calls to complete (10s timeout). After Stop, new events received are ignored.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-13
+      description: Source-inspection — internal/alertrouter (core package, NOT subpackages) imports no external notification SDKs. Channel implementations are isolated.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: Router.Metrics().Snapshot() exposes ReceivedCount, RoutedCount, DedupedCount, ChannelFailureCount; all increment under matching scenarios.
+      priority: high
+    - id: AC-15
+      description: ValidateDedupTTL rejects values < 60s or > 24h with a typed error.
+      priority: high
+      references_constraints: [C-04]


### PR DESCRIPTION
## Summary

Slice B.3b — the alert router. Subscribes to the event bus (B.3a),
translates events to typed Alerts, dedupes per `(alert_type, host_id,
rule_id)` within a configurable TTL (default 60min), and dispatches
matching alerts to registered channels. Concrete channel
implementations (Slack, email, webhook) live in subpackages so the
core router has no external SDK dependencies — this PR ships the
interface + the test fake.

## Stack

Branched off `feat/slice-b-b3a-event-bus`. Includes two upstream
commits that PR #423 also carries — a gofmt cleanup and a
spec-coverage fix linking AC-12 to C-01. When #423 merges, this PR
rebases cleanly with the alertrouter commit on top.

## Spec

`app/specs/system/alert-router.spec.yaml` (status: approved)
**15 ACs across 9 constraints**, all at 100% coverage.

- AC-01/02: AlertType + Severity closed enums (5 values each)
- AC-03/04/05: Event-to-alert translation
  (HeartbeatPulse{reachable=false} → host_unreachable High;
  recovery → host_recovered Info; DriftDetected{major} → High;
  minor → Medium; improvement → Info)
- AC-06/07: Dedup gate (skip within TTL; pass after TTL)
- AC-08/09: Tag-filter routing (specific filter; empty Tags = wildcard)
- AC-10: Channel failure isolation (per-channel + aggregate counters)
- AC-11/12: Router.Start subscribes to both EventKinds; Stop drains
  in-flight Channel.Send with 10s timeout
- AC-13: Source-inspection — core package imports no external
  notification SDKs (slack-go, sendgrid, mailgun, twilio, PagerDuty,
  opsgenie, gomail, etc.)
- AC-14: Metrics (ReceivedCount, RoutedCount, DedupedCount,
  ChannelFailureCount)
- AC-15: ValidateDedupTTL range check (60s, 24h) with typed sentinel

## Files

| Path | Purpose |
|------|---------|
| `app/specs/system/alert-router.spec.yaml` | The spec |
| `app/internal/alertrouter/doc.go` | Architectural choices |
| `app/internal/alertrouter/types.go` | AlertType + Severity enums, Alert, Channel, ChannelRegistration, ValidateDedupTTL |
| `app/internal/alertrouter/dedup.go` | DedupGate with TTL + injectable clock |
| `app/internal/alertrouter/router.go` | Router with Start/Stop, event translation, per-channel dispatch |
| `app/internal/alertrouter/metrics.go` | Counters + JSON snapshot |
| `app/internal/alertrouter/{router,types,source}_test.go` | 15/15 ACs |

## Verification

```
go vet ./...                    clean
golangci-lint                   clean
govulncheck                     clean
go test -race -count=1 ./...    PASS (1.10s)
specter parse                   PASS (system-alert-router@1.0.0)
specter check                   PASS (32 specs, 0 errors)
specter coverage                system-alert-router 15/15 (100%)
```

## Test plan

- [ ] CI: Go CI gates pass (vet, lint, vuln, test-race, specter sync)
- [ ] Verify spec parses + checks cleanly in CI's specter run
- [ ] Confirm `system-alert-router` reaches 100% in `specter coverage`