### PR TITLE
feat(api): fleet observability endpoints — read-only Slice B surface (14/14 ACs, 100%)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -324,553 +324,637 @@
         "filename": "app/internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 598
+        "line_number": 721
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "53542bf8db13d401b685e683e14730f522b680bc",
+        "hashed_secret": "12c33f5bf2d3e44c93f13dc4d0ae06cfb789e39e",
         "is_verified": false,
-        "line_number": 2218
+        "line_number": 2541
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4fcf83b24c88d0bbe63de404c9207771af47da7b",
+        "hashed_secret": "48688c31fd250c9203a9694c5e0e5f1e7a92ecc0",
         "is_verified": false,
-        "line_number": 2219
+        "line_number": 2542
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "123e0efa4fe32d08ebca484ac4449bc9c925d731",
+        "hashed_secret": "14b59fc7ce8be2d456a5df79704a14e24103b6ce",
         "is_verified": false,
-        "line_number": 2220
+        "line_number": 2543
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "878e0bdaec698818ff6369d9ebf22db7e5c40d20",
+        "hashed_secret": "0323b9f0be136671be004752c9e78930ce727259",
         "is_verified": false,
-        "line_number": 2221
+        "line_number": 2544
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4698b507b597c314f64b24307ee58a7b1e6fb57d",
+        "hashed_secret": "34eef5ccec09437ba86c972aa016cadafa0bf36a",
         "is_verified": false,
-        "line_number": 2222
+        "line_number": 2545
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a25a6cee95ba87122d29d8fe1d55cd7f9b1bc665",
+        "hashed_secret": "4e272a1976f21d979bf3ea8cbb4e32212b7f1858",
         "is_verified": false,
-        "line_number": 2223
+        "line_number": 2546
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c1de02ee4d41bfdea4a11be7a23627cf00ba4b66",
+        "hashed_secret": "b6cbce868ddefbe915fa342e63bed88bb3bae691",
         "is_verified": false,
-        "line_number": 2224
+        "line_number": 2547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "add2f02d8f10afa1dd763cd5a23168544ab8b9b4",
+        "hashed_secret": "e5c8a06c07f4076fe256d3d34a38cbc57192adc2",
         "is_verified": false,
-        "line_number": 2225
+        "line_number": 2548
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3fa667b2ad37eb961e0dcef8947ec315f4ef7ba9",
+        "hashed_secret": "174e69dfb4dcb1bc9a8b1e8b8795996d1a89042d",
         "is_verified": false,
-        "line_number": 2226
+        "line_number": 2549
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d03e4cfc9bf3344eb07f4ca85c9e13330cb67af7",
+        "hashed_secret": "00aaa1842f451f75414f8a727a07ff2eb8695925",
         "is_verified": false,
-        "line_number": 2227
+        "line_number": 2550
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "27c7b7e34448f1a61617064c2e253b73ccad1ac6",
+        "hashed_secret": "c94156612d115ea929eec2e998c0d04c8060cf29",
         "is_verified": false,
-        "line_number": 2228
+        "line_number": 2551
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4bbedd5659f7da4506dddf36b8f4ef4deeb3f366",
+        "hashed_secret": "d817c0f562ebe56fc179cc681ce4541b5ebd9e04",
         "is_verified": false,
-        "line_number": 2229
+        "line_number": 2552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "406902515f123120ff53a5f7f4cd3cf464008877",
+        "hashed_secret": "97c7613a07d59cdcfd67d0edf4938070a40df819",
         "is_verified": false,
-        "line_number": 2230
+        "line_number": 2553
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "252b1ef040e99c43bf2ec51cc6424f76e0e49e64",
+        "hashed_secret": "522dd73981cffb89f6a8a4b124d4dee1ea4588d0",
         "is_verified": false,
-        "line_number": 2231
+        "line_number": 2554
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a5f2382dfa574af2b792f590200669569095f4d9",
+        "hashed_secret": "d3cc3755e80e5cf83aa4e0a8d154465b4311b712",
         "is_verified": false,
-        "line_number": 2232
+        "line_number": 2555
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2e9cf58e2316ee1cfdaa662682a91cb803da7615",
+        "hashed_secret": "5c6c1437a64fdab2e740bd5277f8c8aa2cc48982",
         "is_verified": false,
-        "line_number": 2233
+        "line_number": 2556
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07e89bfb3acc1a3a8efc50fa59f601072ad0b296",
+        "hashed_secret": "96883ef5fa530fcfbfcfbe5df9b3505736e65fe3",
         "is_verified": false,
-        "line_number": 2234
+        "line_number": 2557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f6cd0985d7ec5fbcf661f5040239e778d6ddc9bd",
+        "hashed_secret": "c6eb065270536b04858ec407681dc39df36faf12",
         "is_verified": false,
-        "line_number": 2235
+        "line_number": 2558
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "046c4749c64d3fb594e39005ab8c3eddbcf22ece",
+        "hashed_secret": "28cc49f4c8abbcb4c3b630b9d84b474b5a0c0b6c",
         "is_verified": false,
-        "line_number": 2236
+        "line_number": 2559
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "aa86d91a4fa34e3653ee0d5e0d0c3c9fd5bdf4e4",
+        "hashed_secret": "a0f3cb24e3fd181aafceedda8ffbdc23c07a1a59",
         "is_verified": false,
-        "line_number": 2237
+        "line_number": 2560
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e8db2e12c7d4fbea75a0670504c40d07f2a16425",
+        "hashed_secret": "12e7e179520ff6ea03439ae5ad723dd8e9a7bcb2",
         "is_verified": false,
-        "line_number": 2238
+        "line_number": 2561
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c216f62c4b157ac7763dc34cfe7071661c06d0e4",
+        "hashed_secret": "87b02c1279245d59f6ad4a77efdf70ef8ccbcca1",
         "is_verified": false,
-        "line_number": 2239
+        "line_number": 2562
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "83f9477215d7085ac95ac2730e0952105793c8ca",
+        "hashed_secret": "13ab448c20dc11625c890c7cf0b8e649946e639e",
         "is_verified": false,
-        "line_number": 2240
+        "line_number": 2563
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "45fd66c6511960da3a24cf38c9fe4f8702501f69",
+        "hashed_secret": "ccaf38ccf2666028bea674c650ff3dbf473bd894",
         "is_verified": false,
-        "line_number": 2241
+        "line_number": 2564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2052773dc91e6dd0cd100d28cc74f0cbeac69dfb",
+        "hashed_secret": "202eea6183f5865c7af9bd3439c4d220333faa74",
         "is_verified": false,
-        "line_number": 2242
+        "line_number": 2565
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4e06da686ab5291d643e30589179a19bdefc4fdf",
+        "hashed_secret": "09ad08d0d25bb90fee650c2b73f7b3e40855101e",
         "is_verified": false,
-        "line_number": 2243
+        "line_number": 2566
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "701a3d633cff0d18d523d53f7d3c2dba6e052e48",
+        "hashed_secret": "7dd7ad4897877552b86e19dedbc861e9cb7ce87b",
         "is_verified": false,
-        "line_number": 2244
+        "line_number": 2567
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "073bd0d1e6357c71bae546465ec602447b868427",
+        "hashed_secret": "28cfd8686415af8633e6f14d00f9de90e4119324",
         "is_verified": false,
-        "line_number": 2245
+        "line_number": 2568
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8bd7b56d238a828ec85ac12fc31833977b8e31b0",
+        "hashed_secret": "464b4fd869152b99f4e45d4bfbd7ff3d6a38114b",
         "is_verified": false,
-        "line_number": 2246
+        "line_number": 2569
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b4848343f6784bba9c782c5c0b7c73b52e801f7f",
+        "hashed_secret": "0db77bf4b7c98e1e6a8ff777e885e338254bbeb9",
         "is_verified": false,
-        "line_number": 2247
+        "line_number": 2570
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "df72ce61fd702f3482cde64a3d21ea59ed72de48",
+        "hashed_secret": "40002b98443b40286a9a90ce54368e1a1cd5c0da",
         "is_verified": false,
-        "line_number": 2248
+        "line_number": 2571
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "26b991a1c550ffdb64320125be2a785efc1d5bcd",
+        "hashed_secret": "3b98f7f3cdad1630687f6925b41028193382badd",
         "is_verified": false,
-        "line_number": 2249
+        "line_number": 2572
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8e98c9355b49f43e8116d041fe6593044fd0cde8",
+        "hashed_secret": "b2753a9ea2a241c5b2fb5ec69ddc2918c0f387b9",
         "is_verified": false,
-        "line_number": 2250
+        "line_number": 2573
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ab4df883c3253641a1b2d4a6bce90a2561c3a861",
+        "hashed_secret": "24f0fe36c5d45f39e858c2e84ad8a3fb2e90ce1b",
         "is_verified": false,
-        "line_number": 2251
+        "line_number": 2574
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "38b8514e7a15d1a8cbbeeb5a00dc057ebb1fabf3",
+        "hashed_secret": "54b1ae6dfcd3b1c761f5f1000eca8a9558eeee18",
         "is_verified": false,
-        "line_number": 2252
+        "line_number": 2575
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8ff98cebc3703c6db1627c61e36ad94386804f55",
+        "hashed_secret": "7f910e2f72a532403c3b1d6d0d1f726302ab3f67",
         "is_verified": false,
-        "line_number": 2253
+        "line_number": 2576
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ed2216e5a0d567efd13788faee2b65f4f6d0c386",
+        "hashed_secret": "f9ec4d81dda751b177262f8db20ee4d34d862c50",
         "is_verified": false,
-        "line_number": 2254
+        "line_number": 2577
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5785848a96740f60d4ef98e279cdfec00094d441",
+        "hashed_secret": "1a222f925635194d7f9a65a0799b776526cd4a84",
         "is_verified": false,
-        "line_number": 2255
+        "line_number": 2578
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3e6c5005ca89fa7550ab09c4a6fafd2fb8778f71",
+        "hashed_secret": "3bef156047128444e378b656ca2f7e8058c6129d",
         "is_verified": false,
-        "line_number": 2256
+        "line_number": 2579
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "44c5aeb72fb0b68c8fd6bdcf484d0e0ac2e7fc4e",
+        "hashed_secret": "226c409907bbdf3bc8139a3bf876e88a8db7bebe",
         "is_verified": false,
-        "line_number": 2257
+        "line_number": 2580
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0540676b7be58cdd01bd8860aaabbd2fcc674c59",
+        "hashed_secret": "d6dca4f92172258e6da80992cc0fc747d7cdf83a",
         "is_verified": false,
-        "line_number": 2258
+        "line_number": 2581
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e84c6e9bdf10b02212ca4bb44059dbf01cb6be9c",
+        "hashed_secret": "491ae906a79f9e71757a32749982a872f5852d66",
         "is_verified": false,
-        "line_number": 2259
+        "line_number": 2582
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8295d3a976949d2d41993e65cf9be85f390c40d8",
+        "hashed_secret": "fcc623859a0c4c55d3de7a08024ac75ea87fb588",
         "is_verified": false,
-        "line_number": 2260
+        "line_number": 2583
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "52bfb8687f7be9b179d1aa66777457132dd572a9",
+        "hashed_secret": "59770a42338a0531bf6b52f077fb583a6559165e",
         "is_verified": false,
-        "line_number": 2261
+        "line_number": 2584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "24dcfb57f4a1ed5e4a2292e2dbcf6c66af650910",
+        "hashed_secret": "eab7e66517359507daa75ac8c8d579cd87865a75",
         "is_verified": false,
-        "line_number": 2262
+        "line_number": 2585
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5ac25b748ad32b5ae580536f4fde7937c0f9f760",
+        "hashed_secret": "0cfc9de1d457aad682a8df7af414deb2a33f8223",
         "is_verified": false,
-        "line_number": 2263
+        "line_number": 2586
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5e0c66b50ae8f47f18f06781dc7514202e0102b8",
+        "hashed_secret": "b80a03883d673b1ac2642c2ffd2953b32ffef377",
         "is_verified": false,
-        "line_number": 2264
+        "line_number": 2587
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fdf29dfda5ed1e4e275e81121c2703f70a38f727",
+        "hashed_secret": "4004fd784d798dc99deea691c083d640ae497ff4",
         "is_verified": false,
-        "line_number": 2265
+        "line_number": 2588
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6b81afbe053c6713d68eb99b06abe8d9c6ed328d",
+        "hashed_secret": "ff5ffc49943af0757c1617c296f7be4c238cdc80",
         "is_verified": false,
-        "line_number": 2266
+        "line_number": 2589
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "70f79f5e460919e2aef16605134b3d9d83d3deb2",
+        "hashed_secret": "fc2248e35eca67e192fa6d76ffe4017347d82b8e",
         "is_verified": false,
