### PR TITLE
feat(daemon): wire Slice B into cmd/openwatch serve (eventbus + alertrouter + liveness loop)

### DIFF
--- a/app/cmd/openwatch/main.go
+++ b/app/cmd/openwatch/main.go
@@ -21,13 +21,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+	stdoutchan "github.com/Hanalyx/openwatch/internal/alertrouter/channels/stdout"
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/config"
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/license"
+	"github.com/Hanalyx/openwatch/internal/liveness"
 	openlog "github.com/Hanalyx/openwatch/internal/log"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
 	"github.com/Hanalyx/openwatch/internal/server"
@@ -255,8 +259,50 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		}
 	}()
 
+	// ---------------------------------------------------------------
+	// Slice B wiring. Spec: system-daemon-orchestration.
+	//
+	// Boot order (C-01, C-09):
+	//   1. Pub/sub bus           - Bucket B events
+	//   2. Alert router          - subscriber, MUST register and Start
+	//                              BEFORE any producer publishes (C-09)
+	//   3. Liveness probe loop   - producer: HeartbeatPulse on transitions
+	//
+	// drift service is constructed elsewhere with no long-lived loop;
+	// the worker subcommand calls DetectForScan per-scan-completion
+	// in a follow-up PR.
+	//
+	// The scheduler + cron tick land in a follow-up that adds
+	// policy schedules loading + queue HMAC key derivation - both
+	// require a credential DEK accessor not yet exposed.
+	// ---------------------------------------------------------------
+
+	bus := eventbus.NewBus()
+	defer bus.Shutdown()
+
+	router, err := alertrouter.NewRouter(bus, alertrouter.Config{})
+	if err != nil {
+		slog.ErrorContext(bootCtx, "alertrouter init failed", slog.String("error", err.Error()))
+		return 1
+	}
+	// AC-13: register the stdout channel against an empty Tags filter
+	// (wildcard — receives every alert). Operators see fired alerts
+	// in `journalctl -u openwatch -g alertrouter.alert.sent`.
+	router.Register(alertrouter.ChannelRegistration{
+		Channel: stdoutchan.New("stdout"),
+	})
+	router.Start(ctx) // C-09: subscriber active before any publisher.
+
+	liveSvc := liveness.NewService(pool, audit.Emit, bus)
+	go liveSvc.Run(ctx)
+
 	srv := server.New(cfg, pool)
 	runErr := srv.Run(ctx)
+
+	// Shutdown order REVERSE of boot (C-02). liveness.Run + alertrouter
+	// observe ctx cancellation via the same ctx srv.Run watched.
+	router.Stop()
+	// liveSvc.Run returns when ctx is canceled; no explicit Stop call.
 
 	// system.shutdown: best-effort sync emit; failures logged but ignored
 	// because shutdown is in progress.

--- a/app/cmd/openwatch/source_test.go
+++ b/app/cmd/openwatch/source_test.go
@@ -1,0 +1,226 @@
+// @spec system-daemon-orchestration
+//
+// AC traceability (this file):
+//   AC-01  TestMainImportsSliceBPackages
+//   AC-02  TestCmdServe_BootSequenceOrder
+//   AC-03  TestCmdServe_ShutdownOrder
+//   AC-04  TestCmdServe_RouterStartBeforeLivenessRun
+//   AC-05  TestSliceBPackages_DoNotImportAuditEmit
+//   AC-06  TestCmdServe_RegistersStdoutWildcardChannel
+//
+// These tests are source-inspection — they read app/cmd/openwatch/main.go
+// and the Slice B package directories and assert structural invariants.
+// A runtime ordering test would need to refactor cmdServe to accept
+// injected NewX wrappers; that lands when the spec next bumps to v1.1.0.
+
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func mainGoSource(t *testing.T) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	src, err := os.ReadFile(filepath.Join(filepath.Dir(file), "main.go"))
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	return string(src)
+}
+
+// orderedContains reports whether all needles appear in src in the
+// listed order (non-overlapping). Used by AC-02/03/04 to assert textual
+// boot-sequence ordering.
+func orderedContains(src string, needles []string) (int, string) {
+	pos := 0
+	for _, n := range needles {
+		idx := strings.Index(src[pos:], n)
+		if idx < 0 {
+			return -1, n
+		}
+		pos += idx + len(n)
+	}
+	return pos, ""
+}
+
+// @ac AC-01
+// AC-01: cmd/openwatch imports the Slice B packages it wires.
+func TestMainImportsSliceBPackages(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-01", func(t *testing.T) {
+		src := mainGoSource(t)
+		for _, want := range []string{
+			`"github.com/Hanalyx/openwatch/internal/alertrouter"`,
+			`"github.com/Hanalyx/openwatch/internal/alertrouter/channels/stdout"`,
+			`"github.com/Hanalyx/openwatch/internal/eventbus"`,
+			`"github.com/Hanalyx/openwatch/internal/liveness"`,
+		} {
+			if !strings.Contains(src, want) {
+				t.Errorf("main.go imports do not include %s", want)
+			}
+		}
+	})
+}
+
+// @ac AC-02
+// AC-02: cmdServe's textual boot sequence matches C-01.
+func TestCmdServe_BootSequenceOrder(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-02", func(t *testing.T) {
+		src := mainGoSource(t)
+		seq := []string{
+			"eventbus.NewBus",
+			"alertrouter.NewRouter",
+			"router.Register",
+			"router.Start",
+			"liveness.NewService",
+			"liveSvc.Run",
+			"server.New",
+			"srv.Run",
+		}
+		if _, missing := orderedContains(src, seq); missing != "" {
+			t.Errorf("boot sequence broken — could not find %q after the preceding step", missing)
+		}
+	})
+}
+
+// @ac AC-03
+// AC-03: router.Stop appears AFTER srv.Run; bus.Shutdown is deferred
+// BEFORE alertrouter is constructed (so its defer runs after router.Stop).
+func TestCmdServe_ShutdownOrder(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-03", func(t *testing.T) {
+		src := mainGoSource(t)
+		idxSrvRun := strings.Index(src, "srv.Run(ctx)")
+		idxRouterStop := strings.Index(src, "router.Stop()")
+		if idxSrvRun < 0 || idxRouterStop < 0 {
+			t.Fatalf("srv.Run / router.Stop missing — boot sequence broken")
+		}
+		if idxRouterStop < idxSrvRun {
+			t.Errorf("router.Stop() appears BEFORE srv.Run(ctx) — shutdown order broken")
+		}
+		// defer bus.Shutdown() must appear before NewRouter so its
+		// deferred call fires after router.Stop().
+		idxDefer := strings.Index(src, "defer bus.Shutdown()")
+		idxNewRouter := strings.Index(src, "alertrouter.NewRouter")
+		if idxDefer < 0 || idxNewRouter < 0 {
+			t.Fatalf("defer bus.Shutdown() / alertrouter.NewRouter missing")
+		}
+		if idxDefer > idxNewRouter {
+			t.Errorf("defer bus.Shutdown() appears AFTER alertrouter.NewRouter — deferred shutdown would fire BEFORE router.Stop, violating reverse order")
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: alertrouter.Start (router.Start(ctx)) precedes the goroutine
+// that spawns liveSvc.Run.
+func TestCmdServe_RouterStartBeforeLivenessRun(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-04", func(t *testing.T) {
+		src := mainGoSource(t)
+		idxRouterStart := strings.Index(src, "router.Start(ctx)")
+		idxGoLive := strings.Index(src, "go liveSvc.Run(ctx)")
+		if idxRouterStart < 0 || idxGoLive < 0 {
+			t.Fatalf("router.Start / go liveSvc.Run missing")
+		}
+		if idxRouterStart > idxGoLive {
+			t.Errorf("router.Start(ctx) appears AFTER go liveSvc.Run — bus could see a publish before any subscriber exists (C-09 violation)")
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: no Slice B package calls audit.Emit directly. Each takes its
+// EmitFunc via NewX constructor injection.
+func TestSliceBPackages_DoNotImportAuditEmit(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-05", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		appDir := filepath.Join(filepath.Dir(file), "..", "..")
+		sliceBDirs := []string{
+			"internal/scheduler",
+			"internal/kensa",
+			"internal/transactionlog",
+			"internal/liveness",
+			"internal/alertrouter",
+			"internal/eventbus",
+			"internal/fleetrollup",
+			"internal/drift",
+		}
+
+		// Pattern: audit.Emit(ctx, ...) — direct package-global call.
+		// Annotation-only allowance: any line containing //nolint:audit
+		// is exempt. (No package uses that today.)
+		directCall := regexp.MustCompile(`\baudit\.Emit\(`)
+
+		fset := token.NewFileSet()
+		for _, d := range sliceBDirs {
+			full := filepath.Join(appDir, d)
+			entries, err := os.ReadDir(full)
+			if err != nil {
+				t.Logf("skip %s (not present): %v", d, err)
+				continue
+			}
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+					continue
+				}
+				if strings.HasSuffix(e.Name(), "_test.go") {
+					continue
+				}
+				path := filepath.Join(full, e.Name())
+				// Parse to ensure file is valid Go (lints + helps avoid
+				// false positives in string literals — though regex above
+				// is intentionally narrow).
+				if _, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly); err != nil {
+					t.Errorf("parse %s: %v", path, err)
+					continue
+				}
+				b, err := os.ReadFile(path)
+				if err != nil {
+					t.Errorf("read %s: %v", path, err)
+					continue
+				}
+				if directCall.MatchString(string(b)) {
+					t.Errorf("%s contains a direct audit.Emit(...) call — Slice B packages MUST receive audit.Emit via NewX constructor injection (system-daemon-orchestration AC-05)", path)
+				}
+			}
+		}
+	})
+}
+
+// @ac AC-06
+// AC-06: cmdServe registers the stdout channel with no Tags (wildcard).
+func TestCmdServe_RegistersStdoutWildcardChannel(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-06", func(t *testing.T) {
+		src := mainGoSource(t)
+		// Look for the canonical registration block.
+		if !strings.Contains(src, "stdoutchan.New(") {
+			t.Error("main.go does not call stdoutchan.New — stdout alert channel not constructed")
+		}
+		// Channel registered via router.Register with a
+		// ChannelRegistration whose Tags field is omitted (nil) or
+		// explicit empty map. Regex catches both forms; rejects an
+		// explicit non-nil filter that would prevent wildcard match.
+		registerRe := regexp.MustCompile(`router\.Register\(alertrouter\.ChannelRegistration\{[^}]*Channel:\s*stdoutchan\.New\([^)]*\)[^}]*\}\)`)
+		m := registerRe.FindString(src)
+		if m == "" {
+			t.Fatal("main.go does not register the stdoutchan via router.Register with a ChannelRegistration{Channel: stdoutchan.New(...)}")
+		}
+		// Inside the matched block, if a Tags: field is present its
+		// value must be nil or an empty map.
+		if strings.Contains(m, "Tags:") {
+			// Accept Tags: nil or Tags: map[string]string{}.
+			tagsOK := strings.Contains(m, "Tags: nil") ||
+				strings.Contains(m, "Tags: map[string]string{}") ||
+				strings.Contains(m, "Tags:map[string]string{}")
+			if !tagsOK {
+				t.Errorf("stdout channel registered with a non-wildcard Tags filter; got %q", m)
+			}
+		}
+	})
+}

