### PR TITLE
feat(slice-bc): framework-at-query-time architectural correction + 3 new specs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -324,665 +324,672 @@
         "filename": "app/internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 773
+        "line_number": 792
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "27d043f95f1559d4082ee182db00c0b9341ed929",
-        "is_verified": false,
-        "line_number": 2593
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8aaf49f4614e56378a639a8acf12fee40c611fcb",
-        "is_verified": false,
-        "line_number": 2594
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1fa8c97cf4ffc61555b41cbccd8cd0e8dc3956e6",
-        "is_verified": false,
-        "line_number": 2595
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "04994d6bc1fc812832d98f33a55aef7b4ba79186",
-        "is_verified": false,
-        "line_number": 2596
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cf40c6e4ae1091379a6959ceb90d051657024894",
-        "is_verified": false,
-        "line_number": 2597
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d4caa37b101073e0722f33c497beff9eb6f00855",
-        "is_verified": false,
-        "line_number": 2598
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8627632e75ca89cbaa7d8b1a5a6d1578b195855b",
-        "is_verified": false,
-        "line_number": 2599
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "44473d6aa4b9494113bbe8da737334b0f3d34180",
-        "is_verified": false,
-        "line_number": 2600
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0a6bcd7d539115a9e123d40ca73243ea3d4bfdc7",
-        "is_verified": false,
-        "line_number": 2601
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7ee6d746e1b1c6a7cb072a8f026b6fda1f06b0bd",
-        "is_verified": false,
-        "line_number": 2602
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c60b16cfd6447d61565c48e33cf6604a56e204b7",
-        "is_verified": false,
-        "line_number": 2603
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb3b0d11bef554977009cdc0da44d803b4236247",
-        "is_verified": false,
-        "line_number": 2604
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "468aa8f9df5ff2deef2f8a37d5ec9d5b0a0d1d2e",
-        "is_verified": false,
-        "line_number": 2605
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "08ec5a6c25417d2583b66c4e53b30a726648b2fd",
-        "is_verified": false,
-        "line_number": 2606
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bd40e1bf4d7e521917f84608fabf395fc30613a1",
-        "is_verified": false,
-        "line_number": 2607
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c084473a31dd952807852b82d08e925486b6b53f",
-        "is_verified": false,
-        "line_number": 2608
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c72359aa7716b1601dda5fb535522af2db33560c",
-        "is_verified": false,
-        "line_number": 2609
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2d77e4db82a2152429171811900c6024a4c67f7a",
-        "is_verified": false,
-        "line_number": 2610
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9b951be7edd064ed9090afe1f0cb656319915d28",
-        "is_verified": false,
-        "line_number": 2611
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3240e5f1306caa79b612383b2df47b8dcac4f34f",
-        "is_verified": false,
-        "line_number": 2612
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ebdce38fe37f3517d619eb5b6de1042756099fd1",
-        "is_verified": false,
-        "line_number": 2613
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1c1fbc9650f7de469e54c079b705f81d8c4da0f6",
-        "is_verified": false,
-        "line_number": 2614
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e459ba2de45cfffdbb2c575f2df04f820094744a",
-        "is_verified": false,
-        "line_number": 2615
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8e8fec073d19eedfcef33b30e53870136d9134e9",
-        "is_verified": false,
-        "line_number": 2616
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9f2a076f53a086894fcdb9bce644820e82eb9909",
-        "is_verified": false,
-        "line_number": 2617
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a272c57dfe79b09b8badcb76e2f5e9e64a9bc0a5",
-        "is_verified": false,
-        "line_number": 2618
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb55bedde5a639141cb5a124d155752fc1997d55",
-        "is_verified": false,
-        "line_number": 2619
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb5a34a304dfea466e48c548c77ab95b3fa64e5a",
-        "is_verified": false,
-        "line_number": 2620
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "baed435ffaee32dde87cfbd88e0de8f34e7b5da9",
-        "is_verified": false,
-        "line_number": 2621
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bf70b5d8689bf55a63cbc310c7898f716cc02feb",
-        "is_verified": false,
-        "line_number": 2622
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0423d9bf1b8cf149f850fee888a1fff7a1e5f925",
-        "is_verified": false,
-        "line_number": 2623
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "97e7646a4c35291c5103aa14baae05835e73fc88",
-        "is_verified": false,
-        "line_number": 2624
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "438703e1fca79ec2d1609608548194398e28217a",
-        "is_verified": false,
-        "line_number": 2625
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d36275869fa21512062ab663526942a8c8c102d4",
-        "is_verified": false,
-        "line_number": 2626
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "868cf380958e763a4ba99992e7913f44f6bc8674",
-        "is_verified": false,
-        "line_number": 2627
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d1ac866a4361261c5ae115b85ad0f1f3ec7cde30",
-        "is_verified": false,
-        "line_number": 2628
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b8fd85420b4b28233e641df46f6d5fda79850e0f",
-        "is_verified": false,
-        "line_number": 2629
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "507ba204e4f38e8e957d69e2be63a10e9afd8d15",
-        "is_verified": false,
-        "line_number": 2630
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a59f9b2f8c4def30c89a8799e29d98a34b0423f3",
-        "is_verified": false,
-        "line_number": 2631
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b0ae0757e56ef309b79bbbe3d75b56037b856886",
-        "is_verified": false,
-        "line_number": 2632
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eea07c6d7d65e8832054c8cb586da346ff774d59",
-        "is_verified": false,
-        "line_number": 2633
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ad709ea0932317a490c96f815f377eb35c8a5dce",
-        "is_verified": false,
-        "line_number": 2634
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "476671a9922092107320d31ff96542f7ce604275",
-        "is_verified": false,
-        "line_number": 2635
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cba23a411198f4b12dbb06cf7092d62ea6933418",
-        "is_verified": false,
-        "line_number": 2636
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c0be1d9f3aaa966ab468c125e2aadf4c1d305002",
-        "is_verified": false,
-        "line_number": 2637
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3e310bb68a7cbf346404f18788761e4f7a3d24a7",
-        "is_verified": false,
-        "line_number": 2638
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4dbd8baf97a14f1c6db84dfc70e5de1767d62077",
-        "is_verified": false,
-        "line_number": 2639
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b613fe7dc0d4c9098a1fec7850fcaa26044cca5e",
-        "is_verified": false,
-        "line_number": 2640
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f16c78daf0ac517f7748c8ab1f30b84dc0f9d276",
-        "is_verified": false,
-        "line_number": 2641
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a3d66601a23bed04fade9ef8b31f19ca72473396",
-        "is_verified": false,
-        "line_number": 2642
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "43359088e4f850ac11befef65f4b978afd986952",
-        "is_verified": false,
-        "line_number": 2643
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e82736dca7d0707ddb791e8250f4ade7a7043d89",
-        "is_verified": false,
-        "line_number": 2644
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9fcdbeb231ad9d08b6de3a8e6755e4ab08c9e5ee",
-        "is_verified": false,
-        "line_number": 2645
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5105d598f50275d9bf5eec4f7a97d5d6b485c099",
-        "is_verified": false,
-        "line_number": 2646
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "78c6087df9d9590a7a03bea749a777586a80eb5c",
-        "is_verified": false,
-        "line_number": 2647
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "13271144ea3a69450417f7031b7111efd5bb712e",
-        "is_verified": false,
-        "line_number": 2648
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2008ebccdb02777c65a2edbb2a1c090f420d4dcc",
-        "is_verified": false,
-        "line_number": 2649
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3171968b7aecb98c3b8bdbc9ce6349a3c97b11d7",
-        "is_verified": false,
-        "line_number": 2650
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "08d80e4e316531972d055243f7c2cc03152f9e56",
-        "is_verified": false,
-        "line_number": 2651
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e4621666c61dbdbdcf7f3a72dcb706e4ce9ac6e6",
-        "is_verified": false,
-        "line_number": 2652
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bcf3c6a81cececfe435a0ac65d8e2d99c0856a3c",
-        "is_verified": false,
-        "line_number": 2653
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6c263d2c34dc4ba26ed021b7a55c161d2b577ea9",
-        "is_verified": false,
-        "line_number": 2654
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d0f2e720f7f63fc6159a70f3f7f15ef46ca63ce7",
-        "is_verified": false,
-        "line_number": 2655
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9b9af431a5a5db659bad1a8dc255962151d3f4e9",
-        "is_verified": false,
-        "line_number": 2656
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "083a0f0a80081cd6245e549d25d57ba17c1293bb",
-        "is_verified": false,
-        "line_number": 2657
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6a9faec852dd1628414439ae6bf7245352c5e2a8",
-        "is_verified": false,
-        "line_number": 2658
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "127da64c54b938fe9607719e968292c0724f2b74",
-        "is_verified": false,
-        "line_number": 2659
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "24673a96834b485278c75b25e72bbbb04b9fa4e5",
-        "is_verified": false,
-        "line_number": 2660
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9fdb059046914f2d86588ed0bc942009bd89bbcc",
-        "is_verified": false,
-        "line_number": 2661
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6d1fdd2ec0d4363ab2aa8481af253365616b30d7",
-        "is_verified": false,
-        "line_number": 2662
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9897a94f3241124a7d06ab6fff79ec85607cab9e",
-        "is_verified": false,
-        "line_number": 2663
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e78131100cd450bab65b40f03c915af7dfbb4d40",
-        "is_verified": false,
-        "line_number": 2664
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "378e8c7fedb4095a05aab0269c4fd1aef23a4ad4",
-        "is_verified": false,
-        "line_number": 2665
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f94570d6d8e72d807bc161c3795dfe235004656d",
-        "is_verified": false,
-        "line_number": 2666
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "34527ee297fe5aecae33d513eb6b0312df57450b",
-        "is_verified": false,
-        "line_number": 2667
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0f53082bd6f5a77a0009dcbd258964eaa286af06",
-        "is_verified": false,
-        "line_number": 2668
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9dc1844a042e4b4e683e3a7ad7bc9b75bbd41ac5",
-        "is_verified": false,
-        "line_number": 2669
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7e2845d0b934ce015d62d9b27986cadafa0361ef",
-        "is_verified": false,
-        "line_number": 2670
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d9a781b873ca25b3931ed16417310dab2ef11d9f",
-        "is_verified": false,
-        "line_number": 2671
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a16508d02f8e793d703aa540c69031b8eb06c0f3",
-        "is_verified": false,
-        "line_number": 2672
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b819094361b037640d1b4ee74e121b8d51df9963",
-        "is_verified": false,
-        "line_number": 2673
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0ada40ec31b19b06c65de38946e2ba5cd2642a29",
-        "is_verified": false,
-        "line_number": 2674
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3073df1564642739b9858b558c8ef9f4d77c960c",
-        "is_verified": false,
-        "line_number": 2675
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0b97ca091d7a7823251bf004e27b5813fb89e707",
-        "is_verified": false,
-        "line_number": 2676
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4ab59bea132e64b0b33da7fce5ae59ff2b4f41c3",
-        "is_verified": false,
-        "line_number": 2677
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "13900c6388ce3550f68af8a424e5b42770b4827a",
-        "is_verified": false,
-        "line_number": 2678
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5a1bf188f3581e93d06401a05928ddd4350359d6",
-        "is_verified": false,
-        "line_number": 2679
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "99967bcd7dad9752144900c9933992a9f00d7849",
-        "is_verified": false,
-        "line_number": 2680
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "898c84ee78f2d284431c25a04b358cc14b219f56",
-        "is_verified": false,
-        "line_number": 2681
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dc4b14d70e9ee8cc5543bd1fc9360ebdea16fc88",
-        "is_verified": false,
-        "line_number": 2682
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10d8867c4a31304be6df931705d38d32cf55f757",
-        "is_verified": false,
-        "line_number": 2683
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a651db43622ba401c23381ce03f4e3a13c308e89",
-        "is_verified": false,
-        "line_number": 2684
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "729d97229c5dae2e99fd1cc6c7890655eda7a54e",
-        "is_verified": false,
-        "line_number": 2685
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f0c61e68ec18d2bffba5e3236ac22866a28160b7",
+        "hashed_secret": "9de68eb229e7d074f8efeff0b13ab2d99cf5ce94",
         "is_verified": false,
         "line_number": 2686
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "22e748e4550e71faea61a3a668ee9c3cb451210f",
+        "is_verified": false,
+        "line_number": 2687
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2f6ca30840eb651df4be9ff9d8a19823511ec5dd",
+        "is_verified": false,
+        "line_number": 2688
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f2bea6a7c3d5d9c4b72bacb437e458d68cfaa0f3",
+        "is_verified": false,
+        "line_number": 2689
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b6ddda2d0d166207061882f67e7b62a1396227dc",
+        "is_verified": false,
+        "line_number": 2690
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "89ff46f6ba4cebf32c69b2563ec1118bf4eb65ac",
+        "is_verified": false,
+        "line_number": 2691
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1383819b41b12df0805ba1944d4f74d9cd670c54",
+        "is_verified": false,
+        "line_number": 2692
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "898d7eba4839a97ea9cfbddfee0095c50500a8d4",
+        "is_verified": false,
+        "line_number": 2693
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "bdab132a596c293bfc2d5096d8187a25c1f2d79d",
+        "is_verified": false,
+        "line_number": 2694
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "475aaf7c0db8387065161569118bde751bd10fa0",
+        "is_verified": false,
+        "line_number": 2695
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "75f79aa6e3c6621b067703cef2a967f3a2e11fe2",
+        "is_verified": false,
+        "line_number": 2696
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "600281fda8e071edc06a366f4fa4e2ce5a4f71e5",
+        "is_verified": false,
+        "line_number": 2697
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3bafb6e1c56c43cef2962b6c073854344f7205a1",
+        "is_verified": false,
+        "line_number": 2698
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "15232aff24ea0d67e1f800d1971ecb8b7ada9800",
+        "is_verified": false,
+        "line_number": 2699
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b9ed66980afbc3e4a38cb8762d8780561a0a1b39",
+        "is_verified": false,
+        "line_number": 2700
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "dff0fd23927b6202c7702c61d8add1f5f92f908a",
+        "is_verified": false,
+        "line_number": 2701
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4b9250c5e7cd45ff96aa72cfd9191c848e5315d8",
+        "is_verified": false,
+        "line_number": 2702
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "402a36cb76fac71f305c53d065dc8c072fe3f08a",
+        "is_verified": false,
+        "line_number": 2703
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "16ef9ea765fa97ca9f511f0fc1df3cf8b7f5dde0",
+        "is_verified": false,
+        "line_number": 2704
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "68693eed816e6faccfe3ea3a66cc86e7a7a38a1c",
+        "is_verified": false,
+        "line_number": 2705
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "8cd93ba66f97c428ee042acbdfe9e64072e5bc16",
+        "is_verified": false,
+        "line_number": 2706
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "bca0ea372f8cefd3974e35f2ca086101bc18e3f8",
+        "is_verified": false,
+        "line_number": 2707
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "9c15f08bf5bcd9bf2b4a86c210be2c8df36e22e8",
+        "is_verified": false,
+        "line_number": 2708
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "ba198eb818e4ee05dc8b45f770079b83c68b453e",
+        "is_verified": false,
+        "line_number": 2709
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "8d5df16546ab875c4dda394e0a37c4b8951e2624",
+        "is_verified": false,
+        "line_number": 2710
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "6ec84abb4ab70dae9249ee45881777bd8848382e",
+        "is_verified": false,
+        "line_number": 2711
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3dc16350d9e9de1b235b9b4f6dd1c3cb8f091516",
+        "is_verified": false,
+        "line_number": 2712
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "25480d03f8e291d3e8ce78171de19d6c87bd1167",
+        "is_verified": false,
+        "line_number": 2713
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c666c71d2762f6ba3d4ff55d5b3f22234004fdde",
+        "is_verified": false,
+        "line_number": 2714
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f281333b3f26d873314f292cb93f6f376033938f",
+        "is_verified": false,
+        "line_number": 2715
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "12cf70ae04f93f5716d21049670ebaad328cbb26",
+        "is_verified": false,
+        "line_number": 2716
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a4843b1f938e770463a42b18d96d79282610b8cb",
+        "is_verified": false,
+        "line_number": 2717
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "058fe171ff08a56fc3334da8997bbc85bf937ba2",
+        "is_verified": false,
+        "line_number": 2718
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f2fa42824a21a3465282fb921eece652c1453ae9",
+        "is_verified": false,
+        "line_number": 2719
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3ef9a732ac6597c36fe7ef1157acc906a536b6fe",
+        "is_verified": false,
+        "line_number": 2720
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "48ec7be9d5751e628fbad95b29ed63dc0fa48060",
+        "is_verified": false,
+        "line_number": 2721
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "5665fd7c74f65b21c3616591b2457c0bae1b51ab",
+        "is_verified": false,
+        "line_number": 2722
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "60dc31ec61e0adf2166a5a508e20ad0b456a2e69",
+        "is_verified": false,
+        "line_number": 2723
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c7f44cbdfd80a9aeee5b17aee5b1796547a51e28",
+        "is_verified": false,
+        "line_number": 2724
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "6b3e974de6cf7bac927d5d0d62c664e9d4573075",
+        "is_verified": false,
+        "line_number": 2725
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7594fdb1fa8c9bda94d866a3e65ffc4255b848bf",
+        "is_verified": false,
+        "line_number": 2726
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3b7c744426065533eab6c215d35f37314bf6952f",
+        "is_verified": false,
+        "line_number": 2727
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7ee329009b20f0c0f1a4e32ee9faaea70874eec6",
+        "is_verified": false,
+        "line_number": 2728
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2a3db1d78e90604d9109c398841eb35cee1486ff",
+        "is_verified": false,
+        "line_number": 2729
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c9510f4833fc25f4d79b9fc615773f4c8f547504",
+        "is_verified": false,
+        "line_number": 2730
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0696d34d7bc757273cfe1e1692cfdc08946ae849",
+        "is_verified": false,
+        "line_number": 2731
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a6a30862fe268de988d702b21d99e878dc59543f",
+        "is_verified": false,
+        "line_number": 2732
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0758d0eb077882c5ace0c6627bb663631c878690",
+        "is_verified": false,
+        "line_number": 2733
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "098e3e251e749bee09bc3736fea7bc6e492196d8",
+        "is_verified": false,
+        "line_number": 2734
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "149de31d25844d5c160fe44892a09c5ba73506fe",
+        "is_verified": false,
+        "line_number": 2735
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "54b7a672d5b3dd25d81732f0a317efff8c836b4a",
+        "is_verified": false,
+        "line_number": 2736
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4c78a8f9e67f2d50c58872410080ddb61d7db3e8",
+        "is_verified": false,
+        "line_number": 2737
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "8264d16a5648f73309e0159ea632fd562645de49",
+        "is_verified": false,
+        "line_number": 2738
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "33718b3e5d70f72a54796d72e17f90fc55b33855",
+        "is_verified": false,
+        "line_number": 2739
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "507e29b2da2c354a9f4b830d7b076eefcac0b4d8",
+        "is_verified": false,
+        "line_number": 2740
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a803fa9db595f31fe23ab6011ea9aec951fcb216",
+        "is_verified": false,
+        "line_number": 2741
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "5b204176d4fdab56a20c64be20f0a28c945e316a",
+        "is_verified": false,
+        "line_number": 2742
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "04aff3ce92218b019d63317d28c630f4dab40df5",
+        "is_verified": false,
+        "line_number": 2743
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b42664f70902e8e6dee0a419eb7bf93bdae912ef",
+        "is_verified": false,
+        "line_number": 2744
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "9e5091ed80af08229612f10e0ad7d581e20e7aee",
+        "is_verified": false,
+        "line_number": 2745
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0c94001503384f706508fe8276121bd0358e05de",
+        "is_verified": false,
+        "line_number": 2746
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "26637c5162ac75b01787c96a8353f66439fd0e6a",
+        "is_verified": false,
+        "line_number": 2747
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "9f6fbd9dc394e53023394b12c2e8bde3461ba427",
+        "is_verified": false,
+        "line_number": 2748
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1d17950e5c9d6c815cf67f52487388a9b9a213b5",
+        "is_verified": false,
+        "line_number": 2749
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2e2c5f399e11e873f1b51b8ef4f153fb9b654e1c",
+        "is_verified": false,
+        "line_number": 2750
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1aa73742dc235fe3539a83c729769f9da86a70e3",
+        "is_verified": false,
+        "line_number": 2751
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "30b3a9ba5706d64fc6724f793b3689bc12a52f26",
+        "is_verified": false,
+        "line_number": 2752
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4ea4963ef37ed7214cdd594e5d8654016631c51d",
+        "is_verified": false,
+        "line_number": 2753
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "74d7488dfc6fca6f0a629555864f34da1c0cb8d5",
+        "is_verified": false,
+        "line_number": 2754
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "5db97b21ff20390ee85946e9d4bc1230c9993031",
+        "is_verified": false,
+        "line_number": 2755
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "65533e840910a7d3855b9ebf193b6c123483ebb1",
+        "is_verified": false,
+        "line_number": 2756
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "60b319bd6c4ffe193848a5cceaffaca9c8e59f1e",
+        "is_verified": false,
+        "line_number": 2757
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "26cc5e36d5632255fa7ec2818019a6aa4b0bea76",
+        "is_verified": false,
+        "line_number": 2758
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7d93dc57e7d7b576d8c0ea22fe3bd9c5e4dab1ba",
+        "is_verified": false,
+        "line_number": 2759
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1b040151764d4f16e72759959c0aa9dcf1c6a056",
+        "is_verified": false,
+        "line_number": 2760
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1e237d76ac58d9deccd234111620be7de425511f",
+        "is_verified": false,
+        "line_number": 2761
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4154b95760f1f9c8e4f1e1d62c671ee81eb5481d",
+        "is_verified": false,
+        "line_number": 2762
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2bcb11f4c3d51bf1d815009ea5541afa36b4a504",
+        "is_verified": false,
+        "line_number": 2763
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2a9906891d38788f2a51e117db292f16ec241c2f",
+        "is_verified": false,
+        "line_number": 2764
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4daac3a89ed79d19a3bfdfb96f45b4389da78cd6",
+        "is_verified": false,
+        "line_number": 2765
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "6b2ff151c6d28fe3a2b825a5ed290f47e81bc063",
+        "is_verified": false,
+        "line_number": 2766
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "828b83a7403b09e9fdbd2e6abeb7a7ec4640d675",
+        "is_verified": false,
+        "line_number": 2767
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2b907ee3857c9e990f706523ff9fee0a299c4155",
+        "is_verified": false,
+        "line_number": 2768
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "13d10b7dc75ca1ee7420057ad44e08229ddb5d6d",
+        "is_verified": false,
+        "line_number": 2769
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "72a1c10ed5110c75cb1c8e7ee81fb8ad3ec1595b",
+        "is_verified": false,
+        "line_number": 2770
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "d53150bd41ec121ee7b1ba82774122c8eb496551",
+        "is_verified": false,
+        "line_number": 2771
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "763831a9e0e314a91d22d95913e88d5e793cee7f",
+        "is_verified": false,
+        "line_number": 2772
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7521c65a086e94826ec2e4f1d2cb60cd79b30ef4",
+        "is_verified": false,
+        "line_number": 2773
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "6c26ac3ea8cae187cfaa138d010330f1fe0b42d2",
+        "is_verified": false,
+        "line_number": 2774
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2cf0aed83bf771713797d98227d46f9aad7c2183",
+        "is_verified": false,
+        "line_number": 2775
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a967e723645a9f5799208c25bba1b1c6b1d09fdf",
+        "is_verified": false,
+        "line_number": 2776
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c39ffbade1a0847d96058304988a0a1f0a920bbf",
+        "is_verified": false,
+        "line_number": 2777
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "fef6d47b34f3ded72efbc92abd09ba9e79a3236a",
+        "is_verified": false,
+        "line_number": 2778
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "d27117bf1aff297bd69bd43963df562fc92f8560",
+        "is_verified": false,
+        "line_number": 2779
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "338f39c1d002fa923f7cbada050f3b149f284a9c",
+        "is_verified": false,
+        "line_number": 2780
       }
     ],
     "app/internal/server/credentials_handlers.go": [
@@ -1377,5 +1384,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T01:34:00Z"
+  "generated_at": "2026-05-30T13:49:42Z"
 }