-        "line_number": 2267
+        "line_number": 2590
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9477ee5188e73eaa961248a1e8f2634a1791c030",
+        "hashed_secret": "d4189c02d5c475405cb0ee25af5c551c6e7f777f",
         "is_verified": false,
-        "line_number": 2268
+        "line_number": 2591
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f5d111a86a2f251514a4dde3035fac8af0c0c956",
+        "hashed_secret": "5343c2c3351cdbe0e12c17da46b360695adf4d90",
         "is_verified": false,
-        "line_number": 2269
+        "line_number": 2592
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5cf5977e4082fc6647dda0eef9d095e21ddef103",
+        "hashed_secret": "91c05e01d118930dea69aaa0a4b5e4a0d2026f15",
         "is_verified": false,
-        "line_number": 2270
+        "line_number": 2593
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "467231a97a4d89af376d5a8f1fd8c654ee41b6a3",
+        "hashed_secret": "dff7a5548f39ebf9099d8e2fd4cde7bc1912cc4c",
         "is_verified": false,
-        "line_number": 2271
+        "line_number": 2594
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d4e5e220bda5adcd2371495a069ff485d521984c",
+        "hashed_secret": "2539ab852fec8fe0072e06f68d6e8d83e499ec65",
         "is_verified": false,
-        "line_number": 2272
+        "line_number": 2595
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1b19bf066ebe4d4562e2681dbe643b4834754fd4",
+        "hashed_secret": "ebe60700d51452a0abda5069f813579bf4b34436",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2596
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42039aaab3f27872f567facbb0e904821fc7b9a8",
+        "hashed_secret": "919dba66dae9c6f0c05e4140dec9df12cbdfd15a",
         "is_verified": false,
-        "line_number": 2274
+        "line_number": 2597
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "929250547f76c324a84410c2b8adaebf0850d095",
+        "hashed_secret": "ab65ef184befc10ad1e295ae966b9f1e529bef91",
         "is_verified": false,
-        "line_number": 2275
+        "line_number": 2598
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "09b4e1d6a0eff06699b15b064ba4964072db29b1",
+        "hashed_secret": "7c777967a551a9d1247ef3fd0ace3e1fcf7b2796",
         "is_verified": false,
-        "line_number": 2276
+        "line_number": 2599
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ce2275464aba9778e602afed496a905432a74759",
+        "hashed_secret": "eba4f68f41c881b0ee713b66770da6cc2f734478",
         "is_verified": false,
-        "line_number": 2277
+        "line_number": 2600
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "67e69206eee26b489c23d6a8a1a28e3dc51fc721",
+        "hashed_secret": "bdcd610e829ac1df5225fc9fd4fd212e871b7607",
         "is_verified": false,
-        "line_number": 2278
+        "line_number": 2601
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a6e603e641e9cce4ed1269ebefcda0cb45ef045b",
+        "hashed_secret": "1b354f89f529b23f581e816e20d5d8f6a33db36f",
         "is_verified": false,
-        "line_number": 2279
+        "line_number": 2602
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fa1d07643505f38d36cb408e8b12fc26baa2240d",
+        "hashed_secret": "2730785f97c943d0e071bf69240b453dcf0bf381",
         "is_verified": false,
-        "line_number": 2280
+        "line_number": 2603
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "64961d7785a5532daeb760167654f2f499a23fb6",
+        "hashed_secret": "a84725c7b44df55bfcf0b341f35b468de0131997",
         "is_verified": false,
-        "line_number": 2281
+        "line_number": 2604
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3f99345986b6b00d96eaaaad75eac0cc6e26be4d",
+        "hashed_secret": "3cd04287c626656914df8b8d8c01682b9fc797e7",
         "is_verified": false,
-        "line_number": 2282
+        "line_number": 2605
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "56e34505bef34619ba9f2dba2dc9d65f83e9239a",
+        "hashed_secret": "8b3d29b8a8fc07c74fc887ec421c36f1600c1b78",
         "is_verified": false,
-        "line_number": 2283
+        "line_number": 2606
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07793c537f5f77ed8864abb5df53616cbbd08f89",
+        "hashed_secret": "617be33888d7beffb54a6fd57bc5d2a94e3fde76",
         "is_verified": false,
-        "line_number": 2284
+        "line_number": 2607
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "03e79fb47746b112d6c31c0b73ddb032b4661687",
+        "hashed_secret": "99518344c40e6e24d433d6e3b4bb45b4ec29bc82",
         "is_verified": false,
-        "line_number": 2285
+        "line_number": 2608
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e59619966e8b173cef73c798d4bded08fd2d79cf",
+        "hashed_secret": "d43fd08d5b9426b3089427cd55695c8ed0d7d086",
         "is_verified": false,
-        "line_number": 2286
+        "line_number": 2609
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c29e2fb183a6a882ef81b6857ce4468fa052cafb",
+        "hashed_secret": "527a6849acc19f5fac671c0abf29bef45e9627cc",
         "is_verified": false,
-        "line_number": 2287
+        "line_number": 2610
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "52d21d8facbe3b3e3935d472329a8bf5f47b5a54",
+        "hashed_secret": "95e2c7adb22252e9205c95adc6d3d5bc866b2d53",
         "is_verified": false,
-        "line_number": 2288
+        "line_number": 2611
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fac71acc611f780923402764cafc7485d8806a2f",
+        "hashed_secret": "c94d968d3cb368ea61f46cb5d7c039ad6390111a",
         "is_verified": false,
-        "line_number": 2289
+        "line_number": 2612
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ed6022f22383d3e8d622b5f6b964838ecf7db737",
+        "hashed_secret": "7b399e9ba4a1d7a85226689b48176ce1d96a532a",
         "is_verified": false,
-        "line_number": 2290
+        "line_number": 2613
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0b530671addf2b376fc10d6f2651d7a49454ed6a",
+        "hashed_secret": "9967dc41bd231f414264b2959562245a7ebb7c2c",
         "is_verified": false,
-        "line_number": 2291
+        "line_number": 2614
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b9d9c64225e033a66d3e0de6abbd8cfd881bcac9",
+        "hashed_secret": "da34bd9c27a4aa0b8c19f1d04f016eeac85de377",
         "is_verified": false,
-        "line_number": 2292
+        "line_number": 2615
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "19010104da89d53d3d8eb9a9c79b3451742a0321",
+        "hashed_secret": "9af5b0d206f70d73a4a8fc4a6d40c96b55d78326",
         "is_verified": false,
-        "line_number": 2293
+        "line_number": 2616
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b9defae7e682da7b9e333d830e1f5434ba3aa5b4",
+        "hashed_secret": "2a1161144ef7c3d7161a7efdf81e8cb1177386b4",
         "is_verified": false,
-        "line_number": 2294
+        "line_number": 2617
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b23514e15cafb985b65d40c655b099235b3fc8d4",
+        "hashed_secret": "ed1ebcec2fc08abe3d16838d6673da6f0fd88c44",
         "is_verified": false,
-        "line_number": 2295
+        "line_number": 2618
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "ec7925e69dcbaa856e3c64b7516cc50c5b0c6b54",
+        "is_verified": false,
+        "line_number": 2619
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "79c4330781bace65c320f4339fc04c0a981e5341",
+        "is_verified": false,
+        "line_number": 2620
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "88a6ea1e1374be512a1f77208df7b25c7f1623f9",
+        "is_verified": false,
+        "line_number": 2621
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "cdca2f433458500a867360ad00349a088eb78668",
+        "is_verified": false,
+        "line_number": 2622
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c0f48e7b7bb6c5b9c56dfaa0d86c8a5ab4571419",
+        "is_verified": false,
+        "line_number": 2623
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "00322738ee78c49f8ac9c2a414778b5809be21d4",
+        "is_verified": false,
+        "line_number": 2624
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b17dc267efb976fb3ee7240b395ee672e06fc8b8",
+        "is_verified": false,
+        "line_number": 2625
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "dbc59a109e6ff19f227f5be80ee97f28da11af57",
+        "is_verified": false,
+        "line_number": 2626
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1bb9b56d7a8a2c157cf963685c228f09101e0a8f",
+        "is_verified": false,
+        "line_number": 2627
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "ac370b1f37ca3ec9b256e2135866e2acb7408ef5",
+        "is_verified": false,
+        "line_number": 2628
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b8655bc6ae6140353dd2d7b0e19fcbd85d12497c",
+        "is_verified": false,
+        "line_number": 2629
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4b70cc728847c8cf1c4af02c423934295736d2aa",
+        "is_verified": false,
+        "line_number": 2630
       }
     ],
     "app/internal/server/credentials_handlers.go": [
@@ -1265,5 +1349,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-25T21:55:21Z"
+  "generated_at": "2026-05-29T22:04:55Z"
 }

--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -797,6 +797,131 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
 
+  # Spec: app/specs/api/fleet-observability.spec.yaml
+  /api/v1/fleet/score:
+    get:
+      operationId: getFleetScore
+      summary: Fleet-wide compliance score (passing/total)
+      responses:
+        '200':
+          description: Fleet score
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/FleetScore'}
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks system:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/fleet/liveness:
+    get:
+      operationId: getFleetLiveness
+      summary: Host counts by reachability status
+      responses:
+        '200':
+          description: Liveness rollup
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/FleetLiveness'}
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks system:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/fleet/top-failing-rules:
+    get:
+      operationId: getFleetTopFailingRules
+      summary: Rules with the most failing hosts (descending)
+      parameters:
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, maximum: 1000, default: 50}
+      responses:
+        '200':
+          description: Ranked rule failures
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/FleetTopFailingRules'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks system:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/fleet/top-failing-hosts:
+    get:
+      operationId: getFleetTopFailingHosts
+      summary: Hosts with the most failing rules (descending)
+      parameters:
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, maximum: 1000, default: 50}
+      responses:
+        '200':
+          description: Ranked host failures
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/FleetTopFailingHosts'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks system:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/fleet/recent-changes:
+    get:
+      operationId: getFleetRecentChanges
+      summary: Recent transactions (state changes), newest first
+      parameters:
+        - name: since
+          in: query
+          description: Filter to transactions strictly newer than this RFC3339 timestamp
+          schema: {type: string, format: date-time}
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, maximum: 1000, default: 50}
+      responses:
+        '200':
+          description: Recent transaction page
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/FleetRecentChanges'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks system:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
 components:
   responses:
     BadRequest:
@@ -1098,6 +1223,79 @@ components:
           type: string
           nullable: true
           description: Opaque cursor; pass as ?cursor= to fetch the next page
+
+    # Fleet observability schemas (spec: api-fleet-observability)
+    FleetScore:
+      type: object
+      required: [passing_fraction, total_evaluations]
+      properties:
+        passing_fraction:
+          type: number
+          format: double
+          description: Passing rules / (passing + failing) across all hosts. 0..1.
+        total_evaluations:
+          type: integer
+          format: int64
+          description: Count of host_rule_state rows where current_status is pass or fail.
+
+    FleetLiveness:
+      type: object
+      required: [reachable, unreachable, unknown, never_probed]
+      properties:
+        reachable:    {type: integer, format: int64}
+        unreachable:  {type: integer, format: int64}
+        unknown:      {type: integer, format: int64}
+        never_probed: {type: integer, format: int64}
+
+    FleetRuleFailure:
+      type: object
+      required: [rule_id, failing_host_count]
+      properties:
+        rule_id: {type: string}
+        failing_host_count: {type: integer, format: int64}
+
+    FleetTopFailingRules:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: {$ref: '#/components/schemas/FleetRuleFailure'}
+
+    FleetHostFailure:
+      type: object
+      required: [host_id, failing_rule_count]
+      properties:
+        host_id: {type: string, format: uuid}
+        failing_rule_count: {type: integer, format: int64}
+
+    FleetTopFailingHosts:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: {$ref: '#/components/schemas/FleetHostFailure'}
+
+    FleetTransaction:
+      type: object
+      required: [id, host_id, rule_id, status, change_kind, occurred_at]
+      properties:
+        id:          {type: string, format: uuid}
+        host_id:     {type: string, format: uuid}
+        rule_id:     {type: string}
+        status:      {type: string, enum: [pass, fail, skipped, error]}
+        severity:    {type: string}
+        change_kind: {type: string, enum: [first_seen, state_changed, severity_changed]}
+        occurred_at: {type: string, format: date-time}
+
+    FleetRecentChanges:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: {$ref: '#/components/schemas/FleetTransaction'}
 
     ErrorEnvelope:
       type: object

--- a/app/internal/server/api/server.gen.go
+++ b/app/internal/server/api/server.gen.go
@@ -123,6 +123,51 @@ func (e ErrorEnvelopeErrorFault) Valid() bool {
 	}
 }
 