--- a/app/internal/alertrouter/channels/stdout/channel.go
+++ b/app/internal/alertrouter/channels/stdout/channel.go
@@ -1,0 +1,54 @@
+// Package stdout implements an alertrouter.Channel that logs alerts to
+// the structured slog default logger at INFO level.
+//
+// This is the minimum-viable channel for an operator. Once registered,
+// `journalctl -u openwatch -g alertrouter.alert.sent` returns the
+// stream of fired alerts. Slack / email / webhook channels follow the
+// same Channel interface and live in sibling subpackages — keeping
+// this one dependency-free preserves the alertrouter core's
+// "no external SDKs" invariant (system-alert-router AC-13).
+//
+// Spec: system-daemon-orchestration AC-13 (registered at boot).
+package stdout
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+)
+
+// Channel writes each alert via slog.InfoContext. The struct itself
+// holds no state; one instance per process is enough.
+type Channel struct {
+	name string
+}
+
+// New returns a stdout channel ready for alertrouter.Register.
+// channelName is the identifier used in metrics + failure logs;
+// defaults to "stdout" when empty.
+func New(channelName string) *Channel {
+	if channelName == "" {
+		channelName = "stdout"
+	}
+	return &Channel{name: channelName}
+}
+
+// Name satisfies alertrouter.Channel.
+func (c *Channel) Name() string { return c.name }
+
+// Send writes the alert via slog at INFO with structured attributes.
+// Never returns an error — stdout/journald is the operator's last
+// resort even if a downstream channel is misbehaving.
+func (c *Channel) Send(ctx context.Context, a alertrouter.Alert) error {
+	slog.InfoContext(ctx, "alertrouter.alert.sent",
+		slog.String("channel", c.name),
+		slog.String("alert_type", string(a.Type)),
+		slog.String("severity", string(a.Severity)),
+		slog.String("host_id", a.HostID.String()),
+		slog.String("rule_id", a.RuleID),
+		slog.Time("occurred_at", a.OccurredAt),
+		slog.String("title", a.Title),
+	)
+	return nil
+}

--- a/app/internal/alertrouter/channels/stdout/channel_test.go
+++ b/app/internal/alertrouter/channels/stdout/channel_test.go
@@ -1,0 +1,81 @@
+// @spec system-daemon-orchestration
+//
+// AC traceability (this file):
+//   AC-07  TestStdoutChannel_NameAndSend
+//          TestStdoutChannel_DefaultName
+
+package stdout
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+)
+
+// @ac AC-07
+// AC-13 (partial — channel surface): the stdout channel returns its
+// configured Name and emits a structured slog record on Send carrying
+// alert_type / severity / host_id / rule_id / title fields.
+func TestStdoutChannel_NameAndSend(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-07", func(t *testing.T) {
+		// Capture slog output into a buffer.
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+
+		ch := New("stdout-test")
+		if got := ch.Name(); got != "stdout-test" {
+			t.Errorf("Name() = %q, want %q", got, "stdout-test")
+		}
+
+		hostID := uuid.New()
+		err := ch.Send(context.Background(), alertrouter.Alert{
+			Type:       alertrouter.AlertTypeHostUnreachable,
+			Severity:   alertrouter.SeverityHigh,
+			HostID:     hostID,
+			OccurredAt: time.Now(),
+			Title:      "Host went away",
+		})
+		if err != nil {
+			t.Fatalf("Send returned non-nil error: %v", err)
+		}
+
+		// Decode the captured JSON log line.
+		line := strings.TrimSpace(buf.String())
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("decode slog record: %v; raw=%s", err, line)
+		}
+		if rec["msg"] != "alertrouter.alert.sent" {
+			t.Errorf("msg = %v, want alertrouter.alert.sent", rec["msg"])
+		}
+		if rec["alert_type"] != string(alertrouter.AlertTypeHostUnreachable) {
+			t.Errorf("alert_type = %v, want %q", rec["alert_type"], alertrouter.AlertTypeHostUnreachable)
+		}
+		if rec["severity"] != string(alertrouter.SeverityHigh) {
+			t.Errorf("severity = %v, want %q", rec["severity"], alertrouter.SeverityHigh)
+		}
+		if rec["host_id"] != hostID.String() {
+			t.Errorf("host_id = %v, want %q", rec["host_id"], hostID)
+		}
+	})
+}
+
+// @ac AC-07
+// AC-13 (default-name path): New("") falls back to "stdout".
+func TestStdoutChannel_DefaultName(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-07", func(t *testing.T) {
+		if got := New("").Name(); got != "stdout" {
+			t.Errorf("New(\"\").Name() = %q, want \"stdout\"", got)
+		}
+	})
+}