--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -690,6 +690,10 @@ paths:
       x-required-permission: host:read
       parameters:
         - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+        - name: framework
+          in: query
+          description: Filter compliance_summary to host_rule_state rows whose framework_refs contains this key (v1.2.0). Liveness is unaffected.
+          schema: {type: string}
       responses:
         '200':
           description: Host detail (includes liveness + compliance_summary)
@@ -797,11 +801,16 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
 
-  # Spec: app/specs/api/fleet-observability.spec.yaml
+  # Spec: app/specs/api/fleet-observability.spec.yaml (v1.1.0)
   /api/v1/fleet/score:
     get:
       operationId: getFleetScore
       summary: Fleet-wide compliance score (passing/total)
+      parameters:
+        - name: framework
+          in: query
+          description: Filter to host_rule_state rows whose framework_refs contains this key (v1.1.0).
+          schema: {type: string}
       responses:
         '200':
           description: Fleet score
@@ -845,6 +854,10 @@ paths:
       operationId: getFleetTopFailingRules
       summary: Rules with the most failing hosts (descending)
       parameters:
+        - name: framework
+          in: query
+          description: Filter to host_rule_state rows whose framework_refs contains this key (v1.1.0).
+          schema: {type: string}
         - name: limit
           in: query
           schema: {type: integer, minimum: 1, maximum: 1000, default: 50}
@@ -871,6 +884,10 @@ paths:
       operationId: getFleetTopFailingHosts
       summary: Hosts with the most failing rules (descending)
       parameters:
+        - name: framework
+          in: query
+          description: Filter to host_rule_state rows whose framework_refs contains this key (v1.1.0).
+          schema: {type: string}
         - name: limit
           in: query
           schema: {type: integer, minimum: 1, maximum: 1000, default: 50}
@@ -897,6 +914,10 @@ paths:
       operationId: getFleetRecentChanges
       summary: Recent transactions (state changes), newest first
       parameters:
+        - name: framework
+          in: query
+          description: Filter to transactions whose framework_refs contains this key (v1.1.0).
+          schema: {type: string}
         - name: since
           in: query
           description: Filter to transactions strictly newer than this RFC3339 timestamp

--- a/app/internal/fleetrollup/options.go
+++ b/app/internal/fleetrollup/options.go
@@ -1,0 +1,34 @@
+package fleetrollup
+
+// Option is a functional option for fleetrollup query methods.
+// Spec api-fleet-observability v1.1.0 C-07/C-08, api-hosts v1.2.0 C-07/C-08.
+type Option func(*queryOpts)
+
+// queryOpts is the internal options bag.
+type queryOpts struct {
+	// framework, when non-empty, filters results to rows whose
+	// framework_refs JSONB contains the given key. Empty string =
+	// unfiltered (legacy v1.0.0 behavior).
+	framework string
+}
+
+// WithFramework filters fleet aggregations and per-host queries to
+// rows whose framework_refs JSONB contains the given key (e.g.,
+// "cis_rhel9_v2.0.0"). Empty string is a no-op (unfiltered).
+//
+// The match is exact-key on the top-level JSONB object — no fuzzy
+// matching, no case folding.
+func WithFramework(framework string) Option {
+	return func(o *queryOpts) {
+		o.framework = framework
+	}
+}
+
+// applyOpts collects opts into a queryOpts bag.
+func applyOpts(opts []Option) queryOpts {
+	var o queryOpts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}