+// Defines values for FleetTransactionChangeKind.
+const (
+	FirstSeen       FleetTransactionChangeKind = "first_seen"
+	SeverityChanged FleetTransactionChangeKind = "severity_changed"
+	StateChanged    FleetTransactionChangeKind = "state_changed"
+)
+
+// Valid indicates whether the value is a known member of the FleetTransactionChangeKind enum.
+func (e FleetTransactionChangeKind) Valid() bool {
+	switch e {
+	case FirstSeen:
+		return true
+	case SeverityChanged:
+		return true
+	case StateChanged:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for FleetTransactionStatus.
+const (
+	Error   FleetTransactionStatus = "error"
+	Fail    FleetTransactionStatus = "fail"
+	Pass    FleetTransactionStatus = "pass"
+	Skipped FleetTransactionStatus = "skipped"
+)
+
+// Valid indicates whether the value is a known member of the FleetTransactionStatus enum.
+func (e FleetTransactionStatus) Valid() bool {
+	switch e {
+	case Error:
+		return true
+	case Fail:
+		return true
+	case Pass:
+		return true
+	case Skipped:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for HealthResponseStatus.
 const (
 	Degraded HealthResponseStatus = "degraded"
@@ -381,6 +426,67 @@ type EvaluateAlertRequest struct {
 	Score int `json:"score"`
 }
 
+// FleetHostFailure defines model for FleetHostFailure.
+type FleetHostFailure struct {
+	FailingRuleCount int64              `json:"failing_rule_count"`
+	HostId           openapi_types.UUID `json:"host_id"`
+}
+
+// FleetLiveness defines model for FleetLiveness.
+type FleetLiveness struct {
+	NeverProbed int64 `json:"never_probed"`
+	Reachable   int64 `json:"reachable"`
+	Unknown     int64 `json:"unknown"`
+	Unreachable int64 `json:"unreachable"`
+}
+
+// FleetRecentChanges defines model for FleetRecentChanges.
+type FleetRecentChanges struct {
+	Items []FleetTransaction `json:"items"`
+}
+
+// FleetRuleFailure defines model for FleetRuleFailure.
+type FleetRuleFailure struct {
+	FailingHostCount int64  `json:"failing_host_count"`
+	RuleId           string `json:"rule_id"`
+}
+
+// FleetScore defines model for FleetScore.
+type FleetScore struct {
+	// PassingFraction Passing rules / (passing + failing) across all hosts. 0..1.
+	PassingFraction float64 `json:"passing_fraction"`
+
+	// TotalEvaluations Count of host_rule_state rows where current_status is pass or fail.
+	TotalEvaluations int64 `json:"total_evaluations"`
+}
+
+// FleetTopFailingHosts defines model for FleetTopFailingHosts.
+type FleetTopFailingHosts struct {
+	Items []FleetHostFailure `json:"items"`
+}
+
+// FleetTopFailingRules defines model for FleetTopFailingRules.
+type FleetTopFailingRules struct {
+	Items []FleetRuleFailure `json:"items"`
+}
+
+// FleetTransaction defines model for FleetTransaction.
+type FleetTransaction struct {
+	ChangeKind FleetTransactionChangeKind `json:"change_kind"`
+	HostId     openapi_types.UUID         `json:"host_id"`
+	Id         openapi_types.UUID         `json:"id"`
+	OccurredAt time.Time                  `json:"occurred_at"`
+	RuleId     string                     `json:"rule_id"`
+	Severity   *string                    `json:"severity,omitempty"`
+	Status     FleetTransactionStatus     `json:"status"`
+}
+
+// FleetTransactionChangeKind defines model for FleetTransaction.ChangeKind.
+type FleetTransactionChangeKind string
+
+// FleetTransactionStatus defines model for FleetTransaction.Status.
+type FleetTransactionStatus string
+
 // HealthResponse defines model for HealthResponse.
 type HealthResponse struct {
 	DbConnected bool                 `json:"db_connected"`
@@ -579,6 +685,23 @@ type PostDiagnosticsRequireRemediationExecuteParams struct {
 	IdempotencyKey string `json:"Idempotency-Key"`
 }
 
+// GetFleetRecentChangesParams defines parameters for GetFleetRecentChanges.
+type GetFleetRecentChangesParams struct {
+	// Since Filter to transactions strictly newer than this RFC3339 timestamp
+	Since *time.Time `form:"since,omitempty" json:"since,omitempty"`
+	Limit *int       `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetFleetTopFailingHostsParams defines parameters for GetFleetTopFailingHosts.
+type GetFleetTopFailingHostsParams struct {
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetFleetTopFailingRulesParams defines parameters for GetFleetTopFailingRules.
+type GetFleetTopFailingRulesParams struct {
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
 // GetHostsParams defines parameters for GetHosts.
 type GetHostsParams struct {
 	Environment *string `form:"environment,omitempty" json:"environment,omitempty"`
@@ -710,6 +833,21 @@ type ServerInterface interface {
 	// Stage-0 RBAC+license demo; requires remediation:execute + remediation_execution feature
 	// (POST /api/v1/diagnostics:require-remediation-execute)
 	PostDiagnosticsRequireRemediationExecute(w http.ResponseWriter, r *http.Request, params PostDiagnosticsRequireRemediationExecuteParams)
+	// Host counts by reachability status
+	// (GET /api/v1/fleet/liveness)
+	GetFleetLiveness(w http.ResponseWriter, r *http.Request)
+	// Recent transactions (state changes), newest first
+	// (GET /api/v1/fleet/recent-changes)
+	GetFleetRecentChanges(w http.ResponseWriter, r *http.Request, params GetFleetRecentChangesParams)
+	// Fleet-wide compliance score (passing/total)
+	// (GET /api/v1/fleet/score)
+	GetFleetScore(w http.ResponseWriter, r *http.Request)
+	// Hosts with the most failing rules (descending)
+	// (GET /api/v1/fleet/top-failing-hosts)
+	GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Request, params GetFleetTopFailingHostsParams)
+	// Rules with the most failing hosts (descending)
+	// (GET /api/v1/fleet/top-failing-rules)
+	GetFleetTopFailingRules(w http.ResponseWriter, r *http.Request, params GetFleetTopFailingRulesParams)
 	// Liveness + readiness probe (anonymous)
 	// (GET /api/v1/health)
 	GetHealth(w http.ResponseWriter, r *http.Request)
@@ -899,6 +1037,36 @@ func (_ Unimplemented) PostDiagnosticsRequireHostWrite(w http.ResponseWriter, r 
 // Stage-0 RBAC+license demo; requires remediation:execute + remediation_execution feature
 // (POST /api/v1/diagnostics:require-remediation-execute)
 func (_ Unimplemented) PostDiagnosticsRequireRemediationExecute(w http.ResponseWriter, r *http.Request, params PostDiagnosticsRequireRemediationExecuteParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Host counts by reachability status
+// (GET /api/v1/fleet/liveness)
+func (_ Unimplemented) GetFleetLiveness(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Recent transactions (state changes), newest first
+// (GET /api/v1/fleet/recent-changes)
+func (_ Unimplemented) GetFleetRecentChanges(w http.ResponseWriter, r *http.Request, params GetFleetRecentChangesParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Fleet-wide compliance score (passing/total)
+// (GET /api/v1/fleet/score)
+func (_ Unimplemented) GetFleetScore(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Hosts with the most failing rules (descending)
+// (GET /api/v1/fleet/top-failing-hosts)
+func (_ Unimplemented) GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Request, params GetFleetTopFailingHostsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Rules with the most failing hosts (descending)
+// (GET /api/v1/fleet/top-failing-rules)
+func (_ Unimplemented) GetFleetTopFailingRules(w http.ResponseWriter, r *http.Request, params GetFleetTopFailingRulesParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1624,6 +1792,146 @@ func (siw *ServerInterfaceWrapper) PostDiagnosticsRequireRemediationExecute(w ht
 	handler.ServeHTTP(w, r)
 }
 
+// GetFleetLiveness operation middleware
+func (siw *ServerInterfaceWrapper) GetFleetLiveness(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFleetLiveness(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetFleetRecentChanges operation middleware
+func (siw *ServerInterfaceWrapper) GetFleetRecentChanges(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFleetRecentChangesParams
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "since", r.URL.Query(), &params.Since, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "since"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "since", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFleetRecentChanges(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetFleetScore operation middleware
+func (siw *ServerInterfaceWrapper) GetFleetScore(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFleetScore(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetFleetTopFailingHosts operation middleware
+func (siw *ServerInterfaceWrapper) GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFleetTopFailingHostsParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFleetTopFailingHosts(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetFleetTopFailingRules operation middleware
+func (siw *ServerInterfaceWrapper) GetFleetTopFailingRules(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFleetTopFailingRulesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetFleetTopFailingRules(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetHealth operation middleware
 func (siw *ServerInterfaceWrapper) GetHealth(w http.ResponseWriter, r *http.Request) {
 
@@ -2159,6 +2467,21 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/api/v1/diagnostics:require-remediation-execute", wrapper.PostDiagnosticsRequireRemediationExecute)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/fleet/liveness", wrapper.GetFleetLiveness)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/fleet/recent-changes", wrapper.GetFleetRecentChanges)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/fleet/score", wrapper.GetFleetScore)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/fleet/top-failing-hosts", wrapper.GetFleetTopFailingHosts)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/fleet/top-failing-rules", wrapper.GetFleetTopFailingRules)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/health", wrapper.GetHealth)
 	})
 	r.Group(func(r chi.Router) {
@@ -2215,85 +2538,96 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7F17bxs5kv8qRN8Ca2NasZzHYFfB4pBJMpvMJTOGk+wcMJsTqO6SxLib7JBsObrAwH2I+4T3SQ589Jvs",
-	"bnksybMz/yS2xEex6sd6sUh/DSKWZowClSKYfQ04iIxRAfqX73B8CZ9zEFL9FjEqgeofcZYlJMKSMHr2",
-	"STCqPhPRGlKsfvoTh2UwC/7trBr6zHwrzl5yzvhLuoGEZRDc3NyEQQwi4iRTgwWz4B84IbEeOUQZXhFq",
-	"f2YckRjSjEmg0RaBGie4CYO3INcs/pHJZ0nCriE+HKU/c0ZX6NX79xco1UQEqo3trkZ/FqeEXrIExKXl",
-	"qvo04ywDLolhMVdfqx+IhFQM0aQGe0kl36qVy20GwSzAnOOtnprD55xwxYJf7Lgfy1Zs8Qkiqbo9y2Mi",
-	"X24sf5rU4Mis7WvRTUhO6Ep1w5FkfE40f2meJHiRQDCTPIfQ19h87BgrYpxDooViR+w0iUFikmia4pio",
-	"lji5qNHamLhanBltyXiKZTAL8pzEgYM+FkU55xDPsWy0j7GEiSQpuDpxiBiPd+4UG6Y2hdxp1xSm6idY",
-	"ziMYy/GyfcH0wR4CNsCJ3DrIaWFJ87Als7DASkPYTc72o09c4JVjQ5QsGrUhamB2MJHCFzmPci4YVwM1",
-	"t+9PGf6cAzJfP0UZFgJhgf7dfPA3JBlagozWSK4BqZGUOlJLHOBsm3l6GU1a3IyR6zdsRWhN4zY5w2Sm",
-	"/kvxlzdAV3IdzL4Ng5TQ2m8dIatVXTMetzo+fNLseu7omgvgFKewc9cWA8pxatQMMMCnLHEUgRBzya7A",
-	"raQ4LDmIdU8LRc0wqOT6LZRktBfUoKI9p53Bt8C33z97STlLEv8iM842RBBGCV3Nc06G92enR8/s/wBO",
-	"lts7xFiLFjWAd3q4AJ4SoUjtMYkkBiqtYmp/45QpEXNMGd2mLK8r1wVjCWCqccESGKnndNPWmK4FZdVS",
-	"dtHsnSntWpsD+jnoZxuk1mB2+TPOKHqY1NQEIzhY2/CGJju0b1EXVis8X2O6Ai80tV2hct5Qaf0qjML1",
-	"+OatpXSmaw3nW82lUQfeZQypqLYf12jumvQ5lrBifGv8ws58DaPnBccIsdYHctLBQYMZJ885YOkXJM7l",
-	"em49ZoVbmqdqEiHW8yvY1s1EGCyYXNdmq/uHjWXVFNb59OHj0KkkYljiPJFuFXErU9c0sN0vOdlgCXpZ",
-	"A99rYGVrjoV7D4qIGb+uZNdWSEiDMFgzIZ0s0l3m7s0/6B3elfU3dFv2NnRDHQb9eHpDhPTrvahsN95t",
-	"rMaurPyApq5P009uj/9yF8iP9O7aLQop+iy2oyzBOJ0xOIyyoZEkG3DvuLE78uh7wcpnviCybuIJlbAC",
-	"Xm8RsTS1gbV3lCWhK+AZJwPtvNFznsU7A2BHEz5u1zZEWBe3c3/kQrL0kiUwYB78mn2MPjYizrCUwFWU",
-	"91+/4Ml/f1T/TCd/nX/8eh5+++jmTy4WjXboUkJfmy/PB727lt0c9vIqNvnVyK1MupbPIieJnBPq3nB3",
-	"5dJ2Fl2feZgFL6M186IjBSFs3qBj83exS8U4fgL8Sjwmcg4b5RyOVIQj8l0QrRmMcMVsu86YznXQzznk",
-	"8B6E/IEteizoMHmf2GLcYlvk2n7jyG0kXLvxjc74OoiPD51kLG1WYX+ihCitHwYC+Aa4wjhLSKQsOnxR",
-	"iggnTqu0zlNM5zVIOxIakm+Nceru2LaHojhRUFfv2p6oy/w2yDSrnTLa4CTHEp4lwKV3k4qI8WKLklTx",
-	"6Hw61fvT/DYNOza06zZy9+Z8BThRUZZXOS7mEaMUItnYTjU1JySWJlFQyG+tx9xqvbXiOIbYKa4NcOHW",
-	"uW3qzQxhk5hqAOe6mJC3toyemCcmIkvwdu5z5LtaiG4IZ7TwYeppINf4K87y7LZelfLVbhl0kWyO45iD",
-	"EA4qhwI2xmUDmt8+efLoSQ2c56HDwZN41bSJQ6xpp6L74ql+MJV8aqzbB6H+WEmNNT5KUuONjo/M0D6y",
-	"esO3Y4cz7W0ytC32tw9uHWk1NoQX8yNwPQzk/UcfbsTbZTSl4cPbB03lvdWkAzrqV+HpX145dgT+hkRA",
-	"BbyTWuReRaMjK+BeD/xLRjiIPmAP8n4JWOYcdtxShM5XHEcwz4ATNtprscG2gguOdLZdr0CDhM0TwxS1",
-	"h+gGJ8Tt0khijsOKMZcc9CluBvQay2g9zxLtyACVOmchwDlMLghdzTMOm1au0+er6nnDylEqGffRL9+B",
-	"oyu74PmnazmsZ+qNR0zpPXM5GGY8w1QYEnMjZSd4CjEPErPRC55zEM20XNXiGnNK6OpXkdtW+gXt7fld",
-	"kqmOED0HHpE9D3GbekxXwL3nhLfMrBRoWmEJY49TSjLbyZKKxP7li0tYESF5DzztHGSHCqPmaZJDWfmS",
-	"RH2DtmXmqnfZUx1UjQVN2sOeEqkLFb0TEJeQMBz7+ctyGbHUpoWcGQS/9veE3uWQXrq2LyDSp/19CcJb",
-	"5TWG0xGWOo+TqYjzp63t9/4gWjECizHxdUFGc9LOFOWALl5WEPrt51ebuK7T4Vr5BwF8INNQ1hL0BOaP",
-	"bl9u9JfDlBsV1Qe9Z/aKG3cbnf7qQowEi6ruYB7psojd4q39x2gdNnt5yxJ4JgRZ+QvblCK2Xvkuki66",
-	"+WYW/bkQtYLxFqcBk6EtaoZ2pFm1s79k3WLEdxKvAE3RNU6uCF1NxBUkIBlFIudLHAH6v//5XyTXHAAB",
-	"jTNGqBRIrrFE8AV4RAQguYZ/0iXLqameRkLi6Aqd1NLgYb2COkT6ICM0ldQIbN799ME/lUaRRCrnLfgp",
-	"A/qzCgTQiSXxtJbHnAXTB+cPphOcZGv84FxbiAwozkgwCx49mD54pHefXGv2nuGMnG3Oz3CcEnpmfaaZ",
-	"8fi0eJgBhxKSpvd1HMyCCyakLqRuuOSBYTgI+R2Lt3dW8+2MNG6a4lXG0xTcVoXyD6fTfdFQFiF2K+VV",
-	"CzsHMh4zOhG5rk5EjCMFvhgtMUlyDqemOD1PU6xMXvCCbyc8p2hjyu0BYfTDz++RlQq6JnLNcokIFRIn",
-	"CaErRIyz0pRiZj2lGdeu0ggxNn2rYI+M9HhxDk5eAJ8obiGzClQ6YTdh8Hj66HBXCp7jJAGOEhxdCWS8",
-	"mYKzTfGZNSGlViG2LdGSJCDQkrNU1yxHjC7JKucQo5hwiKSJNr5MCixPKr8hmAXd6UpRK0Vxpk88tZBW",
-	"4BDw30HWarv1vuc4BamV7C9fA+UUBZ9z0DQYQ1OVkFfs66h8d89ONfrOIzSq1nfuLQiNmh3HWFnfaDmV",
-	"2lG5m9FskfktVpWQlMhGx7JA58k0rLKCDxuneY6c4M3HPe7r9hUC14ZWpootjYlDFrl6M099o5fkntVu",
-	"PTU3nfInGkOiE8Prib2oBHGIKFyDkGhJuJCnrW0k12cJW5nwoEdNFoXwezJynZsGBzZw3UJ/hwR1A6St",
-	"GcQQP0W6AFYgIkQOsZHl+eEU82uTQ0W1KkBlYt9+/wyVjNNggSg3l2p++ViHzgfrLp8Vbj3SQNB2FrHM",
-	"hOjo/U/vL5yQYbkchRnVriO5xw53E7TWRxw27Aq6xkV9amyINf7CdOgSZwIGv0WQ67cQ7BlMjbsaXdEV",
-	"JfaHxsyPzHhXBfMUYBaAuS13qPNb5pw2+F3eC3Aw/KyVR+hn/kUz57VfObjud7j9LdsMJaSjZl8ul6CP",
-	"NlBtoWipPNpxHFriGehLNsN7pryPs3fedC7+uPhSu8iDPly+RlwjQ3nxdvVqgWrdEZaMI5xlbd7pORqM",
-	"UsEoIlQrF6Ww3AwbFYbVrxDt0Th1rimNMlAONafUs14YOYLJUJMrltvjN7X7OWQJ3nb07XPlqPMUYYoM",
-	"biHWlkVAxEGixdYsYqukidEKqBIMxMhpLQoDMzN5o2GJNq/f7FGs7ns+t5VtMRqyya6ae3cg9Q7XqLTm",
-	"HD7pIi8lLFv7d2i8PTcXliqarjmzWbMa1DTvO/rhz6Ls5kBUpYVn3J45DdkdxzHVXkP9nlMxB6tKkprM",
-	"+T5PEnT53bPnqFgmOqnOj8K6OQqRTrFPCEX6GMnh6dubW8Mb0N4Y2+POa91Ju4/+vtpN2sVHGSb8WG6+",
-	"ZZSlxGruENnCitDo8FxArIAhIhyDdaGR5GS1Ag7xaW8ccMkklmb/8fpcT1FKqERYhY/IXDD+pmigGNKA",
-	"V+vGk28fPq8126N4Pfe0XBqqbIlSkDjGElv/75hptoqbMw6dRJuO+etR30lJOqPJ9rQnodYZOOxRBG1h",
-	"3b0i8N3PHKUNzvdAxkio2CO4g9v3+kM0hQ+n70WFaM2ERJRJpI9bzNs0tsW7d6/QFVjr/9cDept5IkmW",
-	"ADJ34ZBN3Im2/dfMRLgG6XEIvuZEgk8LnX0l8Y1x0RKQ0EX4C/15JdTvtq9feFLEGZbrKiNpruQ3wOlM",
-	"k3ouo3wc40ka4mJ0Ul5g+9sSJwJOjRAfH1AvVagv0dUS4Du2lBPD5ltI0crnJhxhNI4no+nxlE2h3O+j",
-	"6L/Xr9HUhf5nURG8gx2qbeKY4BVlQpJIzCBas35v9UXV+qVq7EbHGnCsqzstPl5Xh86T/4BtL1galR9P",
-	"Bis/PDP+5+R5dT40ed1/PvRxP+a2fovxwA534/6iA2vq+yq1fqtzEdXlyXCXzuNshzaLLewV3rtOu8dk",
-	"uQQdMi+U4FuJNMUj46brJSNbFve0LLgQjffovjEHQ/7NZe5iTiQIOfnEFuM3WuMSZ9eRf3h3zHRfF3Vw",
-	"9Qe20EFKJiF+iq4ZvwKOrkmSoJhjQtsmS+IVTKZIj45iSNlTZNkhVMTDJixDn9gCZZypwMdkURTvCZ3Y",
-	"z+wkfvbae4kTnACX45lbv864J7/beWXywBrBUzjqSkGbUoLYNvWIMitaaVnaBQqToVbLnMu1Cl1ZEosy",
-	"HeaRXMYhJXk62cn6XJhO98II/T7tR6HLHx5Ol9vCKBQzENpJIjRK8hiQhdC8Bitkb1V0onk9xEQX6iMF",
-	"uafF+a3oHabhXRUfzgJHFy/QbfeJCh4n2hEbi/ZL09Pco9Q1U38g/hiIRyeRSRwZxaYEqT3q0+MmsEo6",
-	"PMpaZ7SNqi6xXvapJbV7QojmFIPoNsmCW8D7Z93xD3zfH3xrUd4HgFcJqB0QrjvtAPFulsuFcQ4pxMQE",
-	"l/AFonx3sF9WQ7y0I/yB+t+7H1PD1dzgSnvgx9x6NZJmBdT9e/Cbony8tRcdo6Bv3Msd8rjcPPJva98C",
-	"iv1tnn7pO0YzD87s8wSt9aSNQybvgG9IBIgIVLxVcxMGTw4JixoJxSM5iHGUU7zBxNz17Tv4fEM2QFUg",
-	"r+SOY6J/zjhbADopH9ptnqKXj5V4JaMbjKo0rz/HcIvCaIlXwznEfaGj/aqLQziqzT04SvV5ovoQdW2l",
-	"NcLH7DsoLYS+D1vVfYPpwIejzRd3PHI+/oFocakInSxwjIrnWkJEshBljMsQgYwenB482/vKUoJwooC0",
-	"RfCFCCkQoaiuADxHovrx0J0dRA3rs6/qvzmJb+rHojMOgiWbAefwVfP0/9L2GXPyZif9jR+/2RXXi+uP",
-	"dw73I6uTUdo2XYCrj/0Zbx2xd4q59WpMiV01kr6rqVPkC0D6DEKNOAi6vrM7i7xRR+8KZPfz0N3QHc+x",
-	"RALk4c/cXzVqOXpP28coiOET9uOKYnpQW3W/pFkcoI+RY+mIYBmtHYpbfXxwSe7H42m+lXbgGH2Ux3Os",
-	"Eu+ux3O/AG0kh9Jcahul7dOSQBKL3f2Y4r2wnnjrTfmk2L4vvzefcuvJoQjVsMWVv4M01tcWxCf1tuhE",
-	"EuBhkWYQIfqcM4lFiMxbZM0QtHyVyMcS/dfd9np3qPs35FwuFEvgHsR/il3e+K9ZMN+XsmmM0hDFzMQ+",
-	"/Q615pbx6vdVSut5y/7QpbTdt+Kd90JUK831o4WOtQt/Ob2i7JoePDbUW4TESOIroN6q2IpXQwDtatDy",
-	"QRmfstCP0uxTWXRfvXEwQjW6B7pCccurK3LLKZ8Eap37ckUVw+9eB3Rf0Trw7m++SOSR8z3IFTFevk9S",
-	"96GOijvXYWKpBPQf8BvAnmf3j4zGlWjuYzR+cO9WY3Rc8D1GKsPB93E5Pz3o5r9f0iyC7zFy7Dh/1eay",
-	"fiDWL8r1+4HF63PCPD/3G47S3e/o3fbmtPaEDAOPYBk+GP/P+KOkjRKzQoTN15INA0Y7YxYOvZDJ6U6g",
-	"+VA0/wM2NdhwSNlG35Uq6lDkaScBrpoUItSvke0oxJviD+kYfrcfBopwgmLQCLPnuTlPglmwljITs7Oz",
-	"RLXQWY6/PH78KLj5ePP/AQAA//8=",
+	"7F17bxs5kv8qRN8Ca2MkP/IY7CpYHDKeZJO9zIzhJDsHzOYEurskMe4mOyRbji4wcB/iPuF9kgMf/WA3",
+	"2d1yLNmzm39mHImPYtWPVcVisfQlilmWMwpUimj2JeIgckYF6H/8gJML+FSAkOpfMaMSqP4T53lKYiwJ",
+	"o8cfBaPqMxGvIMPqrz9wWESz6N+O66GPzbfi+AXnjL+ga0hZDtHNzc0kSkDEnORqsGgW/R2nJNEjT1CO",
+	"l4TavxlHJIEsZxJovEGgxoluJtFPIFcs+ZnJ52nKriHZH6W/ckaX6NW7d+co00REqo3trkZ/nmSEXrAU",
+	"xIXlqvo05ywHLolhMVdfqz+IhEwM0aQGe0El36iVy00O0SzCnOONnprDp4JwxYLf7Lgfqlbs8iPEUnV7",
+	"XiREvlhb/rjU4Nis7UvZTUhO6FJ1w7FkfE40f2mRpvgyhWgmeQGTUGPzsWesmHEOqRaKHbHTJAGJSapp",
+	"ShKiWuL0vEGrM3G9ODPagvEMy2gWFQVJIg99LI4LziGZY+m0T7CEqSQZ+DpxiBlPtu6UGKa6Qu60c4Wp",
+	"+glW8BjGcrxqXzJ9sIeANXAiNx5yWljSPGzJbFJixRG2y9l+9IlzvPRsiIpFozZEA8weJlL4LOdxwQXj",
+	"aiB3+/6S408FIPP1M5RjIRAW6N/NB39BkqEFyHiF5AqQGkmpI7XEAc62maeX4dLiZ4xcvWFLQhsa1+UM",
+	"k7n6X4Y/vwG6lKto9v0kyght/KsjZLWqa8aTVsdHT92up56uhQBOcQZbd20xoBqnQc0AA0LKEscxCDGX",
+	"7Ar8SorDgoNY9bRQ1AyDSq5+goqM9oIcKtpz2hlCC/zp5fMXlLM0DS8y52xNBGGU0OW84GR4f3Z69Mz+",
+	"d+BksblDjLVoUQMEp4dz4BkRitQek0gSoNIqpvY3XpkSMceU0U3GiqZyvWQsBUw1LlgKI/Wcbtoa07eg",
+	"vF7KNpq9M6VdqztgmINhtkFmDWaXP+OMYoBJriYYwcHGhjc02aFDizq3WuFshekSgtDUdoXKuaPS+lUY",
+	"hevxzVtL6UzXGi60mgujDoLLGFJRbT/Oae6b9AxLWDK+MX5hZz7H6AXBMUKszYG8dHDQYMbpGQcsw4LE",
+	"hVzNrcescEuLTE0ixGp+BZummZhEl0yuGrM1/UNnWQ2FdXry6MnEqyQSWOAilX4VcStT5xrY7pecrLEE",
+	"vayB7zWw8hXHwr8HRcyMX1exayMkZNEkWjEhvSzSXeb+zT/oHd6V9Td0W/Y6uqEJg348vSFChvVeXLUb",
+	"7zbWY9dWfkBTN6fpJ7fHf7kL5Md6d213Cin7XG5GWYJxOmNwGGVDY0nW4N9xY3fkve8FK5/5JZFNE0+o",
+	"hCXwZouYZZk9WAdHWRC6BJ5zMtAueHou8mRrAGxpwsftWkeETXF790chJMsuWAoD5iGs2cfoYyPiHEsJ",
+	"XJ3y/us3PP3vD+o/J9M/zz98OZ18//jmDz4WjXboMkJfmy9PB727lt0c9vJqNoXVyK1MupbPZUFSOSfU",
+	"v+HuyqXtLLo58zALXsQrFkRHBkLYuEHH5m9jl8pxwgSElXhC5BzWyjkcqQhHxLsgXjEY4YrZdp0xveug",
+	"nwoo4B0I+Td22WNBh8n7yC7HLbZFru03jlwn4No93+iIr4f4ZN9BxspmlfYnTonS+pNIAF8DVxhnKYmV",
+	"RYfPShHh1GuVVkWG6bwBaU9AQ/KNMU7dHdv2UBQnSuqaXdsTdZnfBplmtVdGa5wWWMLzFLgMblIRM15u",
+	"UZIpHp2enOj9af51MunY0K7byP2b82UKIF8xIV9ikhbcA5QFJimhyzkvUpjHrKCunSRUfv8kmnisuPIe",
+	"boXysuPEN3dwEW/IGigI0V0BhTXwec7ZJSQjaeeA41UJlBHtC3pF2TUd3Xq78TuH2LKzO1RNxsRdc5Bn",
+	"FxADlSZSIL42eKxHfMcxFTaWPWja9Khh4ooUBlGpsbINKjWUxpzSy4YT31xBot+We7UVhcRCqCEWvL4T",
+	"cuPn56YFUtMKdIwObBf0HbLzHyIccyYEwmmKFC3iCJ0cHZ0eKRIrt5UVBgqWPFpkl2bhkkmczsFonNIp",
+	"cWk4U2tDbKFHN5tOSCwBcXYt0PUKuA7w60CO+qIQiAgT6mdck+nQMhLOHd74aA0y/B3LXxr+KC12NyBu",
+	"6sOvBHFNnoLz3ZDX3BhfS15ju3Z9Aa0X5leEOufrBeFCzgXo8LzGx9y01Ecdew1WfeQ11KMtw46vIIO6",
+	"oPc+z6zaBMdLpigQW1WhuHBF8lzzo237+46Jtd2rdY+daeIIY/he8BXgVK56zjyX85hRCrF0vOTG6aW7",
+	"xJUec6OPI0uOk4Bw18CF/yjVdkrKpTnE1AN418WEvPWBNxDKTIjIU7yZh+Jz3cMFXRPOaBmaaN7u+MZf",
+	"clbktw2WKEzcMpZK8jlOEm5dohaVQ3FYxqXjcX7/9Onjpw2f89RnWyVeuqpsiDXtG+a+MOmwz2hjKo11",
+	"hyDUHwJdlYZklEpW440Oe5qhQ2T1RmXvO0rZ3iZD22J3++DWAVRnQwQxPwLXw0DefVDRj3i7DFcaIby9",
+	"11Q+WE06oKO+Ck//9MqxI/A3JAYq4K3UIg8qGh0wBR4MrH3OCQfRB+xB3i8Ay4LDlluK0PmS4xjmOXDC",
+	"RnstNoau4IJjfYmuV6BBwuapYYraQ3SNU+J3aSQxWS6VB8xBJ2flQK+xjFfzPNWODFCpryIEeIcp9DEn",
+	"57BuXWGGQlB63oYPWDHuQ1i+AxkpdsHzj9dyWM80G4+YMphKsTfMBIapMSTmRspe8JRiHiRmrRc85yDc",
+	"27a6xTXmlNDlV5HbVvol7e35fZKpM4MCeQyxTXPwm3p11ODB9J9bXpiUaFpiCWOzJCoy23cgNYn9yxcX",
+	"sCRC8h542jnIFonDbpKIR1mF7n76Bm3LzJfGuqP05gYLXNonPZnP5ywlMQFxASnDSZi/rJAxy+xtj/di",
+	"IKz9AxH1asggXZsfIdZJfH33fre6rhi+ZbDUBZxMRVz4Ntp+Hz5E69i0GHO+LslwJ+1MUQ3o42UNod//",
+	"tamL6yYdvpW/F8AHIg1VimDPwfzx7bOI/7SfLOIyqbA3FU9x425Pp1+dX5liUacT2nDjduet3Z/ROmwO",
+	"8pal8FwIsgznqytFbL3ybSRddgvNLPpjIWoF4y2OA5OhLWqG9tyeamd/wbr3E28lXgI6Qdc4vSJ0ORVX",
+	"kIJkFImCL3AM6P/+53+RXHEABDTJGaFSILnCEsFn4DERgOQK/kEXrKDmURQSEsdX6KBxuz1pPoyaIJ2f",
+	"MDEPpBDY6/TDo3/oawoilfMW/ZID/VUdBNCBJfGwEcecRSdHp0cnU5zmK3x0qi1EDhTnJJpFj49Ojh7r",
+	"3SdXmr3HOCfH69NjnGSEHlufaWY8Pi0eZsChhKTpfZ1Es+icCanfRzkueWQYDkL+wJLNnT3l8p40blzx",
+	"KuNp3tHU798enZzsiobqbUH3AZxqYedAxmNGB6LQjw4Q40iBL9F3VwWHQ/PmrMgyrExe9CPfTHlB0dq8",
+	"ogOE0d9+fYesVNA1kStWSESokDhNCV0iYpwVV4q59ZRmXLtKI8To+lbRDhkZ8OI8nDwHPlXcQmYVqHLC",
+	"bibRk5PH+3speIbTFDhKcXwlkPFmSs664jNrQkqtQmJbogVJQaAFZ5l+ihQzuiDLgkOCEsIhlua08Xla",
+	"Ynla+w3RLOpOV4laKYpjncikhbQEj4D/CrLxZEvve44zkFrJ/vYlUk5R9KkATYMxNPXLsJp9HZXv79l5",
+	"ZLb1CM5jtK17C0Jjt+MYKxsaraDSXK7dyWj27dgtVpWSjEinY5V3+/RkUkcFHzlJOp6Y4M2HHe7r9stA",
+	"34ZWpootjIlDFrl6M5+ERq/IPW48ZnY3nfInnCHRgeH11L4/hmSCKFyDkEhfJR+2tpFcHadsaY4HPWqy",
+	"fN+2IyPXeUC4ZwPXfb/nkaBugLQ1gwSSZ0i/axGICFFAYmR5uj/F/NrEUFEjuV+Z2J9ePkcV4zRYIC7M",
+	"3fpvH5rQeW/d5ePSrUcaCNrOIpabIzp698u7cy9kWCFHYUa160juicfdBK31EYc1u4KucVGfGhtijb8w",
+	"HbrEmQND2CLI1U8Q7RhMzhPMrujKl3P7xszPzHhXJfMUYC4Bc5so1OS3LDh1+F099/Mw/LgVR+hn/rkb",
+	"89qtHHzPNv3+lm2GUtJRsy8WC9BXG6ixULRQHu04Di3wDPTb2eE9Uz2z3TlvOu95fXxpvM9F7y9eI66R",
+	"obx4u3q1QLXuGEvGEc7zNu/0HA6j1GEUEaqVi1JYfoaNOoY1Xwbv0Dh1Xh+PMlAeNafUs14YuQeToSZX",
+	"LLfXb2r3c8hTvOno2zPlqPMMYYoMbiHRlkVAzEGiy41ZxEZJE6MlUCUYSJDXWpQGZmbiRsMSdV/V7lCs",
+	"/ue7t5VtORqywa6Ge7cn9Q7XqLLmHD7qJC8lLJvSv2+8nZn01Zqma85s1KwBNc37jn74o6i6eRBVa+EZ",
+	"t3dOQ3bHc02106N+z62Yh1UVSS5zXhZpii5+eH6GymWig/r+aNI0RxOkQ+xTQpG+RvJ4+vZB9vAGtA/B",
+	"d7jzWk/NH6K/r3aTdvFRjgm/LzffMspSYjX3BNnEionR4YWARAFDxDgB60IjyclyCRySw95zwAXTWedq",
+	"//HmXM9QRqhEWB0fkakb8l3ZQDHEgVfrIXNoH541mu1QvIHn1z4NVbVEGUicYImt/3efYbaamzMOnUCb",
+	"PvM3T30HFemMppvDnoBaZ+BJjyJoC+vuFUGo7MIobXC6AzJGQsVewe3dvjfry5U+nH7uPNGPSBBlEunr",
+	"FlNyzrZ4+/YVugJr/f+8R2+zSCXJU0DmiTuygTvRtv+amQg3ID0OwdecSAhpoeMvJLkxLloKEroI/1F/",
+	"Xgv1h83rHwMh4hzLVR2RNG8GHHB6w6SB13cfxniShrgEHVTv0v+ywKmAQyPEJ3vUSzXqK3S1BPiWLeTU",
+	"sPkWUrTyuZmMMBr3J6OT+1M2pXJ/iKJ/qYvMNYX+R1ETvIUdamzihOAlZUKSWMwgXrF+b/XHuvUL1diP",
+	"jhXgRGd3Wny8ri+dp/8Bm16wOJkfTwczPwIz/uf0rL4fmr7uvx/6sBtz2yxOsGeH2ylL4MGa+r4Ord/q",
+	"XkR1eTrcpVNzdd9msYW90nvXYfeELBagj8yXSvCtQJrikXHT9ZKRTYt7ViVcCKfM7HfmYii8uUyJhakE",
+	"Iacf2eX4jebUZug68o/ujpn+KhAerv6NXepDSi4heYauGb8Cjq5JmqKEY0LbJkviJUxPkB4dJZCxZ8iy",
+	"Q6gTD5uyHH1klyjnTB18TBRF8Z7Qqf3MThJmry03MMUpcDmeuc0qBTvyu72VEPasEQKJo74QtEklSGzT",
+	"gCjzspWWpV2gMBFqtcy5XKmjK0sTUYXDApLLOWSkyKZbWZ9z0+lBGKF/TftR6vJH+9PlNjEKJQyEdpII",
+	"jdMiAWQhNG/ACtlXFZ3TvB5iqhP1kYLcs/L+VvQO43hX5YezyNMlCHTbfaoOj1PtiI1F+4Xpad5R6pyp",
+	"b4i/D8Sjg9gEjoxiU4LUHvXh/QawKjoCylpHtI2qrrBe9WkEtXuOEO4Ug+g2wYJbwPtX3fEbvh8OvrUo",
+	"HwLA6wDUFgjXnbaAeDfK5cM4hwwSYg6X8BniYnuwX9RDvLAjfEP9v7of08DV3ODK1pq6v63XIGlWQj28",
+	"B78r08dbe9EzCvrOv9whj8vPo/C2Di2g3N+LFEAep40Ka6HIqFuKbYewdSfyAsh8hzhL0yLf+y3p8zoJ",
+	"ySQRlgmQ94lUc+/R8WlcsCofA+k6ZwJdbpAtMEdSIjfIvkXvgoPrUnLTuK4l1wsRt/JcR6u7S3hJUgkc",
+	"SYZkXa9KIKWUY5ludDYxR3KFKZIrItDFy7PHjx//GUmSgZA4y/X7/l3np4/NCz89udfEcA/7vXf8qkGT",
+	"3+b3Wm4bBv228UZsvC7TBTowFfjsvjp0U+c9+7AqFtq7/UyZwl2jzMziYY3+FhlSv8FjLDw016bXJAGk",
+	"JkwJpjEYLlblIo916cRDDzAky6e2kuS0qnDVC5J2acVRr5V+T1qwvUCfHsT0ChKTy2AfCYpvSnDX3ocw",
+	"d09yBSgrOV8XRz1QUwBNCF0OAZ2XRTdHAt0U6fwnBrpZYBjoimHfgL4fa6/B7Ae6VtBhoJtSnH24NgVA",
+	"d2nhWyVGPSx5C3xNYkBEoLJ26M0kerpPqTRIKIuWIsZRQfEaE1N7qS8RtTpDqnM4Toj+WxfVRgfV75m1",
+	"RDNkWrewpc3yeLd4qCrxcjinY1foaFfZ9AhHnzPvP7U1dDOgk1pXVlojYv59iaul0HcRO+zWxN1zsqpb",
+	"ATUg5/tPUC3NGjq4xMajU/tkgkg+QTnjcoJAxkeHe8++eWUpQThVQNog+EyU9icUNRVAIEVV/0bT1gF7",
+	"DevjL7bi9E0zTXXGQbB0PRCsf+VmY1/YPmMyIRtlrn/H6ZB2xc3HzveXF/kza5JR2Tb9IFIfXRhvpTx3",
+	"Ig96NebJUz2Srp2jU5YuAemcMDXiIOj6cikt8kalQiuQPcwkaEN3MscSCZD7z4F+5eTW92Y/j1EQwxnP",
+	"9yuKk73aqoclzTKheYwcK0cEy3jlUdzq471Lcjcej1u7es93pqM8nvt6ctv1eB4WoI3kUFZIbaNMaI1A",
+	"mojt/ZiyfnPPeetNVeJ518XI3NLaPXfaOqTf4spfQRrrax8op8226EAS4JPy2ldM0KeCSSwm9j7OPYJW",
+	"VWJDLLlgJsq1u8esSUaonqXXhWIpPIDzn2JX8PznPmDuu0J3RnFEMTNnn36HWnPLePW7etoY+MnQfT9t",
+	"7P4kp/edvmqluX5vR8dGAZbyh9X2fTbUW4QkSOIroMFXijWvhgDa1aBVgc+QstBFQnepLLpVSD2MUI0e",
+	"gK5Q3ArqisJyKiSBRue+WFHN8LvXAd2qxnve/W6F2ICcH0CsiPGqXmTTh7pX3PmSOysloFoMYS+w+0ee",
+	"xpVoHuJpfO/ercbouMP3GKkMH77vl/Mne938D0ua5eF7jBw7zl+9uawfiHWF734/sKwGLkw58N/xKd1f",
+	"1/y2lay0J2QYeA+W4b3x/4w/StooMStE2Hwt2TBgtDNm4dALmYJuBZr3ZfNvsGnAhkPG1rp2RfkuQB52",
+	"AuCqSSlCXR16SyHelL9X7stgfcNinKIENMLsfW7B02gWraTMxez4OFUtdJTjT0+ePI5uPtz8fwAAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/app/internal/server/api_fleet_test.go
+++ b/app/internal/server/api_fleet_test.go
@@ -1,0 +1,495 @@
+// @spec api-fleet-observability
+//
+// AC traceability (this file):
+//   AC-01  TestAPI_Fleet_Score_MixedPassFail_ReturnsFraction
+//   AC-02  TestAPI_Fleet_Score_EmptyFleet_ZeroNotError
+//   AC-03  TestAPI_Fleet_Liveness_FourBucketsSumToActiveHosts
+//   AC-04  TestAPI_Fleet_TopFailingRules_OrderedDescByCount
+//   AC-05  TestAPI_Fleet_TopFailingHosts_OrderedDescByCount
+//   AC-06  TestAPI_Fleet_RecentChanges_OrderedDescByOccurred
+//   AC-07  TestAPI_Fleet_RecentChanges_SinceCursorFilters
+//   AC-08  TestAPI_Fleet_RecentChanges_MalformedSince_Returns400
+//   AC-09  TestAPI_Fleet_Limit_Overflow_Returns400
+//   AC-10  TestAPI_Fleet_Limit_Negative_Returns400
+//   AC-11  TestAPI_Fleet_Anonymous_Returns403
+//   AC-12  TestAPI_Fleet_ViewerSession_HappyPath
+//   AC-14  TestAPI_Fleet_NonGET_Returns405
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+)
+
+// ---------------------------------------------------------------------
+// Seed helpers (Slice B tables)
+// ---------------------------------------------------------------------
+
+func seedFleetHost(t *testing.T, pool *pgxpool.Pool, createdBy uuid.UUID) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, $3::inet, $4)`,
+		id, "fleet-"+id.String(), "192.0.2.10", createdBy)
+	if err != nil {
+		t.Fatalf("seed host: %v", err)
+	}
+	return id
+}
+
+func seedFleetRuleState(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status string) {
+	t.Helper()
+	now := time.Now().UTC()
+	scanID, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_rule_state
+			(host_id, rule_id, current_status, severity,
+			 last_checked_at, check_count, last_scan_id, evidence,
+			 framework_refs, first_seen_at, last_changed_at)
+		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, '{}'::jsonb, $4, $4)`,
+		hostID, ruleID, status, now, scanID,
+	)
+	if err != nil {
+		t.Fatalf("seed rule_state: %v", err)
+	}
+}
+
+func seedFleetLiveness(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, status string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_liveness (host_id, reachability_status, last_probe_at)
+		VALUES ($1, $2, now())`, hostID, status)
+	if err != nil {
+		t.Fatalf("seed liveness: %v", err)
+	}
+}
+
+func seedFleetTransaction(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status, changeKind string, occurredAt time.Time) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	scanID, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO transactions
+			(id, host_id, rule_id, scan_id, status, severity,
+			 change_kind, evidence, occurred_at)
+		VALUES ($1, $2, $3, $4, $5, 'medium', $6, '{}'::jsonb, $7)`,
+		id, hostID, ruleID, scanID, status, changeKind, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("seed transaction: %v", err)
+	}
+	return id
+}
+
+// firstSeededUserID reads back the viewer user the API server fixture
+// creates. We need it as the FK for seeded hosts.
+func firstSeededUserID(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(),
+		`SELECT id FROM users LIMIT 1`).Scan(&id)
+	if err != nil {
+		t.Fatalf("read seeded user: %v", err)
+	}
+	return id
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+// @ac AC-01
+// AC-01: GET /fleet/score on mixed pass/fail fleet returns the right
+// fraction + total in the typed schema.
+func TestAPI_Fleet_Score_MixedPassFail_ReturnsFraction(t *testing.T) {
+	t.Run("api-fleet-observability/AC-01", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h1 := seedFleetHost(t, pool, user)
+		h2 := seedFleetHost(t, pool, user)
+		seedFleetRuleState(t, pool, h1, "rule.a", "pass")
+		seedFleetRuleState(t, pool, h1, "rule.b", "pass")
+		seedFleetRuleState(t, pool, h1, "rule.c", "fail")
+		seedFleetRuleState(t, pool, h2, "rule.a", "pass")
+		seedFleetRuleState(t, pool, h2, "rule.b", "fail")
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/score", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			PassingFraction  float64 `json:"passing_fraction"`
+			TotalEvaluations int64   `json:"total_evaluations"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.TotalEvaluations != 5 {
+			t.Errorf("total_evaluations = %d, want 5", body.TotalEvaluations)
+		}
+		want := 3.0 / 5.0
+		if body.PassingFraction != want {
+			t.Errorf("passing_fraction = %v, want %v", body.PassingFraction, want)
+		}
+	})
+}
+
+// @ac AC-02
+// AC-02: empty fleet returns 200 with zeros, not an error.
+func TestAPI_Fleet_Score_EmptyFleet_ZeroNotError(t *testing.T) {
+	t.Run("api-fleet-observability/AC-02", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		req := asRole(t, "GET", url+"/api/v1/fleet/score", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			PassingFraction  float64 `json:"passing_fraction"`
+			TotalEvaluations int64   `json:"total_evaluations"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if body.TotalEvaluations != 0 || body.PassingFraction != 0 {
+			t.Errorf("empty fleet returned %+v, want zeros", body)
+		}
+	})
+}
+
+// @ac AC-03
+// AC-03: liveness rollup returns 4 buckets summing to active hosts.
+func TestAPI_Fleet_Liveness_FourBucketsSumToActiveHosts(t *testing.T) {
+	t.Run("api-fleet-observability/AC-03", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		hReach := seedFleetHost(t, pool, user)
+		hUnreach := seedFleetHost(t, pool, user)
+		hUnknown := seedFleetHost(t, pool, user)
+		_ = seedFleetHost(t, pool, user) // never-probed
+		_ = seedFleetHost(t, pool, user) // never-probed
+		seedFleetLiveness(t, pool, hReach, "reachable")
+		seedFleetLiveness(t, pool, hUnreach, "unreachable")
+		seedFleetLiveness(t, pool, hUnknown, "unknown")
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/liveness", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			Reachable   int64 `json:"reachable"`
+			Unreachable int64 `json:"unreachable"`
+			Unknown     int64 `json:"unknown"`
+			NeverProbed int64 `json:"never_probed"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if body.Reachable != 1 || body.Unreachable != 1 || body.Unknown != 1 || body.NeverProbed != 2 {
+			t.Errorf("got %+v, want {1,1,1,2}", body)
+		}
+		if total := body.Reachable + body.Unreachable + body.Unknown + body.NeverProbed; total != 5 {
+			t.Errorf("sum = %d, want 5", total)
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: top-failing-rules ordered DESC by count; ?limit caps.
+func TestAPI_Fleet_TopFailingRules_OrderedDescByCount(t *testing.T) {
+	t.Run("api-fleet-observability/AC-04", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h1, h2, h3 := seedFleetHost(t, pool, user), seedFleetHost(t, pool, user), seedFleetHost(t, pool, user)
+		// rule.A on 3, rule.B on 2, rule.C on 1.
+		seedFleetRuleState(t, pool, h1, "rule.A", "fail")
+		seedFleetRuleState(t, pool, h2, "rule.A", "fail")
+		seedFleetRuleState(t, pool, h3, "rule.A", "fail")
+		seedFleetRuleState(t, pool, h1, "rule.B", "fail")
+		seedFleetRuleState(t, pool, h2, "rule.B", "fail")
+		seedFleetRuleState(t, pool, h1, "rule.C", "fail")
+		seedFleetRuleState(t, pool, h1, "rule.D", "pass") // must NOT appear
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/top-failing-rules", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			Items []struct {
+				RuleID           string `json:"rule_id"`
+				FailingHostCount int64  `json:"failing_host_count"`
+			} `json:"items"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Items) != 3 {
+			t.Fatalf("got %d items, want 3", len(body.Items))
+		}
+		if body.Items[0].RuleID != "rule.A" || body.Items[0].FailingHostCount != 3 {
+			t.Errorf("Items[0] = %+v, want {rule.A,3}", body.Items[0])
+		}
+		if body.Items[2].FailingHostCount != 1 {
+			t.Errorf("Items[2] = %+v, want last by count", body.Items[2])
+		}
+
+		// limit cap.
+		req = asRole(t, "GET", url+"/api/v1/fleet/top-failing-rules?limit=2", auth.RoleViewer, nil)
+		resp2 := doReq(t, req)
+		defer resp2.Body.Close()
+		_ = json.NewDecoder(resp2.Body).Decode(&body)
+		if len(body.Items) != 2 {
+			t.Errorf("with ?limit=2 got %d items", len(body.Items))
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: top-failing-hosts ordered DESC by count.
+func TestAPI_Fleet_TopFailingHosts_OrderedDescByCount(t *testing.T) {
+	t.Run("api-fleet-observability/AC-05", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		worst := seedFleetHost(t, pool, user)
+		mid := seedFleetHost(t, pool, user)
+		best := seedFleetHost(t, pool, user)
+		seedFleetRuleState(t, pool, worst, "rule.1", "fail")
+		seedFleetRuleState(t, pool, worst, "rule.2", "fail")
+		seedFleetRuleState(t, pool, worst, "rule.3", "fail")
+		seedFleetRuleState(t, pool, mid, "rule.1", "fail")
+		seedFleetRuleState(t, pool, mid, "rule.2", "fail")
+		seedFleetRuleState(t, pool, best, "rule.1", "fail")
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/top-failing-hosts", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			Items []struct {
+				HostID           string `json:"host_id"`
+				FailingRuleCount int64  `json:"failing_rule_count"`
+			} `json:"items"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Items) != 3 {
+			t.Fatalf("got %d items, want 3", len(body.Items))
+		}
+		if body.Items[0].HostID != worst.String() || body.Items[0].FailingRuleCount != 3 {
+			t.Errorf("Items[0] = %+v, want {worst,3}", body.Items[0])
+		}
+	})
+}
+
+// @ac AC-06
+// AC-06: recent-changes ordered DESC by occurred_at.
+func TestAPI_Fleet_RecentChanges_OrderedDescByOccurred(t *testing.T) {
+	t.Run("api-fleet-observability/AC-06", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h := seedFleetHost(t, pool, user)
+		t0 := time.Now().UTC().Truncate(time.Second)
+		seedFleetTransaction(t, pool, h, "rule.a", "fail", "state_changed", t0)
+		seedFleetTransaction(t, pool, h, "rule.b", "pass", "state_changed", t0.Add(time.Minute))
+		seedFleetTransaction(t, pool, h, "rule.c", "fail", "first_seen", t0.Add(2*time.Minute))
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/recent-changes", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			Items []struct {
+				RuleID     string    `json:"rule_id"`
+				OccurredAt time.Time `json:"occurred_at"`
+			} `json:"items"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Items) != 3 {
+			t.Fatalf("got %d items, want 3", len(body.Items))
+		}
+		if body.Items[0].RuleID != "rule.c" {
+			t.Errorf("Items[0].RuleID = %q, want rule.c (newest)", body.Items[0].RuleID)
+		}
+		if body.Items[2].RuleID != "rule.a" {
+			t.Errorf("Items[2].RuleID = %q, want rule.a (oldest)", body.Items[2].RuleID)
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: ?since filters to strictly-newer rows.
+func TestAPI_Fleet_RecentChanges_SinceCursorFilters(t *testing.T) {
+	t.Run("api-fleet-observability/AC-07", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h := seedFleetHost(t, pool, user)
+		t0 := time.Now().UTC().Truncate(time.Second)
+		seedFleetTransaction(t, pool, h, "old", "fail", "state_changed", t0)
+		seedFleetTransaction(t, pool, h, "middle", "pass", "state_changed", t0.Add(time.Minute))
+		seedFleetTransaction(t, pool, h, "new", "fail", "first_seen", t0.Add(2*time.Minute))
+
+		since := t0.Format(time.RFC3339)
+		req := asRole(t, "GET", url+"/api/v1/fleet/recent-changes?since="+since, auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		var body struct {
+			Items []struct {
+				RuleID string `json:"rule_id"`
+			} `json:"items"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		// Strictly newer than t0 → middle + new (not "old").
+		if len(body.Items) != 2 {
+			t.Errorf("with since=t0 got %d items, want 2", len(body.Items))
+		}
+		for _, it := range body.Items {
+			if it.RuleID == "old" {
+				t.Errorf("rule.old should have been filtered out by since=t0")
+			}
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: malformed since returns 400.
+func TestAPI_Fleet_RecentChanges_MalformedSince_Returns400(t *testing.T) {
+	t.Run("api-fleet-observability/AC-08", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		req := asRole(t, "GET", url+"/api/v1/fleet/recent-changes?since=not-a-date", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09: ?limit=2000 (> MaxLimit) returns 400 pagination.limit_exceeded.
+func TestAPI_Fleet_Limit_Overflow_Returns400(t *testing.T) {
+	t.Run("api-fleet-observability/AC-09", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		for _, ep := range []string{
+			"/api/v1/fleet/top-failing-rules?limit=2000",
+			"/api/v1/fleet/top-failing-hosts?limit=2000",
+			"/api/v1/fleet/recent-changes?limit=2000",
+		} {
+			req := asRole(t, "GET", url+ep, auth.RoleViewer, nil)
+			resp := doReq(t, req)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("%s status = %d, want 400; body=%s", ep, resp.StatusCode, body)
+				continue
+			}
+			if !strings.Contains(string(body), "pagination.limit_exceeded") {
+				t.Errorf("%s body lacks pagination.limit_exceeded: %s", ep, body)
+			}
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: ?limit=-1 returns 400 pagination.limit_exceeded.
+func TestAPI_Fleet_Limit_Negative_Returns400(t *testing.T) {
+	t.Run("api-fleet-observability/AC-10", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		req := asRole(t, "GET", url+"/api/v1/fleet/top-failing-rules?limit=-1", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		// oapi-codegen schema minimum=1 catches this first → either 400
+		// from codegen, or 400 from our validatePaginatedLimit. Either
+		// way 400 is correct.
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400; body=%s", resp.StatusCode, body)
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: anonymous request returns 403 authz.permission_denied.
+func TestAPI_Fleet_Anonymous_Returns403(t *testing.T) {
+	t.Run("api-fleet-observability/AC-11", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		req, _ := http.NewRequest("GET", url+"/api/v1/fleet/score", nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 403; body=%s", resp.StatusCode, b)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(b), "authz.permission_denied") {
+			t.Errorf("body lacks authz.permission_denied: %s", b)
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: viewer session (has system:read) → 200 on every fleet endpoint.
+func TestAPI_Fleet_ViewerSession_HappyPath(t *testing.T) {
+	t.Run("api-fleet-observability/AC-12", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		for _, ep := range []string{
+			"/api/v1/fleet/score",
+			"/api/v1/fleet/liveness",
+			"/api/v1/fleet/top-failing-rules",
+			"/api/v1/fleet/top-failing-hosts",
+			"/api/v1/fleet/recent-changes",
+		} {
+			req := asRole(t, "GET", url+ep, auth.RoleViewer, nil)
+			resp := doReq(t, req)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("%s status = %d, want 200; body=%s", ep, resp.StatusCode, body)
+			}
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: POST against a /fleet endpoint returns 405.
+func TestAPI_Fleet_NonGET_Returns405(t *testing.T) {
+	t.Run("api-fleet-observability/AC-14", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		for _, ep := range []string{
+			"/api/v1/fleet/score",
+			"/api/v1/fleet/liveness",
+			"/api/v1/fleet/top-failing-rules",
+			"/api/v1/fleet/top-failing-hosts",
+			"/api/v1/fleet/recent-changes",
+		} {
+			req := asRole(t, "POST", url+ep, auth.RoleViewer, map[string]any{})
+			resp := doReq(t, req)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Errorf("POST %s status = %d, want 405; body=%s", ep, resp.StatusCode, body)
+			}
+		}
+	})
+}

--- a/app/internal/server/api_helpers_test.go
+++ b/app/internal/server/api_helpers_test.go
@@ -98,6 +98,16 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	}
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE idempotency_keys")
+	// Slice-B tables. Clear children before hosts to avoid FK violations.
+	// transactions + host_rule_state FK to hosts ON DELETE RESTRICT;
+	// host_compliance_schedule + host_backoff_state FK to hosts;
+	// host_liveness FK CASCADE so it's safe at any order but explicit
+	// is clearer.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE transactions")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_rule_state")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_liveness")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_compliance_schedule")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_backoff_state")
 	// Slice-A tables. Order matters: credentials FK → hosts, so clear
 	// credentials first. users CASCADE clears sessions/refresh/mfa.
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE credentials")

--- a/app/internal/server/fleet_handlers.go
+++ b/app/internal/server/fleet_handlers.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	openapitypes "github.com/oapi-codegen/runtime/types"
+
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// Fleet observability endpoints.
+//
+// Spec: app/specs/api/fleet-observability.spec.yaml.
+//
+// Every handler is a thin wrapper: RBAC gate, parse/validate, delegate
+// to internal/fleetrollup.Service, JSON-encode. No SQL, no aggregation
+// logic — those live in the fleetrollup package. AC-13 enforces the
+// SQL-free invariant via source inspection.
+
+// GetFleetScore implements api.ServerInterface.GetFleetScore.
+// Spec api-fleet-observability AC-01, AC-02, AC-11, AC-12.
+func (h *handlers) GetFleetScore(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
+		return
+	}
+	score, err := h.fleet.FleetComplianceScore(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"failed to compute fleet compliance score", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.FleetScore{
+		PassingFraction:  score.PassingFraction,
+		TotalEvaluations: score.TotalEvaluations,
+	})
+}
+
+// GetFleetLiveness implements api.ServerInterface.GetFleetLiveness.
+// Spec api-fleet-observability AC-03, AC-11, AC-12.
+func (h *handlers) GetFleetLiveness(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
+		return
+	}
+	roll, err := h.fleet.FleetLiveness(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"failed to compute fleet liveness", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.FleetLiveness{
+		Reachable:   roll.Reachable,
+		Unreachable: roll.Unreachable,
+		Unknown:     roll.Unknown,
+		NeverProbed: roll.NeverProbed,
+	})
+}
+
+// GetFleetTopFailingRules implements api.ServerInterface.GetFleetTopFailingRules.
+// Spec api-fleet-observability AC-04, AC-09, AC-10, AC-11, AC-12.
+func (h *handlers) GetFleetTopFailingRules(w http.ResponseWriter, r *http.Request, params api.GetFleetTopFailingRulesParams) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
+		return
+	}
+	limit, ok := validatePaginatedLimit(w, params.Limit)
+	if !ok {
+		return
+	}
+	rows, err := h.fleet.TopFailingRules(r.Context(), limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"failed to query top failing rules", true)
+		return
+	}
+	out := make([]api.FleetRuleFailure, len(rows))
+	for i, row := range rows {
+		out[i] = api.FleetRuleFailure{
+			RuleId:           row.RuleID,
+			FailingHostCount: row.FailingHostCount,
+		}
+	}
+	writeJSON(w, http.StatusOK, api.FleetTopFailingRules{Items: out})
+}
+
+// GetFleetTopFailingHosts implements api.ServerInterface.GetFleetTopFailingHosts.
+// Spec api-fleet-observability AC-05, AC-09, AC-10, AC-11, AC-12.
+func (h *handlers) GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Request, params api.GetFleetTopFailingHostsParams) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
+		return
+	}
+	limit, ok := validatePaginatedLimit(w, params.Limit)
+	if !ok {
+		return
+	}
+	rows, err := h.fleet.TopFailingHosts(r.Context(), limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"failed to query top failing hosts", true)
+		return
+	}
+	out := make([]api.FleetHostFailure, len(rows))
+	for i, row := range rows {
+		out[i] = api.FleetHostFailure{
+			HostId:           openapitypes.UUID(row.HostID),
+			FailingRuleCount: row.FailingRuleCount,
+		}
+	}
+	writeJSON(w, http.StatusOK, api.FleetTopFailingHosts{Items: out})
+}
+
+// GetFleetRecentChanges implements api.ServerInterface.GetFleetRecentChanges.
+// Spec api-fleet-observability AC-06, AC-07, AC-09, AC-10, AC-11, AC-12.
+func (h *handlers) GetFleetRecentChanges(w http.ResponseWriter, r *http.Request, params api.GetFleetRecentChangesParams) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
+		return
+	}
+	limit, ok := validatePaginatedLimit(w, params.Limit)
+	if !ok {
+		return
+	}
+	// since is already typed *time.Time by oapi-codegen — malformed
+	// values are rejected upstream by the codegen wrapper with 400.
+	var since = nilOrTime(params.Since)
+	rows, err := h.fleet.RecentChanges(r.Context(), since, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"failed to query recent changes", true)
+		return
+	}
+	out := make([]api.FleetTransaction, len(rows))
+	for i, row := range rows {
+		t := api.FleetTransaction{
+			Id:         openapitypes.UUID(row.ID),
+			HostId:     openapitypes.UUID(row.HostID),
+			RuleId:     row.RuleID,
+			Status:     api.FleetTransactionStatus(row.Status),
+			ChangeKind: api.FleetTransactionChangeKind(row.ChangeKind),
+			OccurredAt: row.OccurredAt,
+		}
+		if row.Severity != "" {
+			s := row.Severity
+			t.Severity = &s
+		}
+		out[i] = t
+	}
+	writeJSON(w, http.StatusOK, api.FleetRecentChanges{Items: out})
+}

--- a/app/internal/server/fleet_helpers.go
+++ b/app/internal/server/fleet_helpers.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/fleetrollup"
+)
+
+// validatePaginatedLimit reads the optional ?limit= parameter and
+// returns the value to pass into fleetrollup. On nil it returns the
+// default (50). On values outside [1, fleetrollup.MaxLimit] it writes
+// a 400 pagination.limit_exceeded and returns (0, false).
+//
+// Spec api-fleet-observability AC-09, AC-10.
+func validatePaginatedLimit(w http.ResponseWriter, raw *int) (int, bool) {
+	if raw == nil {
+		return 50, true
+	}
+	v := *raw
+	if v < 1 || v > fleetrollup.MaxLimit {
+		writeError(w, http.StatusBadRequest, "pagination.limit_exceeded", "client",
+			"limit must be between 1 and 1000", false)
+		return 0, false
+	}
+	return v, true
+}
+
+// nilOrTime dereferences a *time.Time or returns the zero value. The
+// fleetrollup methods interpret time.Time{} as "no cursor".
+func nilOrTime(p *time.Time) time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return *p
+}