--- a/app/internal/drift/bus_test.go
+++ b/app/internal/drift/bus_test.go
@@ -1,0 +1,265 @@
+// @spec system-drift-detector
+//
+// AC traceability (this file):
+//   AC-15  TestDetectForScan_MajorWorsening_PublishesDriftDetected
+//   AC-16  TestDetectForScan_Stable_NoPublish
+//   AC-17  TestDetectForScan_PublishCountsMatchAuditDetail
+//   AC-18  TestNewService_NilBus_AuditStillFires
+
+package drift
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+)
+
+// @ac AC-15
+// AC-15: major worsening detection publishes DriftDetected on the bus.
+func TestDetectForScan_MajorWorsening_PublishesDriftDetected(t *testing.T) {
+	t.Run("system-drift-detector/AC-15", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		bus := eventbus.NewBus()
+		defer bus.Shutdown()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{
+			Kinds: []eventbus.EventKind{eventbus.EventKindDriftDetected},
+		})
+		defer sub.Unsubscribe()
+
+		// Prior baseline: 8 pass, 0 fail → 100% score.
+		// (host_rule_state rows tagged to a different scanID so the
+		// prior-reconstruction logic uses them.)
+		priorScanID, _ := uuid.NewV7()
+		for i := 0; i < 8; i++ {
+			ruleID := "rule.prior." + uuid.NewString()[:8]
+			seedRuleState(t, pool, hostID, priorScanID, ruleID, "pass", "high")
+		}
+
+		// Current scan: drop 6 rules to fail → score = 2/8 = 25% (a
+		// 75-point drop, well into major-worsening).
+		currentScanID, _ := uuid.NewV7()
+		for i := 0; i < 6; i++ {
+			ruleID := "rule.now.f." + uuid.NewString()[:8]
+			seedRuleState(t, pool, hostID, currentScanID, ruleID, "fail", "high")
+			seedTransaction(t, pool, hostID, currentScanID, ruleID, "fail", "high", "first_seen")
+		}
+		for i := 0; i < 2; i++ {
+			ruleID := "rule.now.p." + uuid.NewString()[:8]
+			seedRuleState(t, pool, hostID, currentScanID, ruleID, "pass", "high")
+			seedTransaction(t, pool, hostID, currentScanID, ruleID, "pass", "high", "first_seen")
+		}
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), bus)
+		report, err := svc.DetectForScan(context.Background(), hostID, currentScanID)
+		if err != nil {
+			t.Fatalf("DetectForScan: %v", err)
+		}
+		if report.Kind != DriftMajorWorsening {
+			t.Fatalf("Kind = %q, want major_worsening", report.Kind)
+		}
+
+		select {
+		case ev := <-sub.Events():
+			d, ok := ev.(eventbus.DriftDetected)
+			if !ok {
+				t.Fatalf("got %T, want DriftDetected", ev)
+			}
+			if d.DriftType != "major" {
+				t.Errorf("DriftType = %q, want major", d.DriftType)
+			}
+			if d.HostID != hostID {
+				t.Errorf("HostID mismatch")
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("no DriftDetected event received within 500ms")
+		}
+	})
+}
+
+// @ac AC-16
+// AC-16: stable detection publishes nothing to the bus.
+func TestDetectForScan_Stable_NoPublish(t *testing.T) {
+	t.Run("system-drift-detector/AC-16", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		bus := eventbus.NewBus()
+		defer bus.Shutdown()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{
+			Kinds: []eventbus.EventKind{eventbus.EventKindDriftDetected},
+		})
+		defer sub.Unsubscribe()
+
+		// Steady state: same 5 pass + 1 fail before and after.
+		// Use the same scanID for both prior + current so the
+		// reconstruction sees no transition.
+		scanID, _ := uuid.NewV7()
+		for i := 0; i < 5; i++ {
+			ruleID := "rule.stable.p." + uuid.NewString()[:8]
+			seedRuleState(t, pool, hostID, scanID, ruleID, "pass", "high")
+			seedTransaction(t, pool, hostID, scanID, ruleID, "pass", "high", "first_seen")
+		}
+		ruleFailID := "rule.stable.f." + uuid.NewString()[:8]
+		seedRuleState(t, pool, hostID, scanID, ruleFailID, "fail", "high")
+		seedTransaction(t, pool, hostID, scanID, ruleFailID, "fail", "high", "first_seen")
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), bus)
+		_, err := svc.DetectForScan(context.Background(), hostID, scanID)
+		if err != nil {
+			t.Fatalf("DetectForScan: %v", err)
+		}
+
+		select {
+		case ev := <-sub.Events():
+			t.Errorf("received unexpected DriftDetected on stable: %+v", ev)
+		case <-time.After(150 * time.Millisecond):
+			// Expected.
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17: published DriftDetected per-severity counts match the audit
+// detail values produced from the same Report.
+func TestDetectForScan_PublishCountsMatchAuditDetail(t *testing.T) {
+	t.Run("system-drift-detector/AC-17", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		bus := eventbus.NewBus()
+		defer bus.Shutdown()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{
+			Kinds: []eventbus.EventKind{eventbus.EventKindDriftDetected},
+		})
+		defer sub.Unsubscribe()
+
+		// Setup follows the existing AC-09 pattern: only seed CURRENT
+		// state in host_rule_state; the drift detector reconstructs
+		// the PRIOR via transactions.
+		scanID, _ := uuid.NewV7()
+		// 2 critical → fail, 1 high → fail, 2 medium stay pass.
+		critRules := []string{"crit-1", "crit-2"}
+		highRules := []string{"high-1"}
+		passRules := []string{"pass-m-1", "pass-m-2"}
+
+		for _, r := range critRules {
+			seedRuleState(t, pool, hostID, scanID, r, "fail", "critical")
+			seedTransaction(t, pool, hostID, scanID, r, "fail", "critical", "state_changed")
+		}
+		for _, r := range highRules {
+			seedRuleState(t, pool, hostID, scanID, r, "fail", "high")
+			seedTransaction(t, pool, hostID, scanID, r, "fail", "high", "state_changed")
+		}
+		for _, r := range passRules {
+			seedRuleState(t, pool, hostID, scanID, r, "pass", "medium")
+		}
+		currentScanID := scanID
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), bus)
+		report, err := svc.DetectForScan(context.Background(), hostID, currentScanID)
+		if err != nil {
+			t.Fatalf("DetectForScan: %v", err)
+		}
+
+		// Audit detail — severity counts live in detail.severity_transitions.
+		var auditDetail struct {
+			SeverityTransitions struct {
+				CriticalBecameFailing int `json:"critical_became_failing"`
+				HighBecameFailing     int `json:"high_became_failing"`
+			} `json:"severity_transitions"`
+		}
+		mu.Lock()
+		var found bool
+		for _, c := range calls {
+			if c.Code == audit.ComplianceDriftDetected {
+				_ = json.Unmarshal(c.Event.Detail, &auditDetail)
+				found = true
+				break
+			}
+		}
+		mu.Unlock()
+		if !found {
+			t.Fatal("compliance.drift.detected audit not emitted")
+		}
+
+		// Bus event.
+		select {
+		case ev := <-sub.Events():
+			d, ok := ev.(eventbus.DriftDetected)
+			if !ok {
+				t.Fatalf("got %T", ev)
+			}
+			if d.CriticalBecameFailing != auditDetail.SeverityTransitions.CriticalBecameFailing {
+				t.Errorf("bus CriticalBecameFailing = %d, audit detail = %d",
+					d.CriticalBecameFailing, auditDetail.SeverityTransitions.CriticalBecameFailing)
+			}
+			if d.HighBecameFailing != auditDetail.SeverityTransitions.HighBecameFailing {
+				t.Errorf("bus HighBecameFailing = %d, audit detail = %d",
+					d.HighBecameFailing, auditDetail.SeverityTransitions.HighBecameFailing)
+			}
+			if d.CriticalBecameFailing != report.CriticalBecameFailing {
+				t.Errorf("bus vs report CriticalBecameFailing mismatch")
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("no DriftDetected event")
+		}
+	})
+}
+
+// @ac AC-18
+// AC-18: NewService(pool, emit, thresholds, nil) — nil bus, audit still
+// fires.
+func TestNewService_NilBus_AuditStillFires(t *testing.T) {
+	t.Run("system-drift-detector/AC-18", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		// Seed a major worsening so an emit fires.
+		priorScanID, _ := uuid.NewV7()
+		for i := 0; i < 8; i++ {
+			seedRuleState(t, pool, hostID, priorScanID, "rule.p."+uuid.NewString()[:8], "pass", "high")
+		}
+		currentScanID, _ := uuid.NewV7()
+		for i := 0; i < 6; i++ {
+			r := "rule.f." + uuid.NewString()[:8]
+			seedRuleState(t, pool, hostID, currentScanID, r, "fail", "high")
+			seedTransaction(t, pool, hostID, currentScanID, r, "fail", "high", "first_seen")
+		}
+		for i := 0; i < 2; i++ {
+			r := "rule.p2." + uuid.NewString()[:8]
+			seedRuleState(t, pool, hostID, currentScanID, r, "pass", "high")
+			seedTransaction(t, pool, hostID, currentScanID, r, "pass", "high", "first_seen")
+		}
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), nil)
+		_, err := svc.DetectForScan(context.Background(), hostID, currentScanID)
+		if err != nil {
+			t.Fatalf("DetectForScan: %v", err)
+		}
+		// Audit should have fired (major worsening).
+		if countEmissions(&mu, &calls, audit.ComplianceDriftDetected) == 0 {
+			t.Error("nil bus suppressed audit emission; want audit still fires")
+		}
+	})
+}

