### PR TITLE
docs(frontend): six approved Tier 1 specs for the React frontend

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1026,6 +1026,36 @@
         "line_number": 112
       }
     ],
+    "app/specs/frontend/settings.spec.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/specs/frontend/settings.spec.yaml",
+        "hashed_secret": "87efe9302bd12354b93329a9b6677f111fd1d9e3",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/specs/frontend/settings.spec.yaml",
+        "hashed_secret": "18bb8bb05cfccdd915dbf9b2957582352dc739f9",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/specs/frontend/settings.spec.yaml",
+        "hashed_secret": "43b7d5ede4c65b053e7de227e441e7d4e4562842",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/specs/frontend/settings.spec.yaml",
+        "hashed_secret": "119c2d04c23cb8e69e813d2185e42c4e105b0d30",
+        "is_verified": false,
+        "line_number": 181
+      }
+    ],
     "app/specs/system/config.spec.yaml": [
       {
         "type": "Basic Auth Credentials",
@@ -1384,5 +1414,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-30T13:49:42Z"
+  "generated_at": "2026-05-31T13:35:00Z"
 }

--- a/app/specs/frontend/add-host.spec.yaml
+++ b/app/specs/frontend/add-host.spec.yaml
@@ -1,0 +1,196 @@
+spec:
+  id: frontend-add-host
+  title: Add host — single + bulk onboarding form
+  version: "1.1.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Host onboarding flow — single-host form OR bulk CSV/JSON import, plus credentials in one operator session
+    description: >
+      Route /hosts/new renders a tabbed page with two modes:
+
+      Single mode — one host record + (optionally) a host-scoped
+      credential. POST /api/v1/hosts followed by POST /api/v1/credentials.
+      On host-create success + credential-create failure, the host is
+      deleted (best-effort) to preserve the operator's all-or-nothing
+      mental model.
+
+      Bulk mode — CSV upload or pasted JSON. The page parses, validates
+      per row via the same zod schema as Single mode, and then POSTs
+      hosts sequentially. A per-row outcome table (created /
+      validation_failed / api_failed) is shown after the batch
+      completes. Bulk credential association is via a single chosen
+      credential (system default OR one host-scoped credential
+      template per environment) — the form does NOT let operators
+      paste per-row credentials in v1, since that surfaces secrets in
+      bulk paste blocks.
+
+      Form state for Single is managed via react-hook-form + zod. Bulk
+      rows are parsed first, displayed in a review grid, validated,
+      then submitted; the form-level error reporting is per row, not
+      per field.
+
+      Tier 2 because it's a feature flow, not the auth surface.
+    related_specs:
+      - api-hosts
+      - api-credentials
+      - frontend-hosts-list
+
+  objective:
+    summary: >
+      An operator with host:write + credential:write opens /hosts/new,
+      picks Single or Bulk, completes the chosen flow, and lands either
+      at /hosts/{newID} (single) or a per-row outcome table with
+      links to the created hosts (bulk).
+    scope:
+      includes:
+        - "Route /hosts/new requires host:write AND credential:write"
+        - "Two-tab UI: Single (existing) and Bulk (CSV/JSON)"
+        - "Single — form fields: hostname, ip_address, environment, auth_method, plus conditional secret fields"
+        - "Single — three auth_methods: ssh_key, password, both — conditional rendering"
+        - "Single — system default vs. host-scoped credential toggle"
+        - "Single — POST /api/v1/hosts then POST /api/v1/credentials (when host-scoped)"
+        - "Single — best-effort rollback on partial failure (delete host if credential fails)"
+        - "Bulk — CSV file upload (with header row) AND JSON array paste"
+        - "Bulk — pre-flight parse + zod validation per row; display issues in a review grid BEFORE any POST"
+        - "Bulk — sequential POST /api/v1/hosts per row (no parallel; rate-friendly)"
+        - "Bulk — per-row outcome table (created / validation_failed / api_failed) with rule_id + error.code"
+        - "Bulk — operator picks a single credential template at batch level (system default OR one host-scoped credential cloned per row); no per-row secrets"
+        - "Bulk — CSV download of failed-row outcomes for re-import after fix"
+        - "Field validation via zod (IP shape, hostname charset, secret presence) — shared across modes"
+      excludes:
+        - "Per-row secret material in bulk paste (out of scope — security)"
+        - "Credential edit (separate flow)"
+        - "Host SSH connectivity test from this form (deferred — operator tests via Host Detail)"
+        - "Parallel bulk submission (deferred — sequential is the safer default for v1)"
+
+  constraints:
+    - id: C-01
+      description: The route /hosts/new MUST require host:write. Unauthenticated requests redirect; authenticated without permission render 403
+      type: security
+      enforcement: error
+    - id: C-02
+      description: Secret values (password, private_key, private_key_passphrase) MUST NEVER appear in console output. The submit handler MUST scrub these fields before any console.error / console.warn / console.log
+      type: security
+      enforcement: error
+    - id: C-03
+      description: Form submission MUST disable the submit button while the request chain (POST /hosts then optional POST /credentials) is in flight. Re-clicking MUST NOT issue duplicate POST /hosts
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: When auth_method = "ssh_key", the password field MUST be hidden AND not submitted; when "password", the private_key fields MUST be hidden AND not submitted; when "both", all are visible AND validated
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: When the user picks "Use system default credential", the credential fields MUST be hidden AND the second POST MUST be omitted. The host is created with no host-scoped credential
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: If POST /api/v1/hosts succeeds (201) but POST /api/v1/credentials fails (any 4xx/5xx), the frontend MUST issue DELETE /api/v1/hosts/{newID} as best-effort rollback AND surface the credential error inline AND preserve the form fields the user entered. Partial-success surfaces are forbidden
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: Zod validation MUST run on every field before submit. Errors render inline below the offending field with role="alert" so screen readers announce them
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: All form interactions MUST be keyboard-accessible; field labels MUST be visible <label> elements (not placeholders); the form MUST pass axe-core wcag2a + wcag2aa with zero violations in both color modes
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: Bulk mode MUST parse a CSV with a header row whose columns include at minimum hostname and ip_address; optional columns are environment, port, username, group_id, tags (comma-separated cell). Unknown column headers MUST be rejected with a clear error BEFORE any row is processed
+      type: technical
+      enforcement: error
+    - id: C-10
+      description: Bulk mode MUST parse a JSON array whose elements match the HostCreateRequest shape. The same zod schema used by Single mode validates each element BEFORE any POST; rows that fail validation MUST NOT be submitted
+      type: technical
+      enforcement: error
+    - id: C-11
+      description: Bulk mode MUST display a pre-flight review grid showing every row with a parse-or-validate status BEFORE the operator clicks Submit. Only rows with status valid are submitted; failed rows render their failure reason inline
+      type: technical
+      enforcement: error
+    - id: C-12
+      description: Bulk submission MUST be sequential — POST one host at a time, wait for response, then POST the next. NO parallelization. A row's failure does NOT abort the batch — subsequent rows continue
+      type: technical
+      enforcement: error
+    - id: C-13
+      description: After bulk submission completes, the outcome table MUST classify each row as one of created (with link to /hosts/{id}), validation_failed (pre-flight), or api_failed (with error.code from the API response). A "Download failed rows as CSV" button MUST be visible when ANY row failed
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: Navigating to /hosts/new authenticated with host:write renders the form with hostname, ip_address, environment dropdown, auth_method radio, and a "Use system default credential" toggle.
+      priority: critical
+    - id: AC-02
+      description: Submitting a complete valid form (auth_method=ssh_key, system-default off, private_key supplied) issues exactly one POST /api/v1/hosts then exactly one POST /api/v1/credentials with scope="host" and scope_id matching the new host's ID; on 201 from both, redirects to /hosts/{newID}.
+      priority: critical
+    - id: AC-03
+      description: Toggling "Use system default credential" ON hides the credential fields AND on submit issues ONLY POST /api/v1/hosts (no credential POST).
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-04
+      description: Selecting auth_method="password" hides the private_key fields; selecting "ssh_key" hides password; selecting "both" shows all.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-05
+      description: Submitting an invalid IP (e.g., "999.999.999.999") fires inline zod validation BEFORE any API call; the offending field gets role="alert" announce-able feedback.
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-06
+      description: When POST /api/v1/hosts returns 201 but POST /api/v1/credentials returns 400, the frontend issues DELETE /api/v1/hosts/{newID} (best-effort) AND surfaces the credential error inline AND retains all form values the user entered.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-07
+      description: Double-clicking the submit button while a request is in flight issues exactly one POST /api/v1/hosts (the button is disabled after the first click).
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-08
+      description: Source-inspection — the submit handler does NOT include any console.log/warn/error call that interpolates password, private_key, or private_key_passphrase values.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-09
+      description: axe-core scan of the /hosts/new form reports zero violations across wcag2a + wcag2aa rule sets in both color modes.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-10
+      description: Keyboard tab order is hostname → ip_address → environment → auth_method → (conditional secrets) → use-system-default toggle → submit; each field has an explicit <label>.
+      priority: high
+      references_constraints: [C-08]
+    - id: AC-11
+      description: Navigating to /hosts/new renders a two-tab interface — Single and Bulk — with Single active by default. Tab navigation is keyboard accessible with arrow keys (WAI-ARIA tabs pattern).
+      priority: critical
+    - id: AC-12
+      description: Switching to the Bulk tab reveals two input modes — a file picker for CSV upload AND a textarea for JSON paste. Selecting either populates the review grid below.
+      priority: critical
+      references_constraints: [C-09, C-10]
+    - id: AC-13
+      description: Uploading a CSV with unknown column headers (e.g., "passowrd" misspelling) renders a parse-level error BEFORE the review grid AND no rows are added to the review.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: Pasting a JSON array with one invalid row (e.g., missing hostname) renders the review grid with that row marked status=validation_failed AND a per-row error message; the submit button shows the count of valid rows ("Submit 4 valid rows" when 5 are pasted and 1 is invalid).
+      priority: critical
+      references_constraints: [C-10, C-11]
+    - id: AC-15
+      description: Clicking Submit on the bulk review grid issues sequential POST /api/v1/hosts calls. The current row in flight is marked with an in-progress indicator; completed rows update in the outcome table in real time.
+      priority: critical
+      references_constraints: [C-12]
+    - id: AC-16
+      description: When 5 rows are submitted and row 3 fails with 409 hostname_already_exists, rows 1+2 show created (with /hosts/{id} link), row 3 shows api_failed with error.code "hostname_already_exists", and rows 4+5 still complete (no abort).
+      priority: critical
+      references_constraints: [C-12, C-13]
+    - id: AC-17
+      description: After a bulk submission with at least one failure, a "Download failed rows as CSV" button is visible. Clicking it triggers a browser download of a CSV containing only the failed rows plus a "failure_reason" column.
+      priority: high
+      references_constraints: [C-13]
+    - id: AC-18
+      description: Bulk mode batch credential selector lets the operator pick one of (a) "Use system default for all hosts" or (b) one host-scoped credential template (which is cloned and host-scoped for each created host). NO per-row secret entry is offered.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-19
+      description: axe-core scan of /hosts/new in BOTH Single and Bulk tabs reports zero violations across wcag2a + wcag2aa in both color modes.
+      priority: critical
+      references_constraints: [C-08]

--- a/app/specs/frontend/add-host.spec.yaml
+++ b/app/specs/frontend/add-host.spec.yaml
@@ -124,6 +124,7 @@ spec:
     - id: AC-01
       description: Navigating to /hosts/new authenticated with host:write renders the form with hostname, ip_address, environment dropdown, auth_method radio, and a "Use system default credential" toggle.
       priority: critical
+      references_constraints: [C-01]
     - id: AC-02
       description: Submitting a complete valid form (auth_method=ssh_key, system-default off, private_key supplied) issues exactly one POST /api/v1/hosts then exactly one POST /api/v1/credentials with scope="host" and scope_id matching the new host's ID; on 201 from both, redirects to /hosts/{newID}.
       priority: critical

--- a/app/specs/frontend/auth-login.spec.yaml
+++ b/app/specs/frontend/auth-login.spec.yaml
@@ -1,0 +1,149 @@
+spec:
+  id: frontend-auth-login
+  title: Frontend login + MFA + return_to
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Browser sign-in flow — username + password + optional MFA, session cookie + CSRF, return_to restoration
+    description: >
+      The login page is the only browser entry point that talks to the
+      authentication API. Per app/docs/frontend_architecture_adr.md
+      D-08, the browser uses session-cookie authentication with CSRF
+      protection — NOT JWT in localStorage. Login posts credentials to
+      POST /api/v1/auth/login; the server sets the openwatch_session
+      cookie (HttpOnly, Secure, SameSite=Lax). The body's
+      access_token / refresh_token are IGNORED by the browser
+      frontend — those are for API consumers.
+
+      MFA is single-step: when the server returns 401 with
+      error.code = "auth.mfa_required" the form re-renders with an
+      otp field; the next submission resends username + password + otp.
+
+      After successful authentication, the user is redirected to the
+      return_to query parameter (decoded), defaulting to / when absent
+      or invalid.
+
+      Tier 1 because login is the primary auth surface — a regression
+      here is a fleet-wide outage.
+    related_specs:
+      - api-auth
+      - frontend-foundation
+
+  objective:
+    summary: >
+      A user opens /login, enters credentials, optionally enters an
+      otp on MFA prompt, and lands at return_to (or /) with the
+      session cookie set. Wrong credentials surface a clear,
+      non-enumerating error. CSRF protection works on the very first
+      request after login.
+    scope:
+      includes:
+        - "Username + password form via react-hook-form + zod"
+        - "Single-step submission to POST /api/v1/auth/login"
+        - "MFA prompt on error.code = auth.mfa_required"
+        - "Error mapping (invalid_credentials, mfa_invalid, rate_limited)"
+        - "return_to URL preservation and post-login redirect"
+        - "Session cookie + CSRF token consumption on subsequent requests"
+        - "axe-clean keyboard-navigable form"
+      excludes:
+        - "Password reset flow (operator-mediated until email transport ships)"
+        - "OIDC/SAML browser flows (Slice A.5)"
+        - "MFA enrollment (covered by frontend-settings-account)"
+
+  constraints:
+    - id: C-01
+      description: The login form MUST submit username + password via POST /api/v1/auth/login with Content-Type application/json and credentials "include" (so the server can set the session cookie). The body MUST NOT include any other fields on the first submission
+      type: security
+      enforcement: error
+    - id: C-02
+      description: On a successful login response (200), the frontend MUST NOT read or store access_token or refresh_token from the body. The server's Set-Cookie header is the sole authentication credential
+      type: security
+      enforcement: error
+    - id: C-03
+      description: On 401 with error.code = "auth.mfa_required", the form MUST re-render with an otp input. The next submission MUST include all three fields (username + password + otp) — not just otp
+      type: security
+      enforcement: error
+    - id: C-04
+      description: On 401 with error.code = "auth.invalid_credentials" (regardless of whether the cause was wrong password or unknown user), the form MUST render the same generic message — no enumeration oracle in the UI
+      type: security
+      enforcement: error
+    - id: C-05
+      description: On 429 (rate limited), the form MUST render the server-provided retry message and disable the submit button until a 5-second cooldown elapses
+      type: security
+      enforcement: error
+    - id: C-06
+      description: The CSRF token MUST be read from the XSRF-TOKEN cookie (server-set, non-HttpOnly) and echoed on EVERY mutating request via the X-CSRF-Token header — including the first request after login. This is the double-submit-cookie pattern
+      type: security
+      enforcement: error
+    - id: C-07
+      description: After successful login, the frontend MUST redirect to the return_to query parameter (URL-decoded). Invalid or external URLs (any URL not beginning with "/") MUST fall back to "/" — no open-redirect vulnerability
+      type: security
+      enforcement: error
+    - id: C-08
+      description: The login form MUST be reachable by keyboard alone; both fields and the submit button MUST carry explicit labels (not placeholders), the submit button MUST be disabled while the request is in flight, and the form MUST pass axe-core wcag2a+wcag2aa with zero violations
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: Password and otp values MUST NEVER appear in console.log / console.warn / console.error output, even on error paths. The login service code MUST scrub any field literally named "password" or "otp" before any console emission
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: Navigating to /login with no session renders the form with username + password fields and a submit button.
+      priority: critical
+    - id: AC-02
+      description: Submitting valid credentials (no MFA) yields a 200 response; the openwatch_session cookie is observed in document.cookie has-set state; the frontend redirects to / (or return_to if present); the body's access_token is NOT stored in localStorage, sessionStorage, or memory.
+      priority: critical
+      references_constraints: [C-01, C-02]
+    - id: AC-03
+      description: Submitting credentials for an MFA-enrolled user without otp yields 401 auth.mfa_required; the form re-renders with an otp input visible AND focused; the username + password values are preserved (not cleared).
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-04
+      description: Submitting valid credentials + valid otp yields a 200; redirect succeeds.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-05
+      description: Submitting credentials with a wrong password yields 401 auth.invalid_credentials; the form renders the generic "Invalid username or password" message; the username field is preserved but password is cleared.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: Submitting credentials with an unknown username yields 401 auth.invalid_credentials; the rendered message is IDENTICAL to AC-05 — no UI difference between "wrong password" and "unknown user".
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-07
+      description: Submitting six rapid-fire failed logins triggers 429; the submit button is disabled; the rendered message is the server-provided retry hint; after a 5-second cooldown the button re-enables.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-08
+      description: After a successful login, the very next API call (GET /api/v1/auth/me) carries an X-CSRF-Token header equal to the XSRF-TOKEN cookie value; the response is 200.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-09
+      description: Navigating to /login?return_to=%2Fhosts%2F12345, logging in successfully, lands the user at /hosts/12345 (decoded). The URL bar shows /hosts/12345, not /.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-10
+      description: Navigating to /login?return_to=https%3A%2F%2Fevil.example.com lands the user at / after successful login (open-redirect prevention).
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-11
+      description: Keyboard tab order is username → password → submit (and otp → submit when MFA active); each field has an explicit <label>; submit shows aria-busy="true" while the request is in flight.
+      priority: high
+      references_constraints: [C-08]
+    - id: AC-12
+      description: axe-core scan of the /login page reports zero violations across wcag2a + wcag2aa rule sets in both dark and light modes.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-13
+      description: Source-inspection — the compiled frontend bundle (production build) does NOT contain the literal strings "password:" or "otp:" inside any console.log / console.warn / console.error call site. A grep against the build output confirms.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: Source-inspection — the login form's submit handler does NOT include code paths that write access_token or refresh_token to localStorage, sessionStorage, or any Zustand store.
+      priority: critical
+      references_constraints: [C-02]

--- a/app/specs/frontend/foundation.spec.yaml
+++ b/app/specs/frontend/foundation.spec.yaml
@@ -1,0 +1,174 @@
+spec:
+  id: frontend-foundation
+  title: Frontend foundation — theme, color scheme, layout shell, route guards
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: The shared shell every page renders inside — token system, color scheme, sidebar, topbar, route guards, error boundary
+    description: >
+      app/frontend/ is the React 19 + MUI v7 SPA embedded into the Go
+      binary via go:embed. The foundation comprises everything every
+      page assumes is in place: the design token system, the three-mode
+      color scheme, the layout shell, the top-level route table with
+      authentication and RBAC guards, and the global error boundary.
+
+      The token system is defined in app/docs/frontend_design_tokens.md.
+      The architecture decisions (stack, build, hosting, auth contract)
+      are locked in app/docs/frontend_architecture_adr.md. This spec
+      enforces both as behavior.
+
+      The foundation is Tier 1 because color-scheme persistence, no-FOUC
+      first paint, route-guard correctness, and the error boundary all
+      affect every downstream page; a regression here is a fleet-wide
+      regression.
+    related_specs:
+      - api-auth
+      - system-rbac
+      - frontend-auth-login
+
+  objective:
+    summary: >
+      Booting the SPA yields a shell whose color scheme matches the
+      stored preference (no FOUC), whose sidebar + topbar render via
+      MUI v7 primitives styled via the --ow-* token contract, whose
+      route guards redirect anonymous users to /login and 403 users
+      without the required permission, and whose error boundary catches
+      uncaught render errors without unmounting the app.
+    scope:
+      includes:
+        - "Three-mode color scheme (light, dark, system) with localStorage persistence"
+        - "No-FOUC first paint via getInitColorSchemeScript in index.html"
+        - "MUI v7 CssVarsProvider with extendTheme({cssVarPrefix: 'ow', colorSchemes: {...}})"
+        - "Token contract: every --ow-* variable from frontend_design_tokens.md present"
+        - "Layout shell: 56px icon sidebar, sticky topbar, content area"
+        - "Top-level route table with authentication + RBAC guards"
+        - "Global error boundary"
+        - "Document title per route via React 19 <title> in JSX"
+        - "axe-core clean on the shell in both color modes"
+      excludes:
+        - "Per-page content (covered by per-page specs)"
+        - "Login form behavior (covered by frontend-auth-login)"
+        - "Dashboard widget grid (deferred until backend slice unblocks)"
+        - "Real-time Activity feed (deferred with OS Intelligence)"
+
+  constraints:
+    - id: C-01
+      description: The color scheme MUST be one of three values stored in localStorage under key "ow-color-scheme" — "light", "dark", or "system". Default when unset is "system". An invalid stored value MUST fall back to "system" without throwing
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: On first paint (BEFORE the React bundle parses), <html> MUST carry data-mui-color-scheme="light" or "dark" matching the resolved mode. This MUST be set by a synchronous script in index.html <head> so there is NO flash of the wrong scheme
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: >-
+        When the stored mode is system, changes to the OS color preference
+        (via matchMedia prefers-color-scheme=dark) MUST update the rendered
+        scheme live without a page reload
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Every --ow-* CSS variable listed in app/docs/frontend_design_tokens.md MUST be exported from app/frontend/src/theme/tokens.ts AND mapped through the MUI extendTheme call. A token in the doc but not in code is a failed contract
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: The frontend MUST NOT use --mui-* variables in component styles. The cssVarPrefix is "ow" — every reference is via var(--ow-*) or theme.vars.ow.*
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: An unauthenticated request to any guarded route MUST redirect to /login?return_to=<encoded original URL>. The original URL MUST be restored after successful authentication
+      type: security
+      enforcement: error
+    - id: C-07
+      description: An authenticated request to a route requiring a permission the current identity lacks MUST render a 403 region surfacing the API's authz.permission_denied error code. The route MUST NOT silently redirect or render an empty page
+      type: security
+      enforcement: error
+    - id: C-08
+      description: The top-level error boundary MUST catch render errors in any child route, render a recoverable error UI ("Something went wrong. Reload."), and emit the error to console.error (development only). It MUST NOT unmount the shell (sidebar + topbar stay visible)
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: Every interactive element in the shell (sidebar nav buttons, topbar buttons, color-scheme toggle, error-boundary reload button) MUST be reachable via keyboard alone, carry an aria-label or visible text label, and present a visible focus indicator
+      type: technical
+      enforcement: error
+    - id: C-10
+      description: axe-core scan of the rendered shell MUST report zero violations across the wcag2a + wcag2aa rule sets in BOTH dark and light modes
+      type: technical
+      enforcement: error
+    - id: C-11
+      description: No PII or secret value MAY appear in client-side console.log / console.warn / console.error output. Error boundary error messages MUST be scrubbed of any field literally named "evidence", "token", "password", "secret", "private_key" before logging
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: First paint with localStorage unset on a system in dark OS preference renders the dark scheme; <html data-mui-color-scheme="dark"> is set BEFORE React mounts (verified by snapshotting outerHTML in a body-zero-frame test).
+      priority: critical
+      references_constraints: [C-01, C-02]
+    - id: AC-02
+      description: First paint with localStorage="light" on a system in dark OS preference renders the light scheme (user override beats system).
+      priority: critical
+      references_constraints: [C-01, C-02]
+    - id: AC-03
+      description: First paint with localStorage set to an invalid value ("blue", "", "0") falls back to "system" without throwing; matches AC-01 behavior.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-04
+      description: Toggling the color-scheme control in the topbar to "Light" updates <html data-mui-color-scheme="light"> AND writes "light" to localStorage under key "ow-color-scheme" AND re-renders subscribing components with the light palette.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-05
+      description: With stored mode "system", flipping the OS preference at runtime (simulated via matchMedia change event) updates <html data-mui-color-scheme> without a page reload.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-06
+      description: A unit test against app/frontend/src/theme/tokens.ts asserts that every token listed in app/docs/frontend_design_tokens.md is present with the exact dark and light values from the doc.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-07
+      description: A grep of app/frontend/src/ (excluding generated files and node_modules) finds zero references to "var(--mui-" — the codebase uses only "var(--ow-" or theme.vars.ow.* paths.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-08
+      description: Navigating to /hosts (a guarded route) with no session cookie redirects to /login?return_to=%2Fhosts; submitting valid credentials lands the user back at /hosts.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-09
+      description: Navigating to /admin/users (requires admin role) as a viewer-only session renders a 403 region with the API's authz.permission_denied error code, NOT a redirect, NOT a blank page.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-10
+      description: An intentionally-thrown render error in a child route renders the error boundary fallback ("Something went wrong. Reload.") AND the sidebar + topbar remain visible AND clicking Reload remounts the route subtree without a full page refresh.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-11
+      description: Keyboard tab order through the shell reaches every interactive element in document order; each has a visible focus indicator (outline distinguishable from background). Verified by Playwright keyboard-only navigation snapshot.
+      priority: high
+      references_constraints: [C-09]
+    - id: AC-12
+      description: axe-core scan of the rendered shell (sidebar + topbar + a placeholder content region) reports zero violations across wcag2a + wcag2aa rule sets in dark mode.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-13
+      description: axe-core scan of the same shell reports zero violations across wcag2a + wcag2aa rule sets in light mode.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-14
+      description: Source-inspection of app/frontend/src/ — no occurrence of console.log, console.warn, or console.error contains the literal string "evidence" or "token" as a field name (a grep against the source AND the production build).
+      priority: critical
+      references_constraints: [C-11]
+    - id: AC-15
+      description: Source-inspection of index.html — the <head> contains a synchronous <script> that reads localStorage["ow-color-scheme"] and sets data-mui-color-scheme on <html> BEFORE the React bundle loads. The script MUST appear before any <script type="module"> for the bundle.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-16
+      description: Source-inspection — extendTheme is called with cssVarPrefix:"ow" and colorSchemes with both "light" and "dark" keys; defaultColorScheme is "system". CssVarsProvider wraps the route tree.
+      priority: critical
+      references_constraints: [C-01, C-02]
+    - id: AC-17
+      description: The route table includes /login (anonymous) and at least one guarded route; the guard component renders a redirect to /login?return_to=... on missing session, NOT a thrown exception.
+      priority: high
+      references_constraints: [C-06]

--- a/app/specs/frontend/host-detail.spec.yaml
+++ b/app/specs/frontend/host-detail.spec.yaml
@@ -1,0 +1,151 @@
+spec:
+  id: frontend-host-detail
+  title: Host detail — single-host posture, liveness, transactions
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: First user-facing page that surfaces Slice B data — host posture + liveness + recent transactions
+    description: >
+      Route /hosts/{id} renders a single host's compliance posture
+      using the API surface shipped in Slice B plus the
+      framework-at-query-time addendum: GET /api/v1/hosts/{id} (host +
+      liveness + compliance summary) and GET /api/v1/fleet/recent-changes
+      filtered to host_id (recent state transitions).
+
+      The page has three regions: identity header (hostname, IP,
+      environment, liveness state), compliance body (passing / failing /
+      skipped / error counts + derived pass percentage + framework
+      filter), and footer (recent transactions table with cursor
+      pagination).
+
+      Per the framework-at-query-time architecture, an optional
+      ?framework= URL param is propagated to every fetch that supports
+      it. The URL is the source of truth — reloading restores the same
+      view.
+
+      Ported from the original frontend-findings-ui spec at
+      /tmp/findings-spec.yaml; updated for the Go rebuild's MUI v7 +
+      TanStack stack.
+    related_specs:
+      - api-hosts
+      - api-fleet-observability
+      - system-rbac
+      - system-fleet-rollup
+      - frontend-hosts-list
+
+  objective:
+    summary: >
+      An operator with host:read opens /hosts/{id}, sees identity
+      header + compliance summary + recent transactions table. A
+      framework dropdown filters the visible counts and transactions.
+      URL preserves the framework selection across reloads. Empty,
+      loading, and error states render distinctly per region.
+    scope:
+      includes:
+        - "Route /hosts/{id} requires host:read"
+        - "Three regions: identity header, compliance body, transactions footer"
+        - "Optional ?framework=<id> URL param honored across all data fetches"
+        - "Empty / loading / error states for every fetch"
+        - "Recent transactions table with cursor pagination (50 per page)"
+        - "Liveness state rendering (reachable, unreachable, unknown, not-yet-probed)"
+        - "axe-clean rendering in both color modes"
+      excludes:
+        - "Multi-host bulk views (deferred)"
+        - "Trigger-a-scan button (needs scheduler mutation API)"
+        - "Trend lines / time-series (needs temporal API)"
+        - "Remediation actions (different RBAC surface)"
+        - "Per-transaction detail page (TBD by follow-up spec)"
+
+  constraints:
+    - id: C-01
+      description: The route /hosts/{id} MUST require host:read. Unauthenticated requests redirect to /login with return_to; authenticated requests without host:read render the 403 region surfacing authz.permission_denied
+      type: security
+      enforcement: error
+    - id: C-02
+      description: Every API fetch in the view MUST handle three terminal states — success, 4xx/5xx error, network failure. Each state renders a distinct UI region with a human-readable message and (where retryable) a Retry control
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: When the URL carries ?framework=<id>, the value MUST be propagated to GET /api/v1/hosts/{id}?framework=<id> AND GET /api/v1/fleet/recent-changes?host_id=<uuid>&framework=<id>. Changing the filter MUST update the URL via the router; reloading restores the same view
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: The compliance summary region MUST render passing / failing / skipped / error counts AND a derived pass percentage when total > 0. When total = 0 the region MUST render an empty-state message ("No compliance data for this host yet") rather than "0%"
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: The liveness region MUST render one of three states — reachable, unreachable, unknown — with the corresponding semantic color/icon. A null liveness object from the API (never-probed host) MUST render a distinct fourth state ("Not yet probed")
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: The recent-transactions table MUST cap visible rows at 50; a "Show more" or "Next" control fetches the next page via cursor. Rows MAY link to a per-transaction detail view (route TBD); broken links MUST NOT crash the page
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: Every interactive element MUST be reachable by keyboard alone and carry an explicit ARIA label. The page MUST pass axe-core wcag2a + wcag2aa with zero violations in both color modes
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: No PII or secret value MAY appear in client-side console output. The data fetcher MUST scrub error.detail.evidence and error.detail.token if present before any console emission
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: Navigating to /hosts/<existing-uuid> while authenticated with host:read renders the identity header with hostname + ip_address + environment matching the API response.
+      priority: critical
+    - id: AC-02
+      description: Navigating to /hosts/<unknown-uuid> renders a 404 region (host_not_found from API) — not the loading state forever and not a generic JS exception.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: Navigating to /hosts/{id} authenticated without host:read renders the 403 region surfacing authz.permission_denied.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-04
+      description: A host with seeded host_rule_state (3 pass / 2 fail / 1 skipped) renders the compliance summary as "3 passing, 2 failing, 1 skipped, 6 total — 50%".
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-05
+      description: A host with NO host_rule_state renders the compliance summary as "No compliance data for this host yet" — not "0% — 0 of 0".
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: A host with liveness=null renders "Not yet probed" in the liveness region — not a missing element and not "unknown".
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-07
+      description: A host with liveness.reachability_status="reachable" renders the reachable state with last_probe_at in the user's local timezone format.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-08
+      description: The page contains a framework filter control; selecting "cis_rhel9_v2.0.0" updates the URL to /hosts/{id}?framework=cis_rhel9_v2.0.0 AND triggers re-fetches of /api/v1/hosts/{id} + /api/v1/fleet/recent-changes with the same framework value.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-09
+      description: Reloading /hosts/{id}?framework=stig_rhel9_v2r7 restores the framework filter in the control (no manual re-selection) — URL is the SSOT.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-10
+      description: The recent-transactions table renders up to 50 rows from /api/v1/fleet/recent-changes filtered to the current host_id; a host with 60 recent transactions shows "Show more" which fetches the 51..60 cursor page.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-11
+      description: axe-core scan of the rendered page returns zero violations across wcag2a + wcag2aa rule sets in both color modes.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-12
+      description: Tab-key navigation reaches every interactive element in document order; each element has a visible focus indicator and an explicit ARIA label.
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-13
+      description: Triggering a 500 from the hosts API renders the error region with a Retry control; clicking Retry re-fetches with the same parameters.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-14
+      description: Source-inspection — no console.log / console.warn / console.error in the compiled frontend bundle contains the literal string "evidence" or "token" as a field name.
+      priority: critical
+      references_constraints: [C-08]

--- a/app/specs/frontend/hosts-list.spec.yaml
+++ b/app/specs/frontend/hosts-list.spec.yaml
@@ -85,7 +85,7 @@ spec:
     - id: AC-01
       description: Navigating to /hosts authenticated with host:read against a fleet of 60 hosts renders the table with the first 50 rows. A "Next" control is visible; clicking it advances to rows 51-60.
       priority: critical
-      references_constraints: [C-02, C-05]
+      references_constraints: [C-01, C-02, C-05]
     - id: AC-02
       description: Navigating to /hosts with zero hosts and no filters renders the first-run empty state with a link to /hosts/new (visible only to roles with host:write).
       priority: critical

--- a/app/specs/frontend/hosts-list.spec.yaml
+++ b/app/specs/frontend/hosts-list.spec.yaml
@@ -1,0 +1,131 @@
+spec:
+  id: frontend-hosts-list
+  title: Hosts list — inventory page with pagination, sort, filter
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: First user-facing page after login — the host inventory
+    description: >
+      Route /hosts renders the host inventory as a paginated table.
+      Data comes from GET /api/v1/hosts (cursor-paginated per
+      app/docs/api_design_principles.md). The page MUST surface
+      empty / loading / error states for every fetch, and the URL
+      MUST be the source of truth for sort and filter so a refresh
+      restores the same view.
+
+      Tier 2 because the page is functional, not security-sensitive.
+      The route gate is Tier 1 territory (frontend-foundation C-06).
+    related_specs:
+      - api-hosts
+      - frontend-foundation
+      - system-rbac
+
+  objective:
+    summary: >
+      An authenticated user with the host:read permission opens
+      /hosts and sees up to 50 hosts per page with hostname, IP,
+      OS, last-seen, and a status indicator. The list supports
+      sorting by hostname / last-seen, filtering by environment
+      and OS, and cursor pagination. Empty fleet renders a
+      first-run prompt with a link to add a host.
+    scope:
+      includes:
+        - "Route /hosts requires host:read"
+        - "GET /api/v1/hosts with cursor pagination (50 per page)"
+        - "Sortable columns (hostname, last-seen)"
+        - "Filter by environment and OS family"
+        - "URL is SSOT for sort, filter, cursor"
+        - "Empty / loading / error states"
+        - "Per-row link to /hosts/{id}"
+        - "An 'Add host' button visible to host:write roles, hidden otherwise"
+      excludes:
+        - "Bulk operations (deferred)"
+        - "Add host form behavior (covered by frontend-add-host)"
+        - "Host detail page (covered by frontend-host-detail)"
+        - "Real-time updates (deferred — manual refresh in v0)"
+
+  constraints:
+    - id: C-01
+      description: The route /hosts MUST require an authenticated session carrying host:read; unauthenticated requests redirect per frontend-foundation C-06; authenticated requests without host:read render the 403 region per frontend-foundation C-07
+      type: security
+      enforcement: error
+    - id: C-02
+      description: The page MUST fetch GET /api/v1/hosts via the generated openapi-fetch client with credentials "include" (session cookie). It MUST NOT add an Authorization header
+      type: security
+      enforcement: error
+    - id: C-03
+      description: Every fetch MUST handle three terminal states — success, 4xx/5xx error, network failure. Each renders a distinct UI region with a human-readable message and (where retryable) a Retry control
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: URL query params (sort, dir, env, os, cursor) MUST be propagated to the API call AND restored from the URL on initial render. Changing a control updates the URL via the router's navigate; reload restores the same view
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: The page MUST render at most 50 rows. A "Next" cursor button advances to the next page; "Previous" returns to the prior cursor. Cursor values come from the API response, never client-computed
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: When the API returns zero hosts AND no filter is active, the page MUST render the first-run empty state ("No hosts yet — add your first host") with a link/button to /hosts/new. When filters ARE active, the empty state MUST read "No hosts match your filters" with a Clear filters control
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: The "Add host" button MUST be visible only when the current identity has host:write. The visibility check uses the identity from useAuthStore — NOT a client-side role-string comparison
+      type: security
+      enforcement: error
+    - id: C-08
+      description: Every interactive element (sort headers, filter dropdowns, pagination buttons, row link, Add host button) MUST be reachable by keyboard alone and carry an explicit ARIA label. The page MUST pass axe-core wcag2a + wcag2aa with zero violations
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: Navigating to /hosts authenticated with host:read against a fleet of 60 hosts renders the table with the first 50 rows. A "Next" control is visible; clicking it advances to rows 51-60.
+      priority: critical
+      references_constraints: [C-02, C-05]
+    - id: AC-02
+      description: Navigating to /hosts with zero hosts and no filters renders the first-run empty state with a link to /hosts/new (visible only to roles with host:write).
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-03
+      description: Navigating to /hosts?env=production with no matching hosts renders "No hosts match your filters" with a Clear filters control.
+      priority: high
+      references_constraints: [C-06]
+    - id: AC-04
+      description: Clicking the hostname column header sets URL to /hosts?sort=hostname&dir=asc and re-fetches; clicking again sets dir=desc.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-05
+      description: Reloading /hosts?sort=last_seen&dir=desc&env=production restores the column header indicator, the env filter pill, and re-fetches with those params.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: Triggering a 500 from the hosts API renders the error region with a Retry control; clicking Retry re-fetches with the same params.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-07
+      description: A simulated network failure (offline) renders the network-failure region distinct from the 5xx region; both carry Retry.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-08
+      description: Logged in as a host:read-only role (no host:write), the Add host button is NOT rendered. The /hosts/new link in the empty state is also hidden.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-09
+      description: Each row links to /hosts/{id} (the host's UUID); clicking navigates without a full page reload (router transition).
+      priority: high
+    - id: AC-10
+      description: axe-core scan of the /hosts page (both populated and empty states) reports zero violations across wcag2a + wcag2aa rule sets in both color modes.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-11
+      description: Tab navigation reaches every interactive element in document order with a visible focus indicator; sort-header buttons announce aria-sort=ascending/descending appropriately.
+      priority: high
+      references_constraints: [C-08]
+    - id: AC-12
+      description: Source-inspection — the hosts list service code uses the generated openapi-fetch client (no raw fetch() calls with hardcoded /api/v1/hosts paths).
+      priority: high
+      references_constraints: [C-02]

--- a/app/specs/frontend/settings.spec.yaml
+++ b/app/specs/frontend/settings.spec.yaml
@@ -1,0 +1,235 @@
+spec:
+  id: frontend-settings
+  title: Settings — two-pane shell with 11 sub-pages
+  version: "1.1.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Workspace + personal settings surface — 11 categories grouped Workspace / Access / Personal, each its own routed sub-page
+    description: >-
+      Route /settings is a two-pane shell mirroring the v1 prototype
+      (app/docs/prototypes/openwatch-v1/Settings.html). A 260px left
+      nav holds three groups — Workspace, Access, Personal — with
+      11 leaf pages between them. The main pane renders the active
+      page via TanStack Router nested routes.
+
+      v0 wires the four pages whose backends exist in Slice A
+      (Profile, Preferences, SSH & credentials, Users & teams). The
+      remaining seven pages render their structural shells with a
+      "Backend pending" banner identifying the slice that unblocks
+      each one. The shell visually matches the prototype regardless
+      of wiring depth — operators see the same surface they would
+      see when fully wired, just with disabled controls and pending
+      banners.
+
+      Profile combines four backend-wired sub-sections: profile
+      identity (read-only from /auth/me until PATCH lands), password
+      change (POST /auth/password:change), MFA enrollment +
+      verification (POST /auth/mfa:enroll, /auth/mfa:verify), and
+      active sessions (read-only "this device" placeholder until the
+      sessions endpoint ships).
+
+      Tier 2 — feature surface, not the auth boundary. Profile's
+      MFA + password subsections are themselves security-sensitive
+      but follow the auth-login spec contract.
+    related_specs:
+      - api-auth
+      - api-credentials
+      - api-users
+      - frontend-foundation
+      - frontend-auth-login
+
+  objective:
+    summary: >-
+      An authenticated operator navigates /settings/* via the left
+      nav. The Profile page surfaces their identity, lets them change
+      password and enroll MFA against the live backend. Preferences
+      persists theme/density/etc. to localStorage. Credentials and
+      Users list against live endpoints. Other pages render their
+      structural shells with disabled controls.
+    scope:
+      includes:
+        - "Route /settings — redirects to /settings/profile by default"
+        - "Two-pane shell — 260px left nav + main content"
+        - "Left nav with 11 items in 3 groups plus search"
+        - "Active nav item highlighted with warn-pip on Security & auth"
+        - "Profile — identity from /auth/me + password change + MFA enroll + sessions placeholder"
+        - "Preferences — theme/density/accent/landing/host-view/date-format/reduce-motion persisted to localStorage"
+        - "SSH & credentials — list from GET /api/v1/credentials with Add (POST), Replace (POST+DELETE) and Delete (DELETE) modals"
+        - "SSH keys section is a derived view of key-bearing credentials; Add/Replace/Delete a key operates on the parent credential"
+        - "Users & teams — list from GET /api/v1/users (admin-gated)"
+        - "Scanning, Policies, Notifications, Integrations, Security, Audit, About — structural shells with Backend Pending banner"
+        - "All control widgets themed via --ow-* tokens"
+      excludes:
+        - "PATCH /auth/me wiring (backend endpoint deferred)"
+        - "Credential / User CRUD forms (dedicated specs pending)"
+        - "Session listing + revoke (backend /auth/sessions deferred)"
+        - "Sub-page deep-linking inside the seven stubbed pages"
+        - "Full-document settings search"
+
+  constraints:
+    - id: C-01
+      description: The route /settings MUST redirect to /settings/profile by default. Every leaf page MUST live under /settings/<id> with its own routed component
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: >-
+        The left nav MUST render 11 items in 3 groups (Workspace 5,
+        Access 3, Personal 3). The active page MUST be highlighted
+        (ow-bg-3 background, ow-info accent on icon). Inactive items
+        hover to ow-bg-2
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: >-
+        Profile MUST render the identity returned from useAuthStore.
+        The Save-changes button at the bottom of the profile-identity
+        card MUST be disabled with a visible PATCH-pending hint — no
+        broken POST is made
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: >-
+        Password change MUST POST to /api/v1/auth/password:change with
+        current_password + new_password. Zod MUST enforce new_password
+        length >= 15 AND new_password != current_password AND
+        confirm_password == new_password BEFORE any POST. Password
+        values MUST NOT appear in console output
+      type: security
+      enforcement: error
+    - id: C-05
+      description: >-
+        MFA enrollment MUST POST to /api/v1/auth/mfa:enroll then render
+        the returned provisioning_uri AND secret. Verification MUST
+        POST a 6-digit otp to /api/v1/auth/mfa:verify; on success the
+        auth store identity MFA flag is set true AND the section
+        re-renders to the Enabled state
+      type: security
+      enforcement: error
+    - id: C-06
+      description: >-
+        Preferences MUST persist to localStorage under key
+        "ow-preferences" (via Zustand persist middleware). No backend
+        POST is made. Reloading the browser restores the same
+        selections
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: >-
+        SSH & credentials MUST fetch GET /api/v1/credentials and
+        render one row per credential. Add/Edit/Delete buttons render
+        but MUST be disabled
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: >-
+        Users & teams MUST be gated to roles with the admin permission.
+        Non-admin sessions visiting /settings/users render the 403
+        ForbiddenPage. Admin sessions see the list from GET
+        /api/v1/users
+      type: security
+      enforcement: error
+    - id: C-09
+      description: >-
+        The 7 stubbed pages MUST each render a BackendPendingBanner
+        identifying the slice that unblocks them. Every interactive
+        control on these pages MUST be disabled
+      type: technical
+      enforcement: error
+    - id: C-10
+      description: >-
+        Every Settings widget MUST reference --ow-* CSS variables for
+        color and surface. No hardcoded colors outside the token
+        contract
+      type: technical
+      enforcement: error
+    - id: C-11
+      description: >-
+        The left-nav search input MUST filter nav items by
+        case-insensitive label substring. Empty query renders all
+        groups; no-match renders no groups
+      type: technical
+      enforcement: error
+    - id: C-12
+      description: >-
+        Every interactive element across all 11 pages MUST be
+        reachable by keyboard alone. axe-core MUST report zero
+        violations across wcag2a + wcag2aa in both color modes
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: Navigating to /settings redirects to /settings/profile within one router tick. The left nav and the page-head both reflect Profile as active.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: The left nav renders exactly 11 leaf items distributed as Workspace (5) + Access (3) + Personal (3). The Security & auth item carries a warn-tier pip in its right slot.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: Typing "user" in the nav-search filters the visible list to "Users & teams" only; clearing the search restores all groups.
+      priority: high
+      references_constraints: [C-11]
+    - id: AC-04
+      description: Profile page renders the username and email returned by /auth/me. The big-avatar initials match the first 1-2 tokens of the username. The Save-changes button has aria-disabled=true.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-05
+      description: Submitting the password-change form with current=valid + new=15+ chars + confirm=match issues exactly one POST /api/v1/auth/password:change with body {current_password, new_password}. On 200 the form clears and a green success banner renders inline.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: Submitting current=wrong yields 401 auth.invalid_credentials; the form renders the error inline; the new + confirm fields are preserved.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-07
+      description: Submitting new == current MUST fail zod validation client-side BEFORE any POST.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-08
+      description: Submitting new < 15 chars fails zod validation client-side BEFORE any POST.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-09
+      description: With mfa_enabled=false, clicking Begin enrollment issues POST /api/v1/auth/mfa:enroll AND renders the returned provisioning_uri AND the textual secret AND a 6-digit otp input.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-10
+      description: Submitting a valid otp yields 200 from /api/v1/auth/mfa:verify; the section state transitions to Enabled (StatusPill tier=ok); the auth store identity.mfaEnabled becomes true.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-11
+      description: Changing the Theme segmented control to Light updates the page's data-mui-color-scheme attribute AND writes "light" to localStorage under "ow-color-scheme". Reloading restores Light.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-12
+      description: Changing any Preferences control writes to localStorage under "ow-preferences" within one tick. Reloading the browser restores the selection.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-13
+      description: SSH & credentials renders the list returned by GET /api/v1/credentials. Each row shows name + scope + auth_method label. The Add credential and per-row Edit buttons are disabled.
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-14
+      description: A non-admin user navigating to /settings/users sees the 403 ForbiddenPage. An admin user sees the list from GET /api/v1/users.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-15
+      description: Each of the 7 stubbed pages renders a single BackendPendingBanner naming the slice AND every visible button has aria-disabled=true.
+      priority: high
+      references_constraints: [C-09]
+    - id: AC-16
+      description: A grep of src/pages/settings/ and src/components/settings/ finds zero occurrences of var(--mui- or hardcoded HEX literals outside the token-map files.
+      priority: high
+      references_constraints: [C-10]
+    - id: AC-17
+      description: Source-inspection — the password-change submit handler does NOT include any console.log/warn/error call that interpolates current_password, new_password, or confirm_password values.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-18
+      description: axe-core scan of /settings/profile, /settings/preferences, /settings/credentials, /settings/users, and /settings/notifications reports zero violations across wcag2a + wcag2aa in both color modes.
+      priority: critical
+      references_constraints: [C-12]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -41,6 +41,12 @@ domains:
             - api-openapi-docs
             - release-admin-signoff
             - system-worker-subcommand
+            - frontend-foundation
+            - frontend-auth-login
+            - frontend-hosts-list
+            - frontend-add-host
+            - frontend-host-detail
+            - frontend-settings
 settings:
     specs_dir: specs
     coverage:


### PR DESCRIPTION
## Summary

- Lands 6 frontend specs covering the React + MUI v7 frontend that ships in #432: foundation, auth-login, hosts-list, add-host, host-detail, settings
- All status: approved, Tier 1
- specter.yaml registers the new spec IDs in the default domain
- .secrets.baseline updated for spec descriptions referencing JSON body field names like \`current_password\` / \`new_password\` (false positives)

Stack: #431 → this PR → #433 → #434 → #435.

## Test plan

- [x] specter coverage --strict passes locally
- [ ] CI green