--- a/app/internal/server/fleet_source_test.go
+++ b/app/internal/server/fleet_source_test.go
@@ -1,0 +1,64 @@
+// @spec api-fleet-observability
+//
+// AC traceability (this file):
+//   AC-13  TestFleetHandlers_NoSQL_NoPoolAccess
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func fleetHandlerSources(t *testing.T) []string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	return []string{
+		filepath.Join(dir, "fleet_handlers.go"),
+		filepath.Join(dir, "fleet_helpers.go"),
+	}
+}
+
+// @ac AC-13
+// AC-13: fleet handler files contain no SQL statements (SELECT/INSERT/
+// UPDATE/DELETE) and no direct h.pool.Query / h.pool.Exec calls. All
+// data access goes through h.fleet.* methods on fleetrollup.Service.
+func TestFleetHandlers_NoSQL_NoPoolAccess(t *testing.T) {
+	t.Run("api-fleet-observability/AC-13", func(t *testing.T) {
+		sqlPatterns := []*regexp.Regexp{
+			regexp.MustCompile(`(?i)\bSELECT\s`),
+			regexp.MustCompile(`(?i)\bINSERT\s+INTO\b`),
+			regexp.MustCompile(`(?i)\bUPDATE\s+\w+\s+SET\b`),
+			regexp.MustCompile(`(?i)\bDELETE\s+FROM\b`),
+		}
+		poolPattern := regexp.MustCompile(`h\.pool\.(Query|QueryRow|Exec|Begin)\b`)
+
+		for _, f := range fleetHandlerSources(t) {
+			b, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			src := string(b)
+			for _, p := range sqlPatterns {
+				if p.MatchString(src) {
+					t.Errorf("%s contains SQL matching %q — fleet handlers must delegate to fleetrollup.Service (AC-13)",
+						filepath.Base(f), p.String())
+				}
+			}
+			if poolPattern.MatchString(src) {
+				t.Errorf("%s contains direct h.pool access — must go through h.fleet (AC-13)",
+					filepath.Base(f))
+			}
+			// Must reference h.fleet to confirm delegation actually happens.
+			if !strings.Contains(src, "h.fleet.") && filepath.Base(f) == "fleet_handlers.go" {
+				t.Errorf("%s never references h.fleet — handlers do not delegate to fleetrollup.Service (AC-13)",
+					filepath.Base(f))
+			}
+		}
+	})
+}