--- a/app/internal/drift/service.go
+++ b/app/internal/drift/service.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
 )
 
 // EmitFunc mirrors audit.Emit. Same pattern as B.1a / B.1b / B.1c /
@@ -22,17 +24,21 @@ type EmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
 type Service struct {
 	pool       *pgxpool.Pool
 	emit       EmitFunc
+	bus        *eventbus.Bus // may be nil; see v1.1.0 C-10
 	thresholds Thresholds
 }
 
 // NewService wires the detector. emit is audit.Emit in production,
 // a fake recorder in tests. thresholds defaults to DefaultThresholds
 // when unset (any value 0); production wires from policy.AlertThresholds.
-func NewService(pool *pgxpool.Pool, emit EmitFunc, thresholds Thresholds) *Service {
+//
+// v1.1.0: bus may be nil. When nil, the service still emits audit
+// events but skips bus publishes. Spec system-drift-detector C-10.
+func NewService(pool *pgxpool.Pool, emit EmitFunc, thresholds Thresholds, bus *eventbus.Bus) *Service {
 	if thresholds.MajorWorseningPP == 0 && thresholds.MinorWorseningPP == 0 && thresholds.ImprovementPP == 0 {
 		thresholds = DefaultThresholds()
 	}
-	return &Service{pool: pool, emit: emit, thresholds: thresholds}
+	return &Service{pool: pool, emit: emit, bus: bus, thresholds: thresholds}
 }
 
 // Thresholds returns the active thresholds — useful for tests and
@@ -115,9 +121,38 @@ func (s *Service) DetectForScan(ctx context.Context, hostID, scanID uuid.UUID) (
 	// Emit on non-stable kinds (spec C-04).
 	if report.Kind != DriftStable {
 		s.emitDriftDetected(ctx, report)
+		// v1.1.0 C-09: publish DriftDetected on the same trigger.
+		s.publishDrift(ctx, report)
 	}
 
 	return report, nil
+}
+
+// publishDrift publishes a typed DriftDetected event to the eventbus
+// carrying the same per-severity counts the audit detail carries.
+// Best-effort: nil bus is a no-op; bus errors don't affect DetectForScan.
+// Spec v1.1.0 C-09 / AC-15 / AC-16 / AC-17.
+func (s *Service) publishDrift(ctx context.Context, r Report) {
+	if s.bus == nil {
+		return
+	}
+	s.bus.Publish(ctx, eventbus.DriftDetected{
+		HostID:                r.HostID,
+		ScanID:                r.ScanID,
+		OccurredAt:            time.Now().UTC(),
+		DriftType:             TypeForAudit(r.Kind),
+		PriorScore:            r.PriorScore,
+		CurrentScore:          r.CurrentScore,
+		ScoreDelta:            r.ScoreDelta,
+		CriticalBecameFailing: r.CriticalBecameFailing,
+		HighBecameFailing:     r.HighBecameFailing,
+		MediumBecameFailing:   r.MediumBecameFailing,
+		LowBecameFailing:      r.LowBecameFailing,
+		CriticalBecamePassing: r.CriticalBecamePassing,
+		HighBecamePassing:     r.HighBecamePassing,
+		MediumBecamePassing:   r.MediumBecamePassing,
+		LowBecamePassing:      r.LowBecamePassing,
+	})
 }
 
 // readCurrentCounts returns the passed / failed / total counts from

--- a/app/internal/drift/service_test.go
+++ b/app/internal/drift/service_test.go
@@ -164,7 +164,7 @@ func TestDetectForScan_FirstEverScan_ReturnsStable(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds())
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), nil)
 
 		report, err := svc.DetectForScan(context.Background(), hostID, scanID)
 		if err != nil {
@@ -212,7 +212,7 @@ func TestDetectForScan_PopulatesSeverityTransitionCounts(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds())
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), nil)
 
 		report, err := svc.DetectForScan(context.Background(), hostID, scanID)
 		if err != nil {
@@ -264,7 +264,7 @@ func TestDetectForScan_MajorWorsening_EmitsAuditWithDelta(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds())
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), nil)
 
 		report, err := svc.DetectForScan(context.Background(), hostID, scanID)
 		if err != nil {
@@ -334,7 +334,7 @@ func TestDetectForScan_Stable_EmitsNoAudit(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds())
+		svc := NewService(pool, fakeEmitter(&mu, &calls), DefaultThresholds(), nil)
 
 		report, err := svc.DetectForScan(context.Background(), hostID, scanID)
 		if err != nil {

--- a/app/internal/liveness/run_test.go
+++ b/app/internal/liveness/run_test.go
@@ -1,0 +1,395 @@
+// @spec system-liveness-loop
+//
+// AC traceability (this file):
+//   AC-16  TestRun_EmptyInventory_TicksWithoutPanic
+//   AC-17  TestRun_WalksAllActiveHosts
+//   AC-18  TestRun_SkipsBackoffSuppressedHosts
+//   AC-19  TestRun_ReturnsOnCtxCancel
+//   AC-20  TestPublishHeartbeat_ReachableToUnreachable
+//   AC-21  TestPublishHeartbeat_UnreachableToReachable
+//   AC-22  TestPublishHeartbeat_SteadyState_NoPublish
+//   AC-23  TestNewService_NilBus_AuditStillFires
+
+package liveness
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+)
+
+// recordingProbe captures every (hostID, addr) invocation. Returns
+// the reachable result by default; tests can override per call.
+type recordingProbe struct {
+	mu     sync.Mutex
+	calls  []uuid.UUID
+	result ProbeResult
+}
+
+func newRecordingProbe(result ProbeResult) *recordingProbe {
+	return &recordingProbe{result: result}
+}
+
+func (p *recordingProbe) fn() ProbeFunc {
+	return func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+		p.mu.Lock()
+		p.calls = append(p.calls, hostFromAddr(addr))
+		p.mu.Unlock()
+		return p.result
+	}
+}
+
+func (p *recordingProbe) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.calls)
+}
+
+// hostFromAddr is a placeholder — the ProbeFunc receives only the
+// addr (host:port), not the host_id. Tests use a constant address per
+// host and inspect probe counts rather than per-host identity.
+func hostFromAddr(addr string) uuid.UUID { return uuid.Nil }
+
+// seedBackoff inserts a host_backoff_state row with the given
+// suppress_until.
+func seedBackoff(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, suppressUntil time.Time) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_backoff_state (host_id, probe_type, consecutive_failures, suppress_until)
+		VALUES ($1, 'scan', 3, $2)`,
+		hostID, suppressUntil,
+	)
+	if err != nil {
+		t.Fatalf("seed backoff: %v", err)
+	}
+}
+
+// @ac AC-16
+// AC-16: Run on a fleet with no hosts ticks without panic and produces
+// zero probes per tick. We let one tick fire via the initial Run-then-
+// cancel path.
+func TestRun_EmptyInventory_TicksWithoutPanic(t *testing.T) {
+	t.Run("system-liveness-loop/AC-16", func(t *testing.T) {
+		pool := freshPool(t)
+		var mu sync.Mutex
+		var calls []emitCall
+		probe := newRecordingProbe(ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond})
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).
+			WithProbeFunc(probe.fn()).
+			WithInterval(100 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			svc.Run(ctx)
+			close(done)
+		}()
+		<-done
+
+		if probe.count() != 0 {
+			t.Errorf("empty inventory triggered %d probes; want 0", probe.count())
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17: Run walks active hosts. 3 hosts seeded, 1 tick → 3 probes.
+func TestRun_WalksAllActiveHosts(t *testing.T) {
+	t.Run("system-liveness-loop/AC-17", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		for i := 0; i < 3; i++ {
+			seedHost(t, pool, user)
+		}
+		var mu sync.Mutex
+		var calls []emitCall
+		probe := newRecordingProbe(ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond})
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).
+			WithProbeFunc(probe.fn()).
+			WithInterval(time.Hour) // never re-ticks; relies on initial tick
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		done := make(chan struct{})
+		go func() { svc.Run(ctx); close(done) }()
+		<-done
+
+		if probe.count() != 3 {
+			t.Errorf("got %d probes; want 3", probe.count())
+		}
+	})
+}
+
+// @ac AC-18
+// AC-18: Run skips hosts whose host_backoff_state.suppress_until is
+// in the future. 3 hosts seeded; 1 with future suppress → 2 probes per tick.
+func TestRun_SkipsBackoffSuppressedHosts(t *testing.T) {
+	t.Run("system-liveness-loop/AC-18", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		h1 := seedHost(t, pool, user)
+		_ = seedHost(t, pool, user)
+		_ = seedHost(t, pool, user)
+		// h1 is back-offed for 1h.
+		seedBackoff(t, pool, h1, time.Now().Add(1*time.Hour))
+
+		var mu sync.Mutex
+		var calls []emitCall
+		probe := newRecordingProbe(ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond})
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).
+			WithProbeFunc(probe.fn()).
+			WithInterval(time.Hour)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		done := make(chan struct{})
+		go func() { svc.Run(ctx); close(done) }()
+		<-done
+
+		if probe.count() != 2 {
+			t.Errorf("got %d probes; want 2 (1 host suppressed by backoff)", probe.count())
+		}
+	})
+}
+
+// @ac AC-19
+// AC-19: Run returns within 2s of ctx cancel.
+func TestRun_ReturnsOnCtxCancel(t *testing.T) {
+	t.Run("system-liveness-loop/AC-19", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+		var probesStarted atomic.Int64
+		slowProbe := ProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+			probesStarted.Add(1)
+			// Honor ctx — that's the AC; a misbehaving probe could
+			// hang. We sleep up to 500ms but ctx cancellation
+			// short-circuits.
+			select {
+			case <-time.After(500 * time.Millisecond):
+			case <-ctx.Done():
+			}
+			return ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond}
+		})
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).
+			WithProbeFunc(slowProbe).
+			WithInterval(time.Hour)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		start := time.Now()
+		go func() { svc.Run(ctx); close(done) }()
+		// Cancel after 100ms so a probe is in-flight.
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+		select {
+		case <-done:
+			if elapsed := time.Since(start); elapsed > 2*time.Second {
+				t.Errorf("Run took %v to exit after ctx cancel; want < 2s", elapsed)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run did not return within 2s of ctx cancel")
+		}
+	})
+}
+
+// @ac AC-20
+// AC-20: reachable -> unreachable transition publishes HeartbeatPulse{Reachable=false}.
+func TestPublishHeartbeat_ReachableToUnreachable(t *testing.T) {
+	t.Run("system-liveness-loop/AC-20", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		bus := eventbus.NewBus()
+		defer bus.Shutdown()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{
+			Kinds: []eventbus.EventKind{eventbus.EventKindHeartbeatPulse},
+		})
+		defer sub.Unsubscribe()
+
+		// First probe — reachable — establishes the prior state.
+		svc := NewService(pool, fakeEmitter(&mu, &calls), bus).
+			WithProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+				return ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond}
+			})
+		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+
+		// Drain the reachable-transition event so we only assert on
+		// the next one.
+		select {
+		case <-sub.Events():
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("did not receive initial first-seen event")
+		}
+
+		// Threshold = 2 consecutive failures, so probe twice failing.
+		svc2 := NewService(pool, fakeEmitter(&mu, &calls), bus).
+			WithProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+				return ProbeResult{Reachable: false, ResponseTime: 0}
+			})
+		_, _ = svc2.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+		_, _ = svc2.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+
+		select {
+		case ev := <-sub.Events():
+			hp, ok := ev.(eventbus.HeartbeatPulse)
+			if !ok {
+				t.Fatalf("got %T, want HeartbeatPulse", ev)
+			}
+			if hp.Reachable {
+				t.Errorf("HeartbeatPulse.Reachable = true, want false (transition to unreachable)")
+			}
+			if !hp.PriorReachable {
+				t.Errorf("HeartbeatPulse.PriorReachable = false, want true")
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("no HeartbeatPulse received within 500ms")
+		}
+	})
+}
+
+// @ac AC-21
+// AC-21: unreachable -> reachable transition publishes HeartbeatPulse{Reachable=true, PriorReachable=false}.
+func TestPublishHeartbeat_UnreachableToReachable(t *testing.T) {
+	t.Run("system-liveness-loop/AC-21", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		bus := eventbus.NewBus()
+		defer bus.Shutdown()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{
+			Kinds: []eventbus.EventKind{eventbus.EventKindHeartbeatPulse},
+		})
+		defer sub.Unsubscribe()
+
+		// Probe twice failing to drive the host to unreachable.
+		svc := NewService(pool, fakeEmitter(&mu, &calls), bus).
+			WithProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+				return ProbeResult{Reachable: false}
+			})
+		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+
+		// Drain the first-seen + transition-to-unreachable events.
+		for i := 0; i < 2; i++ {
+			select {
+			case <-sub.Events():
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+
+		// Now probe successfully.
+		svc2 := NewService(pool, fakeEmitter(&mu, &calls), bus).
+			WithProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+				return ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond}
+			})
+		_, _ = svc2.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+
+		select {
+		case ev := <-sub.Events():
+			hp, ok := ev.(eventbus.HeartbeatPulse)
+			if !ok {
+				t.Fatalf("got %T", ev)
+			}
+			if !hp.Reachable {
+				t.Errorf("HeartbeatPulse.Reachable = false, want true")
+			}
+			if hp.PriorReachable {
+				t.Errorf("HeartbeatPulse.PriorReachable = true, want false")
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("no HeartbeatPulse received")
+		}
+	})
+}
+
+// @ac AC-22
+// AC-22: steady-state probe (no transition) does NOT publish.
+func TestPublishHeartbeat_SteadyState_NoPublish(t *testing.T) {
+	t.Run("system-liveness-loop/AC-22", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		bus := eventbus.NewBus()
+		defer bus.Shutdown()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{
+			Kinds: []eventbus.EventKind{eventbus.EventKindHeartbeatPulse},
+		})
+		defer sub.Unsubscribe()
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), bus).
+			WithProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+				return ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond}
+			})
+
+		// First probe: first-seen transition. Drain.
+		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+		select {
+		case <-sub.Events():
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("did not receive first-seen event")
+		}
+
+		// Second probe: same state, no transition, no publish expected.
+		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+		select {
+		case ev := <-sub.Events():
+			t.Errorf("received unexpected HeartbeatPulse on steady state: %+v", ev)
+		case <-time.After(150 * time.Millisecond):
+			// Expected — no event.
+		}
+	})
+}
+
+// @ac AC-23
+// AC-23: NewService with nil bus still emits audit on transitions.
+func TestNewService_NilBus_AuditStillFires(t *testing.T) {
+	t.Run("system-liveness-loop/AC-23", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		hostID := seedHost(t, pool, user)
+		var mu sync.Mutex
+		var calls []emitCall
+
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).
+			WithProbeFunc(func(ctx context.Context, addr string, timeout time.Duration) ProbeResult {
+				return ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond}
+			})
+
+		_, err := svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
+		if err != nil {
+			t.Fatalf("ProbeHost: %v", err)
+		}
+		// First-seen transition → audit fires.
+		mu.Lock()
+		got := len(calls)
+		mu.Unlock()
+		if got == 0 {
+			t.Error("nil bus suppressed audit emission; want audit still fires")
+		}
+	})
+}

--- a/app/internal/liveness/service.go
+++ b/app/internal/liveness/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
 )
 
 // EmitFunc mirrors audit.Emit's signature; same pattern as
@@ -33,9 +35,11 @@ type ProbeFunc func(ctx context.Context, addr string, timeout time.Duration) Pro
 type Service struct {
 	pool      *pgxpool.Pool
 	emit      EmitFunc
+	bus       *eventbus.Bus // may be nil; see v1.1.0 C-13
 	probeFunc ProbeFunc
 	timeout   time.Duration
 	threshold int
+	interval  time.Duration
 	metrics   *Metrics
 	inFlight  sync.Map // map[uuid.UUID]struct{}
 	clock     func() time.Time
@@ -43,13 +47,18 @@ type Service struct {
 
 // NewService wires the live probe runner. timeout defaults to
 // DefaultProbeTimeout, threshold defaults to DefaultUnreachableThreshold.
-func NewService(pool *pgxpool.Pool, emit EmitFunc) *Service {
+//
+// v1.1.0: bus may be nil. When nil, the service still emits audit
+// events but skips bus publishes. Spec system-liveness-loop C-13.
+func NewService(pool *pgxpool.Pool, emit EmitFunc, bus *eventbus.Bus) *Service {
 	return &Service{
 		pool:      pool,
 		emit:      emit,
+		bus:       bus,
 		probeFunc: Probe,
 		timeout:   DefaultProbeTimeout,
 		threshold: DefaultUnreachableThreshold,
+		interval:  DefaultProbeInterval,
 		metrics:   NewMetrics(),
 		clock:     time.Now,
 	}
@@ -63,9 +72,28 @@ func (s *Service) WithProbeFunc(fn ProbeFunc) *Service {
 	return &Service{
 		pool:      s.pool,
 		emit:      s.emit,
+		bus:       s.bus,
 		probeFunc: fn,
 		timeout:   s.timeout,
 		threshold: s.threshold,
+		interval:  s.interval,
+		metrics:   s.metrics,
+		clock:     s.clock,
+	}
+}
+
+// WithInterval returns a new Service that ticks at the given interval.
+// Used by tests (and policy.Liveness.IntervalSec loading at boot) to
+// override the default 5-minute cadence. Spec system-liveness-loop C-03.
+func (s *Service) WithInterval(d time.Duration) *Service {
+	return &Service{
+		pool:      s.pool,
+		emit:      s.emit,
+		bus:       s.bus,
+		probeFunc: s.probeFunc,
+		timeout:   s.timeout,
+		threshold: s.threshold,
+		interval:  d,
 		metrics:   s.metrics,
 		clock:     s.clock,
 	}
@@ -73,6 +101,93 @@ func (s *Service) WithProbeFunc(fn ProbeFunc) *Service {
 
 // Metrics returns the runtime counters handle.
 func (s *Service) Metrics() *Metrics { return s.metrics }
+
+// Run is the blocking liveness loop. On every tick at the configured
+// interval it walks the active host inventory and calls ProbeHost for
+// each host whose backoff state allows a probe. Returns when ctx is
+// canceled, allowing the in-flight tick to complete.
+//
+// Spec system-liveness-loop v1.1.0:
+//   - C-10 / AC-16 / AC-17: tick-and-walk semantics.
+//   - C-11 / AC-18: skip hosts whose host_backoff_state.suppress_until is in the future.
+//   - AC-19: returns within 2s of ctx cancellation.
+func (s *Service) Run(ctx context.Context) {
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+
+	// Tick once at start so the loop produces a result before the first
+	// interval elapses. The initial tick respects ctx like any other.
+	s.tick(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+// tick performs one probe walk. Surface for tests: exercising tick
+// directly avoids relying on time.Ticker.
+func (s *Service) tick(ctx context.Context) {
+	hosts, err := s.listProbeTargets(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "liveness: list probe targets failed",
+			slog.String("err", err.Error()))
+		return
+	}
+	for _, h := range hosts {
+		// Per-host probe respects its own ctx — if Run's ctx is
+		// canceled, the probe call sees it and returns quickly.
+		_, _ = s.ProbeHost(ctx, h.HostID, h.Addr)
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+// probeTarget is one host the tick will probe.
+type probeTarget struct {
+	HostID uuid.UUID
+	Addr   string // host:port — derived from hosts.ip_address + hosts.port (defaults to 22)
+}
+
+// listProbeTargets returns active (non-soft-deleted) hosts whose
+// host_backoff_state does not suppress probes at this moment. Spec
+// AC-17 / AC-18.
+func (s *Service) listProbeTargets(ctx context.Context) ([]probeTarget, error) {
+	now := s.clock()
+	const q = `
+		SELECT h.id, h.ip_address::text, COALESCE(h.port, 22)
+		  FROM hosts h
+		  LEFT JOIN host_backoff_state b
+		    ON b.host_id = h.id AND b.probe_type = 'scan'
+		 WHERE h.deleted_at IS NULL
+		   AND (b.suppress_until IS NULL OR b.suppress_until <= $1)`
+	rows, err := s.pool.Query(ctx, q, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []probeTarget
+	for rows.Next() {
+		var (
+			id   uuid.UUID
+			ip   string
+			port int
+		)
+		if err := rows.Scan(&id, &ip, &port); err != nil {
+			return nil, err
+		}
+		out = append(out, probeTarget{
+			HostID: id,
+			Addr:   fmt.Sprintf("%s:%d", ip, port),
+		})
+	}
+	return out, rows.Err()
+}
 
 // ProbeHost runs one probe against the given host and persists the result.
 //
@@ -177,8 +292,29 @@ func (s *Service) persist(ctx context.Context, hostID uuid.UUID, result ProbeRes
 	if didTransition {
 		s.metrics.StateTransitionCount.Add(1)
 		s.emitTransition(ctx, hostID, result, newStatus)
+		// v1.1.0 C-12: publish HeartbeatPulse to the eventbus on the
+		// same trigger. Bus may be nil (test path) — skip in that case.
+		s.publishHeartbeat(ctx, hostID, result, Status(priorStatus), newStatus, now)
 	}
 	return nil
+}
+
+// publishHeartbeat publishes a typed HeartbeatPulse to the eventbus on
+// every reachability state transition. Best-effort: a nil bus is a
+// no-op; publish failures are not propagated to the caller (matches
+// the bus's own "drop on full / dropped count" contract). Spec v1.1.0
+// C-12 / AC-20 / AC-21 / AC-22.
+func (s *Service) publishHeartbeat(ctx context.Context, hostID uuid.UUID, result ProbeResult, prior, current Status, now time.Time) {
+	if s.bus == nil {
+		return
+	}
+	s.bus.Publish(ctx, eventbus.HeartbeatPulse{
+		HostID:         hostID,
+		Reachable:      current == StatusReachable,
+		PriorReachable: prior == StatusReachable,
+		OccurredAt:     now,
+		ResponseTimeMS: int(result.ResponseTime / time.Millisecond),
+	})
 }
 
 // computeNewState applies the hysteresis rules.

--- a/app/internal/liveness/service_test.go
+++ b/app/internal/liveness/service_test.go
@@ -181,7 +181,7 @@ func TestProbeHost_ConcurrencyGuard_SecondReturnsInFlight(t *testing.T) {
 			<-release
 			return ProbeResult{Reachable: true, ResponseTime: 10 * time.Millisecond, BannerSeen: true}
 		}
-		svc := NewService(pool, fakeEmitter(&mu, &calls)).WithProbeFunc(blocking)
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).WithProbeFunc(blocking)
 
 		// Start first probe.
 		started := make(chan struct{})
@@ -226,7 +226,7 @@ func TestProbeHost_DifferentHosts_ParallelRaceClean(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls)).WithProbeFunc(alwaysReachable(15))
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).WithProbeFunc(alwaysReachable(15))
 
 		var wg sync.WaitGroup
 		for _, h := range hosts {
@@ -262,7 +262,7 @@ func TestProbeHost_FirstSuccess_EmitsAuditAndStatusReachable(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls)).WithProbeFunc(alwaysReachable(20))
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).WithProbeFunc(alwaysReachable(20))
 
 		_, err := svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
 		if err != nil {
@@ -311,7 +311,7 @@ func TestProbeHost_FirstFailureFromReachable_NoTransition(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls)).WithProbeFunc(alwaysReachable(20))
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).WithProbeFunc(alwaysReachable(20))
 
 		// Initial reachable probe to seed status.
 		if _, err := svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22"); err != nil {
@@ -348,7 +348,7 @@ func TestProbeHost_NConsecutiveFailures_FlipsToUnreachable(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls)).WithProbeFunc(alwaysReachable(20))
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).WithProbeFunc(alwaysReachable(20))
 
 		// Seed reachable.
 		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")
@@ -388,7 +388,7 @@ func TestProbeHost_SuccessAfterUnreachable_FlipsBackToReachable(t *testing.T) {
 
 		var mu sync.Mutex
 		var calls []emitCall
-		svc := NewService(pool, fakeEmitter(&mu, &calls)).WithProbeFunc(alwaysFails("timeout"))
+		svc := NewService(pool, fakeEmitter(&mu, &calls), nil).WithProbeFunc(alwaysFails("timeout"))
 
 		// Two failures get us to unreachable.
 		_, _ = svc.ProbeHost(context.Background(), hostID, "192.0.2.10:22")

--- a/app/specs/system/daemon-orchestration.spec.yaml
+++ b/app/specs/system/daemon-orchestration.spec.yaml
@@ -1,0 +1,109 @@
+spec:
+  id: system-daemon-orchestration
+  title: openwatch serve daemon lifecycle and Slice B runtime wiring
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Process lifecycle for openwatch serve
+    description: >
+      Defines what `openwatch serve` instantiates from the Slice B
+      library packages, the boot/shutdown order, and the failure
+      semantics for the serve subcommand.
+
+      Scope of this version (v1.0.0):
+        - eventbus + alertrouter + stdout channel registration
+        - liveness probe loop (publishes HeartbeatPulse to the bus)
+        - The HTTP server (unchanged from system-http-server)
+
+      Out of scope (each lands in its own follow-up PR with its own
+      spec amendment):
+        - openwatch worker subcommand (system-worker-subcommand)
+        - scheduler dispatcher tick inside serve (needs the DEK
+          accessor + policy.Schedules loader)
+        - Live Kensa binding for the executor (system-kensa-executor v2 AC-18)
+        - drift detector wiring (constructed but no long-lived loop
+          today; called per-scan-completion by the worker)
+        - openwatch migrate / check-config subcommands
+
+      audit.Emit is the only EmitFunc threaded through Slice B
+      packages — none of them imports audit directly for emission.
+    related_specs:
+      - system-liveness-loop
+      - system-event-bus
+      - system-alert-router
+      - system-http-server
+
+  objective:
+    summary: >
+      openwatch serve boots the Slice B subsystems in a fixed order
+      that guarantees the alert router subscribes BEFORE any producer
+      publishes, then starts the HTTP server. Shutdown is reverse
+      order. Slice B packages are instantiated exactly once per
+      process via constructor injection — no global singletons.
+    scope:
+      includes:
+        - "Boot order: eventbus.NewBus -> alertrouter.NewRouter + Register stdout channel + Start -> liveness.NewService + go Run -> server.Run"
+        - "Shutdown order (reverse): router.Stop, liveness via ctx cancel, bus.Shutdown (deferred), audit.Shutdown (deferred)"
+        - "Stdout alert channel registered with wildcard Tags filter"
+        - "Slice B packages take audit.Emit via constructor injection — no direct audit.Emit calls in those packages"
+      excludes:
+        - "Scheduler dispatcher tick wiring (follow-up)"
+        - "Worker subcommand wiring (follow-up)"
+        - "Drift detector loop (no long-lived loop; called by worker)"
+        - "Live Kensa binding (follow-up)"
+        - "Runtime ordering tests via injected wrappers (deferred; source-inspection only in v1.0.0)"
+
+  constraints:
+    - id: C-01
+      description: openwatch serve MUST instantiate the Slice B subsystems in this order — eventbus.NewBus -> alertrouter.NewRouter -> alertrouter.Register (stdout channel) -> alertrouter.Start -> liveness.NewService -> go liveness.Run -> server.Run. Source-inspection enforces (AC-02)
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: openwatch serve MUST shut down subsystems in REVERSE boot order. router.Stop runs before server.Run returns control; bus.Shutdown + audit.Shutdown run via defer in reverse declaration order. Source-inspection enforces (AC-03)
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: The alert router MUST subscribe to the eventbus BEFORE any producer (liveness, future drift detector wiring) starts publishing. Boot order — bus + router.Start happens before liveness goroutine spawns — enforces this
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Slice B packages MUST receive audit.Emit (or a test fake) as their EmitFunc via constructor injection. No package may call audit.Emit directly via a package-global handle. Source-inspection enforces (AC-05)
+      type: security
+      enforcement: error
+    - id: C-05
+      description: openwatch serve MUST register at least one alert channel at boot — the stdout channel — so alerts are visible to operators via journald. The channel registration uses an empty Tags map (wildcard — receives every alert)
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: openwatch serve binary builds cleanly with the Slice B imports — alertrouter, alertrouter/channels/stdout, eventbus, liveness — present in cmd/openwatch/main.go's import block.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: Source-inspection — cmd/openwatch/main.go's cmdServe function contains the literal call sequence eventbus.NewBus, alertrouter.NewRouter, router.Register, router.Start, liveness.NewService, go liveSvc.Run, server.New, srv.Run in that textual order (so eyeballing the file shows the correct boot sequence).
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-03
+      description: Source-inspection — cmd/openwatch/main.go contains router.Stop AFTER srv.Run returns, and bus.Shutdown is registered via defer BEFORE router is constructed (so deferred shutdown runs after router.Stop).
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: Source-inspection — alertrouter.Start is called BEFORE liveSvc.Run goroutine spawns in cmdServe. Textual ordering check.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-05
+      description: Source-inspection — no Slice B package (internal/scheduler, internal/kensa, internal/transactionlog, internal/liveness, internal/alertrouter, internal/eventbus, internal/fleetrollup, internal/drift) calls audit.Emit directly. Each takes its EmitFunc via NewX constructor.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: Source-inspection — cmd/openwatch/main.go imports internal/alertrouter/channels/stdout and registers it via router.Register with a ChannelRegistration whose Tags map is nil or empty (wildcard).
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-07
+      description: The stdout channel is constructed via stdoutchan.New (alias for the channels/stdout package); the returned Channel's Name and Send methods conform to the alertrouter.Channel interface. Verified by the channels/stdout package's own tests.
+      priority: high
+      references_constraints: [C-05]

--- a/app/specs/system/drift-detector.spec.yaml
+++ b/app/specs/system/drift-detector.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-drift-detector
   title: Compliance drift detector
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -78,6 +78,14 @@ spec:
       description: DriftReport MUST include the per-severity transition counts (critical_became_failing, high_became_failing, etc.) — operators need this granularity for alert routing in B.3
       type: technical
       enforcement: error
+    - id: C-09
+      description: On every non-stable detection (Kind != Stable), Service MUST publish a typed DriftDetected event to the eventbus carrying the same per-severity transition counts that the audit detail carries. The publish is best-effort — bus errors are logged but do not affect DetectForScan's return. v1.1.0 NEW
+      type: technical
+      enforcement: error
+    - id: C-10
+      description: NewService signature is NewService(pool, emit, thresholds, bus). The bus parameter MAY be nil — in that case the service still emits audit events but skips bus publishes. v1.1.0 NEW
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -136,3 +144,19 @@ spec:
       description: DetectForScan computes score as (passed / total) × 100 where total excludes skipped rules — skipped doesn't count for or against compliance.
       priority: high
       references_constraints: [C-03]
+    - id: AC-15
+      description: On a major-worsening detection, DetectForScan publishes a DriftDetected{DriftType="major"} event to the eventbus; verified with an in-memory bus + subscriber.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-16
+      description: On a stable detection (no drift), DetectForScan does NOT publish a DriftDetected event — the bus subscriber sees zero events.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-17
+      description: The DriftDetected event's per-severity transition counts match the audit detail values; verified by asserting both produced from the same Report.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-18
+      description: NewService(pool, emit, thresholds, nil) — when the bus is nil, DetectForScan still emits the audit event; the only difference is no bus publish.
+      priority: high
+      references_constraints: [C-10]

--- a/app/specs/system/liveness-loop.spec.yaml
+++ b/app/specs/system/liveness-loop.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-liveness-loop
   title: Host liveness probe loop
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -87,6 +87,22 @@ spec:
       description: host_liveness writes use ON CONFLICT (host_id) DO UPDATE so the table has at most one row per host
       type: technical
       enforcement: error
+    - id: C-10
+      description: Service MUST expose Run(ctx) — a blocking loop that walks the active host inventory at the policy-configured cadence and calls ProbeHost for each. Run returns when ctx is canceled, draining in-flight probes. v1.1.0 NEW
+      type: technical
+      enforcement: error
+    - id: C-11
+      description: Run MUST skip hosts whose host_backoff_state.suppress_until is in the future at tick time — those hosts are explicitly back-offed by the executor/worker and re-probing immediately would not change the picture. v1.1.0 NEW
+      type: technical
+      enforcement: error
+    - id: C-12
+      description: On every reachability state transition (the same trigger as the host.connectivity.checked audit emission), Service MUST publish a typed HeartbeatPulse event to the eventbus. The publish is best-effort — bus errors are logged but do not affect ProbeHost's return value. v1.1.0 NEW
+      type: technical
+      enforcement: error
+    - id: C-13
+      description: NewService signature is NewService(pool, emit, bus). The bus parameter MAY be nil — in that case the service still emits audit events but skips bus publishes (testable in isolation). v1.1.0 NEW
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -148,3 +164,35 @@ spec:
     - id: AC-15
       description: Service exposes Metrics with last_probe_at, probe_count, probe_success_count, probe_failure_count, state_transition_count counters; all atomic-safe for concurrent read/write.
       priority: high
+    - id: AC-16
+      description: Service.Run(ctx) blocks; calling Run on a Service with no hosts in the inventory ticks at the configured cadence without panicking and produces zero ProbeHost invocations per tick.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-17
+      description: Service.Run(ctx) walks active hosts and calls ProbeHost for each on every tick; a test with 3 seeded hosts and a controllable clock observes exactly 3 ProbeHost invocations per tick.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-18
+      description: Run skips hosts whose host_backoff_state.suppress_until > now; a test seeding 3 hosts where 1 has suppress_until in the future observes exactly 2 probes per tick.
+      priority: critical
+      references_constraints: [C-11]
+    - id: AC-19
+      description: Run returns within 2 seconds of ctx cancellation; any in-flight ProbeHost call is allowed to complete (no abandonment), then Run exits.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-20
+      description: On a reachable → unreachable transition, the service publishes a HeartbeatPulse{Reachable=false} to the eventbus; verified with an in-memory bus + subscriber.
+      priority: critical
+      references_constraints: [C-12]
+    - id: AC-21
+      description: On an unreachable → reachable transition, the service publishes a HeartbeatPulse{Reachable=true, PriorReachable=false} to the eventbus.
+      priority: critical
+      references_constraints: [C-12]
+    - id: AC-22
+      description: A steady-state probe (no transition) does NOT publish a HeartbeatPulse — the bus subscriber sees zero events for that probe.
+      priority: critical
+      references_constraints: [C-12]
+    - id: AC-23
+      description: NewService(pool, emit, nil) — when the bus is nil, ProbeHost still works and the audit emission still fires; the only difference is no bus publish.
+      priority: high
+      references_constraints: [C-13]


### PR DESCRIPTION
## Why

The Slice B packages have been libraries with no runtime wiring since they were merged. \`openwatch serve\` boots HTTP and the existing in-process diagnostics worker — nothing else. This PR turns three of those libraries into actual runtime subsystems:

- \`internal/eventbus\` — in-process pub/sub
- \`internal/alertrouter\` — alert dispatcher with a new stdout channel
- \`internal/liveness\` — probe loop, now publishing \`HeartbeatPulse\` to the bus

After this PR, \`openwatch serve\` runs the alert router and the liveness probe loop. Booting against a fleet with hosts produces a tickable liveness sweep; transitions fire to the bus; the alert router fans them out to the stdout channel (visible via \`journalctl\`).

## Spec changes

### NEW: \`system-daemon-orchestration\` v1.0.0 (7 ACs)
The trimmed version of the spec pulled out of #429. Scope: what's actually wired and tested in this PR.

### Amended: \`system-liveness-loop\` v1.0.0 → **v1.1.0** (+8 ACs)
- \`C-10\` / AC-16/17 — \`Service.Run(ctx)\` blocking loop walks active hosts
- \`C-11\` / AC-18 — skips hosts whose \`host_backoff_state.suppress_until\` is in the future
- AC-19 — returns within 2s of ctx cancel
- \`C-12\` / AC-20/21/22 — publishes \`HeartbeatPulse\` on state transition; no publish on steady state
- \`C-13\` / AC-23 — \`NewService(pool, emit, bus)\`; nil bus is valid

### Amended: \`system-drift-detector\` v1.0.0 → **v1.1.0** (+4 ACs)
- \`C-09\` / AC-15/16/17 — publishes \`DriftDetected\` on non-stable detection; per-severity counts match the audit detail
- \`C-10\` / AC-18 — \`NewService(pool, emit, thresholds, bus)\`; nil bus is valid

## Code

| Path | Change |
|------|--------|
| \`internal/alertrouter/channels/stdout/\` | NEW — slog-based channel; zero external deps |
| \`internal/liveness/service.go\` | \`NewService\` gains \`*Bus\`; new \`Service.Run\` blocking loop; \`publishHeartbeat\` on transition; \`listProbeTargets\` SQL respects backoff |
| \`internal/drift/service.go\` | \`NewService\` gains \`*Bus\`; \`publishDrift\` on non-stable kind |
| \`cmd/openwatch/main.go\` | \`cmdServe\` now boots bus → router → register stdout (wildcard) → router.Start → liveness.NewService → \`go liveSvc.Run\` → server.Run. Reverse-order shutdown via deferred bus.Shutdown + audit.Shutdown + post-server router.Stop |
| \`cmd/openwatch/source_test.go\` | NEW source-inspection tests for the daemon-orchestration ACs |

## Verification

\`\`\`
go vet ./...                  clean
go test -race -count=1 ./...  PASS (full tree, ~4 min with Postgres)
specter parse                 PASS (40 specs)
specter check                 PASS
specter sync                  PASS (all 40 specs at threshold)
\`\`\`

Per-spec coverage:
- \`system-daemon-orchestration\` 7/7 (NEW)
- \`system-liveness-loop\` 23/23 (was 15/15 — +8 v1.1.0 ACs)
- \`system-drift-detector\` 18/18 (was 14/14 — +4 v1.1.0 ACs)

## Not in this PR

Each becomes its own follow-up that takes a future spec as its contract:
- \`openwatch worker\` subcommand (needs \`system-worker-subcommand\` spec)
- Scheduler dispatcher tick inside serve (needs DEK accessor + \`policy.Schedules\` loader)
- Drift detector loop (worker calls DetectForScan inline post-scan)
- Live Kensa binding (\`system-kensa-executor\` v2 AC-18)
- Slack / email / webhook channel implementations

## Test plan

- [ ] CI: \`Quality + security gates\` pass (vet, lint, vuln, test-race, specter sync)
- [ ] Spot-check: \`openwatch serve\` against a populated DB; observe \`journalctl -u openwatch -g alertrouter.alert.sent\` (will be empty until an alert fires, which requires either a liveness transition with a seeded host or the worker firing scans — neither flows in this PR; the channel itself is verified by unit test)