--- a/app/internal/fleetrollup/service.go
+++ b/app/internal/fleetrollup/service.go
@@ -29,14 +29,23 @@ func NewService(pool *pgxpool.Pool) *Service {
 //
 // On an empty fleet, returns Score{0, 0} with nil error (NOT
 // pgx.ErrNoRows). Spec AC-01 / AC-02 / AC-03.
-func (s *Service) FleetComplianceScore(ctx context.Context) (Score, error) {
+//
+// WithFramework filters to rows whose framework_refs JSONB contains
+// the given key (api-fleet-observability v1.1.0 AC-14).
+func (s *Service) FleetComplianceScore(ctx context.Context, opts ...Option) (Score, error) {
+	o := applyOpts(opts)
+
+	// Single SQL covers both the unfiltered (framework="") and
+	// framework-filtered paths via NULLIF + ? operator. PostgreSQL
+	// short-circuits to TRUE when $1 is NULL (no framework given).
 	const q = `
 		SELECT
 			COUNT(*) FILTER (WHERE current_status = 'pass')                  AS passing,
 			COUNT(*) FILTER (WHERE current_status IN ('pass','fail'))        AS evaluations
-		  FROM host_rule_state`
+		  FROM host_rule_state
+		 WHERE ($1::text IS NULL OR framework_refs ? $1)`
 	var passing, evaluations int64
-	if err := s.pool.QueryRow(ctx, q).Scan(&passing, &evaluations); err != nil {
+	if err := s.pool.QueryRow(ctx, q, nullableFramework(o.framework)).Scan(&passing, &evaluations); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Filtered COUNT never returns NoRows but defend anyway.
 			return Score{}, nil
@@ -50,6 +59,16 @@ func (s *Service) FleetComplianceScore(ctx context.Context) (Score, error) {
 		PassingFraction:  float64(passing) / float64(evaluations),
 		TotalEvaluations: evaluations,
 	}, nil
+}
+
+// nullableFramework returns nil for the empty string (so the query's
+// "$1::text IS NULL OR …" short-circuits to TRUE = unfiltered) or the
+// string otherwise. Keeps the SQL constant across both code paths.
+func nullableFramework(framework string) any {
+	if framework == "" {
+		return nil
+	}
+	return framework
 }
 
 // FleetLiveness returns host counts by reachability status. The four
@@ -79,19 +98,24 @@ func (s *Service) FleetLiveness(ctx context.Context) (LivenessRollup, error) {
 // descending order. limit is coerced to [0, MaxLimit]. A coerced
 // limit of 0 returns an empty slice with nil error (no query
 // executed). Spec AC-05 / AC-06 / AC-10.
-func (s *Service) TopFailingRules(ctx context.Context, limit int) ([]RuleFailureRollup, error) {
+//
+// WithFramework filters to rows whose framework_refs JSONB contains
+// the given key (api-fleet-observability v1.1.0 AC-15).
+func (s *Service) TopFailingRules(ctx context.Context, limit int, opts ...Option) ([]RuleFailureRollup, error) {
 	n := clampLimit(limit)
 	if n == 0 {
 		return []RuleFailureRollup{}, nil
 	}
+	o := applyOpts(opts)
 	const q = `
 		SELECT rule_id, COUNT(*)::BIGINT AS failing_host_count
 		  FROM host_rule_state
 		 WHERE current_status = 'fail'
+		   AND ($2::text IS NULL OR framework_refs ? $2)
 		 GROUP BY rule_id
 		 ORDER BY failing_host_count DESC, rule_id ASC
 		 LIMIT $1`
-	rows, err := s.pool.Query(ctx, q, n)
+	rows, err := s.pool.Query(ctx, q, n, nullableFramework(o.framework))
 	if err != nil {
 		return nil, fmt.Errorf("fleetrollup: TopFailingRules: %w", err)
 	}
@@ -113,19 +137,24 @@ func (s *Service) TopFailingRules(ctx context.Context, limit int) ([]RuleFailure
 
 // TopFailingHosts returns the hosts with the most failing rules, in
 // descending order. limit is coerced to [0, MaxLimit]. Spec AC-07 / AC-10.
-func (s *Service) TopFailingHosts(ctx context.Context, limit int) ([]HostFailureRollup, error) {
+//
+// WithFramework filters to rows whose framework_refs JSONB contains
+// the given key (api-fleet-observability v1.1.0).
+func (s *Service) TopFailingHosts(ctx context.Context, limit int, opts ...Option) ([]HostFailureRollup, error) {
 	n := clampLimit(limit)
 	if n == 0 {
 		return []HostFailureRollup{}, nil
 	}
+	o := applyOpts(opts)
 	const q = `
 		SELECT host_id, COUNT(*)::BIGINT AS failing_rule_count
 		  FROM host_rule_state
 		 WHERE current_status = 'fail'
+		   AND ($2::text IS NULL OR framework_refs ? $2)
 		 GROUP BY host_id
 		 ORDER BY failing_rule_count DESC, host_id ASC
 		 LIMIT $1`
-	rows, err := s.pool.Query(ctx, q, n)
+	rows, err := s.pool.Query(ctx, q, n, nullableFramework(o.framework))
 	if err != nil {
 		return nil, fmt.Errorf("fleetrollup: TopFailingHosts: %w", err)
 	}
@@ -149,25 +178,29 @@ func (s *Service) TopFailingHosts(ctx context.Context, limit int) ([]HostFailure
 // occurred_at DESC. since filters to rows strictly newer than the
 // given timestamp. Pass time.Time{} (the zero value) to disable the
 // cursor. limit is coerced to [0, MaxLimit]. Spec AC-08 / AC-10.
-func (s *Service) RecentChanges(ctx context.Context, since time.Time, limit int) ([]TransactionRollup, error) {
+//
+// WithFramework filters to transactions whose framework_refs JSONB
+// contains the given key (api-fleet-observability v1.1.0 AC-16).
+func (s *Service) RecentChanges(ctx context.Context, since time.Time, limit int, opts ...Option) ([]TransactionRollup, error) {
 	n := clampLimit(limit)
 	if n == 0 {
 		return []TransactionRollup{}, nil
 	}
+	o := applyOpts(opts)
 	// The "$2::timestamptz IS NULL" idiom lets us encode "no cursor"
-	// without branching the SQL. Pass NULL for since to skip the
-	// filter, otherwise apply the strict >.
+	// without branching the SQL. Same trick for framework via $3::text.
 	const q = `
 		SELECT id, host_id, rule_id, status, COALESCE(severity, ''), change_kind, occurred_at
 		  FROM transactions
 		 WHERE ($2::timestamptz IS NULL OR occurred_at > $2)
+		   AND ($3::text IS NULL OR framework_refs ? $3)
 		 ORDER BY occurred_at DESC
 		 LIMIT $1`
 	var sinceParam any
 	if !since.IsZero() {
 		sinceParam = since
 	}
-	rows, err := s.pool.Query(ctx, q, n, sinceParam)
+	rows, err := s.pool.Query(ctx, q, n, sinceParam, nullableFramework(o.framework))
 	if err != nil {
 		return nil, fmt.Errorf("fleetrollup: RecentChanges: %w", err)
 	}

--- a/app/internal/kensa/executor.go
+++ b/app/internal/kensa/executor.go
@@ -58,7 +58,13 @@ type Executor struct {
 // Returns either a populated *Result on success, or a typed
 // FailureReason classifying the failure (the caller emits the
 // scan.failed audit and maps the reason to a sentinel error).
-type ScanFunc func(ctx context.Context, hostID uuid.UUID, framework, policyVersion string, plain []byte) (*Result, FailureReason, error)
+// ScanFunc is the per-Run scan-invocation seam. Production binds it
+// to a closure that constructs a Kensa via pkg/kensa.Default and calls
+// Kensa.Scan over the full rule corpus applicable to the host.
+//
+// v2.0.0 breaking change: the framework parameter is removed.
+// Per system-kensa-executor v2 C-12, scans are framework-agnostic.
+type ScanFunc func(ctx context.Context, hostID uuid.UUID, policyVersion string, plain []byte) (*Result, FailureReason, error)
 
 // CredentialBridge is the contract for resolving a host's SSH
 // credential into in-memory plaintext bytes ready to be parsed by
@@ -108,14 +114,26 @@ func (e *Executor) WithScanFunc(fn ScanFunc) *Executor {
 	}
 }
 
-// unwiredScanFunc is the placeholder until the live Kensa integration
-// chunk wires Kensa.Scan + the in-memory TransportFactory. Returns the
-// kensa_error reason so the failure-emit path runs end-to-end.
-func unwiredScanFunc(ctx context.Context, hostID uuid.UUID, framework, policyVersion string, plain []byte) (*Result, FailureReason, error) {
-	return nil, ReasonKensaError, errors.New("kensa: scan path not yet wired (AC-01 pending)")
+// unwiredScanFunc is the test-only fallback scanFunc bound by
+// NewExecutor when production wiring isn't set up (e.g., during the
+// transition period before cmd/openwatch/main.go calls
+// WithScanFunc(pkg/kensa.Default-backed closure)). Tests typically
+// inject their own via WithScanFunc; this exists so an executor
+// constructed in isolation still has a sane non-nil scanFunc.
+//
+// system-kensa-executor v2 AC-18 will be fully satisfied once
+// cmd/openwatch/main.go's worker wiring binds the live ScanFunc.
+//
+//nolint:unused // test-only fallback per AC-18; live binding added in worker subcommand.
+func unwiredScanFunc(ctx context.Context, hostID uuid.UUID, policyVersion string, plain []byte) (*Result, FailureReason, error) {
+	return nil, ReasonKensaError, errors.New("kensa: scan path not yet wired (production wiring pending — see system-kensa-executor v2 AC-18)")
 }
 
-// Run executes a single-framework Kensa scan against hostID.
+// Run executes a Kensa scan against hostID using the FULL rule corpus
+// applicable to the host's detected OS capabilities. Framework
+// identity is per-rule metadata, not a scan input.
+//
+// v2.0.0 signature change: framework parameter removed.
 //
 // Spec ACs satisfied here (this chunk):
 //
@@ -127,9 +145,10 @@ func unwiredScanFunc(ctx context.Context, hostID uuid.UUID, framework, policyVer
 //     ErrNoCredential, Run returns immediately without emitting
 //     scan.started and without consuming a concurrency-guard slot.
 //
-// ACs landing in later chunks of this PR:
+// ACs landing in later chunks of this PR family:
 //
 //   - AC-01: live Kensa.Scan invocation returning a populated Result
+//     covering every rule applicable to the host
 //   - AC-02: in-memory SSH key (TransportFactory hook)
 //   - AC-04: context cancellation propagation
 //   - AC-05/06: scan.started / scan.completed / scan.failed audit
@@ -137,7 +156,9 @@ func unwiredScanFunc(ctx context.Context, hostID uuid.UUID, framework, policyVer
 //   - AC-08: parallel safety verified under -race
 //   - AC-13/14/15: host-key, evidence cap, decryption-failure audits
 //   - AC-16: backoff state writes to host_backoff_state
-func (e *Executor) Run(ctx context.Context, hostID uuid.UUID, framework string, policyVersion string) (*Result, error) {
+//   - AC-17 (this PR): source-inspection confirms Run signature
+//   - AC-18: production scanFunc binds pkg/kensa.Default
+func (e *Executor) Run(ctx context.Context, hostID uuid.UUID, policyVersion string) (*Result, error) {
 	// Concurrency guard (AC-03). LoadOrStore returns loaded=true if
 	// the key was already present; another goroutine owns this hostID.
 	if _, loaded := e.inFlight.LoadOrStore(hostID, struct{}{}); loaded {
@@ -156,22 +177,22 @@ func (e *Executor) Run(ctx context.Context, hostID uuid.UUID, framework string, 
 		if errors.Is(err, ErrNoCredential) {
 			return nil, ErrNoCredential
 		}
-		e.emitFailure(ctx, hostID, framework, policyVersion, ReasonCredentialDecryptionFailed, "")
+		e.emitFailure(ctx, hostID, policyVersion, ReasonCredentialDecryptionFailed, "")
 		return nil, ErrCredentialDecryption
 	}
 	defer wipe() // AC-07
 
 	// Successful credential resolve → scan.started (AC-05 first half).
-	e.emitStarted(ctx, hostID, framework, policyVersion)
+	e.emitStarted(ctx, hostID, policyVersion)
 
 	// Invoke the per-Run scan function. Production wires this to a
-	// Kensa.Scan call constructed with an in-memory TransportFactory;
-	// tests inject controllable behavior via WithScanFunc.
+	// Kensa.Scan call constructed with pkg/kensa.Default; tests inject
+	// controllable behavior via WithScanFunc.
 	//
 	// Spec AC-04: ctx cancellation must propagate. The scanFunc is
 	// contracted to honor ctx.Done(); Run trusts the contract here
 	// and returns ctx.Err() unchanged if the scan returns it.
-	result, reason, scanErr := e.scanFunc(ctx, hostID, framework, policyVersion, plain)
+	result, reason, scanErr := e.scanFunc(ctx, hostID, policyVersion, plain)
 	if scanErr != nil {
 		// Cancellation passes through without scan.failed (the scan
 		// didn't fail — it was cancelled before completion).
@@ -181,13 +202,13 @@ func (e *Executor) Run(ctx context.Context, hostID uuid.UUID, framework string, 
 		// Any other failure: emit scan.failed with the classified reason.
 		// reason MUST be one of the FailureReason values (closed enum
 		// per AC-06).
-		e.emitFailure(ctx, hostID, framework, policyVersion, reason, "")
+		e.emitFailure(ctx, hostID, policyVersion, reason, "")
 		// Map reason → sentinel error for the caller.
 		return nil, mapReasonToErr(reason, scanErr)
 	}
 
 	// Successful scan → scan.completed with summary (AC-05 second half).
-	e.emitCompleted(ctx, hostID, framework, policyVersion, summaryFromResult(result))
+	e.emitCompleted(ctx, hostID, policyVersion, summaryFromResult(result))
 	return result, nil
 }
 
@@ -236,12 +257,12 @@ func mapReasonToErr(reason FailureReason, scanErr error) error {
 
 // emitStarted produces a scan.started audit event. Called exactly once
 // per Run that successfully resolves a credential. Spec AC-05.
-func (e *Executor) emitStarted(ctx context.Context, hostID uuid.UUID, framework, policyVersion string) {
+// v2.0.0: no framework_id in detail.
+func (e *Executor) emitStarted(ctx context.Context, hostID uuid.UUID, policyVersion string) {
 	e.emit(ctx, audit.ScanStarted, audit.Event{
 		ActorType: "system",
 		Detail: mustJSON(map[string]string{
 			"host_id":        hostID.String(),
-			"framework_id":   framework,
 			"policy_version": policyVersion,
 		}),
 	})
@@ -249,10 +270,11 @@ func (e *Executor) emitStarted(ctx context.Context, hostID uuid.UUID, framework,
 
 // emitCompleted produces a scan.completed audit event. Called exactly
 // once per Run that finished a Kensa scan successfully. Spec AC-05.
-func (e *Executor) emitCompleted(ctx context.Context, hostID uuid.UUID, framework, policyVersion string, summary map[string]any) {
+// v2.0.0: no framework_id in detail; the summary carries per-status
+// counts aggregated across all rules in the scan result.
+func (e *Executor) emitCompleted(ctx context.Context, hostID uuid.UUID, policyVersion string, summary map[string]any) {
 	detail := map[string]any{
 		"host_id":        hostID.String(),
-		"framework_id":   framework,
 		"policy_version": policyVersion,
 	}
 	for k, v := range summary {
@@ -265,7 +287,8 @@ func (e *Executor) emitCompleted(ctx context.Context, hostID uuid.UUID, framewor
 }
 
 // emitFailure produces a scan.failed audit event with detail.reason set
-// to one of the closed-enum FailureReason values. Called by:
+// to one of the closed-enum FailureReason values. v2.0.0: no
+// framework_id in detail. Called by:
 //
 //   - AC-13: SSH host key unknown (reason=host_key_unknown). No
 //     credential decrypted before this fires.
@@ -274,10 +297,9 @@ func (e *Executor) emitCompleted(ctx context.Context, hostID uuid.UUID, framewor
 //   - AC-15: credential decryption failed
 //     (reason=credential_decryption_failed). No scan.started before this.
 //   - AC-06: Kensa-side failure (reason=kensa_error).
-func (e *Executor) emitFailure(ctx context.Context, hostID uuid.UUID, framework, policyVersion string, reason FailureReason, ruleID string) {
+func (e *Executor) emitFailure(ctx context.Context, hostID uuid.UUID, policyVersion string, reason FailureReason, ruleID string) {
 	detail := map[string]string{
 		"host_id":        hostID.String(),
-		"framework_id":   framework,
 		"policy_version": policyVersion,
 		"reason":         string(reason),
 	}
@@ -294,26 +316,27 @@ func (e *Executor) emitFailure(ctx context.Context, hostID uuid.UUID, framework,
 // calls when known_hosts verification fails before authentication.
 // Centralizes the AC-13 audit emission so the SSH path can stay focused.
 // Returns ErrHostKeyUnknown so callers can wrap and bubble up.
-func (e *Executor) reportHostKeyUnknown(ctx context.Context, hostID uuid.UUID, framework, policyVersion string) error {
-	e.emitFailure(ctx, hostID, framework, policyVersion, ReasonHostKeyUnknown, "")
+// v2.0.0: no framework parameter.
+func (e *Executor) reportHostKeyUnknown(ctx context.Context, hostID uuid.UUID, policyVersion string) error {
+	e.emitFailure(ctx, hostID, policyVersion, ReasonHostKeyUnknown, "")
 	return ErrHostKeyUnknown
 }
 
 // reportEvidenceOversize is the entry point the result-handling code
 // calls when a rule's evidence exceeds MaxEvidenceBytes. Returns
-// ErrEvidenceOversize. Spec AC-14.
-func (e *Executor) reportEvidenceOversize(ctx context.Context, hostID uuid.UUID, framework, policyVersion, ruleID string) error {
-	e.emitFailure(ctx, hostID, framework, policyVersion, ReasonEvidenceOversize, ruleID)
+// ErrEvidenceOversize. Spec AC-14. v2.0.0: no framework parameter.
+func (e *Executor) reportEvidenceOversize(ctx context.Context, hostID uuid.UUID, policyVersion, ruleID string) error {
+	e.emitFailure(ctx, hostID, policyVersion, ReasonEvidenceOversize, ruleID)
 	return ErrEvidenceOversize
 }
 
 // reportKensaError is the entry point the Kensa-invocation code calls
 // when Kensa.Scan (or any execution method) returns a non-classified
-// error: SSH refused, framework unsupported, planner error, etc.
+// error: SSH refused, transport error, planner error, etc.
 // Emits scan.failed with reason=kensa_error and returns ErrKensaInternal.
-// Spec AC-06.
-func (e *Executor) reportKensaError(ctx context.Context, hostID uuid.UUID, framework, policyVersion string) error {
-	e.emitFailure(ctx, hostID, framework, policyVersion, ReasonKensaError, "")
+// Spec AC-06. v2.0.0: no framework parameter.
+func (e *Executor) reportKensaError(ctx context.Context, hostID uuid.UUID, policyVersion string) error {
+	e.emitFailure(ctx, hostID, policyVersion, ReasonKensaError, "")
 	return ErrKensaInternal
 }
 

--- a/app/internal/kensa/executor_test.go
+++ b/app/internal/kensa/executor_test.go
@@ -141,7 +141,7 @@ func TestRun_PerHostConcurrencyGuard_SecondCallReturnsErrHostBusy(t *testing.T) 
 		go func() {
 			defer close(firstDone)
 			close(started)
-			_, _ = exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+			_, _ = exec.Run(context.Background(), hostID, "1.0.0")
 		}()
 		<-started
 
@@ -149,7 +149,7 @@ func TestRun_PerHostConcurrencyGuard_SecondCallReturnsErrHostBusy(t *testing.T) 
 		time.Sleep(50 * time.Millisecond)
 
 		callsBefore := atomic.LoadInt64(&bridge.resolveCalls)
-		_, err := exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err := exec.Run(context.Background(), hostID, "1.0.0")
 		callsAfter := atomic.LoadInt64(&bridge.resolveCalls)
 
 		if !errors.Is(err, ErrHostBusy) {
@@ -183,10 +183,10 @@ func TestRun_DifferentHosts_RunInParallel(t *testing.T) {
 		hostB := uuid.New()
 
 		go func() {
-			_, _ = exec.Run(context.Background(), hostA, "cis-rhel9-v2.0.0", "1.0.0")
+			_, _ = exec.Run(context.Background(), hostA, "1.0.0")
 		}()
 		go func() {
-			_, _ = exec.Run(context.Background(), hostB, "cis-rhel9-v2.0.0", "1.0.0")
+			_, _ = exec.Run(context.Background(), hostB, "1.0.0")
 		}()
 
 		// Both goroutines block in credential resolve. Wait until the
@@ -220,13 +220,13 @@ func TestRun_GuardReleasedOnReturn(t *testing.T) {
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
 		hostID := uuid.New()
-		_, _ = exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, _ = exec.Run(context.Background(), hostID, "1.0.0")
 
 		if exec.inFlightCount() != 0 {
 			t.Errorf("inFlightCount = %d after Run returned, want 0 (guard slot leaked)", exec.inFlightCount())
 		}
 
-		_, err := exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err := exec.Run(context.Background(), hostID, "1.0.0")
 		if errors.Is(err, ErrHostBusy) {
 			t.Error("second Run got ErrHostBusy; guard slot was not released after the first Run")
 		}
@@ -249,7 +249,7 @@ func TestRun_NoCredential_NoScanStarted_NoGuardConsumed(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		_, err := exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err := exec.Run(context.Background(), hostID, "1.0.0")
 		if !errors.Is(err, ErrNoCredential) {
 			t.Errorf("err = %v, want ErrNoCredential", err)
 		}
@@ -258,7 +258,7 @@ func TestRun_NoCredential_NoScanStarted_NoGuardConsumed(t *testing.T) {
 			t.Errorf("emitted %d audit events on no-credential path, want 0", emitCallCount(&mu, &calls))
 		}
 
-		_, err = exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err = exec.Run(context.Background(), hostID, "1.0.0")
 		if errors.Is(err, ErrHostBusy) {
 			t.Error("second Run got ErrHostBusy; the no-credential path leaked a guard slot")
 		}
@@ -267,8 +267,9 @@ func TestRun_NoCredential_NoScanStarted_NoGuardConsumed(t *testing.T) {
 
 // @ac AC-05
 // AC-05 (first half): when credential resolve succeeds, Run emits
-// exactly one scan.started carrying host_id, framework_id, and
-// policy_version. The completed half lands when the scan path is wired.
+// exactly one scan.started carrying host_id + policy_version. The
+// completed half lands when the scan path is wired.
+// v2.0.0: no framework_id in detail — scans are framework-agnostic.
 func TestRun_SuccessfulCredentialResolve_EmitsScanStarted(t *testing.T) {
 	t.Run("system-kensa-executor/AC-05", func(t *testing.T) {
 		hostID := uuid.New()
@@ -280,7 +281,7 @@ func TestRun_SuccessfulCredentialResolve_EmitsScanStarted(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		_, _ = exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.7.0")
+		_, _ = exec.Run(context.Background(), hostID, "1.7.0")
 
 		started := findCallsByCode(&mu, &calls, audit.ScanStarted)
 		if len(started) != 1 {
@@ -291,11 +292,12 @@ func TestRun_SuccessfulCredentialResolve_EmitsScanStarted(t *testing.T) {
 		if detail["host_id"] != hostID.String() {
 			t.Errorf("Detail.host_id = %q, want %q", detail["host_id"], hostID.String())
 		}
-		if detail["framework_id"] != "cis-rhel9-v2.0.0" {
-			t.Errorf("Detail.framework_id = %q, want %q", detail["framework_id"], "cis-rhel9-v2.0.0")
-		}
 		if detail["policy_version"] != "1.7.0" {
 			t.Errorf("Detail.policy_version = %q, want %q", detail["policy_version"], "1.7.0")
+		}
+		// v2.0.0: framework_id must NOT be in detail.
+		if _, present := detail["framework_id"]; present {
+			t.Errorf("Detail.framework_id is still present — v2.0.0 removed it")
 		}
 	})
 }
@@ -318,14 +320,14 @@ func TestRun_CredentialWipeCalledOnEveryReturnPath(t *testing.T) {
 		// Run returns an error because the scan path isn't wired yet,
 		// but the credential resolve succeeded so wipe MUST have been
 		// called exactly once.
-		_, _ = exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, _ = exec.Run(context.Background(), hostID, "1.0.0")
 
 		if got := atomic.LoadInt64(&bridge.wipeCalls); got != 1 {
 			t.Errorf("wipeCalls = %d after one Run, want 1 (AC-07: every return path zeros the credential)", got)
 		}
 
 		// Run again — wipe should fire a second time.
-		_, _ = exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, _ = exec.Run(context.Background(), hostID, "1.0.0")
 		if got := atomic.LoadInt64(&bridge.wipeCalls); got != 2 {
 			t.Errorf("wipeCalls after two Runs = %d, want 2", got)
 		}
@@ -358,7 +360,7 @@ func TestRun_100ParallelDistinctHosts_RaceClean(t *testing.T) {
 			wg.Add(1)
 			go func(host uuid.UUID) {
 				defer wg.Done()
-				_, _ = exec.Run(context.Background(), host, "cis-rhel9-v2.0.0", "1.0.0")
+				_, _ = exec.Run(context.Background(), host, "1.0.0")
 			}(h)
 		}
 		wg.Wait()
@@ -395,7 +397,7 @@ func TestReportHostKeyUnknown_EmitsScanFailedWithHostKeyReason(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		err := exec.reportHostKeyUnknown(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		err := exec.reportHostKeyUnknown(context.Background(), hostID, "1.0.0")
 		if !errors.Is(err, ErrHostKeyUnknown) {
 			t.Errorf("err = %v, want ErrHostKeyUnknown", err)
 		}
@@ -428,7 +430,7 @@ func TestReportEvidenceOversize_EmitsScanFailedWithRuleID(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		err := exec.reportEvidenceOversize(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0", "sshd-disable-root-login")
+		err := exec.reportEvidenceOversize(context.Background(), hostID, "1.0.0", "sshd-disable-root-login")
 		if !errors.Is(err, ErrEvidenceOversize) {
 			t.Errorf("err = %v, want ErrEvidenceOversize", err)
 		}
@@ -463,7 +465,7 @@ func TestRun_DecryptionFailure_EmitsScanFailedAndNoScanStarted(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		_, err := exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err := exec.Run(context.Background(), hostID, "1.0.0")
 		if !errors.Is(err, ErrCredentialDecryption) {
 			t.Errorf("err = %v, want ErrCredentialDecryption", err)
 		}
@@ -500,7 +502,7 @@ func TestReportKensaError_EmitsScanFailedWithKensaErrorReason(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		err := exec.reportKensaError(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		err := exec.reportKensaError(context.Background(), hostID, "1.0.0")
 		if !errors.Is(err, ErrKensaInternal) {
 			t.Errorf("err = %v, want ErrKensaInternal", err)
 		}
@@ -534,7 +536,7 @@ func TestRun_ContextDeadline_PropagatesAsCtxErr(t *testing.T) {
 
 		// scanFunc blocks until ctx.Done() and returns ctx.Err().
 		// Models Kensa.Scan honoring its context contract.
-		blocking := func(ctx context.Context, _ uuid.UUID, _, _ string, _ []byte) (*Result, FailureReason, error) {
+		blocking := func(ctx context.Context, _ uuid.UUID, _ string, _ []byte) (*Result, FailureReason, error) {
 			<-ctx.Done()
 			return nil, "", ctx.Err()
 		}
@@ -545,7 +547,7 @@ func TestRun_ContextDeadline_PropagatesAsCtxErr(t *testing.T) {
 		defer cancel()
 
 		start := time.Now()
-		_, err := exec.Run(ctx, hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err := exec.Run(ctx, hostID, "1.0.0")
 		elapsed := time.Since(start)
 
 		// Run must return the ctx error verbatim (errors.Is recognizes
@@ -591,7 +593,7 @@ func TestRun_AlreadyCancelledCtx_ReturnsImmediately(t *testing.T) {
 		var calls []emitCall
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
-		blocking := func(ctx context.Context, _ uuid.UUID, _, _ string, _ []byte) (*Result, FailureReason, error) {
+		blocking := func(ctx context.Context, _ uuid.UUID, _ string, _ []byte) (*Result, FailureReason, error) {
 			<-ctx.Done()
 			return nil, "", ctx.Err()
 		}
@@ -601,7 +603,7 @@ func TestRun_AlreadyCancelledCtx_ReturnsImmediately(t *testing.T) {
 		cancel() // cancel BEFORE calling Run
 
 		start := time.Now()
-		_, err := exec.Run(ctx, hostID, "cis-rhel9-v2.0.0", "1.0.0")
+		_, err := exec.Run(ctx, hostID, "1.0.0")
 		elapsed := time.Since(start)
 
 		if !errors.Is(err, context.Canceled) {
@@ -626,10 +628,9 @@ func TestRun_SuccessfulScan_EmitsScanCompleted(t *testing.T) {
 		exec := NewExecutor(bridge, fakeEmitFunc(&mu, &calls))
 
 		// Successful scan returning a typed result.
-		successful := func(ctx context.Context, h uuid.UUID, fw, pv string, _ []byte) (*Result, FailureReason, error) {
+		successful := func(ctx context.Context, h uuid.UUID, pv string, _ []byte) (*Result, FailureReason, error) {
 			return &Result{
 				HostID:        h,
-				FrameworkID:   fw,
 				PolicyVersion: pv,
 				Outcomes: []RuleOutcome{
 					{RuleID: "sshd-disable-root", Status: StatusPass},
@@ -640,7 +641,7 @@ func TestRun_SuccessfulScan_EmitsScanCompleted(t *testing.T) {
 		}
 		exec = exec.WithScanFunc(successful)
 
-		result, err := exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.7.0")
+		result, err := exec.Run(context.Background(), hostID, "1.7.0")
 		if err != nil {
 			t.Fatalf("Run: %v", err)
 		}
@@ -678,7 +679,6 @@ func TestRun_PopulatedResult_AllFieldsFlowThrough(t *testing.T) {
 		// explicitly — the test fails if Run silently drops any of them.
 		expected := &Result{
 			HostID:        hostID,
-			FrameworkID:   "cis-rhel9-v2.0.0",
 			PolicyVersion: "1.7.0",
 			StartedAt:     time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC),
 			CompletedAt:   time.Date(2026, 5, 28, 10, 0, 5, 0, time.UTC),
@@ -706,11 +706,11 @@ func TestRun_PopulatedResult_AllFieldsFlowThrough(t *testing.T) {
 			},
 		}
 
-		exec = exec.WithScanFunc(func(ctx context.Context, h uuid.UUID, fw, pv string, _ []byte) (*Result, FailureReason, error) {
+		exec = exec.WithScanFunc(func(ctx context.Context, h uuid.UUID, pv string, _ []byte) (*Result, FailureReason, error) {
 			return expected, "", nil
 		})
 
-		got, err := exec.Run(context.Background(), hostID, "cis-rhel9-v2.0.0", "1.7.0")
+		got, err := exec.Run(context.Background(), hostID, "1.7.0")
 		if err != nil {
 			t.Fatalf("Run: %v", err)
 		}
@@ -751,10 +751,8 @@ func TestRun_PopulatedResult_AllFieldsFlowThrough(t *testing.T) {
 			}
 		}
 
-		// FrameworkID must match the request.
-		if got.FrameworkID != "cis-rhel9-v2.0.0" {
-			t.Errorf("FrameworkID = %q, want %q", got.FrameworkID, "cis-rhel9-v2.0.0")
-		}
+		// v2.0.0: Result has no FrameworkID — framework metadata lives
+		// per-rule in RuleOutcome.FrameworkRefs (already verified above).
 		// PolicyVersion preserved (the job-payload snapshot).
 		if got.PolicyVersion != "1.7.0" {
 			t.Errorf("PolicyVersion = %q, want %q", got.PolicyVersion, "1.7.0")

--- a/app/internal/kensa/source_test.go
+++ b/app/internal/kensa/source_test.go
@@ -7,6 +7,8 @@
 //   AC-11  TestImports_OnlyCredentialFromInternal
 //          TestImports_NoDirectEncryptionAESCalls
 //   AC-12  TestNoEngineAbstractionInterface
+//   AC-17  TestRunSignature_HasNoFrameworkParameter
+//   AC-18  TestScanFunc_HasNoFrameworkParameter
 
 package kensa
 
@@ -249,6 +251,61 @@ func TestSource_NoDiskWriteOfCredentialBytes(t *testing.T) {
 						f, p.pattern, p.reason)
 				}
 			}
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17 (v2.0.0): Executor.Run signature is Run(ctx, hostID, policyVersion).
+// No framework parameter. The string "framework" appears only in
+// FrameworkRefs (per-rule metadata) or in v1-history doc comments.
+func TestRunSignature_HasNoFrameworkParameter(t *testing.T) {
+	t.Run("system-kensa-executor/AC-17", func(t *testing.T) {
+		src, err := os.ReadFile(filepath.Join(packageDir(t), "executor.go"))
+		if err != nil {
+			t.Fatalf("read executor.go: %v", err)
+		}
+		// Match the Run method signature line specifically.
+		// Allow whitespace variations.
+		signaturePattern := regexp.MustCompile(`(?m)^func \(e \*Executor\) Run\(([^)]*)\)`)
+		m := signaturePattern.FindStringSubmatch(string(src))
+		if m == nil {
+			t.Fatal("could not locate Executor.Run signature in executor.go")
+		}
+		params := m[1]
+		// Acceptable: ctx context.Context, hostID uuid.UUID, policyVersion string
+		// Forbidden: any occurrence of "framework" in the parameter list.
+		if strings.Contains(params, "framework") {
+			t.Errorf("Executor.Run signature still references 'framework': params=%q (v2.0.0 AC-17 requires removal)", params)
+		}
+	})
+}
+
+// @ac AC-18
+// AC-18 (v2.0.0): the ScanFunc type signature has no framework
+// parameter. unwiredScanFunc still exists as a test-only fallback
+// (annotated //nolint:unused) — the production binding via
+// pkg/kensa.Default lands with the worker subcommand.
+func TestScanFunc_HasNoFrameworkParameter(t *testing.T) {
+	t.Run("system-kensa-executor/AC-18", func(t *testing.T) {
+		src, err := os.ReadFile(filepath.Join(packageDir(t), "executor.go"))
+		if err != nil {
+			t.Fatalf("read executor.go: %v", err)
+		}
+		// Match the ScanFunc type alias.
+		typePattern := regexp.MustCompile(`type ScanFunc func\(([^)]*)\)`)
+		m := typePattern.FindStringSubmatch(string(src))
+		if m == nil {
+			t.Fatal("could not locate ScanFunc type definition in executor.go")
+		}
+		if strings.Contains(m[1], "framework") {
+			t.Errorf("ScanFunc signature still references 'framework': params=%q (v2.0.0 AC-18 requires removal)", m[1])
+		}
+		// unwiredScanFunc is allowed to remain but MUST be marked
+		// //nolint:unused — otherwise it would fail the unused linter
+		// once removed from NewExecutor's binding.
+		if !strings.Contains(string(src), "//nolint:unused") {
+			t.Log("note: unwiredScanFunc lacks //nolint:unused — fine if still referenced; will fail unused-lint once production binding lands")
 		}
 	})
 }

--- a/app/internal/kensa/types.go
+++ b/app/internal/kensa/types.go
@@ -75,9 +75,12 @@ const MaxEvidenceBytes = 10 * 1024 * 1024 // 10 MiB
 // Result is what Executor.Run returns on success. It mirrors the
 // Kensa-side ScanResult but flattens transactions into rule outcomes
 // suitable for the transaction log writer (B.1c).
+//
+// v2.0.0 breaking change: FrameworkID is removed. A scan covers the
+// full rule corpus applicable to the host; per-rule framework
+// metadata lives on RuleOutcome.FrameworkRefs.
 type Result struct {
 	HostID        uuid.UUID
-	FrameworkID   string
 	Outcomes      []RuleOutcome
 	StartedAt     time.Time
 	CompletedAt   time.Time

--- a/app/internal/scheduler/hmac.go
+++ b/app/internal/scheduler/hmac.go
@@ -15,20 +15,24 @@ import (
 
 // JobPayload is the typed payload of a scheduler-enqueued scan job.
 //
+// Spec system-scheduler v2.0.0 (breaking change from v1.0.0): the
+// FrameworkID field is REMOVED. Per the framework-at-query-time
+// architecture, a scan job names a host and a policy version;
+// the executor runs the full rule corpus applicable to the host
+// and per-rule framework mapping is metadata, not a scan input.
+//
 // Spec ACs satisfied here:
 //
-//   - AC-06 (C-06): a scheduler-enqueued job payload contains host_id,
-//     framework_id, AND policy_version (snapshotted at enqueue time).
+//   - AC-06 (C-06, C-12): a scheduler-enqueued job payload contains
+//     host_id, policy_version, enqueued_at — NOT framework_id.
+//   - AC-16 (C-12): source-inspection — JobPayload has no FrameworkID
+//     field (this struct's source is what AC-16 inspects).
 //   - C-11 / AC-15: the payload is signed with an HMAC over its canonical
 //     byte representation; the dequeue path verifies before executing.
 //     Tampered fields cause Verify to return false.
 type JobPayload struct {
 	// HostID identifies the target host (FK to hosts.id). Required.
 	HostID uuid.UUID
-
-	// FrameworkID is the compliance framework being scanned (e.g.,
-	// "cis-rhel9-v2.0.0"). Required.
-	FrameworkID string
 
 	// PolicyVersion is the snapshot of policy.Schedules.Version at the
 	// moment the job was enqueued. Reloads of the policy do not affect
@@ -87,29 +91,26 @@ func DeriveQueueKey(dek []byte) ([]byte, error) {
 // MUST use this exact encoding so a stable HMAC is computed regardless
 // of how the payload is otherwise serialized to JSONB on the queue row.
 //
-// Layout (big-endian throughout):
+// Layout (big-endian throughout), v2.0.0 — framework_id removed:
 //
-//	[0:16]   host_id (raw 16-byte UUID)
-//	[16:20]  framework_id length (uint32)
-//	[20:..]  framework_id bytes
-//	[..:..]  policy_version length (uint32)
-//	[..:..]  policy_version bytes
+//	[0:16]    host_id (raw 16-byte UUID)
+//	[16:20]   policy_version length (uint32)
+//	[20:..]   policy_version bytes
 //	[..:..+8] enqueued_at as int64 Unix nanoseconds
+//
+// Old (v1.0.0) payloads with a framework_id segment will produce a
+// different tag under this encoding and so fail Verify; that is the
+// intended migration behavior — pre-v2 queued jobs are dead-lettered.
 func (p JobPayload) Encode() []byte {
-	fid := []byte(p.FrameworkID)
 	pv := []byte(p.PolicyVersion)
 
-	// 16 (uuid) + 4 + len(fid) + 4 + len(pv) + 8 (unix nanos)
-	size := 16 + 4 + len(fid) + 4 + len(pv) + 8
+	// 16 (uuid) + 4 + len(pv) + 8 (unix nanos)
+	size := 16 + 4 + len(pv) + 8
 	buf := make([]byte, 0, size)
 
 	buf = append(buf, p.HostID[:]...)
 
 	lenBuf := make([]byte, 4)
-	binary.BigEndian.PutUint32(lenBuf, uint32(len(fid))) //nolint:gosec // length is bounded by struct field size
-	buf = append(buf, lenBuf...)
-	buf = append(buf, fid...)
-
 	binary.BigEndian.PutUint32(lenBuf, uint32(len(pv))) //nolint:gosec // length is bounded by struct field size
 	buf = append(buf, lenBuf...)
 	buf = append(buf, pv...)

--- a/app/internal/scheduler/hmac_test.go
+++ b/app/internal/scheduler/hmac_test.go
@@ -29,7 +29,6 @@ import (
 func fixedPayload() JobPayload {
 	return JobPayload{
 		HostID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-		FrameworkID:   "cis-rhel9-v2.0.0",
 		PolicyVersion: "1.0.0",
 		EnqueuedAt:    time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC),
 	}
@@ -41,9 +40,9 @@ func testKey() []byte {
 }
 
 // @ac AC-06
-// AC-06: the JobPayload struct exposes host_id, framework_id, and
-// policy_version (plus enqueued_at for HMAC binding). Verified via
-// reflection so a future rename or removal is caught immediately.
+// AC-06: the JobPayload struct exposes host_id, policy_version,
+// enqueued_at (v2.0.0 — no FrameworkID). Reflection-checks both
+// presence and absence.
 func TestJobPayload_HasRequiredFields(t *testing.T) {
 	t.Run("system-scheduler/AC-06", func(t *testing.T) {
 		typ := reflect.TypeOf(JobPayload{})
@@ -52,7 +51,6 @@ func TestJobPayload_HasRequiredFields(t *testing.T) {
 			kind reflect.Kind
 		}{
 			{"HostID", reflect.Array}, // uuid.UUID is [16]byte
-			{"FrameworkID", reflect.String},
 			{"PolicyVersion", reflect.String},
 			{"EnqueuedAt", reflect.Struct}, // time.Time
 		}
@@ -65,6 +63,10 @@ func TestJobPayload_HasRequiredFields(t *testing.T) {
 			if f.Type.Kind() != r.kind {
 				t.Errorf("JobPayload.%s: kind = %v, want %v", r.name, f.Type.Kind(), r.kind)
 			}
+		}
+		// v2.0.0 AC-16 also enforced here: FrameworkID MUST NOT exist.
+		if _, ok := typ.FieldByName("FrameworkID"); ok {
+			t.Error("JobPayload still has FrameworkID field — v2.0.0 removed it (system-scheduler AC-16)")
 		}
 	})
 }
@@ -85,7 +87,6 @@ func TestJobPayload_Encode_IncludesAllFields(t *testing.T) {
 			{"HostID", func(p *JobPayload) {
 				p.HostID = uuid.MustParse("00000000-0000-0000-0000-000000000002")
 			}},
-			{"FrameworkID", func(p *JobPayload) { p.FrameworkID = "stig-rhel9-v2r7" }},
 			{"PolicyVersion", func(p *JobPayload) { p.PolicyVersion = "1.0.1" }},
 			{"EnqueuedAt", func(p *JobPayload) { p.EnqueuedAt = p.EnqueuedAt.Add(time.Second) }},
 		}
@@ -134,23 +135,12 @@ func TestVerify_TamperedHostID_Rejected(t *testing.T) {
 	})
 }
 
-// @ac AC-15
-// AC-15: tampered FrameworkID fails verification (scope-escalation
-// threat: change "cis-rhel9-v2.0.0" → some other framework after enqueue).
-func TestVerify_TamperedFramework_Rejected(t *testing.T) {
-	t.Run("system-scheduler/AC-15", func(t *testing.T) {
-		key := testKey()
-		p := fixedPayload()
-		mac := Sign(key, p)
-
-		tampered := p
-		tampered.FrameworkID = "stig-rhel9-v2r7"
-
-		if Verify(key, tampered, mac) {
-			t.Error("Verify accepted payload with mutated FrameworkID; AC-15 broken")
-		}
-	})
-}
+// v2.0.0: TestVerify_TamperedFramework_Rejected removed. The
+// FrameworkID field no longer exists in JobPayload; the scope-
+// escalation threat it modeled (change framework post-enqueue)
+// is now impossible because no framework identifier is carried on
+// the wire. AC-15 retains coverage via TestVerify_TamperedHostID_Rejected
+// and TestVerify_TamperedPolicyVersion_Rejected.
 
 // @ac AC-15
 // AC-15: tampered PolicyVersion fails verification (policy-bypass threat:

--- a/app/internal/scheduler/service.go
+++ b/app/internal/scheduler/service.go
@@ -27,27 +27,26 @@ type Service struct {
 	// Now is the wall-clock function used by Dispatch. Defaults to
 	// time.Now; tests override with a deterministic clock.
 	Now func() time.Time
-
-	// DefaultFramework is the framework the scheduler enqueues for hosts
-	// whose preferred framework is not set. Sourced from policy.Schedules.
-	DefaultFramework string
 }
 
 // NewService wires the scheduler. The pool is the shared application
 // pgxpool; load carries the clamped ladder + snapshotted policy_version;
 // hmacKey is the DeriveQueueKey-derived HMAC key; emit is audit.Emit in
-// production (or a fake in tests); defaultFramework is the framework
-// to schedule (e.g. "cis-rhel9-v2.0.0").
-func NewService(pool *pgxpool.Pool, load LoadResult, hmacKey []byte, emit EmitFunc, defaultFramework string) *Service {
+// production (or a fake in tests).
+//
+// v2.0.0 breaking change: the defaultFramework parameter is removed.
+// Per the framework-at-query-time architecture, the scheduler does
+// not carry a framework — the executor scans the full applicable
+// rule corpus and framework slicing is a query-time projection.
+func NewService(pool *pgxpool.Pool, load LoadResult, hmacKey []byte, emit EmitFunc) *Service {
 	return &Service{
-		pool:             pool,
-		ladder:           load.Ladder,
-		policyVersion:    load.PolicyVersion,
-		hmacKey:          hmacKey,
-		emit:             emit,
-		metrics:          NewMetrics(),
-		Now:              time.Now,
-		DefaultFramework: defaultFramework,
+		pool:          pool,
+		ladder:        load.Ladder,
+		policyVersion: load.PolicyVersion,
+		hmacKey:       hmacKey,
+		emit:          emit,
+		metrics:       NewMetrics(),
+		Now:           time.Now,
 	}
 }
 
@@ -88,7 +87,7 @@ const dispatchBatchSize = 100
 //     calls (from two workers or two ticks) claim disjoint rows.
 //   - AC-05 (C-05): maintenance_mode = true rows are excluded from the
 //     SELECT and so never dispatched.
-//   - AC-06 (C-06): each job payload carries host_id, framework_id,
+//   - AC-06 (C-06, C-12): each job payload carries host_id,
 //     policy_version, enqueued_at; all HMAC-signed.
 //   - AC-13 (C-09): every UPDATE to host_compliance_schedule emits
 //     scheduler.schedule.updated.
@@ -135,7 +134,6 @@ func (s *Service) Dispatch(ctx context.Context) (int, error) {
 	for _, r := range due {
 		payload := JobPayload{
 			HostID:        r.HostID,
-			FrameworkID:   s.DefaultFramework,
 			PolicyVersion: s.policyVersion,
 			EnqueuedAt:    now,
 		}
@@ -143,9 +141,9 @@ func (s *Service) Dispatch(ctx context.Context) (int, error) {
 
 		// JobPayload encoded into JSONB. host_id is a string for
 		// JSON-friendly storage; the HMAC tag is hex for the same.
+		// v2.0.0 — no framework_id key (per system-scheduler v2 C-12).
 		body := map[string]any{
 			"host_id":        payload.HostID.String(),
-			"framework_id":   payload.FrameworkID,
 			"policy_version": payload.PolicyVersion,
 			"enqueued_at":    payload.EnqueuedAt.UTC().Format(time.RFC3339Nano),
 			"hmac":           fmt.Sprintf("%x", tag[:]),

--- a/app/internal/scheduler/service_test.go
+++ b/app/internal/scheduler/service_test.go
@@ -151,7 +151,7 @@ func newTestService(t *testing.T, pool *pgxpool.Pool, now time.Time, calls *[]em
 		*calls = append(*calls, emitCall{Code: code, Event: ev})
 	}
 
-	svc := NewService(pool, load, testKey(), emit, "cis-rhel9-v2.0.0")
+	svc := NewService(pool, load, testKey(), emit)
 	svc.Now = func() time.Time { return now }
 	return svc
 }

--- a/app/internal/scheduler/source_test.go
+++ b/app/internal/scheduler/source_test.go
@@ -1,0 +1,68 @@
+// @spec system-scheduler
+//
+// AC traceability (this file):
+//   AC-16  TestNoFrameworkInScheduler_V2
+
+package scheduler
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// @ac AC-16
+// AC-16: source-inspection — JobPayload has no FrameworkID field;
+// NewService has no defaultFramework parameter; Dispatch's body map
+// does not contain the "framework_id" key. Confirms the v2.0.0
+// architectural correction is materially in place, not just spec'd.
+func TestNoFrameworkInScheduler_V2(t *testing.T) {
+	t.Run("system-scheduler/AC-16", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		dir := filepath.Dir(file)
+
+		// 1. JobPayload has no FrameworkID field.
+		if _, ok := reflect.TypeOf(JobPayload{}).FieldByName("FrameworkID"); ok {
+			t.Error("JobPayload still has FrameworkID — v2.0.0 removed it")
+		}
+
+		// 2. service.go does not declare DefaultFramework on Service.
+		serviceSrc, err := os.ReadFile(filepath.Join(dir, "service.go"))
+		if err != nil {
+			t.Fatalf("read service.go: %v", err)
+		}
+		if regexp.MustCompile(`(?m)^\s+DefaultFramework\s+string`).MatchString(string(serviceSrc)) {
+			t.Error("service.go still declares DefaultFramework on Service")
+		}
+
+		// 3. NewService signature does not include defaultFramework param.
+		if regexp.MustCompile(`func NewService\([^)]*defaultFramework`).MatchString(string(serviceSrc)) {
+			t.Error("NewService still accepts a defaultFramework parameter")
+		}
+
+		// 4. Dispatch's enqueued body map does not contain the
+		//    literal "framework_id" key. (The string may appear in
+		//    a doc comment — that's allowed.)
+		// Look for the JSONB body construction specifically.
+		bodyMapRe := regexp.MustCompile(`body\s*:=\s*map\[string\]any\{[^}]*"framework_id"`)
+		if bodyMapRe.MatchString(string(serviceSrc)) {
+			t.Error("Dispatch's body map still contains framework_id key — v2.0.0 forbids")
+		}
+
+		// 5. hmac.go's Encode does not reference FrameworkID.
+		hmacSrc, err := os.ReadFile(filepath.Join(dir, "hmac.go"))
+		if err != nil {
+			t.Fatalf("read hmac.go: %v", err)
+		}
+		// Allow comments to mention removed history. The struct
+		// field assignment p.FrameworkID would be the violation.
+		if strings.Contains(string(hmacSrc), "p.FrameworkID") ||
+			strings.Contains(string(hmacSrc), "fid := []byte(p.FrameworkID)") {
+			t.Error("hmac.go's Encode still references p.FrameworkID")
+		}
+	})
+}

--- a/app/internal/server/api/server.gen.go
+++ b/app/internal/server/api/server.gen.go
@@ -739,25 +739,44 @@ type PostDiagnosticsRequireRemediationExecuteParams struct {
 
 // GetFleetRecentChangesParams defines parameters for GetFleetRecentChanges.
 type GetFleetRecentChangesParams struct {
+	// Framework Filter to transactions whose framework_refs contains this key (v1.1.0).
+	Framework *string `form:"framework,omitempty" json:"framework,omitempty"`
+
 	// Since Filter to transactions strictly newer than this RFC3339 timestamp
 	Since *time.Time `form:"since,omitempty" json:"since,omitempty"`
 	Limit *int       `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// GetFleetScoreParams defines parameters for GetFleetScore.
+type GetFleetScoreParams struct {
+	// Framework Filter to host_rule_state rows whose framework_refs contains this key (v1.1.0).
+	Framework *string `form:"framework,omitempty" json:"framework,omitempty"`
+}
+
 // GetFleetTopFailingHostsParams defines parameters for GetFleetTopFailingHosts.
 type GetFleetTopFailingHostsParams struct {
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+	// Framework Filter to host_rule_state rows whose framework_refs contains this key (v1.1.0).
+	Framework *string `form:"framework,omitempty" json:"framework,omitempty"`
+	Limit     *int    `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // GetFleetTopFailingRulesParams defines parameters for GetFleetTopFailingRules.
 type GetFleetTopFailingRulesParams struct {
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+	// Framework Filter to host_rule_state rows whose framework_refs contains this key (v1.1.0).
+	Framework *string `form:"framework,omitempty" json:"framework,omitempty"`
+	Limit     *int    `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // GetHostsParams defines parameters for GetHosts.
 type GetHostsParams struct {
 	Environment *string `form:"environment,omitempty" json:"environment,omitempty"`
 	Tag         *string `form:"tag,omitempty" json:"tag,omitempty"`
+}
+
+// GetHostByIDParams defines parameters for GetHostByID.
+type GetHostByIDParams struct {
+	// Framework Filter compliance_summary to host_rule_state rows whose framework_refs contains this key (v1.2.0). Liveness is unaffected.
+	Framework *string `form:"framework,omitempty" json:"framework,omitempty"`
 }
 
 // PostAdminLicenseVerifyJSONRequestBody defines body for PostAdminLicenseVerify for application/json ContentType.
@@ -893,7 +912,7 @@ type ServerInterface interface {
 	GetFleetRecentChanges(w http.ResponseWriter, r *http.Request, params GetFleetRecentChangesParams)
 	// Fleet-wide compliance score (passing/total)
 	// (GET /api/v1/fleet/score)
-	GetFleetScore(w http.ResponseWriter, r *http.Request)
+	GetFleetScore(w http.ResponseWriter, r *http.Request, params GetFleetScoreParams)
 	// Hosts with the most failing rules (descending)
 	// (GET /api/v1/fleet/top-failing-hosts)
 	GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Request, params GetFleetTopFailingHostsParams)
@@ -917,7 +936,7 @@ type ServerInterface interface {
 	DeleteHostByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// Fetch a host with liveness + compliance enrichment
 	// (GET /api/v1/hosts/{id})
-	GetHostByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	GetHostByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params GetHostByIDParams)
 	// Update mutable host fields
 	// (PATCH /api/v1/hosts/{id})
 	PatchHostByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
@@ -1106,7 +1125,7 @@ func (_ Unimplemented) GetFleetRecentChanges(w http.ResponseWriter, r *http.Requ
 
 // Fleet-wide compliance score (passing/total)
 // (GET /api/v1/fleet/score)
-func (_ Unimplemented) GetFleetScore(w http.ResponseWriter, r *http.Request) {
+func (_ Unimplemented) GetFleetScore(w http.ResponseWriter, r *http.Request, params GetFleetScoreParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1154,7 +1173,7 @@ func (_ Unimplemented) DeleteHostByID(w http.ResponseWriter, r *http.Request, id
 
 // Fetch a host with liveness + compliance enrichment
 // (GET /api/v1/hosts/{id})
-func (_ Unimplemented) GetHostByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+func (_ Unimplemented) GetHostByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params GetHostByIDParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1867,6 +1886,19 @@ func (siw *ServerInterfaceWrapper) GetFleetRecentChanges(w http.ResponseWriter, 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetFleetRecentChangesParams
 
+	// ------------- Optional query parameter "framework" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "framework", r.URL.Query(), &params.Framework, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "framework"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "framework", Err: err})
+		}
+		return
+	}
+
 	// ------------- Optional query parameter "since" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "since", r.URL.Query(), &params.Since, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
@@ -1907,8 +1939,27 @@ func (siw *ServerInterfaceWrapper) GetFleetRecentChanges(w http.ResponseWriter, 
 // GetFleetScore operation middleware
 func (siw *ServerInterfaceWrapper) GetFleetScore(w http.ResponseWriter, r *http.Request) {
 
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFleetScoreParams
+
+	// ------------- Optional query parameter "framework" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "framework", r.URL.Query(), &params.Framework, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "framework"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "framework", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetFleetScore(w, r)
+		siw.Handler.GetFleetScore(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1926,6 +1977,19 @@ func (siw *ServerInterfaceWrapper) GetFleetTopFailingHosts(w http.ResponseWriter
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetFleetTopFailingHostsParams
+
+	// ------------- Optional query parameter "framework" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "framework", r.URL.Query(), &params.Framework, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "framework"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "framework", Err: err})
+		}
+		return
+	}
 
 	// ------------- Optional query parameter "limit" -------------
 
@@ -1959,6 +2023,19 @@ func (siw *ServerInterfaceWrapper) GetFleetTopFailingRules(w http.ResponseWriter
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetFleetTopFailingRulesParams
+
+	// ------------- Optional query parameter "framework" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "framework", r.URL.Query(), &params.Framework, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "framework"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "framework", Err: err})
+		}
+		return
+	}
 
 	// ------------- Optional query parameter "limit" -------------
 
@@ -2125,8 +2202,24 @@ func (siw *ServerInterfaceWrapper) GetHostByID(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetHostByIDParams
+
+	// ------------- Optional query parameter "framework" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "framework", r.URL.Query(), &params.Framework, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "framework"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "framework", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetHostByID(w, r, id)
+		siw.Handler.GetHostByID(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2590,100 +2683,101 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7F17bxs5kv8qRN8CayOSH3kMdhQsDhkn2WQuM2M4yc4B2ZxAd5fUjLvJDsmWowsM3Ie4T3if5MBHv8nu",
-	"lmNJnt38k9gSH8WqH6uKxWL5axCyNGMUqBTB7GvAQWSMCtC//ISjC/icg5Dqt5BRCVT/iLMsISGWhNHj",
-	"T4JR9ZkIY0ix+ulPHBbBLPi342roY/OtOH7BOeMv6AoSlkFwc3MzCSIQISeZGiyYBX/HCYn0yBOU4SWh",
-	"9mfGEYkgzZgEGq4RqHGCm0nwC8iYRb8y+SxJ2DVEu6P0d87oEr169+4cpZqIQLWx3dXoz6KU0AuWgLiw",
-	"XFWfZpxlwCUxLObqa/UDkZCKIZrUYC+o5Gu1crnOIJgFmHO81lNz+JwTrljwwY77sWzFLj9BKFW3Z3lE",
-	"5IuV5U+TGhyatX0tugnJCV2qbjiUjM+J5i/NkwRfJhDMJM9h4mtsPnaMFTLOIdFCsSN2mkQgMUk0TVFE",
-	"VEucnNdobUxcLc6MtmA8xTKYBXlOosBBHwvDnHOI5lg22kdYwlSSFFydOISMRxt3igxTm0LutGsKU/UT",
-	"LOchjOV42b5g+mAPASvgRK4d5LSwpHnYktmkwEpD2E3O9qNPnOOlY0OULBq1IWpgdjCRwhc5D3MuGFcD",
-	"Nbfvbxn+nAMyXz9FGRYCYYH+3XzwVyQZWoAMYyRjQGokpY7UEgc422aeXkaTFjdjZPyGLQmtadwmZ5jM",
-	"1H8p/vIG6FLGweyHSZASWvutI2S1qmvGo1bHh0+aXU8dXXMBnOIUNu7aYkA5To2aAQb4lCUOQxBiLtkV",
-	"uJUUhwUHEfe0UNQMg0rGv0BJRntBDSrac9oZfAv85eWzF5SzJPEvMuNsRQRhlNDlPOdkeH92evTM/nfg",
-	"ZLG+Q4y1aFEDeKeHc+ApEYrUHpNIIqDSKqb2N06ZEjHHlNF1yvK6cr1kLAFMNS5YAiP1nG7aGtO1oKxa",
-	"yiaavTOlXWtzQD8H/WyD1BrMLn/GGUUPk5qaYAQHaxve0GSH9i3q3GqFsxjTJXihqe0KlfOGSutXYRSu",
-	"xzdvLaUzXWs432oujDrwLmNIRbX9uEZz16RnWMKS8bXxCzvzNYyeFxwjxFofyEkHBw1mnJxxwNIvSJzL",
-	"eG49ZoVbmqdqEiHi+RWs62ZiElwyGddmq/uHjWXVFNbpycPHE6eSiGCB80S6VcStTF3TwHa/5GSFJehl",
-	"DXyvgZXFHAv3HhQhM35dya61kJAGkyBmQjpZpLvM3Zt/0Du8K+tv6LbsbeiGOgz68fSGCOnXe2HZbrzb",
-	"WI1dWfkBTV2fpp/cHv/lLpAf6t212Smk6HO5HmUJxumMwWGUDQ0lWYF7x43dkXvfC1Y+80si6yaeUAlL",
-	"4PUWIUtTe7D2jrIgdAk842Sgnff0nGfRxgDY0ISP27UNEdbF7dwfuZAsvWAJDJgHv2Yfo4+NiDMsJXB1",
-	"yvuvD3j63x/VPyfTH+cfv55Ofnh08ycXi0Y7dCmhr82Xp4PeXctuDnt5FZv8auRWJl3L5zIniZwT6t5w",
-	"d+XSdhZdn3mYBS/CmHnRkYIQNm7Qsfmb2KViHD8BfiUeETmHlXIORyrCEfEuCGMGI1wx264zpnMd9HMO",
-	"ObwDIX9mlz0WdJi8T+xy3GJb5Np+48htBFy75xsd8XUQH+06yFjarML+hAlRWn8SCOAr4ArjLCGhsujw",
-	"RSkinDitUpynmM5rkHYENCRfG+PU3bFtD0VxoqCu3rU9UZf5bZBpVjtltMJJjiU8S4BL7yYVIePFFiWp",
-	"4tHpyYnen+a3k0nHhnbdRu7enC8TAPmKCfkSkyTnDqAsMEkIXc55nsA8ZDlt2klC5Q+Pg4nDiivv4VYo",
-	"LzpOXHN7F/GGrICCEN0VUFgBn2ecXUI0knYOOIwLoIxon9Mryq7p6Nabjd85xBadm0NVZEyaa/by7AJC",
-	"oNJECsS3Bo/1iO84psLGsgdNmx7VT1yewCAqNVY2QaWG0phTetFw4prLS/TbYq+2opBYCDXEgld3Qs34",
-	"+blpgdS0Ah2jA9sFPUB2/kOEQ86EQDhJkKJFHKGTo6PTI0Vi6bay3EDBkkfz9NIsXDKJkzkYjVM4JU0a",
-	"ztTaEFvo0c2mExJLQJxdC3QdA9cBfh3IUV/kAhFhQv2MazIbtIyEc4c3Llq9DH/HspeGP0qL3Q2I6/rw",
-	"G0FckafgfDfk1TfGt5JX265dX0DrhfkVoY3z9YJwIecCdHhe42NuWuqjjr0GKz9yGurRlmHLV5BeXdB7",
-	"n2dWbYLjBVMUiK2qUFy4Ilmm+dG2/X3HxMruVbrHzjRpCGP4XvAV4ETGPWeey3nIKIVQNrzk2umlu8RY",
-	"j7nWx5Elx5FHuCvgwn2UajslxdIaxFQDONfFhDxjaZYQTEN4m6cpdkVpS+d2hEGw2nVka6usRrYucDCu",
-	"tdZ6t3EICqKqxXQhWAzv5eptwwieAHFERJbg9dwX9ewe2eiKcEaLgE/9zsw1/pKzPLttCErttFtGqEk2",
-	"x1HEraPZonIous24bPjxPzx58uhJzZM/dcICL5sGYog17Xv7vuDzsCduI1W1dfsg9Fyf//oOxsXGnYtq",
-	"5/aZO/d2twIc07kej05qBwScJL8tgtmH4RHKY8XNx3bG0q95kiiviCLKUDE60j43irFAyoIgnlOEl5hQ",
-	"IZGMidC+1VEHpC7O63N+h2U+7veH9ePCORrlZrRZ1+timKH9ZPmOZaEaPcwlWcF8YdwZTzw4wULOtRob",
-	"n4+j+2hZ9LkE44YpsvjmhnOeTm2C667RN9FgT3gkUX5V1y4PHwcH3Q/XDD6B9l4d7fsqpW11hqzM9szK",
-	"rW95GvbFa0JGmIlhu7D9mw+3AbHLaErDh7f3msp765gMmPxvwtM/va/REfgbEgIV8FZqkXsVjb7VAe6N",
-	"/n/JCAfxTUp3AVgWFmn8liJ0vuQ4hHkGnLDRRyt70afggkOd6aNXoEHC5olhitpDdIUT4j53SWJS8cpj",
-	"OgedQZoBvcYyjOdZok9bQKW+LxXgHCbXsZiMw6qVZ+GLk+t5awfVknEf/fIdSJuzC55/upbDeqbeeMSU",
-	"3nyvnWHGM0yFITE3UnaCpxDzIDErvWDluzRTAqoW15hTQpffRG5b6Re0t+d3SaZKX/QkW4U2F8tt6pVf",
-	"xb05ire81S3QtMQSxqZylWS2L2orEvuXLy5gSYTkPfC0c5ANXjc0M9kcysp3Qd03aFtmrlz7Lb3BqLGg",
-	"Sfuk53nGOUtISEBcQMJw5Ocvy2XIUnsl7by99Gt/z7VfOaSXrvVzCHWmcV9ywq3uVIevQi11HidTEedP",
-	"mbHf+yN9+swixgQBCzKak3amKAd08bKC0B8/t6OJ6zodrpW/F8AHAndlHnNPnOvR7Z86/GU3Tx2KzOfe",
-	"fGHFjbs9nX5zEriJQliiR8QC9pGd1mGzl7csgWdCkKX/UY1SxNYr30TSRTffzKI/uKVWMN7iNGAytEXN",
-	"0I4UD+3sL1j3EvWtxEtAJ+gaJ1eELqfiChKQjCKR8wUOAf3f//wvkjEHQECjjBEqBZIxlgi+AA+JACRj",
-	"+AddsJyal5tISBxeoYNaCs6k/npzgnQS1cS84kRgc34Oj/6h71KJVM5b8FsG9Hd1EEAHlsTD2mXLLDg5",
-	"Oj06meIki/HRqbYQGVCckWAWPDo6OXqkd5+MNXuPcUaOV6fHOEoJPbY+08x4fFo8NjyrhKTpfR0Fs+Cc",
-	"CakfcTZc8sAwHIT8iUXrO3tv6jxp3DTFqwOvk+Yj3YcnJ9uioXwA1X2lq1rYOZDxmNGByPXLKMQ4UuCL",
-	"kA2SHpqHsUUEPXjO11OeU7QyT30BYfTz7++QlQq6JjJmuUSEComThNAlIsZZaUoxs57SjGtXaYQYm75V",
-	"sEVGerw4ByfPgU8Vt5BZBSqdsJtJ8Pjk0e6eM5/hJAGOEhxeCWS8mYKzTfGZNSGlViGyLdGCJCDQgrNU",
-	"v5cMGV2QZc4hQhHhEEpz2vgyLbA8rfyGYBZ0pytFrRTFsc621EJagkPAfwNZe1eq9z3HKUitZD98DZRT",
-	"FHzOQdNgDE31fLViX0flu3t2XsJuPELjxezGvQWhYbPjGCvrGy2n0mQA3Mlo9oHrLVaVkJTIRsfyccCT",
-	"k0kVFXzYyCR0xARvPm5xX7efL7s2tDJVbGFMHLLI1Zv5xDd6Se5xreJCc9Mpf6IxJDowvJ7aIgkQTRCF",
-	"axAS6XyXw9Y2kvFxwpbmeNCjJotHuFsycp1Xzjs2cN1Hxg4J6gZIWzOIIHqK9OM7gYgQOURGlqe7U8yv",
-	"TQwV1V4gKRP7y8tnqGScBguEuUkA+vCxDp331l0+Ltx6pIGg7SximTmio3e/vTt3QoblchRmVLuO5B47",
-	"3E3QWh9xWLEr6BoX9amxIdb4C9OhS5w5MPgtgox/gWDLYGq8E++Krnjeu2vM/MqMd1UwTwHmEjC3uTh1",
-	"fsuc0wa/yzfJDoYft+II/cw/b8a8tisH19tyt79lm6GEdNTsi8UC9NUGqi0ULZRHO45DCzwD/cB/eM+U",
-	"tQC2zptO0QEXX2pFBND7i9eIa2QoL96uXi1QrTvEknGEs6zNOz1Hg1HqMIoI1cpFKSw3w0Ydw+rlC7Zo",
-	"nDolEkYZKIeaU+pZL4zswWSoyRXL7fWb2v0csgSvO/r2TDnqPEWYIoNbiLRlERBykOhybRaxVtLEaAlU",
-	"CQYi5LQWhYGZmbjRsESbT/+3KFZ3jYHbyrYYDdlgV82925F6h2tUWnMOn3QmqhKWfXe0a7ydmRz7iqZr",
-	"zmzUrAY1zfuOfvizKLs5EFVp4Rm3d05DdsdxTbXVo37PrZiDVSVJTea8zJMEXfz07AwVy0QH1f3RpG6O",
-	"JkiH2KeEIn2N5PD0bdWI4Q1oq1Vscee16mHcR39f7Sbt4qMME74vN98yylJiNfcE2cSKidHhuYBIAUOE",
-	"OALrQiPJyXIJHKLD3nPABdNPY9T+4/W5nqKUUImwOj4iU9zoQdFAMaQBr1a1Bd8+PKs126J4PTUiXBqq",
-	"bIlSkDjCElv/b59htoqbMw6dQJs+89dPfQcl6Ywm68OegFpn4EmPImgL6+4Vga82zChtcLoFMkZCxV7B",
-	"7dy+14tgFj6crskw0dnYiDKJ9HWLqYtpW7x9+wpdgbX+P+7Q28wTSbIEkKnDgWzgTrTtv2YmwjVIj0Pw",
-	"NScSfFro+CuJboyLloCELsKf688rof60fv3cEyLOsIyriKR52NQApzNM6nki/HGMJ2mIi9BBWTzjrwuc",
-	"CDg0Qny8Q71Uob5EV0uAb9lCTg2bbyFFK5+byQijsT8ZnexP2RTK/T6K/qWuhFkX+p9FRfAGdqi2iSOC",
-	"l5QJSUIxgzBm/d7q86r1C9XYjY4YcKSzOy0+XleXztP/gHUvWBqZH08GMz88M/7n9Ky6H5q+7r8f+rgd",
-	"c1uvoLJjh7tRO8WBNfV9FVq/1b2I6vJkuEunMPSuzWILe4X3rsPuEVksQB+ZL5XgW4E0xSPjpuslI5sW",
-	"97RMuBCNWtgPzMWQf3OZOjBTCUJOP7HL8RutUUCm68g/vDtmukvVOLj6M7vUh5RMQvQUXTN+BRxdkyRB",
-	"EceEtk2WxEuYniA9OoogZU+RZYdQJx42ZRn6xC5Rxpk6+JgoiuI9oVP7mZ3Ez15bE2WKE+ByPHPrpVS2",
-	"5Hc7y7XsWCN4EkddIWiTShDZph5RZkUrLUu7QGEi1GqZcxmroytLIlGGwzySyzikJE+nG1mfc9PpXhih",
-	"f037Uejyh7vT5TYxCkUMhHaSCA2TPAJkITSvwQrZVxWd07weYqoT9ZGC3NPi/lb0DtPwrooPZ4Gjixfo",
-	"tvtUHR6n2hEbi/YL09O8o9Q5U98Rvw/Eo4PQBI6MYlOC1B714X4DWCUdHmWtI9pGVZdYL/vUgto9R4jm",
-	"FIPoNsGCW8D7d93xO77vD761KO8DwKsA1AYI1502gHg3yuXCOIcUImIOl/AFwnxzsF9UQ7ywI3xH/b+6",
-	"H1PD1dzgyhbE29/Wq5E0K6Du34MPivTx1l50jIIeuJc75HG5eeTf1r4FFPt7kQDI43qVF19ktFkvcouw",
-	"bU7kBJCtGsNZkuTZzm9Jn1VJSCaJsEiA3CdSzb1Hx6dpglX5GEgXYxToco3qFUyQfYveBQfX9S6nYVXw",
-	"shcizfKYHa3eXMJLkkjgSDIkq6J6AimlHMpkrbOJOZIxpqYO0MXLs0ePHv2IJElBSJxm+n3/tvPTx+aF",
-	"n57sNTHcwX7nHb9qUOe3+aNStw2Dft94IzZel+kCHZgyoXZfHTZT5x37sKxo3Lv9TC3VbaPMzOJgjf4W",
-	"GVK/w2MsPDTXptckAlQVLzNcLGvaHutShIcOYEiWTW0Nw2lZsqwXJO36r6NeK/2RtGB7gS49iOkVRCaX",
-	"oayk9l0Jbtn7EObuScaA0oLzVQXnAzUF0IjQ5RDQeVEZeCTQTSXhf2KgmwX6ga4Y9h3ou7H2GsxuoGsF",
-	"7Qe6qRfch2tTpXibFr5VB9nBkrfAVyQERAQqChzfTIInu5RKjYSisjJiHOUUrzAxtZf6ElHLM6Q6h+OI",
-	"1KqQHpR/dLElmiHTuoEtrZfHu8VDVYmXwzkd20JHu2yqQzj6nLn/1FbfzYBOao2ttEbE/PsSVwuhbyN2",
-	"2C0xveNk1WZJW4+c95+gWpg1dHCJjUen9skEkWyCMsblBIEMjw53nn3zylKCcKKAtEbwhSjtTyiqKwBP",
-	"iqqtZrxhwF7D+virLYt/U09TnXEQLFkNBOtfNbOxL2yfMZmQtVr8f+B0SLvi+mPn/eVF/srqZJS2TT+I",
-	"1EcXxlspz53Ig16NefJUjaRr5+iUpUtAOidMjTgIur5cSou8UanQCmT3Mwna0B3NsUQC5O5zoF81cut7",
-	"s5/HKIjhjOf9iuJu/ZJWMX0fe019QHRgL55EVYf+AeoWj79nGCjSoPXu12cMJ/UIKCdhbD3McU4OlmHs",
-	"MArq452jZDveVLMu9o7vY0d5U/t6ztv1pu4X7I3kUJpLbf9M2I5AEonNfaSiNnTPWe5NWT5624XOmmW7",
-	"e+7L9XVBiyt/A2ksu338nNTbogNJgE+KK2UxQZ9zJrGY2Lu+5vG2rEDrY8kFMxG07T2UjVJC9Sy97hlL",
-	"4B6cLRW7vGfL5uPovuv5xigNUczMuarfWdfcMieGbT2b9PzN5F0/m+z+TWJnDQDVSnN9b8fSWnGX4k+J",
-	"7PrcqbcIiZDEV0C9LyArXg0BtKtBy+KhPmWhC5BuU1l0K5w6GKEa3QNdobjl1RW55ZRPArXOfXGoiuF3",
-	"rwO6FZN3vPub1Wc9cr4HcSjGy1qUdR9qr7hzJY6WSkC1GMKeZ/ePPOkr0dzHk/7OvVuN0XEH+zFSGT7Y",
-	"75fzJzvd/PdLmsURfYwcO85ftbmsH4h19fB+P7CoNC5MqfE/8CndXTP9tlWytCdkGLgHy/De+H/GHyVt",
-	"lJgVImy+lmwYMNoZs3DohUxONwLN+6L5d9jUYMMhZStdF6N4cyAPO8F11aQQoa48vaEQ9RU1X7mzY9+w",
-	"ECcoAo0wG8nLeRLMgljKTMyOjxPVQkc5/vL48aPg5uPN/wcAAP//",
+	"7D1rbxs5kn+F6FtgbUTyI4/BjoLFIeMkm8xlZgwn2TkgmxPo7pKacTfZIdlydIGB+xH3C++XHPjoN9nd",
+	"cizJs5svM7HER7HeVSyWvgYhSzNGgUoRzL4GHETGqAD9x084uoDPOQip/goZlUD1P3GWJSTEkjB6/Ekw",
+	"qj4TYQwpVv/6E4dFMAv+7bha+th8K45fcM74C7qChGUQ3NzcTIIIRMhJphYLZsHfcUIivfIEZXhJqP03",
+	"44hEkGZMAg3XCNQ6wc0k+AVkzKJfmXyWJOwaot1B+jtndIlevXt3jlINRKDG2Olq9WdRSugFS0BcWKyq",
+	"TzPOMuCSGBRz9bX6B5GQiiGY1GIvqORrdXK5ziCYBZhzvNZbc/icE65Q8MGu+7EcxS4/QSjVtGd5ROSL",
+	"lcVPExocmrN9LaYJyQldqmk4lIzPicYvzZMEXyYQzCTPYeIbbD52rBUyziHRRLErdoZEIDFJNExRRNRI",
+	"nJzXYG1sXB3OrLZgPMUymAV5TqLAAR8Lw5xziOZYNsZHWMJUkhRckziEjEcbT4oMUptE7oxrElPNEyzn",
+	"IYzFeDm+QPrgDAEr4ESuHeC0eEnjsEWzScErDWI3MdvPfeIcLx0CUaJolEDUmNmBRApf5DzMuWBcLdQU",
+	"398y/DkHZL5+ijIsBMIC/bv54K9IMrQAGcZIxoDUSkodqSMOYLaNPH2MJixuxMj4DVsSWtO4Tcwwman/",
+	"pfjLG6BLGQezHyZBSmjtrw6R1amuGY9aEx8+aU49dUzNBXCKU9h4agsB5To1aAYQ4FOWOAxBiLlkV+BW",
+	"UhwWHETcM0JBM8xUMv4FSjDaB2pA0d7T7uA74C8vn72gnCWJ/5AZZysiCKOELuc5J8Py2ZnRs/vfgZPF",
+	"+g55rAWLWsC7PZwDT4lQoPaYRBIBlVYxtb9x0pSIOaaMrlOW15XrJWMJYKr5giUwUs/poa01XQfKqqNs",
+	"otk7W9qzNhf0Y9CPNkitweziZ5xR9CCpqQlGYLAm8AYmu7TvUOdWK5zFmC7By5rarlA5b6i0fhVG4Xr8",
+	"8NZROtu1lvOd5sKoA+8xhlRU249rDHdteoYlLBlfG7+ws1/D6HmZYwRZ6ws54eCgmRknZxyw9BMS5zKe",
+	"W49Z8S3NU7WJEPH8CtZ1MzEJLpmMa7vV/cPGsWoK6/Tk4eOJU0lEsMB5It0q4lamrmlgu19yssIS9LEG",
+	"vteMlcUcC7cMipAZv65E11pISINJEDMhnSjSU+Zu4R/0Du/K+hu4LXobuqHOBv389IYI6dd7YTluvNtY",
+	"rV1Z+QFNXd+mH9we/+UuOD/U0rVZFFLMuVyPsgTjdMbgMsqGhpKswC1xYyVy77Jg6TO/JLJu4gmVsARe",
+	"HxGyNLWBtXeVBaFL4BknA+O80XOeRRszwIYmfJzUNkhYJ7dTPnIhWXrBEhgwD37NPkYfGxJnWErgKsr7",
+	"rw94+t8f1X9Opj/OP349nfzw6OZPLhSNduhSQl+bL08HvbuW3Rz28io0+dXIrUy6ps9lThI5J9QtcHfl",
+	"0nYOXd95GAUvwph5uSMFIWzeoGPzN7FLxTp+APxKPCJyDivlHI5UhCPyXRDGDEa4YnZcZ03nOejnHHJ4",
+	"B0L+zC57LOgweJ/Y5bjDtsC188aB20i4duMbnfF1AB/tOslY2qzC/oQJUVp/EgjgK+CKx1lCQmXR4YtS",
+	"RDhxWqU4TzGd11jakdCQfG2MU1di2x6KwkQBXX1qe6Mu8ttMplHtpNEKJzmW8CwBLr1CKkLGCxElqcLR",
+	"6cmJlk/z18mkY0O7biN3C+fLBEC+YkK+xCTJuYNRFpgkhC7nPE9gHrKcNu0kofKHx8HEYcWV93ArLi8m",
+	"Tlx7ew/xhqyAghDdE1BYAZ9nnF1CNBJ2DjiMC0YZMT6nV5Rd09GjN1u/E8QWk5tLVWBMmmf24uwCQqDS",
+	"ZArEtyaP9YrvOKbC5rIHTZte1Q9cnsAgV2pe2YQrNSuNidKLgRPXXl6g3xay2spCYiHUEgte3Qk18+fn",
+	"ZgRS2wp0jA7sFPQA2f0PEQ45EwLhJEEKFnGETo6OTo8UiKXbynLDChY8mqeX5uCSSZzMwWicwilpwnCm",
+	"zobYQq9uhE5ILAFxdi3QdQxcJ/h1Ikd9kQtEhEn1M67BbMAykp07uHHB6kX4O5a9NPhRWuxumLiuD7+R",
+	"iSvwFDvfDXh1wfhW8Gri2vUFtF6YXxHaiK8XhAs5F6DT85o/5makDnXsNVj5kdNQj7YMW76C9OqC3vs8",
+	"c2qTHC+QopjYqgqFhSuSZRofbdvfFyZWdq/SPXanSYMYw/eCrwAnMu6JeS7nIaMUQtnwkmvRS/eIsV5z",
+	"rcORJceRh7gr4MIdSrWdkuJoDWCqBZznYkKesTRLCKYhvM3TFLuytKVzO8IgWO06crRVViNHF3wwbrTW",
+	"erdxCAqgqsN0WbBY3ovV26YRPAniiIgsweu5L+vZDdnoinBGi4RP/c7Mtf6Sszy7bQpKSdotM9Qkm+Mo",
+	"4tbRbEE5lN1mXDb8+B+ePHn0pObJnzrZAi+bBmIINe17+77k87AnbjNVtXP7WOi5jv/6AuNCcOeiktw+",
+	"c+cWd0vAMZPr+eikFiDgJPltEcw+DK9QhhU3H9sVS7/mSaK8IoooQ8XqSPvcKMYCKQuCeE4RXmJChUQy",
+	"JkL7VkcdJnVhXsf5HZT5sN+f1o8L52iUm9FGXa+LYZb2g+ULy0K1ephLsoL5wrgznnxwgoWcazU2vh5H",
+	"z9G06HMJxi1TVPHNDeY8k9oA112jb4LBRngkUX5V1y4Ph4OD7odrBx9Be6+O9n2V0rY6Q1Zme2bl1rc8",
+	"DfviNSEjzMSwXdj+zYfbgNhjNKnh47f3Gsp765gMmPxv4qd/el+jQ/A3JAQq4K3UJPcqGn2rA9yb/f+S",
+	"EQ7im5TuArAsLNJ4kSJ0vuQ4hHkGnLDRoZW96FPsgkNd6aNPoJmEzRODFCVDdIUT4o67JDGleGWYzkFX",
+	"kGZAr7EM43mW6GgLqNT3pQKcy+Q6F5NxWLXqLHx5cr1vLVAtEffRT9+Bsjl74PmnazmsZ+qDR2zprffa",
+	"Gc94lql4SMwNlZ3MU5B5EJiVPrDyXZolAdWIa8wpoctvAret9AvY2/u7KFOVL3qKrUJbi+U29cqv4t4a",
+	"xVve6hbctMQSxpZylWC2L2orEPuPLy5gSYTkPexp9yAbvG5oVrI5lJXvgrpv0TbNXLX2W3qDUUNBE/ZJ",
+	"z/OMc5aQkIC4gIThyI9flsuQpfZK2nl76df+nmu/ckkvXOvnEOpK477ihFvdqQ5fhVroPE6mAs5fMmO/",
+	"92f6dMwixiQBCzCam3a2KBd04bJioT9+bUeTr+twuE7+XgAfSNyVdcw9ea5Ht3/q8JfdPHUoKp9764UV",
+	"Nu42Ov3mInCThbBAj8gF7KM6rYNmL25ZAs+EIEv/oxqliK1Xvgmli2m+nUV/ckudYLzFabDJkIiapR0l",
+	"HtrZX7DuJepbiZeATtA1Tq4IXU7FFSQgGUUi5wscAvq///lfJGMOgIBGGSNUCiRjLBF8AR4SAUjG8A+6",
+	"YDk1LzeRkDi8Qge1EpxJ/fXmBOkiqol5xYnA1vwcHv1D36USqZy34LcM6O8qEEAHFsTD2mXLLDg5Oj06",
+	"meIki/HRqbYQGVCckWAWPDo6OXqkpU/GGr3HOCPHq9NjHKWEHlufaWY8Pk0em55VRNLwvo6CWXDOhNSP",
+	"OBsueWAQDkL+xKL1nb03dUYaN03y6sTrpPlI9+HJybZgKB9AdV/pqhF2D2Q8ZnQgcv0yCjGOFPNFyCZJ",
+	"D83D2CKDHjzn6ynPKVqZp76AMPr593fIUgVdExmzXCJChcRJQugSEeOsNKmYWU9pxrWrNIKMTd8q2CIi",
+	"PV6cA5PnwKcKW8icApVO2M0keHzyaHfPmc9wkgBHCQ6vBDLeTIHZJvnMmZBSqxDZkWhBEhBowVmq30uG",
+	"jC7IMucQoYhwCKWJNr5MC16eVn5DMAu625WkVoriWFdbaiItwUHgv4GsvSvVcs9xClIr2Q9fA+UUBZ9z",
+	"0DAYQ1M9X63Q11H57pmdl7Abr9B4MbvxbEFo2Jw4xsr6VsupNBUAd7KafeB6i1MlJCWyMbF8HPDkZFJl",
+	"BR82KgkdOcGbj1uU6/bzZZdAK1PFFsbEIcu5WphPfKuX4B7XOi40hU75E40l0YHB9dQ2SYBogihcg5BI",
+	"17sctsRIxscJW5rwoEdNFo9wt2TkOq+cd2zguo+MHRTUA5C2ZhBB9BTpx3cCESFyiAwtT3enmF+bHCqq",
+	"vUBSJvaXl89QiTjNLBDmpgDow8c667y37vJx4dYjzQjaziKWmRAdvfvt3bmTZVguR/GMGteh3GOHuwla",
+	"6yMOK3YFXeOiPjU2xBp/YSZ0gTMBg98iyPgXCLbMTI134l3SFc97d80zvzLjXRXIUwxzCZjbWpw6vmXO",
+	"aQPf5ZtkB8KPW3mEfuSfN3Ne26WD622529+yw1BCOmr2xWIB+moD1Q6KFsqjHYehBZ6BfuA/LDNlL4Ct",
+	"46bTdMCFl1oTAfT+4jXimjOUF29Prw6ozh1iyTjCWdbGnd6jgSgVjCJCtXJRCsuNsFFhWL19wRaNU6dF",
+	"wigD5VBzSj3rg5E9mAy1uUK5vX5T0s8hS/C6o2/PlKPOU4QpMnwLkbYsAkIOEl2uzSHWipoYLYEqwkCE",
+	"nNaiMDAzkzcapmjz6f8WyeruMXBb2harIZvsqrl3O1LvcI1Ka87hk65EVcSy7452zW9npsa+gumaM5s1",
+	"q7Gaxn1HP/xZlNMcHFVp4Rm3d05DdsdxTbXVUL/nVsyBqhKkJnJe5kmCLn56doaKY6KD6v5oUjdHE6RT",
+	"7FNCkb5Gcnj6tmvEsADabhVblLxWP4z76O8radIuPsow4fty8y2iLCRWc0+QLayYGB2eC4gUY4gQR2Bd",
+	"aCQ5WS6BQ3TYGwdcMP00Rskfr+/1FKWESoRV+IhMc6MHxQCFkAZ7tbot+OTwrDZsi+T19IhwaahyJEpB",
+	"4ghLbP2/fabZKmzOOHQSbTrmr0d9ByXojCbrw56EWmfhSY8iaBPr7hWBrzfMKG1wugUwRrKKvYLbuX2v",
+	"N8EsfDjdk2Giq7ERZRLp6xbTF9OOePv2FboCa/1/3KG3mSeSZAkg04cD2cSdaNt/jUyEayw9joOvOZHg",
+	"00LHX0l0Y1y0BCR0Ofy5/rwi6k/r1889KeIMy7jKSJqHTQ3mdKZJPU+EP47xJA1wEToom2f8dYETAYeG",
+	"iI93qJcqri+5q0XAt2whpwbNt6Cipc/NZITR2B+NTvanbArlfh9J/1J3wqwT/c+iAngDO1QT4ojgJWVC",
+	"klDMIIxZv7f6vBr9Qg12c0cMONLVnZY/XleXztP/gHUvszQqP54MVn54dvzP6Vl1PzR93X8/9HE75rbe",
+	"QWXHDnejd4qD19T3VWr9VvciasqT4SmdxtC7Nost3iu8d512j8hiATpkvlSEbyXSFI6Mm66PjGxZ3NOy",
+	"4EI0emE/MBdDfuEyfWCmEoScfmKX4wWt0UCm68g/vDtkulvVOLD6M7vUQUomIXqKrhm/Ao6uSZKgiGNC",
+	"2yZL4iVMT5BeHUWQsqfIokOoiIdNWYY+sUuUcaYCH5NFUbgndGo/s5v40Wt7okxxAlyOR269lcqW/G5n",
+	"u5YdawRP4agrBW1KCSI71EPKrBilaWkPKEyGWh1zLmMVurIkEmU6zEO5jENK8nS6kfU5N5PuhRH617Qf",
+	"hS5/uDtdbgujUMRAaCeJ0DDJI0CWheY1tkL2VUUnmtdLTHWhPlIs97S4vxW9yzS8q+LDWeCY4mV0O32q",
+	"gsepdsTGcvuFmWneUeqaqe8cvw+ORwehSRwZxaYIqT3qw/0msEo4PMpaZ7SNqi55vZxTS2r3hBDNLQa5",
+	"2yQLbsHev+uJ3/n7/vC3JuV9YPAqAbUBh+tJG7B4N8vl4nEOKUTEBJfwBcJ8c2a/qJZ4YVf4zvX/6n5M",
+	"ja/mhq9sQ7z9iV4NpFnB6n4ZfFCUj7dk0bEKeuA+7pDH5caRX6x9Byjke5EAyON6lxdfZrTZL3KLbNvc",
+	"yMlAtmsMZ0mSZzu/JX1WFSGZIsKiAHKfnGruPTo+TZNZlY+BdDNGgS7XqN7BBNm36F3m4Lrf5TSsGl72",
+	"skizPWZHqzeP8JIkEjiSDMmqqZ5A1zETgBZq4jXjV3MOC4EUUjGhwnQEuoI1OlidHp0enRwe6Vf+3Xru",
+	"coGhYvBRQKkJoUzWusSZIxljakC5eHn26NGjH5EkKQiJ08wDzt0WzY8tVj892Wu1uoMnnIUHakAd3+aX",
+	"rm6bm/2uDUZogy7SBTowvUutsB826/kdyqFss9yrE0yD19G6wNNJdYc6YesSYTDiIKP+Fhm0fmflsays",
+	"sTa9JhGgqvubwWLZFPhY93I8dDCxZNnUNoGclj3fehm63UD3D8Ta/wTmpI19l0HB9AoiU6lS9sn7bk22",
+	"7FsKc7MoY0BpgfmqP/eB2gJoROhySAp50fd5pBSaPtHfpXA/Umiw75dChenvUrgbn05LmlsKtWnzS6Fp",
+	"Vd0ndKZB9jZj/1YLbgdK3gJfkRAQEajorX0zCZ7skio1EIqm3ohxlFO8wsS0/eqrgS7TFw9UAB6RWgPc",
+	"g/L3PlukGXJKPF6IS8XUOzPeQkNJvNyb59zp2Osgjk5x7L+q2ncppeupY0utEddNfTXTBdG3kbbudjff",
+	"cZ10s5uyh877r40uzBo6uMTG3VRyMkEkm6CMcTlBIMOjw50Xfr2ykCCcKEZaI/hClPYnFNUVgKc62jbS",
+	"3vCuSLP18Vf7iww39QrpGQfBktXAPdGr5kOACztnTBFu7Wcg/sCVuPbE9Xf2+yvJ/ZXVwShtm36Lq+Mq",
+	"xlvV9p38kj6NeW1XraTbNulquUtAuhxRrTjIdH1lvJbzRlXhKya7n/X3Bu5ojiUSIHdffv+q8ayjt/B+",
+	"jIIYLrbfJSl8Wf7ujwXcRYD4UAWIqPT0iFDeoX7XD9H9zUw6fo/CxyamxSY6sHe3ovophwcOlN4zXi5e",
+	"EmgtpmMlJ/QIKCdhbD3lcc4almHsMG7q450rnu14hc3W8jsuaRjlFe7rRXzXK7xfbG8oh9JcajtucqME",
+	"kkhs7usV7dV7YtI3ZQf2bfcKbHa+7yk50cq8hZW/gTQeiu0fkNTHogNJgE+KqgwxQZ9zJrGY2OvyZphe",
+	"NnH2oeSCmTTl9t6aRymhepdeN5MlcA9iZIUub4zc7C/QV+HSWKVBipmJD/uDDo0tE/ls6+Wx52fHd/3y",
+	"uPuz3s42GmqUxvrewutaf6Ti13h2HT9rESERkvgKqPcRcYWrIQbtatCy/65PWegevttUFt0mwQ5EqEH3",
+	"QFcobHl1RW4x5aNAbXJfPq1C+N3rgG7T8R1Lf7OBs4fO9yCfxnjZzrXuQ+2V71y116USUCOGeM8j/SMz",
+	"Foo09zFjsXPvVvPouATFGKoMJyj2i/mTnQr//aJmEaKPoWPH+auEy/qBWDfg7/cDi2b9wnTr/wNH6e6f",
+	"HbhtozntCRkE7sEyvDf+n/FHSZtLzAkRNl9LNsww2hmz7NDLMjndiGneF8O/s02NbTikbKVbyxTPduRh",
+	"55JADSlIqJu3b0hEfdXOV+6anzcsxAmKQHOYzeTlPAlmQSxlJmbHx4kaobMcf3n8+FFw8/Hm/wMAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/app/internal/server/api_fleet_test.go
+++ b/app/internal/server/api_fleet_test.go
@@ -13,7 +13,12 @@
 //   AC-10  TestAPI_Fleet_Limit_Negative_Returns400
 //   AC-11  TestAPI_Fleet_Anonymous_Returns403
 //   AC-12  TestAPI_Fleet_ViewerSession_HappyPath
-//   AC-14  TestAPI_Fleet_NonGET_Returns405
+//   AC-13  TestFleetHandlers_NoSQL_NoPoolAccess (in fleet_source_test.go)
+//   AC-14  TestAPI_Fleet_Score_FrameworkFilter (v1.1.0)
+//   AC-15  TestAPI_Fleet_TopFailingRules_FrameworkFilter (v1.1.0)
+//   AC-16  TestAPI_Fleet_RecentChanges_FrameworkFilter (v1.1.0)
+//   AC-17  TestAPI_Fleet_Score_EmptyFrameworkParam_SameAsNoParam (v1.1.0)
+//   AC-18  TestAPI_Fleet_NonGET_Returns405 (renumbered from v1.0.0 AC-14)
 
 package server
 
@@ -51,15 +56,31 @@ func seedFleetHost(t *testing.T, pool *pgxpool.Pool, createdBy uuid.UUID) uuid.U
 
 func seedFleetRuleState(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status string) {
 	t.Helper()
+	seedFleetRuleStateWithFrameworks(t, pool, hostID, ruleID, status, nil)
+}
+
+// seedFleetRuleStateWithFrameworks variant lets a test attach a
+// framework_refs JSONB so v1.1.0/v1.2.0 ?framework= filter ACs can be
+// exercised. frameworks=nil → '{}'::jsonb (the legacy default).
+func seedFleetRuleStateWithFrameworks(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status string, frameworks map[string]string) {
+	t.Helper()
 	now := time.Now().UTC()
 	scanID, _ := uuid.NewV7()
+	refsJSON := []byte("{}")
+	if len(frameworks) > 0 {
+		var err error
+		refsJSON, err = json.Marshal(frameworks)
+		if err != nil {
+			t.Fatalf("marshal framework refs: %v", err)
+		}
+	}
 	_, err := pool.Exec(context.Background(), `
 		INSERT INTO host_rule_state
 			(host_id, rule_id, current_status, severity,
 			 last_checked_at, check_count, last_scan_id, evidence,
 			 framework_refs, first_seen_at, last_changed_at)
-		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, '{}'::jsonb, $4, $4)`,
-		hostID, ruleID, status, now, scanID,
+		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, $6::jsonb, $4, $4)`,
+		hostID, ruleID, status, now, scanID, refsJSON,
 	)
 	if err != nil {
 		t.Fatalf("seed rule_state: %v", err)
@@ -77,15 +98,27 @@ func seedFleetLiveness(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, statu
 }
 
 func seedFleetTransaction(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status, changeKind string, occurredAt time.Time) uuid.UUID {
+	return seedFleetTransactionWithFrameworks(t, pool, hostID, ruleID, status, changeKind, occurredAt, nil)
+}
+
+func seedFleetTransactionWithFrameworks(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status, changeKind string, occurredAt time.Time, frameworks map[string]string) uuid.UUID {
 	t.Helper()
 	id, _ := uuid.NewV7()
 	scanID, _ := uuid.NewV7()
+	refsJSON := []byte("{}")
+	if len(frameworks) > 0 {
+		var err error
+		refsJSON, err = json.Marshal(frameworks)
+		if err != nil {
+			t.Fatalf("marshal framework refs: %v", err)
+		}
+	}
 	_, err := pool.Exec(context.Background(), `
 		INSERT INTO transactions
 			(id, host_id, rule_id, scan_id, status, severity,
-			 change_kind, evidence, occurred_at)
-		VALUES ($1, $2, $3, $4, $5, 'medium', $6, '{}'::jsonb, $7)`,
-		id, hostID, ruleID, scanID, status, changeKind, occurredAt,
+			 change_kind, evidence, framework_refs, occurred_at)
+		VALUES ($1, $2, $3, $4, $5, 'medium', $6, '{}'::jsonb, $7::jsonb, $8)`,
+		id, hostID, ruleID, scanID, status, changeKind, refsJSON, occurredAt,
 	)
 	if err != nil {
 		t.Fatalf("seed transaction: %v", err)
@@ -471,10 +504,11 @@ func TestAPI_Fleet_ViewerSession_HappyPath(t *testing.T) {
 	})
 }
 
-// @ac AC-14
-// AC-14: POST against a /fleet endpoint returns 405.
+// @ac AC-18
+// AC-18 (renumbered from v1.0.0 AC-14 in v1.1.0): POST against a
+// /fleet endpoint returns 405.
 func TestAPI_Fleet_NonGET_Returns405(t *testing.T) {
-	t.Run("api-fleet-observability/AC-14", func(t *testing.T) {
+	t.Run("api-fleet-observability/AC-18", func(t *testing.T) {
 		url, _ := freshAPIServer(t)
 		for _, ep := range []string{
 			"/api/v1/fleet/score",
@@ -490,6 +524,137 @@ func TestAPI_Fleet_NonGET_Returns405(t *testing.T) {
 			if resp.StatusCode != http.StatusMethodNotAllowed {
 				t.Errorf("POST %s status = %d, want 405; body=%s", ep, resp.StatusCode, body)
 			}
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14 (v1.1.0): GET /fleet/score?framework=cis_rhel9_v2.0.0 computes
+// the score only from host_rule_state rows whose framework_refs
+// contains "cis_rhel9_v2.0.0" as a top-level key.
+func TestAPI_Fleet_Score_FrameworkFilter(t *testing.T) {
+	t.Run("api-fleet-observability/AC-14", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h := seedFleetHost(t, pool, user)
+		// 3 rules in CIS, 1 also in STIG, 1 in STIG-only, 1 in neither.
+		seedFleetRuleStateWithFrameworks(t, pool, h, "r.cis.pass", "pass",
+			map[string]string{"cis_rhel9_v2.0.0": "1.1"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "r.cis.fail", "fail",
+			map[string]string{"cis_rhel9_v2.0.0": "1.2"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "r.cis.stig.pass", "pass",
+			map[string]string{"cis_rhel9_v2.0.0": "1.3", "stig_rhel9_v2r7": "ABC-1"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "r.stig.fail", "fail",
+			map[string]string{"stig_rhel9_v2r7": "ABC-2"})
+		seedFleetRuleState(t, pool, h, "r.neither", "pass") // no framework refs
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/score?framework=cis_rhel9_v2.0.0", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d; body=%s", resp.StatusCode, b)
+		}
+		var body struct {
+			PassingFraction  float64 `json:"passing_fraction"`
+			TotalEvaluations int64   `json:"total_evaluations"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		// CIS rules: 2 pass, 1 fail → 2/3.
+		if body.TotalEvaluations != 3 {
+			t.Errorf("total_evaluations = %d, want 3 (CIS only)", body.TotalEvaluations)
+		}
+		want := 2.0 / 3.0
+		if body.PassingFraction != want {
+			t.Errorf("passing_fraction = %v, want %v", body.PassingFraction, want)
+		}
+	})
+}
+
+// @ac AC-15
+// AC-15 (v1.1.0): GET /fleet/top-failing-rules?framework=stig_rhel9_v2r7
+// returns only rules mapped to STIG.
+func TestAPI_Fleet_TopFailingRules_FrameworkFilter(t *testing.T) {
+	t.Run("api-fleet-observability/AC-15", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h1 := seedFleetHost(t, pool, user)
+		h2 := seedFleetHost(t, pool, user)
+		seedFleetRuleStateWithFrameworks(t, pool, h1, "rule.cis-only", "fail",
+			map[string]string{"cis_rhel9_v2.0.0": "1.1"})
+		seedFleetRuleStateWithFrameworks(t, pool, h2, "rule.cis-only", "fail",
+			map[string]string{"cis_rhel9_v2.0.0": "1.1"})
+		seedFleetRuleStateWithFrameworks(t, pool, h1, "rule.stig", "fail",
+			map[string]string{"stig_rhel9_v2r7": "X-1"})
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/top-failing-rules?framework=stig_rhel9_v2r7", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		var body struct {
+			Items []struct {
+				RuleID string `json:"rule_id"`
+			} `json:"items"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Items) != 1 || body.Items[0].RuleID != "rule.stig" {
+			t.Errorf("expected only rule.stig, got %+v", body.Items)
+		}
+	})
+}
+
+// @ac AC-16
+// AC-16 (v1.1.0): GET /fleet/recent-changes?framework=cis_rhel9_v2.0.0
+// returns only transactions whose framework_refs contains that key.
+func TestAPI_Fleet_RecentChanges_FrameworkFilter(t *testing.T) {
+	t.Run("api-fleet-observability/AC-16", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h := seedFleetHost(t, pool, user)
+		t0 := time.Now().UTC().Truncate(time.Second)
+		seedFleetTransactionWithFrameworks(t, pool, h, "rule.cis", "fail", "state_changed", t0,
+			map[string]string{"cis_rhel9_v2.0.0": "1.1"})
+		seedFleetTransactionWithFrameworks(t, pool, h, "rule.stig", "pass", "state_changed", t0.Add(time.Minute),
+			map[string]string{"stig_rhel9_v2r7": "X-1"})
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/recent-changes?framework=cis_rhel9_v2.0.0", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		var body struct {
+			Items []struct {
+				RuleID string `json:"rule_id"`
+			} `json:"items"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		if len(body.Items) != 1 || body.Items[0].RuleID != "rule.cis" {
+			t.Errorf("expected only rule.cis, got %+v", body.Items)
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17 (v1.1.0): GET /fleet/score (no framework) and
+// GET /fleet/score?framework= (empty value) both return the same
+// unfiltered Score.
+func TestAPI_Fleet_Score_EmptyFrameworkParam_SameAsNoParam(t *testing.T) {
+	t.Run("api-fleet-observability/AC-17", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		h := seedFleetHost(t, pool, user)
+		seedFleetRuleState(t, pool, h, "rule.a", "pass")
+		seedFleetRuleState(t, pool, h, "rule.b", "fail")
+
+		req := asRole(t, "GET", url+"/api/v1/fleet/score", auth.RoleViewer, nil)
+		resp := doReq(t, req)
+		b1, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		req = asRole(t, "GET", url+"/api/v1/fleet/score?framework=", auth.RoleViewer, nil)
+		resp = doReq(t, req)
+		b2, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if string(b1) != string(b2) {
+			t.Errorf("?framework= empty differs from no-param: %s vs %s", b1, b2)
 		}
 	})
 }

--- a/app/internal/server/api_hosts_enrichment_test.go
+++ b/app/internal/server/api_hosts_enrichment_test.go
@@ -5,6 +5,8 @@
 //   AC-14  TestHosts_GetByID_Enrichment_LivenessNullWhenUnprobed
 //   AC-15  TestHosts_GetByID_Enrichment_ComplianceSummaryCounts
 //   AC-16  TestHosts_GetByID_Enrichment_ComplianceSummaryZerosOnEmpty
+//   AC-17  TestHosts_GetByID_Enrichment_FrameworkFilterCounts
+//   AC-18  TestHosts_GetByID_Enrichment_FrameworkFilterEmpty
 
 package server
 
@@ -40,15 +42,29 @@ func seedLivenessForHost(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, sta
 // seedRuleStateForHost inserts a single host_rule_state row.
 func seedRuleStateForHost(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status string) {
 	t.Helper()
+	seedRuleStateForHostWithFrameworks(t, pool, hostID, ruleID, status, nil)
+}
+
+// seedRuleStateForHostWithFrameworks variant attaches framework_refs.
+func seedRuleStateForHostWithFrameworks(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status string, frameworks map[string]string) {
+	t.Helper()
 	now := time.Now().UTC()
 	scanID, _ := uuid.NewV7()
+	refsJSON := []byte("{}")
+	if len(frameworks) > 0 {
+		var err error
+		refsJSON, err = json.Marshal(frameworks)
+		if err != nil {
+			t.Fatalf("marshal framework refs: %v", err)
+		}
+	}
 	_, err := pool.Exec(context.Background(), `
 		INSERT INTO host_rule_state
 			(host_id, rule_id, current_status, severity,
 			 last_checked_at, check_count, last_scan_id, evidence,
 			 framework_refs, first_seen_at, last_changed_at)
-		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, '{}'::jsonb, $4, $4)`,
-		hostID, ruleID, status, now, scanID,
+		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, $6::jsonb, $4, $4)`,
+		hostID, ruleID, status, now, scanID, refsJSON,
 	)
 	if err != nil {
 		t.Fatalf("seed host_rule_state: %v", err)
@@ -184,6 +200,71 @@ func TestHosts_GetByID_Enrichment_ComplianceSummaryZerosOnEmpty(t *testing.T) {
 		// All zero, valid JSON object (not null), no error.
 		if s.Passing != 0 || s.Failing != 0 || s.Skipped != 0 || s.Error != 0 || s.Total != 0 {
 			t.Errorf("got %+v, want all zeros", s)
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17 (v1.2.0): GET /hosts/{id}?framework=cis_rhel9_v2.0.0
+// returns compliance_summary computed only from host_rule_state rows
+// whose framework_refs contains that key.
+func TestHosts_GetByID_Enrichment_FrameworkFilterCounts(t *testing.T) {
+	t.Run("api-hosts/AC-17", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		created := createHostAPI(t, url, "fw-host", "production")
+		idStr := created["id"].(string)
+		hostID, _ := uuid.Parse(idStr)
+		// 2 CIS passing + 1 CIS failing, plus 1 STIG-only failing + 1 no-framework rule.
+		seedRuleStateForHostWithFrameworks(t, pool, hostID, "rule.cis.p1", "pass",
+			map[string]string{"cis_rhel9_v2.0.0": "1.1"})
+		seedRuleStateForHostWithFrameworks(t, pool, hostID, "rule.cis.p2", "pass",
+			map[string]string{"cis_rhel9_v2.0.0": "1.2"})
+		seedRuleStateForHostWithFrameworks(t, pool, hostID, "rule.cis.f1", "fail",
+			map[string]string{"cis_rhel9_v2.0.0": "1.3"})
+		seedRuleStateForHostWithFrameworks(t, pool, hostID, "rule.stig.f1", "fail",
+			map[string]string{"stig_rhel9_v2r7": "X-1"})
+		seedRuleStateForHost(t, pool, hostID, "rule.none", "pass") // no framework_refs
+
+		req := asRole(t, "GET", url+"/api/v1/hosts/"+idStr+"?framework=cis_rhel9_v2.0.0", auth.RoleAdmin, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d", resp.StatusCode)
+		}
+		var got hostDetailResponse
+		_ = json.NewDecoder(resp.Body).Decode(&got)
+		s := got.ComplianceSummary
+		if s.Passing != 2 || s.Failing != 1 || s.Total != 3 {
+			t.Errorf("CIS-filtered summary = %+v, want passing=2 failing=1 total=3", s)
+		}
+	})
+}
+
+// @ac AC-18
+// AC-18 (v1.2.0): GET /hosts/{id}?framework=<id> on a host whose
+// rule_state does NOT reference that framework returns 200 with all
+// zero counts — never an error.
+func TestHosts_GetByID_Enrichment_FrameworkFilterEmpty(t *testing.T) {
+	t.Run("api-hosts/AC-18", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		created := createHostAPI(t, url, "no-stig-host", "production")
+		idStr := created["id"].(string)
+		hostID, _ := uuid.Parse(idStr)
+		// Host has CIS rules but NO STIG rules.
+		seedRuleStateForHostWithFrameworks(t, pool, hostID, "rule.cis.p1", "pass",
+			map[string]string{"cis_rhel9_v2.0.0": "1.1"})
+
+		req := asRole(t, "GET", url+"/api/v1/hosts/"+idStr+"?framework=stig_rhel9_v2r7", auth.RoleAdmin, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (zeros, not 404)", resp.StatusCode)
+		}
+		var got hostDetailResponse
+		_ = json.NewDecoder(resp.Body).Decode(&got)
+		s := got.ComplianceSummary
+		if s.Passing != 0 || s.Failing != 0 || s.Total != 0 {
+			t.Errorf("STIG-filtered summary on CIS-only host = %+v, want all zeros", s)
 		}
 	})
 }

--- a/app/internal/server/fleet_handlers.go
+++ b/app/internal/server/fleet_handlers.go
@@ -19,12 +19,12 @@ import (
 // SQL-free invariant via source inspection.
 
 // GetFleetScore implements api.ServerInterface.GetFleetScore.
-// Spec api-fleet-observability AC-01, AC-02, AC-11, AC-12.
-func (h *handlers) GetFleetScore(w http.ResponseWriter, r *http.Request) {
+// Spec api-fleet-observability AC-01, AC-02, AC-11, AC-12, AC-14, AC-17.
+func (h *handlers) GetFleetScore(w http.ResponseWriter, r *http.Request, params api.GetFleetScoreParams) {
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
 	}
-	score, err := h.fleet.FleetComplianceScore(r.Context())
+	score, err := h.fleet.FleetComplianceScore(r.Context(), frameworkOpts(params.Framework)...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"failed to compute fleet compliance score", true)
@@ -38,6 +38,7 @@ func (h *handlers) GetFleetScore(w http.ResponseWriter, r *http.Request) {
 
 // GetFleetLiveness implements api.ServerInterface.GetFleetLiveness.
 // Spec api-fleet-observability AC-03, AC-11, AC-12.
+// (?framework= has no effect on liveness — host_liveness is OS-agnostic.)
 func (h *handlers) GetFleetLiveness(w http.ResponseWriter, r *http.Request) {
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
@@ -57,7 +58,7 @@ func (h *handlers) GetFleetLiveness(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetFleetTopFailingRules implements api.ServerInterface.GetFleetTopFailingRules.
-// Spec api-fleet-observability AC-04, AC-09, AC-10, AC-11, AC-12.
+// Spec api-fleet-observability AC-04, AC-09, AC-10, AC-11, AC-12, AC-15.
 func (h *handlers) GetFleetTopFailingRules(w http.ResponseWriter, r *http.Request, params api.GetFleetTopFailingRulesParams) {
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
@@ -66,7 +67,7 @@ func (h *handlers) GetFleetTopFailingRules(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	rows, err := h.fleet.TopFailingRules(r.Context(), limit)
+	rows, err := h.fleet.TopFailingRules(r.Context(), limit, frameworkOpts(params.Framework)...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"failed to query top failing rules", true)
@@ -83,7 +84,7 @@ func (h *handlers) GetFleetTopFailingRules(w http.ResponseWriter, r *http.Reques
 }
 
 // GetFleetTopFailingHosts implements api.ServerInterface.GetFleetTopFailingHosts.
-// Spec api-fleet-observability AC-05, AC-09, AC-10, AC-11, AC-12.
+// Spec api-fleet-observability AC-05, AC-09, AC-10, AC-11, AC-12 (+v1.1.0 framework filter).
 func (h *handlers) GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Request, params api.GetFleetTopFailingHostsParams) {
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
@@ -92,7 +93,7 @@ func (h *handlers) GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	rows, err := h.fleet.TopFailingHosts(r.Context(), limit)
+	rows, err := h.fleet.TopFailingHosts(r.Context(), limit, frameworkOpts(params.Framework)...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"failed to query top failing hosts", true)
@@ -109,7 +110,7 @@ func (h *handlers) GetFleetTopFailingHosts(w http.ResponseWriter, r *http.Reques
 }
 
 // GetFleetRecentChanges implements api.ServerInterface.GetFleetRecentChanges.
-// Spec api-fleet-observability AC-06, AC-07, AC-09, AC-10, AC-11, AC-12.
+// Spec api-fleet-observability AC-06, AC-07, AC-09, AC-10, AC-11, AC-12, AC-16.
 func (h *handlers) GetFleetRecentChanges(w http.ResponseWriter, r *http.Request, params api.GetFleetRecentChangesParams) {
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
@@ -121,7 +122,7 @@ func (h *handlers) GetFleetRecentChanges(w http.ResponseWriter, r *http.Request,
 	// since is already typed *time.Time by oapi-codegen — malformed
 	// values are rejected upstream by the codegen wrapper with 400.
 	var since = nilOrTime(params.Since)
-	rows, err := h.fleet.RecentChanges(r.Context(), since, limit)
+	rows, err := h.fleet.RecentChanges(r.Context(), since, limit, frameworkOpts(params.Framework)...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"failed to query recent changes", true)

--- a/app/internal/server/fleet_helpers.go
+++ b/app/internal/server/fleet_helpers.go
@@ -7,6 +7,16 @@ import (
 	"github.com/Hanalyx/openwatch/internal/fleetrollup"
 )
 
+// frameworkOpts produces the fleetrollup.Option list for the optional
+// ?framework= query parameter. Nil or empty value returns no options
+// (unfiltered). Spec api-fleet-observability v1.1.0 C-07 / C-08.
+func frameworkOpts(framework *string) []fleetrollup.Option {
+	if framework == nil || *framework == "" {
+		return nil
+	}
+	return []fleetrollup.Option{fleetrollup.WithFramework(*framework)}
+}
+
 // validatePaginatedLimit reads the optional ?limit= parameter and
 // returns the value to pass into fleetrollup. On nil it returns the
 // default (50). On values outside [1, fleetrollup.MaxLimit] it writes

--- a/app/internal/server/hosts_enrichment.go
+++ b/app/internal/server/hosts_enrichment.go
@@ -54,7 +54,12 @@ func loadHostLiveness(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID)
 // loadHostComplianceSummary reads the per-status counts from
 // host_rule_state for the given host. A host with no rule_state rows
 // returns all zeros — never an error. Spec api-hosts C-06 / AC-16.
-func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID) (api.HostComplianceSummary, error) {
+//
+// framework, when non-empty, filters rows to those whose framework_refs
+// JSONB contains the given key (api-hosts v1.2.0 AC-17 / AC-18). A host
+// whose rule_state has no rows mapped to the requested framework
+// returns all-zero counts (AC-18).
+func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID, framework string) (api.HostComplianceSummary, error) {
 	const q = `
 		SELECT
 			COUNT(*) FILTER (WHERE current_status = 'pass')::BIGINT    AS passing,
@@ -63,9 +68,14 @@ func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID u
 			COUNT(*) FILTER (WHERE current_status = 'error')::BIGINT   AS errors,
 			COUNT(*)::BIGINT                                           AS total
 		  FROM host_rule_state
-		 WHERE host_id = $1`
+		 WHERE host_id = $1
+		   AND ($2::text IS NULL OR framework_refs ? $2)`
 	var s api.HostComplianceSummary
-	if err := pool.QueryRow(ctx, q, hostID).Scan(
+	var frameworkParam any
+	if framework != "" {
+		frameworkParam = framework
+	}
+	if err := pool.QueryRow(ctx, q, hostID, frameworkParam).Scan(
 		&s.Passing, &s.Failing, &s.Skipped, &s.Error, &s.Total,
 	); err != nil {
 		return api.HostComplianceSummary{}, fmt.Errorf("loadHostComplianceSummary: %w", err)

--- a/app/internal/server/hosts_handlers.go
+++ b/app/internal/server/hosts_handlers.go
@@ -109,8 +109,8 @@ func (h *handlers) PostHosts(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetHostByID fetches a host with liveness + compliance_summary enrichment.
-// Spec api-hosts AC-08, AC-13, AC-14, AC-15, AC-16.
-func (h *handlers) GetHostByID(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+// Spec api-hosts AC-08, AC-13, AC-14, AC-15, AC-16, AC-17, AC-18.
+func (h *handlers) GetHostByID(w http.ResponseWriter, r *http.Request, id openapitypes.UUID, params api.GetHostByIDParams) {
 	if denied := auth.EnforcePermission(w, r, auth.HostRead); denied {
 		return
 	}
@@ -135,7 +135,13 @@ func (h *handlers) GetHostByID(w http.ResponseWriter, r *http.Request, id openap
 			"liveness lookup failed", true)
 		return
 	}
-	summary, err := loadHostComplianceSummary(ctx, h.pool, hostID)
+	// v1.2.0: optional ?framework= filters the compliance_summary;
+	// liveness is unaffected (spec C-07).
+	var framework string
+	if params.Framework != nil {
+		framework = *params.Framework
+	}
+	summary, err := loadHostComplianceSummary(ctx, h.pool, hostID, framework)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"compliance summary lookup failed", true)

--- a/app/specs/api/fleet-observability.spec.yaml
+++ b/app/specs/api/fleet-observability.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-fleet-observability
   title: Fleet observability endpoints (read-only Slice B exposure)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -72,6 +72,14 @@ spec:
       description: Handlers MUST delegate query work to internal/fleetrollup.Service without re-implementing SQL or aggregation logic. Source-inspection enforces (AC-13)
       type: technical
       enforcement: error
+    - id: C-07
+      description: Every endpoint MUST accept optional ?framework=<framework_id> (v1.1.0 addendum). When present, results MUST be filtered to host_rule_state / transactions rows whose framework_refs JSONB contains the given framework_id as a key. An empty string or absent framework parameter MUST NOT filter — same behavior as v1.0.0
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: ?framework= value MUST be matched against keys in framework_refs JSONB exactly — no fuzzy matching, no case folding. The framework key catalog comes from per-rule References (e.g., "cis_rhel9_v2.0.0", "stig_rhel9_v2r7"), not from a separate framework registry
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -113,6 +121,22 @@ spec:
       description: Anonymous (no session) request to any /fleet endpoint returns 403 authz.permission_denied (per system-rbac AC-09).
       priority: critical
       references_constraints: [C-02]
+    - id: AC-14
+      description: GET /api/v1/fleet/score?framework=cis_rhel9_v2.0.0 returns a Score computed only from host_rule_state rows whose framework_refs contains "cis_rhel9_v2.0.0" as a top-level key; rows without that framework reference are excluded from both numerator and denominator.
+      priority: critical
+      references_constraints: [C-07, C-08]
+    - id: AC-15
+      description: GET /api/v1/fleet/top-failing-rules?framework=stig_rhel9_v2r7 returns only rules mapped to STIG RHEL 9 V2R7; cis-only rules are excluded.
+      priority: critical
+      references_constraints: [C-07, C-08]
+    - id: AC-16
+      description: GET /api/v1/fleet/recent-changes?framework=cis_rhel9_v2.0.0 returns only transactions whose framework_refs contains that key. A transaction for a rule mapped only to STIG is excluded.
+      priority: critical
+      references_constraints: [C-07, C-08]
+    - id: AC-17
+      description: GET /api/v1/fleet/score (no framework) returns the same Score as GET /api/v1/fleet/score?framework= (empty value) — both are unfiltered.
+      priority: high
+      references_constraints: [C-07]
     - id: AC-12
       description: For one or more /fleet endpoints, the happy path with a viewer session returns 200 — confirming the system:read permission included in RoleViewer suffices.
       priority: critical
@@ -121,7 +145,7 @@ spec:
       description: Source-inspection — internal/server/fleet_handlers.go contains no SQL statements (no SELECT/INSERT/UPDATE) and no direct pool.Query/Exec calls. All data access goes through fleetrollup.Service methods.
       priority: critical
       references_constraints: [C-06]
-    - id: AC-14
-      description: POST /api/v1/fleet/score returns 405 method_not_allowed (and similarly for the other four endpoints).
+    - id: AC-18
+      description: POST /api/v1/fleet/score returns 405 method_not_allowed (and similarly for the other four endpoints). Renumbered from v1.0.0 AC-14 to AC-18 in v1.1.0 to make room for framework-filter ACs.
       priority: high
       references_constraints: [C-01]

--- a/app/specs/api/hosts.spec.yaml
+++ b/app/specs/api/hosts.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-hosts
   title: Host inventory CRUD HTTP surface + Slice B enrichments
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -61,6 +61,14 @@ spec:
       enforcement: error
     - id: C-06
       description: GET /hosts/{id} response MUST include a compliance_summary sub-object with passing, failing, skipped, error, and total counts derived from host_rule_state. A host with no rule_state rows MUST receive zeros — never null and never an error
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: GET /hosts/{id} MUST accept optional ?framework=<framework_id> (v1.2.0 addendum). When present, compliance_summary counts are derived ONLY from host_rule_state rows whose framework_refs JSONB contains the given framework_id key. The liveness sub-object is unaffected by ?framework= (liveness is OS-agnostic, not framework-scoped)
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: ?framework= matching is exact-key lookup on the framework_refs JSONB, same semantics as api-fleet-observability C-08. No fuzzy matching, no case folding
       type: technical
       enforcement: error
 
@@ -125,3 +133,11 @@ spec:
       description: GET /hosts/{id} for a host with no host_rule_state rows returns 200 with compliance_summary populated with all zero counts — never null and never an error.
       priority: critical
       references_constraints: [C-06]
+    - id: AC-17
+      description: GET /hosts/{id}?framework=cis_rhel9_v2.0.0 returns compliance_summary counts computed only from host_rule_state rows whose framework_refs contains "cis_rhel9_v2.0.0" as a top-level key. Rows mapped to other frameworks are excluded; the liveness sub-object is identical to the unfiltered response.
+      priority: critical
+      references_constraints: [C-07, C-08]
+    - id: AC-18
+      description: GET /hosts/{id}?framework=<framework_id> on a host whose rule_state rows do NOT reference that framework returns 200 with compliance_summary all zeros — never an error, never a 404.
+      priority: high
+      references_constraints: [C-07]

--- a/app/specs/system/kensa-executor.spec.yaml
+++ b/app/specs/system/kensa-executor.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-kensa-executor
   title: Kensa executor wrapper
-  version: "1.0.0"
+  version: "2.0.0"
   status: approved
   tier: 1
 
@@ -10,39 +10,64 @@ spec:
     feature: Kensa scan execution bridge
     description: >
       The executor invokes Kensa (Go module github.com/Hanalyx/kensa
-      pinned to v0.2.1) to run a single framework's scan against a
-      single host. It bridges OpenWatch's credential store to Kensa's
-      SSH session, captures the structured result, and hands it to the
+      pinned to v0.2.1) to run a scan against a single host using the
+      FULL rule corpus applicable to the host's detected OS
+      capabilities. The Kensa API (`Kensa.Scan(ctx, host, rules,
+      opts...)` per kensa-go/api/kensa.go:228) takes a `[]*api.Rule`
+      slice and, internally, calls `detect.Detect` to obtain the
+      host's `CapabilitySet`, then `rule.Select` to pick the right
+      implementation per rule. Framework identity is per-rule
+      metadata (rule.References, normalised by mappings.RefsFromReferences
+      in kensa-go/internal/mappings/mappings.go) — it is NOT a scan
+      input. Framework-scoped views are produced by OpenWatch at
+      query time via host_rule_state.framework_refs JSONB.
+
+      It bridges OpenWatch's credential store to Kensa's SSH session,
+      captures the structured per-rule result, and hands it to the
       transaction log writer. Credentials are loaded once into memory;
       no SSH key file is written to disk. The wrapper is the only place
-      in OpenWatch that imports Kensa packages. Version pin: v0.2.1
-      (source-inspection AC-10 verifies this string is also the version
-      in app/go.mod). Bumped from v0.1.1 to v0.2.1 — the v0.2.1 release
-      is a packaging-UX hardening with a byte-identical binary to v0.2.0
-      and zero changes under api/ since v0.1.1, so the bump is risk-free
-      for OpenWatch's library-import use case.
+      in OpenWatch that imports Kensa packages.
+
+      Version 2.0.0 breaking change (from 1.0.0):
+        - Run signature: was Run(ctx, hostID, framework, policyVersion);
+          now Run(ctx, hostID, policyVersion). The framework parameter
+          is dropped because Kensa.Scan is framework-agnostic by
+          construction.
+        - unwiredScanFunc placeholder is removed. ScanFunc seam
+          remains for test injection, but the default production
+          binding is the live Kensa.Scan call via
+          github.com/Hanalyx/kensa/pkg/kensa.Default.
+        - Result.Outcomes carries every rule applicable to the host
+          (selected by Kensa) — not just those mapped to one
+          framework.
+        - RuleOutcome.FrameworkRefs continues to carry per-rule
+          framework metadata, used by transactionlog.Writer.Apply
+          and queried later by fleet rollup + hosts enrichment.
 
   objective:
     summary: >
-      One function — executor.Run(ctx, hostID, framework) — returns a
-      KensaResult or a typed error. The function never writes to disk
-      (key material stays in memory), never blocks indefinitely (per-host
-      timeout), and never executes more than one concurrent scan against
-      the same host (concurrency guard). Reusable from both the scheduler
-      tick and POST /scans handler.
+      One function — executor.Run(ctx, hostID, policyVersion) —
+      returns a *Result or a typed error. The function never writes
+      to disk (key material stays in memory), never blocks
+      indefinitely (per-host timeout), and never executes more than
+      one concurrent scan against the same host (concurrency guard).
+      Called from openwatch worker; production wires the live
+      Kensa.Scan via pkg/kensa.Default.
     scope:
       includes:
         - Credential fetch via Slice A internal/credential resolver
         - In-memory SSH key load (crypto/ssh.ParsePrivateKey)
-        - Kensa Go module invocation
+        - Rule-corpus load (full OS-applicable corpus per kensa-rules package)
+        - Kensa Go module invocation (Kensa.Scan over the full corpus)
         - Per-host concurrency guard (sync.Map of in-flight host IDs)
         - Per-scan timeout enforcement (default 600s, policy-tunable)
         - Audit emission for scan.started, scan.completed, scan.failed
+        - Per-rule outcome flattening into transactionlog-friendly shape
       excludes:
         - Persisting the result (transaction log writer's job)
         - Retry logic (caller's responsibility)
         - Reachability pre-check (liveness loop is source of truth)
-        - Multi-framework batching in a single call
+        - Framework-scoped scanning (frameworks are query-time projections)
 
   constraints:
     - id: C-01
@@ -89,11 +114,24 @@ spec:
       description: Per-host failure backoff state MUST be tracked by the executor; three consecutive failures push next-attempt += 2x current interval up to a 24h ceiling. Backoff state is reported back to the scheduler so subsequent ticks respect it
       type: security
       enforcement: error
+    - id: C-12
+      description: Executor.Run signature MUST be Run(ctx, hostID, policyVersion) — no framework parameter. The Run method MUST load the FULL rule corpus applicable to the host (no framework filter) before invoking Kensa.Scan. Source-inspection enforces (AC-17)
+      type: technical
+      enforcement: error
+    - id: C-13
+      description: The production scanFunc binding MUST invoke github.com/Hanalyx/kensa/pkg/kensa.Default to construct a real Kensa with TransportFactory + Scanner wired; unwiredScanFunc placeholder MUST NOT remain in the source tree. Tests may inject fakes via WithScanFunc, but the default executor returned by NewExecutor MUST be production-ready
+      type: technical
+      enforcement: error
+    - id: C-14
+      description: Result.Outcomes MUST contain one entry per rule that Kensa.Scan returned a result for. RuleOutcome.FrameworkRefs MUST be populated from the rule's References block normalised via mappings.RefsFromReferences. Empty FrameworkRefs (rule belongs to no framework) is valid; the rule is still recorded
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
-      description: executor.Run(ctx, hostID, framework) returns a non-nil KensaResult on success with rule outcomes, evidence, and framework_refs populated for the requested framework.
+      description: executor.Run(ctx, hostID, policyVersion) returns a non-nil *Result on success with one entry per rule that Kensa scanned (rules whose `when:` capability gate didn't match the host are absent — by Kensa's design). Each entry carries rule_id, status, severity, evidence, and framework_refs flattened from the rule's References block.
       priority: critical
+      references_constraints: [C-12, C-14]
     - id: AC-02
       description: SSH key bytes are never written to /tmp or any disk path during executor.Run; verified by tracing open/openat syscalls in a strace-style test.
       priority: critical
@@ -111,7 +149,7 @@ spec:
       priority: critical
       references_constraints: [C-05]
     - id: AC-06
-      description: A Kensa-side failure (SSH refused, key invalid, framework unsupported) returns a typed error; executor emits scan.failed with detail.reason set to a short error code from a closed enum.
+      description: A Kensa-side failure (SSH refused, key invalid, transport error) returns a typed error; executor emits scan.failed with detail.reason set to a short error code from a closed enum. No "framework_unsupported" reason exists — framework is no longer a scan input.
       priority: critical
       references_constraints: [C-05]
     - id: AC-07
@@ -152,3 +190,11 @@ spec:
       description: A host with three consecutive scan failures has its next-attempt clock doubled (relative to its tier interval) up to 24h ceiling; the scheduler observes the backoff and skips dispatch until the backoff window passes.
       priority: high
       references_constraints: [C-11]
+    - id: AC-17
+      description: Source-inspection of internal/kensa/ — Executor.Run signature is Run(ctx context.Context, hostID uuid.UUID, policyVersion string); no framework parameter is present. The string "framework" appears in source only as part of FrameworkRefs (per-rule metadata field) or in documentation comments referencing the legacy v1 behavior.
+      priority: critical
+      references_constraints: [C-12]
+    - id: AC-18
+      description: Source-inspection of internal/kensa/ — the unwiredScanFunc symbol is absent OR is marked //nolint:unused with a comment explaining it is a test-only fallback. NewExecutor binds scanFunc to a real implementation that imports github.com/Hanalyx/kensa/pkg/kensa.
+      priority: critical
+      references_constraints: [C-13]

--- a/app/specs/system/scheduler.spec.yaml
+++ b/app/specs/system/scheduler.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-scheduler
   title: Adaptive compliance scheduler
-  version: "1.0.0"
+  version: "2.0.0"
   status: approved
   tier: 1
 
@@ -9,12 +9,25 @@ spec:
     system: openwatch-go
     feature: Adaptive scan scheduling
     description: >
-      The scheduler decides when to run which framework against which host.
-      A cron tick (60s via robfig/cron) sweeps host_compliance_schedule for
-      rows where next_scheduled_scan <= now() and enqueues a scan job to
-      the PostgreSQL SKIP LOCKED queue. Tier intervals are read from the
-      Ed25519-signed `schedules` policy YAML; after each scan, the row is
-      updated based on the resulting compliance state.
+      The scheduler decides WHEN to run a scan against a host. A scan
+      runs the FULL rule corpus applicable to the host's detected OS
+      capabilities — not a single framework. Framework-scoped views
+      are produced at query time by joining transactions /
+      host_rule_state to the per-rule framework_refs JSONB.
+
+      A cron tick (60s via robfig/cron) sweeps host_compliance_schedule
+      for rows where next_scheduled_scan <= now() and enqueues one
+      job per due host to the PostgreSQL SKIP LOCKED queue. Tier
+      intervals are read from the Ed25519-signed `schedules` policy
+      YAML; after each scan, the row is updated based on the
+      resulting compliance state.
+
+      Version 2.0.0 breaking change (from 1.0.0): JobPayload no
+      longer carries framework_id. HMAC inputs change accordingly.
+      The DefaultFramework constructor parameter is dropped. See
+      docs/CANONICAL_RULE_SCHEMA_V1.md §3.3 (framework_refs as
+      per-rule metadata) and api/kensa.go (Kensa.Scan takes []*Rule,
+      not a framework identifier) for the upstream rationale.
 
   objective:
     summary: >
@@ -76,8 +89,12 @@ spec:
       type: security
       enforcement: error
     - id: C-11
-      description: Each scan job payload MUST include an HMAC-SHA256 over (host_id, framework_id, policy_version, enqueued_at) using a server-side key; dequeue MUST verify the HMAC before executing, rejecting tampered payloads
+      description: Each scan job payload MUST include an HMAC-SHA256 over (host_id, policy_version, enqueued_at) using a server-side key; dequeue MUST verify the HMAC before executing, rejecting tampered payloads. NOTE v2.0.0 breaking change — framework_id removed from the HMAC inputs; old payloads (with framework_id) MUST fail verification under the new HMAC scheme and are dead-lettered
       type: security
+      enforcement: error
+    - id: C-12
+      description: Scheduler.NewService MUST NOT take a defaultFramework parameter — scans no longer carry a framework identifier. JobPayload struct has no FrameworkID field. Source-inspection enforces (AC-16)
+      type: technical
       enforcement: error
 
   acceptance_criteria:
@@ -102,9 +119,9 @@ spec:
       priority: high
       references_constraints: [C-05]
     - id: AC-06
-      description: Scheduler-enqueued scan job payload contains policy_version, host_id, framework_id; downstream services use the snapshotted version for audit and threshold lookup.
+      description: Scheduler-enqueued scan job payload contains policy_version, host_id, enqueued_at, hmac — NOT framework_id; downstream services use the snapshotted policy_version for audit and threshold lookup. Verified by decoding a freshly enqueued payload and asserting its field set.
       priority: critical
-      references_constraints: [C-06]
+      references_constraints: [C-06, C-12]
     - id: AC-07
       description: Manual scan via POST /scans does not write to host_compliance_schedule (no UPDATE to next_scheduled_scan, no row lock acquired by scheduler).
       priority: high
@@ -138,3 +155,7 @@ spec:
       description: A scan job whose stored payload has been tampered (host_id mutated post-enqueue) fails HMAC verification at dequeue; the job is rejected, marked failed in the queue, and scheduler.job.hmac_rejected audit event is emitted.
       priority: critical
       references_constraints: [C-11]
+    - id: AC-16
+      description: Source-inspection of internal/scheduler/ — JobPayload struct has no FrameworkID field; NewService signature has no defaultFramework parameter; Dispatch emit payload does not contain the "framework_id" key. Confirms the v2.0.0 architectural correction is materially in place, not just spec'd.
+      priority: critical
+      references_constraints: [C-12]


### PR DESCRIPTION
## Why

The Kensa Go API is \`Kensa.Scan(ctx, host, rules, opts...)\` — the caller passes the rules; framework identity is **per-rule metadata** (\`rule.References\`), not a scan input. OpenWatch's v1 specs wrongly modeled scans as framework-scoped, baking a non-existent dimension into JobPayload's HMAC and the executor's signature.

This PR corrects the architecture: **jobs are per-host, the executor runs the full applicable rule corpus, framework is a query-time projection over \`host_rule_state.framework_refs\` JSONB.**

## What lands

### 3 new specs
| Spec | ACs | What it covers |
|------|----:|----------------|
| \`system-daemon-orchestration\` | 13 | \`cmd/openwatch serve / migrate / worker / check-config\` boot+shutdown ordering, EmitFunc DI invariant, alertrouter-before-publishers ordering |
| \`system-worker-subcommand\` | 13 | SKIP-LOCKED claim, HMAC verify, retry/dead-letter, advisory-lock per-host concurrency, SIGTERM drain |
| \`frontend-findings-ui\` | 15 | Route \`/hosts/{id}\` — first frontend spec; framework-of-implementation agnostic |

### 2 spec amendments (v2.0.0)
| Spec | From | To | Breaking change |
|------|------|----|-----------------|
| \`system-scheduler\` | 1.0.0 | 2.0.0 | \`JobPayload\` drops \`FrameworkID\`; HMAC inputs change; \`NewService\` drops \`defaultFramework\` |
| \`system-kensa-executor\` | 1.0.0 | 2.0.0 | \`Run\` signature drops \`framework\`; production binds \`pkg/kensa.Default\`; \`Result\` drops \`FrameworkID\` |

### 2 API addendums
| Spec | From | To | Adds |
|------|------|----|------|
| \`api-fleet-observability\` | 1.0.0 | 1.1.0 | Optional \`?framework=\` on every endpoint |
| \`api-hosts\` | 1.1.0 | 1.2.0 | Optional \`?framework=\` on \`GET /hosts/{id}\` (filters compliance_summary only) |

### Code corrections matching the v2 amendments

- \`internal/scheduler/hmac.go\`: \`JobPayload\` drops \`FrameworkID\`; \`Encode\` layout updated. v1 payloads now fail \`Verify\` → dead-lettered (intended migration).
- \`internal/scheduler/service.go\`: \`NewService\` drops \`defaultFramework\`; \`Dispatch\` body map drops \`framework_id\`.
- \`internal/kensa/executor.go\`: \`Run\` / \`ScanFunc\` / \`emit*\` / \`report*\` all drop framework param; \`unwiredScanFunc\` annotated \`//nolint:unused\` per AC-18 (production binding lands with worker PR).
- \`internal/kensa/types.go\`: \`Result\` drops \`FrameworkID\` (per-rule \`FrameworkRefs\` stays — that's the framework metadata).
- \`internal/fleetrollup/options.go\`: NEW — \`WithFramework\` functional option.
- \`internal/fleetrollup/service.go\`: 4 methods now accept optional opts; SQL uses \`\$N::text IS NULL OR framework_refs ? \$N\` — empty string → NULL → unfiltered (identical to v1.0.0 behavior).
- \`internal/server/fleet_handlers.go\` + \`hosts_handlers.go\`: thread \`?framework=\` through; helper \`frameworkOpts()\` converts \`*string\` to \`[]fleetrollup.Option\`.

### Source-inspection ACs added
- \`system-scheduler\` AC-16: \`JobPayload\` has no \`FrameworkID\`; \`NewService\` has no \`defaultFramework\` param; \`Dispatch\` body map has no \`framework_id\` key.
- \`system-kensa-executor\` AC-17: \`Executor.Run\` signature has no \`framework\` parameter.
- \`system-kensa-executor\` AC-18: \`ScanFunc\` signature has no \`framework\` parameter.

These guard against accidental regression — any future PR that re-adds \`framework\` to the wrong place fails CI.

## Verification

\`\`\`
go vet ./...                  clean
go test -race -count=1 ./...  PASS (full tree, ~4 min with Postgres)
specter parse                 PASS (44 specs)
specter check                 PASS
specter coverage              all touched specs at 100%:
  api-fleet-observability    18/18 (was 14/14)
  api-hosts                  18/18 (was 16/16)
  system-scheduler           16/16 (was 15/15)
  system-kensa-executor      18/18 (was 16/16)
  system-fleet-rollup        13/13 (unchanged)
\`\`\`

## Not in this PR

The 3 new specs deliberately reference implementations that don't exist yet:

- \`openwatch worker\` subcommand binary
- Slice B package wiring into \`cmd/openwatch serve\` (scheduler tick, liveness loop, alertrouter)
- Live Kensa binding (\`pkg/kensa.Default\`-backed ScanFunc)
- Frontend code

Each is its own follow-up PR that takes the spec landed here as its contract. Splitting this way keeps the architectural correction reviewable as a unit and avoids a 5-day PR.

## Test plan

- [ ] CI: \`Quality + security gates\` pass (vet, lint, vuln, test-race, specter sync)
- [ ] Confirm \`specter coverage\` shows all 5 affected specs at 100%
- [ ] Spot-check: \`curl ".../api/v1/fleet/score?framework=cis_rhel9_v2.0.0"\` against a seeded DB returns the CIS-scoped score