--- a/app/internal/server/handlers.go
+++ b/app/internal/server/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/fleetrollup"
 	"github.com/Hanalyx/openwatch/internal/host"
 	"github.com/Hanalyx/openwatch/internal/license"
 	"github.com/Hanalyx/openwatch/internal/policy"
@@ -35,6 +36,7 @@ type handlers struct {
 	users       *users.Service
 	credentials *credential.Service
 	hosts       *host.Service
+	fleet       *fleetrollup.Service
 }
 
 // newHandlers constructs the ServerInterface implementation. The user
@@ -46,6 +48,7 @@ func newHandlers(pool *pgxpool.Pool) *handlers {
 		users:       users.NewService(pool, nil),
 		credentials: credential.NewService(pool),
 		hosts:       host.NewService(pool),
+		fleet:       fleetrollup.NewService(pool),
 	}
 }
 

--- a/app/specs/api/fleet-observability.spec.yaml
+++ b/app/specs/api/fleet-observability.spec.yaml
@@ -1,0 +1,127 @@
+spec:
+  id: api-fleet-observability
+  title: Fleet observability endpoints (read-only Slice B exposure)
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Read-only HTTP exposure of internal/fleetrollup aggregations
+    description: >
+      Slice B built fleetrollup as a Go-level API but exposed nothing
+      over HTTP. This spec adds five read-only endpoints that wrap
+      the existing fleetrollup.Service methods — fleet compliance
+      score, fleet liveness counts, top failing rules, top failing
+      hosts, and recent change transactions. The handlers are thin:
+      parse + validate + delegate + JSON-encode. All heavy logic
+      stays in internal/fleetrollup.
+
+      Every endpoint requires the system:read permission via
+      auth.EnforcePermission middleware. No mutation, no side
+      effects.
+    related_specs:
+      - system-fleet-rollup
+      - system-host-inventory
+      - system-rbac
+
+  objective:
+    summary: >
+      Five GET routes under /api/v1/fleet. Each returns a typed JSON
+      response that mirrors the fleetrollup struct shape. Caller-
+      provided limits are clamped (negative -> 0, > 1000 -> 1000)
+      inside fleetrollup; the handler returns 400 only for malformed
+      input (non-numeric limit, malformed since timestamp).
+    scope:
+      includes:
+        - "GET /api/v1/fleet/score"
+        - "GET /api/v1/fleet/liveness"
+        - "GET /api/v1/fleet/top-failing-rules"
+        - "GET /api/v1/fleet/top-failing-hosts"
+        - "GET /api/v1/fleet/recent-changes"
+        - RBAC enforcement (system:read)
+        - Typed response schemas in openapi.yaml
+      excludes:
+        - Push/SSE (this is poll-only; subscribe-style fanout is
+          event-bus territory)
+        - Mutating operations (read-only by C-01)
+        - Cross-tenant scoping (single-tenant Stage 0)
+
+  constraints:
+    - id: C-01
+      description: All endpoints MUST be GET only. POST/PUT/DELETE return 405
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: Every endpoint MUST require the system:read permission via auth.EnforcePermission. Both anonymous callers and authenticated callers without system:read return 403 authz.permission_denied (matches the established RBAC pattern — see system-rbac AC-09)
+      type: security
+      enforcement: error
+    - id: C-03
+      description: Default limit for paginated endpoints (top-failing-rules, top-failing-hosts, recent-changes) MUST be 50; maximum 1000 (matches fleetrollup.MaxLimit). Caller-provided limit < 1 or > 1000 returns 400 pagination.limit_exceeded
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: GET /fleet/recent-changes MUST accept optional since (RFC3339 timestamp). Malformed since returns 400 (per oapi-codegen's default validation handler)
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: All response shapes MUST be typed structs in openapi.yaml — no map[string]any in responses
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: Handlers MUST delegate query work to internal/fleetrollup.Service without re-implementing SQL or aggregation logic. Source-inspection enforces (AC-13)
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: GET /api/v1/fleet/score returns 200 with {passing_fraction, total_evaluations} populated from host_rule_state — typed response struct, no map[string]any.
+      priority: critical
+      references_constraints: [C-01, C-05]
+    - id: AC-02
+      description: GET /api/v1/fleet/score on an empty fleet returns 200 with {passing_fraction=0, total_evaluations=0} — never an error.
+      priority: critical
+    - id: AC-03
+      description: GET /api/v1/fleet/liveness returns 200 with four counts (reachable, unreachable, unknown, never_probed) that sum to the count of active hosts.
+      priority: critical
+    - id: AC-04
+      description: GET /api/v1/fleet/top-failing-rules returns 200 with items sorted by failing_host_count DESC. Default limit 50, ?limit=10 returns at most 10.
+      priority: critical
+    - id: AC-05
+      description: GET /api/v1/fleet/top-failing-hosts returns 200 with items sorted by failing_rule_count DESC. Default limit 50.
+      priority: critical
+    - id: AC-06
+      description: GET /api/v1/fleet/recent-changes returns 200 with transactions ordered by occurred_at DESC. Default limit 50.
+      priority: critical
+    - id: AC-07
+      description: GET /api/v1/fleet/recent-changes?since=2026-05-01T00:00:00Z filters to transactions strictly newer than the cursor.
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-08
+      description: GET /api/v1/fleet/recent-changes?since=not-a-date returns 400 (handled by oapi-codegen's default ErrorHandlerFunc on InvalidParamFormatError).
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-09
+      description: ?limit=2000 on any paginated endpoint returns 400 pagination.limit_exceeded.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-10
+      description: ?limit=-1 on any paginated endpoint returns 400 pagination.limit_exceeded.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-11
+      description: Anonymous (no session) request to any /fleet endpoint returns 403 authz.permission_denied (per system-rbac AC-09).
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-12
+      description: For one or more /fleet endpoints, the happy path with a viewer session returns 200 — confirming the system:read permission included in RoleViewer suffices.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-13
+      description: Source-inspection — internal/server/fleet_handlers.go contains no SQL statements (no SELECT/INSERT/UPDATE) and no direct pool.Query/Exec calls. All data access goes through fleetrollup.Service methods.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-14
+      description: POST /api/v1/fleet/score returns 405 method_not_allowed (and similarly for the other four endpoints).
+      priority: high
+      references_constraints: [C-01]


### PR DESCRIPTION
## Summary

Closes the visibility gap identified after Slice B landed: the
fleetrollup package was a Go-level API with no HTTP surface. This PR
wraps it with five read-only endpoints.

| Endpoint | Returns |
|----------|---------|
| \`GET /api/v1/fleet/score\` | passing/total compliance fraction |
| \`GET /api/v1/fleet/liveness\` | 4-bucket reachability counts |
| \`GET /api/v1/fleet/top-failing-rules\` | rules with most failing hosts |
| \`GET /api/v1/fleet/top-failing-hosts\` | hosts with most failing rules |
| \`GET /api/v1/fleet/recent-changes\` | transactions DESC, optional \`?since\` cursor |

## Spec

\`app/specs/api/fleet-observability.spec.yaml\` (status: approved) — **14 ACs across 6 constraints**, all at 100%.

## RBAC + pagination

- Every endpoint requires \`system:read\` (in RoleViewer and above)
- Anonymous returns 403 \`authz.permission_denied\` (per system-rbac AC-09)
- Paginated endpoints default to \`limit=50\`, max 1000
- Out-of-range \`?limit\` returns 400 \`pagination.limit_exceeded\`
- Malformed \`?since\` returns 400 (oapi-codegen InvalidParamFormatError)

## Architectural invariant (AC-13)

\`fleet_handlers.go\` and \`fleet_helpers.go\` contain **no SQL**, **no direct \`h.pool\` access**, and **must reference \`h.fleet\`** — enforced by regex source inspection. All data access goes through \`internal/fleetrollup.Service\`.

## Verification

\`\`\`
go vet ./...                  clean
go test -race -count=1        PASS (9.1s with Postgres)
specter parse                 PASS (api-fleet-observability@1.0.0)
specter check                 PASS
specter coverage              api-fleet-observability 14/14 (100%)
\`\`\`

## Test plan

- [ ] CI Quality + security gates pass (vet, lint, vuln, test-race, specter sync)
- [ ] Confirm \`api-fleet-observability\` reaches 100% in \`specter coverage\`
- [ ] Manual smoke after merge: \`curl -H "Cookie: session=..." .../api/v1/fleet/score\`