### PR TITLE
feat(fleetrollup): B.4 — system-fleet-rollup (13/13 ACs, 100%) — closes Slice B

### DIFF
--- a/app/internal/db/migrations/0013_host_liveness.sql
+++ b/app/internal/db/migrations/0013_host_liveness.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- Slice B.2a: host liveness (TCP-banner reachability probe).
+--
+-- One row per host. UPSERTed by the liveness probe loop. The
+-- scheduler reads reachability_status alongside host_backoff_state.
+-- suppress_until to decide whether to dispatch a scan.
+
+CREATE TABLE host_liveness (
+    host_id              UUID PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
+    reachability_status  TEXT NOT NULL DEFAULT 'unknown'
+                         CHECK (reachability_status IN ('reachable','unreachable','unknown')),
+    last_probe_at        TIMESTAMPTZ,
+    last_response_ms     INTEGER,   -- NULL when last probe failed
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    last_state_change_at TIMESTAMPTZ,
+    last_error_type      TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Lets the scheduler quickly find unreachable hosts to skip during dispatch.
+CREATE INDEX idx_host_liveness_status
+  ON host_liveness (reachability_status)
+  WHERE reachability_status = 'unreachable';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_host_liveness_status;
+DROP TABLE IF EXISTS host_liveness;

--- a/app/internal/fleetrollup/doc.go
+++ b/app/internal/fleetrollup/doc.go
@@ -1,0 +1,34 @@
+// Package fleetrollup answers "how is my fleet doing right now?" via
+// read-only aggregations over the Slice B persistence layer
+// (host_rule_state, transactions, host_liveness).
+//
+// Spec: specs/system/fleet-rollup.spec.yaml (status: approved)
+//
+// Architectural choices:
+//
+//   - Read-only. No INSERT/UPDATE/DELETE. Source-inspection enforces
+//     (AC-11). Mutation belongs to the producers (B.1c writer for
+//     transactions + host_rule_state, B.2a liveness for host_liveness).
+//
+//   - Typed results. Every method returns a concrete struct. No
+//     map[string]any leaks across the API. JSON encoding happens at
+//     the HTTP layer, not here. Spec C-08.
+//
+//   - Parameterized SQL only. No fmt.Sprintf-into-SQL, no string
+//     concatenation of values into SQL fragments. Source-inspection
+//     enforces (AC-12). Bounds (LIMIT) and column lists are static
+//     in the query string.
+//
+//   - Hard upper limit (1000) on every paginated query, regardless
+//     of caller input. Protects callers from DoS-ing the dashboard
+//     when a fleet grows unexpectedly. Spec C-03 / C-04.
+//
+//   - Context-aware. Every method respects ctx cancellation — a
+//     canceled context returns context.Canceled, never blocks. Spec
+//     C-07 / AC-09.
+//
+//   - Empty-fleet semantics. An empty host_rule_state, empty
+//     host_liveness, empty transactions table → zero values, never
+//     ErrNoRows. The dashboard renders "no data yet" instead of
+//     swallowing an error. Spec C-05 / AC-02.
+package fleetrollup

--- a/app/internal/fleetrollup/service.go
+++ b/app/internal/fleetrollup/service.go
@@ -1,0 +1,194 @@
+package fleetrollup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Service is the read-only fleet rollup query handle. Constructed
+// once at boot via NewService.
+type Service struct {
+	pool *pgxpool.Pool
+}
+
+// NewService returns a Service bound to the given pool.
+func NewService(pool *pgxpool.Pool) *Service {
+	return &Service{pool: pool}
+}
+
+// FleetComplianceScore returns the fleet-wide compliance score from
+// host_rule_state. Counts only rows with current_status IN
+// ('pass','fail') — skipped + error rows are excluded from both
+// numerator and denominator.
+//
+// On an empty fleet, returns Score{0, 0} with nil error (NOT
+// pgx.ErrNoRows). Spec AC-01 / AC-02 / AC-03.
+func (s *Service) FleetComplianceScore(ctx context.Context) (Score, error) {
+	const q = `
+		SELECT
+			COUNT(*) FILTER (WHERE current_status = 'pass')                  AS passing,
+			COUNT(*) FILTER (WHERE current_status IN ('pass','fail'))        AS evaluations
+		  FROM host_rule_state`
+	var passing, evaluations int64
+	if err := s.pool.QueryRow(ctx, q).Scan(&passing, &evaluations); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Filtered COUNT never returns NoRows but defend anyway.
+			return Score{}, nil
+		}
+		return Score{}, fmt.Errorf("fleetrollup: FleetComplianceScore: %w", err)
+	}
+	if evaluations == 0 {
+		return Score{PassingFraction: 0, TotalEvaluations: 0}, nil
+	}
+	return Score{
+		PassingFraction:  float64(passing) / float64(evaluations),
+		TotalEvaluations: evaluations,
+	}, nil
+}
+
+// FleetLiveness returns host counts by reachability status. The four
+// buckets sum to the count of active (deleted_at IS NULL) hosts. Hosts
+// that have a row in `hosts` but no row in `host_liveness` are counted
+// as never_probed. Spec AC-04.
+func (s *Service) FleetLiveness(ctx context.Context) (LivenessRollup, error) {
+	const q = `
+		SELECT
+			COUNT(*) FILTER (WHERE hl.reachability_status = 'reachable')                AS reachable,
+			COUNT(*) FILTER (WHERE hl.reachability_status = 'unreachable')              AS unreachable,
+			COUNT(*) FILTER (WHERE hl.reachability_status = 'unknown')                  AS unknown,
+			COUNT(*) FILTER (WHERE hl.host_id IS NULL)                                  AS never_probed
+		  FROM hosts h
+		  LEFT JOIN host_liveness hl ON hl.host_id = h.id
+		 WHERE h.deleted_at IS NULL`
+	var out LivenessRollup
+	if err := s.pool.QueryRow(ctx, q).Scan(
+		&out.Reachable, &out.Unreachable, &out.Unknown, &out.NeverProbed,
+	); err != nil {
+		return LivenessRollup{}, fmt.Errorf("fleetrollup: FleetLiveness: %w", err)
+	}
+	return out, nil
+}
+
+// TopFailingRules returns the rules with the most failing hosts, in
+// descending order. limit is coerced to [0, MaxLimit]. A coerced
+// limit of 0 returns an empty slice with nil error (no query
+// executed). Spec AC-05 / AC-06 / AC-10.
+func (s *Service) TopFailingRules(ctx context.Context, limit int) ([]RuleFailureRollup, error) {
+	n := clampLimit(limit)
+	if n == 0 {
+		return []RuleFailureRollup{}, nil
+	}
+	const q = `
+		SELECT rule_id, COUNT(*)::BIGINT AS failing_host_count
+		  FROM host_rule_state
+		 WHERE current_status = 'fail'
+		 GROUP BY rule_id
+		 ORDER BY failing_host_count DESC, rule_id ASC
+		 LIMIT $1`
+	rows, err := s.pool.Query(ctx, q, n)
+	if err != nil {
+		return nil, fmt.Errorf("fleetrollup: TopFailingRules: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]RuleFailureRollup, 0, n)
+	for rows.Next() {
+		var r RuleFailureRollup
+		if err := rows.Scan(&r.RuleID, &r.FailingHostCount); err != nil {
+			return nil, fmt.Errorf("fleetrollup: TopFailingRules scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("fleetrollup: TopFailingRules iterate: %w", err)
+	}
+	return out, nil
+}
+
+// TopFailingHosts returns the hosts with the most failing rules, in
+// descending order. limit is coerced to [0, MaxLimit]. Spec AC-07 / AC-10.
+func (s *Service) TopFailingHosts(ctx context.Context, limit int) ([]HostFailureRollup, error) {
+	n := clampLimit(limit)
+	if n == 0 {
+		return []HostFailureRollup{}, nil
+	}
+	const q = `
+		SELECT host_id, COUNT(*)::BIGINT AS failing_rule_count
+		  FROM host_rule_state
+		 WHERE current_status = 'fail'
+		 GROUP BY host_id
+		 ORDER BY failing_rule_count DESC, host_id ASC
+		 LIMIT $1`
+	rows, err := s.pool.Query(ctx, q, n)
+	if err != nil {
+		return nil, fmt.Errorf("fleetrollup: TopFailingHosts: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]HostFailureRollup, 0, n)
+	for rows.Next() {
+		var h HostFailureRollup
+		if err := rows.Scan(&h.HostID, &h.FailingRuleCount); err != nil {
+			return nil, fmt.Errorf("fleetrollup: TopFailingHosts scan: %w", err)
+		}
+		out = append(out, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("fleetrollup: TopFailingHosts iterate: %w", err)
+	}
+	return out, nil
+}
+
+// RecentChanges returns the most recent transactions, ordered by
+// occurred_at DESC. since filters to rows strictly newer than the
+// given timestamp. Pass time.Time{} (the zero value) to disable the
+// cursor. limit is coerced to [0, MaxLimit]. Spec AC-08 / AC-10.
+func (s *Service) RecentChanges(ctx context.Context, since time.Time, limit int) ([]TransactionRollup, error) {
+	n := clampLimit(limit)
+	if n == 0 {
+		return []TransactionRollup{}, nil
+	}
+	// The "$2::timestamptz IS NULL" idiom lets us encode "no cursor"
+	// without branching the SQL. Pass NULL for since to skip the
+	// filter, otherwise apply the strict >.
+	const q = `
+		SELECT id, host_id, rule_id, status, COALESCE(severity, ''), change_kind, occurred_at
+		  FROM transactions
+		 WHERE ($2::timestamptz IS NULL OR occurred_at > $2)
+		 ORDER BY occurred_at DESC
+		 LIMIT $1`
+	var sinceParam any
+	if !since.IsZero() {
+		sinceParam = since
+	}
+	rows, err := s.pool.Query(ctx, q, n, sinceParam)
+	if err != nil {
+		return nil, fmt.Errorf("fleetrollup: RecentChanges: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]TransactionRollup, 0, n)
+	for rows.Next() {
+		var (
+			t      TransactionRollup
+			hostID uuid.UUID
+			id     uuid.UUID
+		)
+		if err := rows.Scan(&id, &hostID, &t.RuleID, &t.Status, &t.Severity, &t.ChangeKind, &t.OccurredAt); err != nil {
+			return nil, fmt.Errorf("fleetrollup: RecentChanges scan: %w", err)
+		}
+		t.ID = id
+		t.HostID = hostID
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("fleetrollup: RecentChanges iterate: %w", err)
+	}
+	return out, nil
+}

--- a/app/internal/fleetrollup/service_test.go
+++ b/app/internal/fleetrollup/service_test.go
@@ -1,0 +1,489 @@
+// @spec system-fleet-rollup
+//
+// AC traceability (this file):
+//   AC-01  TestFleetComplianceScore_MixedPassFail_ReturnsFraction
+//   AC-02  TestFleetComplianceScore_EmptyFleet_ZeroNotError
+//   AC-03  TestFleetComplianceScore_SkipsAndErrorsExcluded
+//   AC-04  TestFleetLiveness_FourBucketsSumToActiveHosts
+//   AC-05  TestTopFailingRules_OrderedDescByCount
+//   AC-06  TestTopFailingRules_ZeroLimit_EmptySlice
+//   AC-07  TestTopFailingHosts_OrderedDescByCount
+//   AC-08  TestRecentChanges_SinceCursorFilters_OrderDesc
+//   AC-09  TestEveryMethod_RespectsContextCancellation
+//   AC-10  TestLimitClamping_NegativeAndOverflow
+
+package fleetrollup
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+)
+
+// ---------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------
+
+func testDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run fleetrollup integration tests")
+	}
+	return dsn
+}
+
+func freshPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := testDSN(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	pool, err := db.NewPool(ctx, dsn, 5)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := migrations.Apply(ctx, pool); err != nil {
+		t.Fatalf("migrations.Apply: %v", err)
+	}
+	for _, stmt := range []string{
+		"TRUNCATE TABLE transactions CASCADE",
+		"TRUNCATE TABLE host_rule_state CASCADE",
+		"TRUNCATE TABLE host_liveness CASCADE",
+		"TRUNCATE TABLE hosts CASCADE",
+		"TRUNCATE TABLE users CASCADE",
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			t.Logf("truncate (ok if benign): %v", err)
+		}
+	}
+	return pool
+}
+
+func seedUser(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO users (id, username, email, password_hash)
+		 VALUES ($1, $2, $3, $4)`,
+		id, "rollup-user", "rollup@example.com", "argon2id$dummy") // pragma: allowlist secret
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func seedHost(t *testing.T, pool *pgxpool.Pool, createdBy uuid.UUID) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, $3::inet, $4)`,
+		id, "host-"+id.String(), "192.0.2.10", createdBy)
+	if err != nil {
+		t.Fatalf("seed host: %v", err)
+	}
+	return id
+}
+
+// seedRuleState inserts a host_rule_state row with the given status.
+func seedRuleState(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status string) {
+	t.Helper()
+	now := time.Now().UTC()
+	scanID, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_rule_state
+			(host_id, rule_id, current_status, severity,
+			 last_checked_at, check_count, last_scan_id, evidence,
+			 framework_refs, first_seen_at, last_changed_at)
+		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, '{}'::jsonb, $4, $4)`,
+		hostID, ruleID, status, now, scanID,
+	)
+	if err != nil {
+		t.Fatalf("seed rule_state: %v", err)
+	}
+}
+
+// seedLiveness inserts a host_liveness row with the given status.
+func seedLiveness(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, status string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_liveness (host_id, reachability_status, last_probe_at)
+		VALUES ($1, $2, now())`, hostID, status)
+	if err != nil {
+		t.Fatalf("seed liveness: %v", err)
+	}
+}
+
+// seedTransaction inserts a transactions row.
+func seedTransaction(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status, changeKind string, occurredAt time.Time) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	scanID, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO transactions
+			(id, host_id, rule_id, scan_id, status, severity,
+			 change_kind, evidence, occurred_at)
+		VALUES ($1, $2, $3, $4, $5, 'medium', $6, '{}'::jsonb, $7)`,
+		id, hostID, ruleID, scanID, status, changeKind, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("seed transaction: %v", err)
+	}
+	return id
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+// @ac AC-01
+// AC-01: mixed pass/fail returns PassingFraction = passing / (pass+fail).
+func TestFleetComplianceScore_MixedPassFail_ReturnsFraction(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-01", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		h1 := seedHost(t, pool, user)
+		h2 := seedHost(t, pool, user)
+
+		// 3 passing + 2 failing across 2 hosts.
+		seedRuleState(t, pool, h1, "rule.a", "pass")
+		seedRuleState(t, pool, h1, "rule.b", "pass")
+		seedRuleState(t, pool, h1, "rule.c", "fail")
+		seedRuleState(t, pool, h2, "rule.a", "pass")
+		seedRuleState(t, pool, h2, "rule.b", "fail")
+
+		score, err := svc.FleetComplianceScore(context.Background())
+		if err != nil {
+			t.Fatalf("FleetComplianceScore: %v", err)
+		}
+		if score.TotalEvaluations != 5 {
+			t.Errorf("TotalEvaluations = %d, want 5", score.TotalEvaluations)
+		}
+		want := 3.0 / 5.0
+		if score.PassingFraction != want {
+			t.Errorf("PassingFraction = %v, want %v", score.PassingFraction, want)
+		}
+	})
+}
+
+// @ac AC-02
+// AC-02: empty fleet → Score{0,0}, nil error.
+func TestFleetComplianceScore_EmptyFleet_ZeroNotError(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-02", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+
+		score, err := svc.FleetComplianceScore(context.Background())
+		if err != nil {
+			t.Fatalf("FleetComplianceScore: %v", err)
+		}
+		if score.TotalEvaluations != 0 {
+			t.Errorf("TotalEvaluations = %d, want 0", score.TotalEvaluations)
+		}
+		if score.PassingFraction != 0 {
+			t.Errorf("PassingFraction = %v, want 0", score.PassingFraction)
+		}
+	})
+}
+
+// @ac AC-03
+// AC-03: skipped + error rows are excluded from numerator AND denominator.
+func TestFleetComplianceScore_SkipsAndErrorsExcluded(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-03", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		h := seedHost(t, pool, user)
+
+		seedRuleState(t, pool, h, "rule.pass", "pass")
+		seedRuleState(t, pool, h, "rule.fail", "fail")
+		seedRuleState(t, pool, h, "rule.skipped", "skipped")
+		seedRuleState(t, pool, h, "rule.error", "error")
+
+		score, err := svc.FleetComplianceScore(context.Background())
+		if err != nil {
+			t.Fatalf("FleetComplianceScore: %v", err)
+		}
+		// Only the pass + fail rows count.
+		if score.TotalEvaluations != 2 {
+			t.Errorf("TotalEvaluations = %d, want 2 (skipped + error excluded)",
+				score.TotalEvaluations)
+		}
+		if score.PassingFraction != 0.5 {
+			t.Errorf("PassingFraction = %v, want 0.5", score.PassingFraction)
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: FleetLiveness returns four buckets summing to active hosts.
+func TestFleetLiveness_FourBucketsSumToActiveHosts(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-04", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+
+		hReach1 := seedHost(t, pool, user)
+		hReach2 := seedHost(t, pool, user)
+		hUnreach := seedHost(t, pool, user)
+		hUnknown := seedHost(t, pool, user)
+		// Three never-probed hosts (no host_liveness row).
+		_ = seedHost(t, pool, user)
+		_ = seedHost(t, pool, user)
+		_ = seedHost(t, pool, user)
+
+		seedLiveness(t, pool, hReach1, "reachable")
+		seedLiveness(t, pool, hReach2, "reachable")
+		seedLiveness(t, pool, hUnreach, "unreachable")
+		seedLiveness(t, pool, hUnknown, "unknown")
+
+		rollup, err := svc.FleetLiveness(context.Background())
+		if err != nil {
+			t.Fatalf("FleetLiveness: %v", err)
+		}
+		if rollup.Reachable != 2 {
+			t.Errorf("Reachable = %d, want 2", rollup.Reachable)
+		}
+		if rollup.Unreachable != 1 {
+			t.Errorf("Unreachable = %d, want 1", rollup.Unreachable)
+		}
+		if rollup.Unknown != 1 {
+			t.Errorf("Unknown = %d, want 1", rollup.Unknown)
+		}
+		if rollup.NeverProbed != 3 {
+			t.Errorf("NeverProbed = %d, want 3", rollup.NeverProbed)
+		}
+		if rollup.Total() != 7 {
+			t.Errorf("Total = %d, want 7", rollup.Total())
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: TopFailingRules ordered by FailingHostCount DESC.
+func TestTopFailingRules_OrderedDescByCount(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-05", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		h1 := seedHost(t, pool, user)
+		h2 := seedHost(t, pool, user)
+		h3 := seedHost(t, pool, user)
+
+		// rule.A fails on 3 hosts (top); rule.B fails on 2; rule.C fails on 1.
+		seedRuleState(t, pool, h1, "rule.A", "fail")
+		seedRuleState(t, pool, h2, "rule.A", "fail")
+		seedRuleState(t, pool, h3, "rule.A", "fail")
+		seedRuleState(t, pool, h1, "rule.B", "fail")
+		seedRuleState(t, pool, h2, "rule.B", "fail")
+		seedRuleState(t, pool, h1, "rule.C", "fail")
+		// rule.D passes — must NOT appear.
+		seedRuleState(t, pool, h1, "rule.D", "pass")
+
+		out, err := svc.TopFailingRules(context.Background(), 10)
+		if err != nil {
+			t.Fatalf("TopFailingRules: %v", err)
+		}
+		if len(out) != 3 {
+			t.Fatalf("len(out) = %d, want 3", len(out))
+		}
+		if out[0].RuleID != "rule.A" || out[0].FailingHostCount != 3 {
+			t.Errorf("out[0] = %+v, want {rule.A,3}", out[0])
+		}
+		if out[1].RuleID != "rule.B" || out[1].FailingHostCount != 2 {
+			t.Errorf("out[1] = %+v, want {rule.B,2}", out[1])
+		}
+		if out[2].RuleID != "rule.C" || out[2].FailingHostCount != 1 {
+			t.Errorf("out[2] = %+v, want {rule.C,1}", out[2])
+		}
+		// Limit cap.
+		limited, err := svc.TopFailingRules(context.Background(), 2)
+		if err != nil {
+			t.Fatalf("TopFailingRules limit=2: %v", err)
+		}
+		if len(limited) != 2 {
+			t.Errorf("limit=2 returned %d rows", len(limited))
+		}
+	})
+}
+
+// @ac AC-06
+// AC-06: limit=0 → empty slice, no error.
+func TestTopFailingRules_ZeroLimit_EmptySlice(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-06", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+
+		out, err := svc.TopFailingRules(context.Background(), 0)
+		if err != nil {
+			t.Fatalf("TopFailingRules(limit=0): %v", err)
+		}
+		if len(out) != 0 {
+			t.Errorf("len(out) = %d, want 0", len(out))
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: TopFailingHosts ordered by FailingRuleCount DESC.
+func TestTopFailingHosts_OrderedDescByCount(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-07", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		hWorst := seedHost(t, pool, user)
+		hMid := seedHost(t, pool, user)
+		hBest := seedHost(t, pool, user)
+
+		// hWorst fails 4 rules, hMid fails 2, hBest fails 1.
+		seedRuleState(t, pool, hWorst, "rule.1", "fail")
+		seedRuleState(t, pool, hWorst, "rule.2", "fail")
+		seedRuleState(t, pool, hWorst, "rule.3", "fail")
+		seedRuleState(t, pool, hWorst, "rule.4", "fail")
+		seedRuleState(t, pool, hMid, "rule.1", "fail")
+		seedRuleState(t, pool, hMid, "rule.2", "fail")
+		seedRuleState(t, pool, hBest, "rule.1", "fail")
+		// hBest passes rule.2 — does NOT count toward failing.
+		seedRuleState(t, pool, hBest, "rule.2", "pass")
+
+		out, err := svc.TopFailingHosts(context.Background(), 10)
+		if err != nil {
+			t.Fatalf("TopFailingHosts: %v", err)
+		}
+		if len(out) != 3 {
+			t.Fatalf("len(out) = %d, want 3", len(out))
+		}
+		if out[0].HostID != hWorst || out[0].FailingRuleCount != 4 {
+			t.Errorf("out[0] = %+v, want {%s,4}", out[0], hWorst)
+		}
+		if out[1].HostID != hMid || out[1].FailingRuleCount != 2 {
+			t.Errorf("out[1] = %+v, want {%s,2}", out[1], hMid)
+		}
+		if out[2].HostID != hBest || out[2].FailingRuleCount != 1 {
+			t.Errorf("out[2] = %+v, want {%s,1}", out[2], hBest)
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: RecentChanges returns transactions DESC by occurred_at;
+// since cursor filters strictly newer.
+func TestRecentChanges_SinceCursorFilters_OrderDesc(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-08", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		h := seedHost(t, pool, user)
+
+		t0 := time.Now().UTC().Truncate(time.Second)
+		seedTransaction(t, pool, h, "rule.a", "fail", "state_changed", t0)
+		seedTransaction(t, pool, h, "rule.b", "fail", "first_seen", t0.Add(1*time.Minute))
+		seedTransaction(t, pool, h, "rule.c", "pass", "state_changed", t0.Add(2*time.Minute))
+
+		// All three.
+		all, err := svc.RecentChanges(context.Background(), time.Time{}, 10)
+		if err != nil {
+			t.Fatalf("RecentChanges all: %v", err)
+		}
+		if len(all) != 3 {
+			t.Fatalf("len(all) = %d, want 3", len(all))
+		}
+		// Order: c (newest), b, a (oldest).
+		if all[0].RuleID != "rule.c" {
+			t.Errorf("all[0].RuleID = %q, want rule.c", all[0].RuleID)
+		}
+		if all[2].RuleID != "rule.a" {
+			t.Errorf("all[2].RuleID = %q, want rule.a", all[2].RuleID)
+		}
+
+		// since cursor filtering — only strictly newer than t0.
+		since, err := svc.RecentChanges(context.Background(), t0, 10)
+		if err != nil {
+			t.Fatalf("RecentChanges since=t0: %v", err)
+		}
+		if len(since) != 2 {
+			t.Errorf("with since=t0, got %d rows, want 2 (b + c only)", len(since))
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09: every method respects context cancellation.
+func TestEveryMethod_RespectsContextCancellation(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-09", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel before calling
+
+		if _, err := svc.FleetComplianceScore(ctx); err == nil {
+			t.Error("FleetComplianceScore: expected error from canceled ctx, got nil")
+		}
+		if _, err := svc.FleetLiveness(ctx); err == nil {
+			t.Error("FleetLiveness: expected error from canceled ctx, got nil")
+		}
+		if _, err := svc.TopFailingRules(ctx, 5); err == nil {
+			t.Error("TopFailingRules: expected error from canceled ctx, got nil")
+		}
+		if _, err := svc.TopFailingHosts(ctx, 5); err == nil {
+			t.Error("TopFailingHosts: expected error from canceled ctx, got nil")
+		}
+		if _, err := svc.RecentChanges(ctx, time.Time{}, 5); err == nil {
+			t.Error("RecentChanges: expected error from canceled ctx, got nil")
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: limit < 0 → 0; limit > MaxLimit → MaxLimit.
+func TestLimitClamping_NegativeAndOverflow(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-10", func(t *testing.T) {
+		// Pure-function check: clampLimit covers the AC.
+		if got := clampLimit(-5); got != 0 {
+			t.Errorf("clampLimit(-5) = %d, want 0", got)
+		}
+		if got := clampLimit(0); got != 0 {
+			t.Errorf("clampLimit(0) = %d, want 0", got)
+		}
+		if got := clampLimit(500); got != 500 {
+			t.Errorf("clampLimit(500) = %d, want 500", got)
+		}
+		if got := clampLimit(MaxLimit); got != MaxLimit {
+			t.Errorf("clampLimit(MaxLimit) = %d, want MaxLimit", got)
+		}
+		if got := clampLimit(MaxLimit + 1); got != MaxLimit {
+			t.Errorf("clampLimit(MaxLimit+1) = %d, want MaxLimit", got)
+		}
+		if got := clampLimit(1_000_000); got != MaxLimit {
+			t.Errorf("clampLimit(1M) = %d, want MaxLimit", got)
+		}
+
+		// End-to-end on a populated fleet: ensure the LIMIT is respected.
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		for i := 0; i < 5; i++ {
+			h := seedHost(t, pool, user)
+			seedRuleState(t, pool, h, "rule.shared", "fail")
+		}
+		// Negative limit on TopFailingRules → empty slice.
+		out, err := svc.TopFailingRules(context.Background(), -1)
+		if err != nil {
+			t.Fatalf("TopFailingRules(-1): %v", err)
+		}
+		if len(out) != 0 {
+			t.Errorf("TopFailingRules(-1) returned %d rows, want 0", len(out))
+		}
+	})
+}

--- a/app/internal/fleetrollup/source_test.go
+++ b/app/internal/fleetrollup/source_test.go
@@ -1,0 +1,161 @@
+// @spec system-fleet-rollup
+//
+// AC traceability (this file):
+//   AC-11  TestNoMutationSQL_InPackage
+//   AC-12  TestNoRawSQLConcat_InPackage
+//   AC-13  TestServiceMethodsReturnTypedStructs
+
+package fleetrollup
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func packageDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Dir(file)
+}
+
+func goNonTestFiles(t *testing.T) []string {
+	t.Helper()
+	dir := packageDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		if strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		out = append(out, filepath.Join(dir, e.Name()))
+	}
+	return out
+}
+
+// @ac AC-11
+// AC-11: internal/fleetrollup contains no INSERT, UPDATE, or DELETE
+// SQL statements (case-insensitive). Enforces the read-only invariant.
+func TestNoMutationSQL_InPackage(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-11", func(t *testing.T) {
+		// Case-insensitive whole-word patterns. Avoid false positives
+		// on identifiers that contain the word (e.g. "InsertSomething"
+		// in a Go func name would be caught by the strings approach,
+		// but we use \b to keep this tight).
+		mutationPatterns := []*regexp.Regexp{
+			regexp.MustCompile(`(?i)\bINSERT\s+INTO\b`),
+			regexp.MustCompile(`(?i)\bUPDATE\s+\w+\s+SET\b`),
+			regexp.MustCompile(`(?i)\bDELETE\s+FROM\b`),
+			regexp.MustCompile(`(?i)\bTRUNCATE\s+TABLE\b`),
+		}
+		for _, f := range goNonTestFiles(t) {
+			b, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			src := string(b)
+			for _, p := range mutationPatterns {
+				if p.MatchString(src) {
+					t.Errorf("%s contains mutation SQL matching %q — fleetrollup is read-only (AC-11)",
+						f, p.String())
+				}
+			}
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: internal/fleetrollup contains no fmt.Sprintf-into-SQL nor
+// string-concatenated SQL. All SQL is parameterized via $1, $2, ...
+func TestNoRawSQLConcat_InPackage(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-12", func(t *testing.T) {
+		concatPattern := regexp.MustCompile(`\.(?:Exec|Query|QueryRow)\(\s*\w+\s*,\s*fmt\.Sprintf`)
+		stringPlusPattern := regexp.MustCompile(`\.(?:Exec|Query|QueryRow)\([^)]*"\s*\+\s*\w`)
+
+		// Imports: database/sql import would suggest raw driver use,
+		// which contradicts our pgxpool-only stance.
+		fset := token.NewFileSet()
+		for _, f := range goNonTestFiles(t) {
+			astFile, err := parser.ParseFile(fset, f, nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", f, err)
+			}
+			for _, imp := range astFile.Imports {
+				path := strings.Trim(imp.Path.Value, `"`)
+				if path == "database/sql" {
+					t.Errorf("%s imports database/sql — fleetrollup uses pgxpool directly (AC-12)", f)
+				}
+			}
+			src, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			s := string(src)
+			if concatPattern.MatchString(s) {
+				t.Errorf("%s builds SQL via fmt.Sprintf — parameterize instead (AC-12)", f)
+			}
+			if stringPlusPattern.MatchString(s) {
+				t.Errorf("%s builds SQL via string concatenation — parameterize instead (AC-12)", f)
+			}
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: every exported method on *Service returns a concrete struct
+// type (not map[string]any). Reflection walks Service's method set.
+func TestServiceMethodsReturnTypedStructs(t *testing.T) {
+	t.Run("system-fleet-rollup/AC-13", func(t *testing.T) {
+		st := reflect.TypeOf((*Service)(nil))
+		// AnyType is the forbidden return type at any position.
+		anyType := reflect.TypeOf((*any)(nil)).Elem()
+
+		for i := 0; i < st.NumMethod(); i++ {
+			m := st.Method(i)
+			// Skip non-exported (defensive — Go reflection on a pointer
+			// type already filters to exported, but explicit is better).
+			if !m.IsExported() {
+				continue
+			}
+			ft := m.Type
+			// Return positions: the first non-error result must be a
+			// concrete struct (or a slice of one). Walk all results.
+			for j := 0; j < ft.NumOut(); j++ {
+				rt := ft.Out(j)
+				// Allow error.
+				errIface := reflect.TypeOf((*error)(nil)).Elem()
+				if rt.Implements(errIface) {
+					continue
+				}
+				// Allow slice — unwrap.
+				if rt.Kind() == reflect.Slice {
+					rt = rt.Elem()
+				}
+				// Reject map[string]any.
+				if rt.Kind() == reflect.Map {
+					if rt.Key().Kind() == reflect.String && rt.Elem() == anyType {
+						t.Errorf("Service.%s returns map[string]any — must return typed structs (AC-13)", m.Name)
+					}
+					continue
+				}
+				// At this point rt should be a struct (concrete value type).
+				if rt.Kind() != reflect.Struct {
+					t.Errorf("Service.%s returns %s (kind %s) — expected concrete struct (AC-13)",
+						m.Name, rt, rt.Kind())
+				}
+			}
+		}
+	})
+}

--- a/app/internal/fleetrollup/types.go
+++ b/app/internal/fleetrollup/types.go
@@ -1,0 +1,92 @@
+package fleetrollup
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MaxLimit is the hard upper bound on every paginated query. Per
+// Spec C-03 / C-04, regardless of caller input.
+const MaxLimit = 1000
+
+// ReachabilityStatus is the closed enum FleetLiveness reports counts
+// for. Mirrors host_liveness.reachability_status plus the synthesized
+// "never_probed" bucket for hosts with no row in host_liveness yet.
+type ReachabilityStatus string
+
+const (
+	StatusReachable   ReachabilityStatus = "reachable"
+	StatusUnreachable ReachabilityStatus = "unreachable"
+	StatusUnknown     ReachabilityStatus = "unknown"
+	StatusNeverProbed ReachabilityStatus = "never_probed"
+)
+
+// AllReachabilityStatuses is the closed set in display order. Spec AC-04.
+var AllReachabilityStatuses = []ReachabilityStatus{
+	StatusReachable,
+	StatusUnreachable,
+	StatusUnknown,
+	StatusNeverProbed,
+}
+
+// Score is the fleet-wide compliance summary. PassingFraction is 0..1;
+// multiply by 100 for percentage at the UI. TotalEvaluations is the
+// count of host_rule_state rows whose current_status is pass or fail
+// (skipped / error rows are excluded). Spec AC-01 / AC-03.
+type Score struct {
+	PassingFraction  float64 `json:"passing_fraction"`
+	TotalEvaluations int64   `json:"total_evaluations"`
+}
+
+// LivenessRollup is the host-count breakdown by reachability status.
+// The four counts sum to len(hosts WHERE deleted_at IS NULL). Spec AC-04.
+type LivenessRollup struct {
+	Reachable   int64 `json:"reachable"`
+	Unreachable int64 `json:"unreachable"`
+	Unknown     int64 `json:"unknown"`
+	NeverProbed int64 `json:"never_probed"`
+}
+
+// Total returns the sum of all four buckets. Convenience method for
+// callers that want a denominator.
+func (l LivenessRollup) Total() int64 {
+	return l.Reachable + l.Unreachable + l.Unknown + l.NeverProbed
+}
+
+// RuleFailureRollup is one entry in TopFailingRules.
+type RuleFailureRollup struct {
+	RuleID           string `json:"rule_id"`
+	FailingHostCount int64  `json:"failing_host_count"`
+}
+
+// HostFailureRollup is one entry in TopFailingHosts.
+type HostFailureRollup struct {
+	HostID           uuid.UUID `json:"host_id"`
+	FailingRuleCount int64     `json:"failing_rule_count"`
+}
+
+// TransactionRollup is one entry in RecentChanges. Mirrors a
+// transactions row plus the change_kind so the UI can render
+// "first_seen", "state_changed", "severity_changed" distinctly.
+type TransactionRollup struct {
+	ID         uuid.UUID `json:"id"`
+	HostID     uuid.UUID `json:"host_id"`
+	RuleID     string    `json:"rule_id"`
+	Status     string    `json:"status"`
+	Severity   string    `json:"severity,omitempty"`
+	ChangeKind string    `json:"change_kind"`
+	OccurredAt time.Time `json:"occurred_at"`
+}
+
+// clampLimit enforces the hard upper bound + non-negative invariant.
+// Spec AC-10.
+func clampLimit(limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	if limit > MaxLimit {
+		return MaxLimit
+	}
+	return limit
+}

--- a/app/specs/system/fleet-rollup.spec.yaml
+++ b/app/specs/system/fleet-rollup.spec.yaml
@@ -1,0 +1,140 @@
+spec:
+  id: system-fleet-rollup
+  title: Fleet rollup queries
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Read-only fleet-wide aggregations over transactions, host_rule_state, and host_liveness
+    description: >
+      The fleet rollup service answers "how is my fleet doing right
+      now?" via a small, fixed set of typed queries. It reads from the
+      write-on-change tables produced by Slice B (host_rule_state for
+      current compliance state per host×rule; transactions for
+      meaningful state changes; host_liveness for reachability).
+
+      Every query is read-only, parameterized, context-aware, and
+      returns typed structs (no map[string]any). The package has no
+      side effects — it never writes, mutates, or emits audit events.
+      Results are bounded in size (LIMIT clauses) so large fleets
+      don't blow up callers.
+    related_specs:
+      - system-transaction-log-writer
+      - system-host-inventory
+      - service-host-liveness
+
+  objective:
+    summary: >
+      One Service value, constructed once with a *pgxpool.Pool. Each
+      query method returns a typed result struct + error. No internal
+      mutable state. Production wires this to the FastAPI/HTTP layer
+      via the dashboard endpoints (lands in a follow-up); tests hit it
+      directly with a freshly migrated DB.
+    scope:
+      includes:
+        - FleetComplianceScore — fleet-wide passing fraction (0..1)
+        - FleetLiveness — host counts by reachability status
+        - TopFailingRules — rules with most failing hosts (current state)
+        - TopFailingHosts — hosts with most failing rules (current state)
+        - RecentChanges — last N transactions ordered by observed_at DESC
+        - Parameterized SQL only; source-inspection enforces
+        - Closed enums for stable identifiers (e.g., reachability statuses)
+      excludes:
+        - Time-series histograms (drift over time) — follow-up after
+          we know which time grain the UI actually consumes
+        - Caching layer (Postgres is fast enough for v1 dashboards;
+          slot a Redis or in-process LRU behind the same interface
+          if the dashboard endpoints get hot)
+        - WebSocket / SSE push (clients poll; subscribe-style fanout
+          is event-bus territory, not fleet rollup territory)
+        - Mutation of any kind — this package is strictly read-only
+
+  constraints:
+    - id: C-01
+      description: The package MUST contain no INSERT/UPDATE/DELETE statements. Source-inspection enforces (AC-11)
+      type: security
+      enforcement: error
+    - id: C-02
+      description: Every SQL statement MUST be parameterized — no fmt.Sprintf or string concatenation of values into SQL. Source-inspection enforces (AC-12)
+      type: security
+      enforcement: error
+    - id: C-03
+      description: TopFailingRules and TopFailingHosts MUST enforce a hard maximum limit (1000) regardless of caller input
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: RecentChanges MUST enforce a hard maximum limit (1000) regardless of caller input
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: FleetComplianceScore on an empty fleet (zero host_rule_state rows) MUST return a Score with PassingFraction=0 and TotalEvaluations=0 — never an error
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: FleetLiveness MUST count exactly four buckets — reachable, unreachable, unknown, never_probed (hosts with no host_liveness row)
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: Every method MUST respect ctx cancellation. Tests use canceled contexts to verify
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: All result structs MUST be typed (no map[string]any returned across the API). Encoding to JSON happens at the HTTP layer, not here
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: FleetComplianceScore on a fleet with mixed pass/fail returns PassingFraction = passing / (passing + failing) and TotalEvaluations = passing + failing. Verified with seeded host_rule_state rows.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-02
+      description: FleetComplianceScore on an empty fleet returns Score{PassingFraction=0, TotalEvaluations=0} with nil error — never ErrNoRows.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-03
+      description: FleetComplianceScore counts only current_status IN ('passing','failing') — skipped/error rows are excluded from both numerator and denominator.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-04
+      description: FleetLiveness returns counts for each of four statuses — reachable, unreachable, unknown, never_probed. The four counts sum to len(hosts where deleted_at IS NULL).
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-05
+      description: TopFailingRules orders results by FailingHostCount DESC. Returns up to caller-requested limit, capped at 1000.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-06
+      description: TopFailingRules with limit=0 returns an empty slice — never an error.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-07
+      description: TopFailingHosts orders results by FailingRuleCount DESC. Returns up to caller-requested limit, capped at 1000.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-08
+      description: RecentChanges returns transactions ordered by observed_at DESC, up to the caller's limit (capped at 1000). A since cursor filters to rows strictly newer than the given timestamp.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-09
+      description: Every method respects context cancellation — a context canceled before the call returns context.Canceled (wrapped in the error chain).
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-10
+      description: Caller-provided limit < 0 is coerced to 0 (returns empty slice, never an error). limit > 1000 is coerced to 1000.
+      priority: high
+      references_constraints: [C-03, C-04]
+    - id: AC-11
+      description: Source-inspection — internal/fleetrollup contains no INSERT, UPDATE, or DELETE SQL statements (case-insensitive). Enforces the read-only invariant.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-12
+      description: Source-inspection — internal/fleetrollup contains no fmt.Sprintf-into-SQL nor string-concatenated SQL. Enforces parameterization invariant.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-13
+      description: All result types are typed Go structs — verified by reflection-style check that exported methods on Service return concrete struct types (not map[string]any).
+      priority: high
+      references_constraints: [C-08]


### PR DESCRIPTION
## Summary

Closes **Slice B**. Read-only fleet rollup queries that answer "how is
my fleet doing right now?" via a small, fixed set of typed
aggregations over the Slice B persistence layer.

Surfaces:
- **FleetComplianceScore** — pass / (pass+fail) from host_rule_state
- **FleetLiveness** — 4-bucket counts (reachable, unreachable, unknown, never_probed)
- **TopFailingRules / TopFailingHosts** — descending count ranks
- **RecentChanges** — DESC by occurred_at with optional since cursor

## Stack

Carries identical copies of migrations 0011 (scheduler), 0012
(transaction-log), 0013 (liveness) so test-race has the tables it
needs. goose treats identical migrations as no-ops when the earlier
PRs merge first.

## Spec

`app/specs/system/fleet-rollup.spec.yaml` (status: approved) — **13
ACs across 8 constraints**, all at 100% coverage.

- AC-01/02/03 score math + empty fleet + skipped/error exclusion
- AC-04 four-bucket liveness sum
- AC-05/07 ORDER BY count DESC
- AC-06 limit=0 → empty slice
- AC-08 RecentChanges DESC + since cursor (NULL-typed param)
- AC-09 ctx-canceled errors on every method
- AC-10 clampLimit boundaries (negative → 0; overflow → MaxLimit)
- AC-11 no INSERT/UPDATE/DELETE in non-test files
- AC-12 no fmt.Sprintf-into-SQL nor concatenation
- AC-13 reflection-walks Service methods — no map[string]any returns

## Files

| Path | Purpose |
|------|---------|
| `app/specs/system/fleet-rollup.spec.yaml` | The spec |
| `app/internal/fleetrollup/doc.go` | Architectural choices |
| `app/internal/fleetrollup/types.go` | Closed enums + result structs + clampLimit |
| `app/internal/fleetrollup/service.go` | Service with 5 query methods |
| `app/internal/fleetrollup/service_test.go` | AC-01..10 integration |
| `app/internal/fleetrollup/source_test.go` | AC-11/12/13 source inspection |

## Verification

```
go vet ./...                    clean
go test -race -count=1 ./...    PASS (5.4s with Postgres)
specter parse                   PASS (system-fleet-rollup@1.0.0)
specter check                   PASS
specter coverage                system-fleet-rollup 13/13 (100%)
```

## Test plan

- [ ] CI: Go CI gates pass (vet, lint, vuln, test-race, specter sync)
- [ ] Confirm `system-fleet-rollup` reaches 100% in `specter coverage`