### PR TITLE
feat(credentials): POST /credentials/{id}:clone + bulk-import selector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -347,854 +347,889 @@
         "filename": "app/internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 922
+        "line_number": 956
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e1893ec55ab1024ac89aeca22993a8c96e006753",
-        "is_verified": false,
-        "line_number": 2989
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f56961c31660c499b6928c18e8bcec44244b00fc",
-        "is_verified": false,
-        "line_number": 2990
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6ce26d1cef559f3cc474187999d67b5feacd87b0",
-        "is_verified": false,
-        "line_number": 2991
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "70a39bff50c4ff36264e52e8a069cd3f6b50b1af",
-        "is_verified": false,
-        "line_number": 2992
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb7cd6bb2216cbaa67ca4dd76b0b5a190138a807",
-        "is_verified": false,
-        "line_number": 2993
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d4df415a55ca09b7d03bd3e2f2e33a7d05ccddb4",
-        "is_verified": false,
-        "line_number": 2994
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "818093d75557d89ebb60a9a452cde4776e372c22",
-        "is_verified": false,
-        "line_number": 2995
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7c67170cbdbb2e907d3a1131dfd0659311823c50",
-        "is_verified": false,
-        "line_number": 2996
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "40e6fe42c0265d2ff577023c329b0024a95d98de",
-        "is_verified": false,
-        "line_number": 2997
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "313343316ec700b61b6a875cadd0bf5a809b3e23",
-        "is_verified": false,
-        "line_number": 2998
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "080b171ae0d54bb91c803ea2b9352573bd244277",
-        "is_verified": false,
-        "line_number": 2999
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4a3fc886324af9d28dd98b92fa2b19aeaa28035e",
-        "is_verified": false,
-        "line_number": 3000
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "32b2ff7715fdda5d561578012e609ce8b705fd5a",
-        "is_verified": false,
-        "line_number": 3001
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "baea02cdcc532cf5d806718ff96d5ad00bd26fa1",
-        "is_verified": false,
-        "line_number": 3002
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "34ae2703d871cb85dc8f8b4ac97a69915a14ccd5",
-        "is_verified": false,
-        "line_number": 3003
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d392724a5eb39b552497c67f6140dbc6ff104625",
-        "is_verified": false,
-        "line_number": 3004
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7ea97a5ef62a866c66dd28f9b59e19d905786962",
-        "is_verified": false,
-        "line_number": 3005
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "67342dde0688b623416f93d3ce3f20b08498db2f",
-        "is_verified": false,
-        "line_number": 3006
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "02380af4360d5174834afe6f0431b41e995daa09",
-        "is_verified": false,
-        "line_number": 3007
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b77ac4d23ed376cff7559ce589b1766159da1a0c",
-        "is_verified": false,
-        "line_number": 3008
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b3dccf03b4ed7024981919a5bcdc3d09de82b5f4",
-        "is_verified": false,
-        "line_number": 3009
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "61d5e2f176fd71555ab9bc7c9601deabfd4ab9d5",
-        "is_verified": false,
-        "line_number": 3010
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "73b2d8225ba5e0583dc4198afc5c025a92ab0dec",
-        "is_verified": false,
-        "line_number": 3011
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "510bb9a72c2693a5711e23c35d9c66802985bcb9",
-        "is_verified": false,
-        "line_number": 3012
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "779094bf49d3da08ca800452e086e8df26d16361",
-        "is_verified": false,
-        "line_number": 3013
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a220fc96f78a39c70a46d47307c9a844825dfe70",
-        "is_verified": false,
-        "line_number": 3014
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "67ab0c2149f6dab29a06d204b33905d0eaa8f9d6",
-        "is_verified": false,
-        "line_number": 3015
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a6cb0e5c0464f68d4ace61c616844a3818e6469c",
-        "is_verified": false,
-        "line_number": 3016
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0008aa5a8531114084a1c1040d71791a50bbcb4d",
-        "is_verified": false,
-        "line_number": 3017
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e776d5f97c418dfcabee0422d844f3530d3d7efb",
-        "is_verified": false,
-        "line_number": 3018
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4fc83c9f3f9275aa780a979e6ce4d0df13428560",
-        "is_verified": false,
-        "line_number": 3019
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "97bdfce48608fdc6d64c51db3bb7eb0acdb85d21",
-        "is_verified": false,
-        "line_number": 3020
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1d43a821583fb53b0ec2fa12d3329449e91ac430",
-        "is_verified": false,
-        "line_number": 3021
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ed81aecb7a2e8ce1db51b410b171851448986fa7",
-        "is_verified": false,
-        "line_number": 3022
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "18455c481eac7eb158406bf232454e1abd87ff89",
-        "is_verified": false,
-        "line_number": 3023
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "abaad89cd5993a064b000985de07767189301458",
-        "is_verified": false,
-        "line_number": 3024
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0535fd189b16dc3bdccbd57474f3f08440e2b235",
-        "is_verified": false,
-        "line_number": 3025
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e66f4760aa92780e35acd61f83586efedd2994bb",
-        "is_verified": false,
-        "line_number": 3026
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d742c23246c6df496c94e6ae6808d18f30630e48",
-        "is_verified": false,
-        "line_number": 3027
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "18c0cd18c71c7de21070c4055489abb07d10f22d",
-        "is_verified": false,
-        "line_number": 3028
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "095a21fa9dad9713cf51e46b70a1cd401b437373",
-        "is_verified": false,
-        "line_number": 3029
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c87a59f1461bd84358876700381f01e662f3c781",
-        "is_verified": false,
-        "line_number": 3030
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "097218e807f3ad2cf87a919770f584e0a996e1d5",
-        "is_verified": false,
-        "line_number": 3031
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "213c296508365b2d7f3d42dbbaceb8e40a80cd84",
-        "is_verified": false,
-        "line_number": 3032
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dd3697d63d82f36e21775a6994f867733923ed94",
-        "is_verified": false,
-        "line_number": 3033
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1710a4c9b9d7eb0f233bdd2b86b092f55837506d",
-        "is_verified": false,
-        "line_number": 3034
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "51f8016fc53d5a4f155abe63a32d4d21622d0499",
-        "is_verified": false,
-        "line_number": 3035
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "df6e37a73a17c5b2b0f799accf80f91a93bec2d0",
-        "is_verified": false,
-        "line_number": 3036
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e3a25c1a7d32508ca1997223e74e3e51bd35a46d",
-        "is_verified": false,
-        "line_number": 3037
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8620e5045acb633f2f9a97bf075baf782be28ae5",
-        "is_verified": false,
-        "line_number": 3038
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e92feb1b03e58781d89022a1128fa97efe544fb3",
-        "is_verified": false,
-        "line_number": 3039
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9aa292fd1a744ae89b04a6cd0e23618aa606491a",
-        "is_verified": false,
-        "line_number": 3040
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9d5d9a060075848b1bb62e7beffd7996f26c1dd8",
-        "is_verified": false,
-        "line_number": 3041
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6301d34670c47935d6ad0d9dc05e0815f9faf1b8",
-        "is_verified": false,
-        "line_number": 3042
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "93dbcab1f0bf8d083f3aea71f6b58ffebdb3540f",
-        "is_verified": false,
-        "line_number": 3043
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e279b09fa5684ee1514a4f961d645d0cb66f8979",
-        "is_verified": false,
-        "line_number": 3044
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d6b56555be0db5599dc6f47dc22096552f906c96",
-        "is_verified": false,
-        "line_number": 3045
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d8acfe2813d870a3613f2014756273f13d070103",
-        "is_verified": false,
-        "line_number": 3046
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4712918ba13bf3a4ba9a359a8ed05adfea189ffc",
-        "is_verified": false,
-        "line_number": 3047
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e36344fe6676a59fe092c20eeedddab78e8d1764",
-        "is_verified": false,
-        "line_number": 3048
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "163ed9d3ad005baec3e62bec2c3550fc55189259",
-        "is_verified": false,
-        "line_number": 3049
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8f1d5a9c228547d1a4a90f9420f7b8c1ec92ac32",
-        "is_verified": false,
-        "line_number": 3050
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1d95b6309082d631d6ad7fff4cbf0e98158171ef",
-        "is_verified": false,
-        "line_number": 3051
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4cadf69702aa7ef354def541b6dc5e8e06245b81",
-        "is_verified": false,
-        "line_number": 3052
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "02b80293001f3a00a5f5945295d94dd3c54ef1dc",
-        "is_verified": false,
-        "line_number": 3053
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d56aeea41e52b439eb6098f3082d2c606bb1f021",
-        "is_verified": false,
-        "line_number": 3054
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7dc5265feb1f4f2be66d0b42b966cf36258e3dc6",
-        "is_verified": false,
-        "line_number": 3055
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "86b5c63395de42dbc3358b6dfdf87e6ea1914c1a",
-        "is_verified": false,
-        "line_number": 3056
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bcb7855c13ea4bf2a0f805137dd2d0b0bfe05d62",
-        "is_verified": false,
-        "line_number": 3057
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10b2e482c5862d5fd3a9d5c6d4e9096b8f39ba98",
-        "is_verified": false,
-        "line_number": 3058
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b954b255b34c78fdedff004287a8752637ea0635",
-        "is_verified": false,
-        "line_number": 3059
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b92a084890f4bfc60cd6c2e5d2a4e399f83fb9a3",
-        "is_verified": false,
-        "line_number": 3060
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ffbb266af7e34c46796cef998b4b01456bd686d8",
-        "is_verified": false,
-        "line_number": 3061
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "40a2042c6adc06dccd69ce6c3b382ae51e1aa477",
-        "is_verified": false,
-        "line_number": 3062
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e93cb020864f87121b659a7eb41aad623f0a430e",
-        "is_verified": false,
-        "line_number": 3063
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "511c2f8bcfd1cd4f54e4d4762bf99cd53f48ee16",
+        "hashed_secret": "74fc3c10e8dcedf558b4cee5b9eba20589bf9459",
         "is_verified": false,
         "line_number": 3064
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "73ad8a49515a4e11b77f30bd6594f94385ce6376",
+        "hashed_secret": "08502fe0072cda411d1c2a3b8a58812a87dc9334",
         "is_verified": false,
         "line_number": 3065
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "482a1022c0bf1fc027b617d0123c8d1498cc2336",
+        "hashed_secret": "aee73a62280c49f2048f620408bdf706492e7304",
         "is_verified": false,
         "line_number": 3066
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4775d75fb2c2b144d7cb485ba01358bb9650e6fd",
+        "hashed_secret": "271d9c98d9dea15ca96fc1f1b61d91520cf0b665",
         "is_verified": false,
         "line_number": 3067
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dacccdd15aa26a7f5f0e9415bb7f9baf9027d63a",
+        "hashed_secret": "0c09d8a6bd246eaaf749fa011ce8d794d0d9a659",
         "is_verified": false,
         "line_number": 3068
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f14f082a3e9ce6de38293919cc65fcdd3af95303",
+        "hashed_secret": "4a18153fd617f4a20206053b76152b5c18163c75",
         "is_verified": false,
         "line_number": 3069
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "691201d21960f377dc75d019c8f780f249ea8000",
+        "hashed_secret": "9bd4fc3f73b31aaa9dde970ecfac66dd334614fa",
         "is_verified": false,
         "line_number": 3070
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "49b0437ff918e42cc4512c647adc132f45f6d648",
+        "hashed_secret": "7d483fadf21d81b5136f01d515dd575e264c07bd",
         "is_verified": false,
         "line_number": 3071
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b5986a40d59948c140561ab05678698b987ce6f0",
+        "hashed_secret": "9ad3f8f8f381c31e3364ef9cc16451a32d2182c9",
         "is_verified": false,
         "line_number": 3072
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8cb69011946894063a17ec9f89a6345258211d5f",
+        "hashed_secret": "e4a119943e55a439968a991809c5a6cfef405522",
         "is_verified": false,
         "line_number": 3073
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2b36ee37261505427281fd7821071629489ec966",
+        "hashed_secret": "97f9d695cc5879730d3672c9646db70aae45286f",
         "is_verified": false,
         "line_number": 3074
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f86c36e01fc2c5bc7ae2c96bfc1cb8c5f1cce532",
+        "hashed_secret": "c56382747a2b1b8092026f59446bbcd545285c40",
         "is_verified": false,
         "line_number": 3075
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8738e416e4dc0010313f38f0f913a0f8313c4d16",
+        "hashed_secret": "85156b84f239a0b26cc2d0263223367c34bb5112",
         "is_verified": false,
         "line_number": 3076
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f0a36238d96ed6030db8bb4ae1d4827ee7860ecd",
+        "hashed_secret": "d3808779b2c578601bca30684dd42745b32b4329",
         "is_verified": false,
         "line_number": 3077
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a416065462b927e08689e635090180e0ed329274",
+        "hashed_secret": "ef4a95e494387a0a7168151f545ea48a35e0bc46",
         "is_verified": false,
         "line_number": 3078
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "04abaca6336b80adadc83a3ebcf0709ae3da5e7c",
+        "hashed_secret": "14ce70a8f431cc75fad17b556e12a86df53b11a8",
         "is_verified": false,
         "line_number": 3079
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7af61b33e2519359066b3bf7cdc3036e7a709252",
+        "hashed_secret": "1988bee5456821c75614a4b58c114c4985a652f5",
         "is_verified": false,
         "line_number": 3080
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f3eacc52cbed0ccd60bbfe3376d0c793c30f1696",
+        "hashed_secret": "be69029a44d2779dbd108f38933e184c0585ad20",
         "is_verified": false,
         "line_number": 3081
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8bcf04ffdee50c4b4084b92628e522f55921cf17",
+        "hashed_secret": "154bb7c4e26528b63be8a9c7de963051d487a135",
         "is_verified": false,
         "line_number": 3082
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "826633007a65716798681bbd050aa7b2b0d910aa",
+        "hashed_secret": "4e6d004a76d369a01b10ac3e210eec8c7b311859",
         "is_verified": false,
         "line_number": 3083
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f32622e0c548e534901a02beaef43c1180118cea",
+        "hashed_secret": "9187c384ee702a730fd9c26673c5e5323ab28f95",
         "is_verified": false,
         "line_number": 3084
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "549a4b3212ce2694a36a723dad5cbf0a1f8aa753",
+        "hashed_secret": "9ce11c7535ff2ff7b0c2e6e7e2bf0687c51f24ad",
         "is_verified": false,
         "line_number": 3085
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "483718a6cc2bcbf92e0cea985615473823e39091",
+        "hashed_secret": "919e723884d2680c9f505e9a25d408479ab56764",
         "is_verified": false,
         "line_number": 3086
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "107da5514a27f220ab3974a29d28deb313092d74",
+        "hashed_secret": "301067f4b48b2472d0bc8d1d986557550433fc0a",
         "is_verified": false,
         "line_number": 3087
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "00c0beee19d5ce83fdac3d0bafe7a326382902c7",
+        "hashed_secret": "64951e1556e41b0f1a974002b2cd3891ef2f316c",
         "is_verified": false,
         "line_number": 3088
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "358fa3676cbe4b007b30556bc1cdf1db65690ed6",
+        "hashed_secret": "5e27602522fd7fa4304ea444e3c00ad33ee4de76",
         "is_verified": false,
         "line_number": 3089
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b5cfcd79fad58688026965154f4abf62ff86a957",
+        "hashed_secret": "849e30a8ea28efee1f1391a87de11773ff4e14ec",
         "is_verified": false,
         "line_number": 3090
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ab5d84cb73786f06c32f94f755041ff89888f215",
+        "hashed_secret": "a99d2db32a1266eb36d147fd4da66753cc398361",
         "is_verified": false,
         "line_number": 3091
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "63faa8ebc080fbde6addde4580ee4f1957e7f918",
+        "hashed_secret": "1173e82bd3d2e86e935b84d6bb87d05d7e550d33",
         "is_verified": false,
         "line_number": 3092
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6a18545d1e2af49f441559261763cce70cc366fc",
+        "hashed_secret": "b8303024fac1c91184bcb0ce5110674d7e5b6df1",
         "is_verified": false,
         "line_number": 3093
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "24de1d7a64adcd07752dc5fc21f86784a395a758",
+        "hashed_secret": "307a03e609cad15b8ec5efa4ff3bb364e6d9a03c",
         "is_verified": false,
         "line_number": 3094
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f71a62f5e1064fafbdfba8d260dde2ec122d7b8c",
+        "hashed_secret": "d599b2839ac0363695752d2414e0950ada6d399a",
         "is_verified": false,
         "line_number": 3095
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "774fcfdaac4f2751d193aae936b38f3300d1019d",
+        "hashed_secret": "79e01b6c09303fe714f233dfc86f673159459390",
         "is_verified": false,
         "line_number": 3096
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d4c4ad93f74b9dde25c4e7076470c538d7d4b834",
+        "hashed_secret": "096e323e44e22f6c84cda0a300f37cb56f7b6151",
         "is_verified": false,
         "line_number": 3097
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "18bd75d99a478895d6e59956967300a723e6f75b",
+        "hashed_secret": "92b04b7e59faff825af16a5879d87a35664f7720",
         "is_verified": false,
         "line_number": 3098
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f5c902d5621ae4d94ac9356fde2eb6f8e5c933c0",
+        "hashed_secret": "b4b6b62d6d9aa7e2e413295950a7e191a0f35a88",
         "is_verified": false,
         "line_number": 3099
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4b5fb31799b0aa8e34f8aa0d2820df944caad535",
+        "hashed_secret": "53c95cf3231eb390bc218aecc96abe62de98156c",
         "is_verified": false,
         "line_number": 3100
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1e66ef5b6a00ab56a72ca8e07bcda5da4a01543e",
+        "hashed_secret": "f5fa74c3035a59bcbd513cabca7789a1df3a4614",
         "is_verified": false,
         "line_number": 3101
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4a33be15e876214e6409b1ba1879aa8798ff12c0",
+        "hashed_secret": "1ce821c2a98b9ee02c2e6d3a0daedba2cc4b73d0",
         "is_verified": false,
         "line_number": 3102
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10590406ded0fb54a0d4a1cba2b6df9e35542242",
+        "hashed_secret": "69739cbe236c9f36022714277987ccab2ddfb642",
         "is_verified": false,
         "line_number": 3103
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9a371bab79320adeff713d21f2628a039c0d2f9f",
+        "hashed_secret": "3771a7b4dbf59f8a59d0e34b3f4f37a6e48c5fbe",
         "is_verified": false,
         "line_number": 3104
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42e46f0c79953e45cb00f5189514b0b9592faebe",
+        "hashed_secret": "6d8ccd7b34484c31dab6bfe0a97b19b4aa9e7470",
         "is_verified": false,
         "line_number": 3105
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0ff1a09ab15bae43e4b31ac8780a07fbf786d3a5",
+        "hashed_secret": "13ce4fb10e5c362ec55fa7feebd28d9fa48b7d24",
         "is_verified": false,
         "line_number": 3106
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1ec903a9160fe5f9f40fa49944dd4ac282ea1544",
+        "hashed_secret": "cbd59a23d9fdcd33f67da6e98e12a0acbf140e42",
         "is_verified": false,
         "line_number": 3107
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5ef4d125a0e4aafc4b254ae1bb7aa68e0b55e4a4",
+        "hashed_secret": "4e04e1a2272ae7d69a6ed8ce9e2dfb121cf33caa",
         "is_verified": false,
         "line_number": 3108
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b12a31d61216ba1da1294e74c0bf339580b2de1c",
+        "hashed_secret": "9413b9e3cf9e81dbcc7e13246455c047676de23f",
         "is_verified": false,
         "line_number": 3109
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a6ac385bea24519db0d325f0745ce0c15f282c10",
+        "is_verified": false,
+        "line_number": 3110
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "70ed37fae345de5c83e214f2249fca3c5a950c68",
+        "is_verified": false,
+        "line_number": 3111
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2b46d2dd7886a0a3cbcab0eebd37304d98c82633",
+        "is_verified": false,
+        "line_number": 3112
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "76b44b805d9571f9516b267eefd8db88c9b4c9ba",
+        "is_verified": false,
+        "line_number": 3113
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0e54ad5c35a35271fca554f5d6b60baca0c7f4f3",
+        "is_verified": false,
+        "line_number": 3114
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "e8f6f6d55a56b4e0312aedd427aa176071803b72",
+        "is_verified": false,
+        "line_number": 3115
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "df159f94ac12c2f81c5da4f14dcfc4d661fe754b",
+        "is_verified": false,
+        "line_number": 3116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f2b6d2c84ef288784c5fc2bc7cc4e06b8fa91abe",
+        "is_verified": false,
+        "line_number": 3117
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0fa1ee793d25af98e6a6f7ca6ef13937a44b47e4",
+        "is_verified": false,
+        "line_number": 3118
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4d3563c03a58a54b416ea0e97259d787d143a639",
+        "is_verified": false,
+        "line_number": 3119
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4204a0ef4b1c8ea9deea745a20ffbf629cfbd71c",
+        "is_verified": false,
+        "line_number": 3120
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "59fa46cbfdd9d520192e8473d5d5913f6ee1ea11",
+        "is_verified": false,
+        "line_number": 3121
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "46c02bdd74aa5b9b716443714560360ebcbb1c5f",
+        "is_verified": false,
+        "line_number": 3122
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "d2dc0eb41851397fe38f1fc89c3903111f689474",
+        "is_verified": false,
+        "line_number": 3123
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3e946790e750a0ee5567ab0d6792e6d150b81706",
+        "is_verified": false,
+        "line_number": 3124
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b375d7cc3930bbea5cd412999d0dd88a4473d529",
+        "is_verified": false,
+        "line_number": 3125
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "8c7bb768969fe5adf5f9505f61947bb094562724",
+        "is_verified": false,
+        "line_number": 3126
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1971540de88234e5e3b05567c44805e14db7edb1",
+        "is_verified": false,
+        "line_number": 3127
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0fa6fbd1060b51cd2fac3a6df9473732a9387762",
+        "is_verified": false,
+        "line_number": 3128
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "74b52e5253a232db721aa53d95e3703db5e4cbb3",
+        "is_verified": false,
+        "line_number": 3129
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "de832decf14b50e3032152d9601a92bb9493bd1a",
+        "is_verified": false,
+        "line_number": 3130
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "82eb527cb05f6cf95048d79bd05649fe3ebfa446",
+        "is_verified": false,
+        "line_number": 3131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "6baaba3895c13336798cc56bf912f60a1e6c4106",
+        "is_verified": false,
+        "line_number": 3132
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "98a2af9524e3fbf0f6f8a1a09e90569155265335",
+        "is_verified": false,
+        "line_number": 3133
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "401633f1f4e46d87a752f3b078ca0b3c1e7e0502",
+        "is_verified": false,
+        "line_number": 3134
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f3e4c2c00a8d1212cfd58ad8d27f2cd424a974b0",
+        "is_verified": false,
+        "line_number": 3135
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1b24414d2b6e267aec205798f57b43595495b320",
+        "is_verified": false,
+        "line_number": 3136
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f5574fcbdcb3841000add9324fe1f79a72e76295",
+        "is_verified": false,
+        "line_number": 3137
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a742f5796f3fb09500d2e94b398e711b21fb07bb",
+        "is_verified": false,
+        "line_number": 3138
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "109135e75765fa9712ef2141d8256a4bc9781361",
+        "is_verified": false,
+        "line_number": 3139
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2e09c4d1b872ea62f59a21ee55293f8a3cb3ed50",
+        "is_verified": false,
+        "line_number": 3140
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a3aa6e8fb351c16bbe02523547fb7568f165ec5d",
+        "is_verified": false,
+        "line_number": 3141
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "48b4046fa6b401d7be0a2c244192ee8e4cde3884",
+        "is_verified": false,
+        "line_number": 3142
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "5f9f06f46b4bd253a69c491310b325130983fc35",
+        "is_verified": false,
+        "line_number": 3143
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "286e8b3188345ee91a11ac197479ab0dd852dfba",
+        "is_verified": false,
+        "line_number": 3144
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "62b080a362f92a8dc93b8cbf4ebcec9abdc9619c",
+        "is_verified": false,
+        "line_number": 3145
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a1cc3a2e03724a70f823cf9e98dc5100c07a1862",
+        "is_verified": false,
+        "line_number": 3146
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "01aefc4e163587a9ff3571418bdff2e799741cce",
+        "is_verified": false,
+        "line_number": 3147
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "e27b6ab5c37ea7cbc7e96395df493cedb1ef0cb8",
+        "is_verified": false,
+        "line_number": 3148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f647c984d4877a6a4699ee3f403719e3dd4bf8a8",
+        "is_verified": false,
+        "line_number": 3149
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "26cf0b81d335923a635019d58af36696f5cafd55",
+        "is_verified": false,
+        "line_number": 3150
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "71b5adcb787434f89cbd7512983edc7af603e9c1",
+        "is_verified": false,
+        "line_number": 3151
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1204d6078bc2a60c5a12211432df7dd561680e48",
+        "is_verified": false,
+        "line_number": 3152
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3fff6dd23a839210c1170153e6089b604e8d890f",
+        "is_verified": false,
+        "line_number": 3153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "dfc36bd0d3ef901dac2541b0753d907900b7d4d1",
+        "is_verified": false,
+        "line_number": 3154
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4c612ea994c298854c79d7bd8d47fe535a3954f8",
+        "is_verified": false,
+        "line_number": 3155
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1dd74a56d84ba6b537b58a6093e8e86713c61791",
+        "is_verified": false,
+        "line_number": 3156
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "b997b4223715fa9bc9370a02f23dec1ce45f19c7",
+        "is_verified": false,
+        "line_number": 3157
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7233bc04888f285f8cfb251306ffe4ac1155cca5",
+        "is_verified": false,
+        "line_number": 3158
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "22419ef5cad3e5c88010d0eb97fc68838fb71638",
+        "is_verified": false,
+        "line_number": 3159
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3265ed90f7a90101435a3540c026069f516151f7",
+        "is_verified": false,
+        "line_number": 3160
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "cc2ff5ece683e07e10364485a033a61af9492b1c",
+        "is_verified": false,
+        "line_number": 3161
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0d5474a442f2c1061b236eba041cd6f43658c86a",
+        "is_verified": false,
+        "line_number": 3162
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4e4b79ff10932d9ab89140c90a1f75f2d3c7eecf",
+        "is_verified": false,
+        "line_number": 3163
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "ca600253bd6eeb12f6deeed2a1640afea332c66d",
+        "is_verified": false,
+        "line_number": 3164
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7f0c82ee3010550d4ed6b64ff64a754d8e6ab1f5",
+        "is_verified": false,
+        "line_number": 3165
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c4910a718c161063e0a2174619a550aa53b92425",
+        "is_verified": false,
+        "line_number": 3166
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "69607f7b71406fa5bb401d7e686004900cda38d1",
+        "is_verified": false,
+        "line_number": 3167
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "abdd63fab669943cefdf5596d1fd5f72b7e7b6cb",
+        "is_verified": false,
+        "line_number": 3168
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c98b35f4484e1776e1a6eda2a4cb27af1ebc30ab",
+        "is_verified": false,
+        "line_number": 3169
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "eeb60f850eb031a338b76a74b8dd66df178624d5",
+        "is_verified": false,
+        "line_number": 3170
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "13e4a713ad872c380fae2af3bde9cd7f14112dbd",
+        "is_verified": false,
+        "line_number": 3171
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "d263db5f2294adad25ca4a0b239751ebc558d3e3",
+        "is_verified": false,
+        "line_number": 3172
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a41a4d9099f841ac45a591bc68b2794a080f6814",
+        "is_verified": false,
+        "line_number": 3173
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "e81370e67d755e5b06801fcc86c7fd5f750c43fa",
+        "is_verified": false,
+        "line_number": 3174
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "36034834d6ba3eab9a195ec3b3f2fea7f0c5380f",
+        "is_verified": false,
+        "line_number": 3175
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c9471c0b21175c199b8f6721eb01c4e38f4b5ebe",
+        "is_verified": false,
+        "line_number": 3176
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "0229b36d7d9e38d28ce8145a423d878913e8ebd6",
+        "is_verified": false,
+        "line_number": 3177
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "fef5c1dead7110218f629d3b7033899521c5126a",
+        "is_verified": false,
+        "line_number": 3178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "20ff1cd678689ac65301add0bded81008c1a6600",
+        "is_verified": false,
+        "line_number": 3179
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4699280c35d52ec62f500a326c306dd0c5974301",
+        "is_verified": false,
+        "line_number": 3180
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "ca0057aab0d6063a5c5fecb4651440aa2b3d2424",
+        "is_verified": false,
+        "line_number": 3181
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "6e1b31a1775e6db9f00e67958fc9cf0fa4f0bbfe",
+        "is_verified": false,
+        "line_number": 3182
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c9e80887829d918be89e18ee16966ada3675e606",
+        "is_verified": false,
+        "line_number": 3183
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "d39fd0238109b893e330420442cd1e5ff1917741",
+        "is_verified": false,
+        "line_number": 3184
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "4ab62a3834aaff667dba7c7da93a3ff5b9a9e658",
+        "is_verified": false,
+        "line_number": 3185
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3442b610c7dd845347a62e871f2d634e04eaf9a0",
+        "is_verified": false,
+        "line_number": 3186
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a09d7fa49e97c8a2e5ceaab132da2c18523808dd",
+        "is_verified": false,
+        "line_number": 3187
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "d80c10066fb0a75ba9b40e2bc266790645a9c896",
+        "is_verified": false,
+        "line_number": 3188
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "88898fbd423acab905d2bca26e8831bf9c5707a2",
+        "is_verified": false,
+        "line_number": 3189
       }
     ],
     "app/internal/server/credentials_handlers.go": [
@@ -1203,7 +1238,7 @@
         "filename": "app/internal/server/credentials_handlers.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-        "line_number": 212
+        "line_number": 296
       }
     ],
     "app/internal/ssh/ssh_test.go": [
@@ -1589,5 +1624,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-31T20:39:51Z"
+  "generated_at": "2026-05-31T21:02:03Z"
 }

--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -638,6 +638,45 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/credentials/{id}:clone:
+    post:
+      operationId: postCredentialClone
+      summary: Clone a credential into a new scope (system → host or host → host)
+      description: >
+        Copies the source credential's encrypted secret material verbatim
+        into a new row with the target scope/scope_id. Used by the bulk
+        import flow to attach a chosen credential template to each newly
+        imported host without re-prompting for the secret material.
+      x-required-permission: credential:write
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CredentialCloneRequest'}
+      responses:
+        '201':
+          description: Clone created
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/CredentialResponse'}
+        '400':
+          description: Invalid scope, host not found, or validation failure
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Source credential not found or already soft-deleted
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: is_default=true collides with an existing system default
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/hosts:
     get:
       operationId: getHosts
@@ -1353,6 +1392,18 @@ components:
         private_key:            {type: string}
         private_key_passphrase: {type: string}
         is_default:             {type: boolean}
+
+    # Clone target shape. The source credential's secret material is
+    # inherited verbatim (no plaintext crosses the wire); only the new
+    # scope, scope_id, name, and is_default are operator-controlled.
+    CredentialCloneRequest:
+      type: object
+      required: [scope]
+      properties:
+        scope:      {type: string, enum: [system, host]}
+        scope_id:   {type: string, format: uuid, nullable: true, description: "Required when scope=host"}
+        name:       {type: string, minLength: 1, maxLength: 256, description: "Defaults to '<source name> (clone)' when omitted"}
+        is_default: {type: boolean, description: "Mark this clone as the system default (only valid when scope=system)"}
 
     HealthResponse:
       type: object

--- a/app/frontend/src/api/schema.d.ts
+++ b/app/frontend/src/api/schema.d.ts
@@ -484,6 +484,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/credentials/{id}:clone": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Clone a credential into a new scope (system → host or host → host)
+         * @description Copies the source credential's encrypted secret material verbatim into a new row with the target scope/scope_id. Used by the bulk import flow to attach a chosen credential template to each newly imported host without re-prompting for the secret material.
+         */
+        post: operations["postCredentialClone"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/hosts": {
         parameters: {
             query?: never;
@@ -934,6 +954,19 @@ export interface components {
             password?: string;
             private_key?: string;
             private_key_passphrase?: string;
+            is_default?: boolean;
+        };
+        CredentialCloneRequest: {
+            /** @enum {string} */
+            scope: "system" | "host";
+            /**
+             * Format: uuid
+             * @description Required when scope=host
+             */
+            scope_id?: string | null;
+            /** @description Defaults to '<source name> (clone)' when omitted */
+            name?: string;
+            /** @description Mark this clone as the system default (only valid when scope=system) */
             is_default?: boolean;
         };
         HealthResponse: {
@@ -2192,6 +2225,59 @@ export interface operations {
             };
             /** @description Credential not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postCredentialClone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CredentialCloneRequest"];
+            };
+        };
+        responses: {
+            /** @description Clone created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CredentialResponse"];
+                };
+            };
+            /** @description Invalid scope, host not found, or validation failure */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Source credential not found or already soft-deleted */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description is_default=true collides with an existing system default */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/app/frontend/src/components/hosts/bulk/BulkImportWizard.tsx
+++ b/app/frontend/src/components/hosts/bulk/BulkImportWizard.tsx
@@ -19,7 +19,11 @@ export function BulkImportWizard() {
   const [fileName, setFileName] = useState<string | null>(null);
   const [analysis, setAnalysis] = useState<CSVAnalysis | null>(null);
   const [mappings, setMappings] = useState<FieldMapping[]>([]);
-  const [options, setOptions] = useState<ImportOptions>({ dryRun: false, updateExisting: false });
+  const [options, setOptions] = useState<ImportOptions>({
+    dryRun: false,
+    updateExisting: false,
+    credentialMode: 'system_default',
+  });
 
   const handleAnalyzed = (text: string, name: string, a: CSVAnalysis) => {
     setCsvText(text);

--- a/app/frontend/src/components/hosts/bulk/PreviewImportStep.tsx
+++ b/app/frontend/src/components/hosts/bulk/PreviewImportStep.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
 import {
   AlertCircle,
   CheckCircle2,
@@ -23,12 +24,28 @@ import {
   th,
 } from './wizardStyles';
 
+interface CredentialListEntry {
+  id: string;
+  name: string;
+  scope: 'system' | 'host';
+  username: string;
+  auth_method: 'ssh_key' | 'password' | 'both';
+  is_default: boolean;
+  is_active: boolean;
+}
+
 // Step 3: validate every row against the host-create zod schema, show a
 // preview, and (when the operator clicks Import) submit sequentially via
-// POST /api/v1/hosts. Bulk credential association is out of scope for v1
-// — operators attach credentials per-host afterwards. This mirrors the
-// `system-default credential` constraint the single-host form already
-// enforces in bulk mode.
+// POST /api/v1/hosts. Two credential strategies are wired:
+//
+//   - 'system_default' (default) — POST /hosts, no follow-up. Each host
+//     resolves to the system-default credential at scan time.
+//   - 'clone_template' — POST /hosts, then POST /credentials/{srcId}:clone
+//     with scope=host + scope_id=newHostId. The host gets a dedicated
+//     host-scoped credential that mirrors the chosen template's secret
+//     material verbatim (server-side ciphertext copy — no plaintext
+//     crosses the wire). A failed clone surfaces as 'partial' so the
+//     operator can fix the credential association without losing the host.
 
 interface Props {
   csvText: string;
@@ -59,6 +76,25 @@ export function PreviewImportStep({ csvText, mappings, options, onOptionsChange 
   const [submitting, setSubmitting] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const [finished, setFinished] = useState(false);
+
+  const credentialsQuery = useQuery({
+    queryKey: ['credentials'],
+    queryFn: async () => {
+      const { data, response, error } = await api.GET('/api/v1/credentials');
+      if (!response.ok || error) {
+        // 403 → operator can't read credentials. Treat as empty so the
+        // wizard still works (system-default mode), instead of breaking.
+        return [] as CredentialListEntry[];
+      }
+      const raw = data as unknown as { credentials?: CredentialListEntry[] } | null;
+      return (raw?.credentials ?? []).filter((c) => c.is_active);
+    },
+  });
+
+  const credentialOptions = useMemo(
+    () => credentialsQuery.data ?? [],
+    [credentialsQuery.data],
+  );
 
   useEffect(() => {
     // Re-seed pending outcomes whenever the preview changes (e.g. operator
@@ -123,6 +159,43 @@ export function PreviewImportStep({ csvText, mappings, options, onOptionsChange 
         });
         if (response.ok && data) {
           const hostId = (data as { id: string }).id;
+          let credentialNote: string | undefined;
+
+          // Clone-template mode: attach a host-scoped credential by
+          // cloning the chosen system credential into this host's
+          // scope. Server-side ciphertext copy — no secret material
+          // crosses the wire.
+          if (
+            options.credentialMode === 'clone_template' &&
+            options.cloneSourceId
+          ) {
+            try {
+              const cloneRes = await api.POST(
+                '/api/v1/credentials/{id}:clone',
+                {
+                  params: { path: { id: options.cloneSourceId } },
+                  body: {
+                    scope: 'host',
+                    scope_id: hostId,
+                    name: `${row.payload.hostname} credential`,
+                  } as never,
+                },
+              );
+              if (!cloneRes.response.ok) {
+                const cerr = cloneRes.error as
+                  | { error?: { message?: string } }
+                  | undefined;
+                credentialNote =
+                  cerr?.error?.message ??
+                  `Host created but credential attach failed (HTTP ${cloneRes.response.status}). Attach manually under Settings → Credentials.`;
+              }
+            } catch (cloneErr) {
+              credentialNote =
+                describeNetworkError(cloneErr) ||
+                'Host created but credential attach failed. Attach manually under Settings → Credentials.';
+            }
+          }
+
           states[i] = {
             preview: row,
             outcome: {
@@ -130,6 +203,7 @@ export function PreviewImportStep({ csvText, mappings, options, onOptionsChange 
               status: 'created',
               action: 'create',
               hostId,
+              error: credentialNote,
             },
           };
         } else {
@@ -209,7 +283,7 @@ export function PreviewImportStep({ csvText, mappings, options, onOptionsChange 
               <strong>Dry run</strong> — validate every row but skip the POST. No hosts are created.
             </span>
           </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
             <input
               type="checkbox"
               checked={options.updateExisting}
@@ -222,6 +296,134 @@ export function PreviewImportStep({ csvText, mappings, options, onOptionsChange 
               regardless.
             </span>
           </label>
+
+          <fieldset
+            style={{
+              border: '1px solid var(--ow-line)',
+              borderRadius: 6,
+              padding: '10px 14px',
+              margin: 0,
+            }}
+            disabled={submitting}
+          >
+            <legend
+              style={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: 'var(--ow-fg-1)',
+                padding: '0 6px',
+              }}
+            >
+              Credentials
+            </legend>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 8,
+                marginBottom: 8,
+              }}
+            >
+              <input
+                type="radio"
+                name="bulk-credential-mode"
+                value="system_default"
+                checked={options.credentialMode === 'system_default'}
+                onChange={() =>
+                  onOptionsChange({
+                    ...options,
+                    credentialMode: 'system_default',
+                    cloneSourceId: undefined,
+                  })
+                }
+                style={{ marginTop: 3 }}
+              />
+              <span style={{ fontSize: 13 }}>
+                <strong>Use system default</strong> — each imported host falls back to the system-default credential at scan time. No per-host credential is created.
+              </span>
+            </label>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 8,
+              }}
+            >
+              <input
+                type="radio"
+                name="bulk-credential-mode"
+                value="clone_template"
+                checked={options.credentialMode === 'clone_template'}
+                onChange={() =>
+                  onOptionsChange({
+                    ...options,
+                    credentialMode: 'clone_template',
+                    cloneSourceId:
+                      options.cloneSourceId ?? credentialOptions[0]?.id,
+                  })
+                }
+                disabled={credentialOptions.length === 0}
+                style={{ marginTop: 3 }}
+              />
+              <div style={{ flex: 1 }}>
+                <span style={{ fontSize: 13 }}>
+                  <strong>Clone an existing credential</strong> — every imported host gets a dedicated host-scoped credential cloned from the template you choose. The template&apos;s key / password is copied server-side as ciphertext; no secret material crosses the wire.
+                </span>
+                {options.credentialMode === 'clone_template' && (
+                  <div style={{ marginTop: 6 }}>
+                    {credentialsQuery.isLoading ? (
+                      <span style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>
+                        Loading credentials…
+                      </span>
+                    ) : credentialOptions.length === 0 ? (
+                      <span style={{ fontSize: 12, color: 'var(--ow-warn)' }}>
+                        No credentials available. Add one under Settings → Credentials first.
+                      </span>
+                    ) : (
+                      <select
+                        value={options.cloneSourceId ?? ''}
+                        onChange={(e) =>
+                          onOptionsChange({
+                            ...options,
+                            cloneSourceId: e.target.value || undefined,
+                          })
+                        }
+                        aria-label="Credential template to clone"
+                        style={{
+                          fontSize: 13,
+                          padding: '4px 8px',
+                          background: 'var(--ow-bg-2)',
+                          color: 'var(--ow-fg-0)',
+                          border: '1px solid var(--ow-line)',
+                          borderRadius: 4,
+                          minWidth: 320,
+                        }}
+                      >
+                        {credentialOptions.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.name} — {c.username} ({c.auth_method})
+                            {c.is_default ? ' · default' : ''}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                )}
+                {credentialOptions.length === 0 &&
+                  options.credentialMode === 'system_default' && (
+                    <div
+                      style={{
+                        fontSize: 11,
+                        color: 'var(--ow-fg-3)',
+                        marginTop: 4,
+                      }}
+                    >
+                      You have no credentials yet — the clone option will become available once you add one.
+                    </div>
+                  )}
+              </div>
+            </label>
+          </fieldset>
         </div>
       </section>
 

--- a/app/frontend/src/components/hosts/bulk/types.ts
+++ b/app/frontend/src/components/hosts/bulk/types.ts
@@ -65,6 +65,11 @@ export interface ImportResult {
 export interface ImportOptions {
   updateExisting: boolean;
   dryRun: boolean;
+  /** Which credential strategy applies to every imported host. */
+  credentialMode: 'system_default' | 'clone_template';
+  /** When credentialMode === 'clone_template', the source credential id
+   *  to clone into a host-scoped row for each created host. */
+  cloneSourceId?: string;
 }
 
 export interface TargetField {

--- a/app/frontend/tests/pages/add-host-bulk.test.ts
+++ b/app/frontend/tests/pages/add-host-bulk.test.ts
@@ -7,6 +7,7 @@
 //   AC-13  test('frontend-add-host/AC-13 — auto-mapping + required-field validation in Map step')
 //   AC-14  test('frontend-add-host/AC-14 — applyMappings runs zod validation; valid-row count shown')
 //   AC-17  test('frontend-add-host/AC-17 — failed-rows CSV download button surfaced in Preview step')
+//   AC-18  test('frontend-add-host/AC-18 — bulk credential selector clones template per host')
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -89,6 +90,26 @@ describe('frontend-add-host — structural', () => {
     expect(PREVIEW_SRC).toContain('downloadFailedRowsCSV');
     // Helper exported from applyMappings.
     expect(APPLY_SRC).toContain('export function downloadFailedRowsCSV');
+  });
+
+  // @ac AC-18
+  test('frontend-add-host/AC-18 — bulk credential selector clones template per host', () => {
+    // Wizard seeds the default credential mode.
+    expect(WIZARD_SRC).toContain("credentialMode: 'system_default'");
+    // Preview step renders both modes as a radio group.
+    expect(PREVIEW_SRC).toContain('Use system default');
+    expect(PREVIEW_SRC).toContain('Clone an existing credential');
+    // Credentials list is fetched via the React Query 'credentials' key.
+    expect(PREVIEW_SRC).toMatch(/queryKey:\s*\[['"]credentials['"]\]/);
+    expect(PREVIEW_SRC).toContain("api.GET('/api/v1/credentials')");
+    // Submission loop calls the clone endpoint with the chosen source id
+    // and scopes the new credential to the freshly-created host id.
+    expect(PREVIEW_SRC).toContain("'/api/v1/credentials/{id}:clone'");
+    expect(PREVIEW_SRC).toContain("scope: 'host'");
+    expect(PREVIEW_SRC).toContain('scope_id: hostId');
+    // Failure of the clone is surfaced as a credential note on the row
+    // (host stays created — partial outcome, not a hard failure).
+    expect(PREVIEW_SRC).toContain('credentialNote');
   });
 });
 

--- a/app/internal/credential/credential.go
+++ b/app/internal/credential/credential.go
@@ -173,6 +173,125 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (*Credential, error
 	return s.queryOne(ctx, `WHERE id = $1 AND is_active = true`, id)
 }
 
+// CloneParams describes the target row CloneCredential should create.
+// The source row's secret material (ciphertext columns) is copied
+// verbatim — no decrypt/re-encrypt round-trip. This keeps the DEK off
+// the call path entirely and avoids re-exposing plaintext anywhere
+// outside the original create.
+type CloneParams struct {
+	SourceID  uuid.UUID
+	Scope     Scope
+	ScopeID   *uuid.UUID
+	Name      string // when "", server appends " (clone)" to the source name
+	IsDefault bool
+	CreatedBy uuid.UUID
+}
+
+// CloneCredential creates a new credential row whose secret material
+// (encrypted_password, encrypted_private_key, encrypted_private_key_passphrase)
+// and identity fields (username, auth_method, ssh_key_*) match the
+// source. The clone gets a fresh id, the caller's scope/scope_id, and
+// the caller's choice of name + is_default.
+//
+// Validates scope/scope_id consistency. Returns:
+//   - ErrNotFound when the source id is unknown or inactive
+//   - ErrInvalidScope when target scope/scope_id are inconsistent
+//   - ErrMultipleSystemDefaults when is_default=true collides with an
+//     existing system default
+//
+// Spec api-credentials C-05 / AC-13..15.
+func (s *Service) CloneCredential(ctx context.Context, p CloneParams) (uuid.UUID, error) {
+	if err := validateCloneScope(p); err != nil {
+		return uuid.Nil, err
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("credential: clone begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	const srcQuery = `
+		SELECT name, COALESCE(description, ''), username, auth_method,
+		       encrypted_password, encrypted_private_key, encrypted_private_key_passphrase,
+		       COALESCE(ssh_key_fingerprint, ''), COALESCE(ssh_key_type, ''),
+		       COALESCE(ssh_key_bits, 0), COALESCE(ssh_key_comment, '')
+		  FROM credentials
+		 WHERE id = $1 AND is_active = true
+		 FOR UPDATE`
+	var (
+		srcName, srcDesc, srcUser, srcMethod string
+		srcEncPw, srcEncKey, srcEncPass      []byte
+		srcKeyFP, srcKeyType, srcKeyComment  string
+		srcKeyBits                           int
+	)
+	if err := tx.QueryRow(ctx, srcQuery, p.SourceID).Scan(
+		&srcName, &srcDesc, &srcUser, &srcMethod,
+		&srcEncPw, &srcEncKey, &srcEncPass,
+		&srcKeyFP, &srcKeyType, &srcKeyBits, &srcKeyComment,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, ErrNotFound
+		}
+		return uuid.Nil, fmt.Errorf("credential: clone source: %w", err)
+	}
+
+	newName := p.Name
+	if newName == "" {
+		newName = srcName + " (clone)"
+	}
+
+	newID, err := uuid.NewV7()
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("credential: clone uuid: %w", err)
+	}
+
+	const insertStmt = `
+		INSERT INTO credentials (
+			id, scope, scope_id, name, description, username, auth_method,
+			encrypted_password, encrypted_private_key, encrypted_private_key_passphrase,
+			ssh_key_fingerprint, ssh_key_type, ssh_key_bits, ssh_key_comment,
+			is_default, is_active, created_by
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, true, $16)`
+	_, err = tx.Exec(ctx, insertStmt,
+		newID, string(p.Scope), p.ScopeID, newName, nilIfEmpty(srcDesc),
+		srcUser, srcMethod,
+		srcEncPw, srcEncKey, srcEncPass,
+		nilIfEmpty(srcKeyFP), nilIfEmpty(srcKeyType),
+		nilIfZero(srcKeyBits), nilIfEmpty(srcKeyComment),
+		p.IsDefault, p.CreatedBy,
+	)
+	if err != nil {
+		if isUniqueViolation(err) && strings.Contains(err.Error(), "idx_credentials_one_system_default") {
+			return uuid.Nil, ErrMultipleSystemDefaults
+		}
+		return uuid.Nil, fmt.Errorf("credential: clone insert: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, fmt.Errorf("credential: clone commit: %w", err)
+	}
+	return newID, nil
+}
+
+// validateCloneScope enforces scope/scope_id consistency for the clone
+// target. Mirrors validateNewParams but skips the auth_method/secret
+// checks since the source row already satisfied them.
+func validateCloneScope(p CloneParams) error {
+	switch p.Scope {
+	case ScopeSystem:
+		if p.ScopeID != nil {
+			return ErrInvalidScope
+		}
+	case ScopeHost:
+		if p.ScopeID == nil {
+			return ErrInvalidScope
+		}
+	default:
+		return ErrInvalidScope
+	}
+	return nil
+}
+
 // Resolve returns the highest-precedence credential for the given host:
 // host-scope row first, then system-default. Returns ErrNoCredential
 // when neither is available.

--- a/app/internal/server/api/server.gen.go
+++ b/app/internal/server/api/server.gen.go
@@ -42,6 +42,24 @@ func (e ConnectivityCheckResultNewReachabilityStatus) Valid() bool {
 	}
 }
 
+// Defines values for CredentialCloneRequestScope.
+const (
+	CredentialCloneRequestScopeHost   CredentialCloneRequestScope = "host"
+	CredentialCloneRequestScopeSystem CredentialCloneRequestScope = "system"
+)
+
+// Valid indicates whether the value is a known member of the CredentialCloneRequestScope enum.
+func (e CredentialCloneRequestScope) Valid() bool {
+	switch e {
+	case CredentialCloneRequestScopeHost:
+		return true
+	case CredentialCloneRequestScopeSystem:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CredentialCreateRequestAuthMethod.
 const (
 	CredentialCreateRequestAuthMethodBoth     CredentialCreateRequestAuthMethod = "both"
@@ -104,16 +122,16 @@ func (e CredentialResponseAuthMethod) Valid() bool {
 
 // Defines values for CredentialResponseScope.
 const (
-	CredentialResponseScopeHost   CredentialResponseScope = "host"
-	CredentialResponseScopeSystem CredentialResponseScope = "system"
+	Host   CredentialResponseScope = "host"
+	System CredentialResponseScope = "system"
 )
 
 // Valid indicates whether the value is a known member of the CredentialResponseScope enum.
 func (e CredentialResponseScope) Valid() bool {
 	switch e {
-	case CredentialResponseScopeHost:
+	case Host:
 		return true
-	case CredentialResponseScopeSystem:
+	case System:
 		return true
 	default:
 		return false
@@ -447,6 +465,22 @@ type ConnectivityStatus struct {
 	ProbeSuccessCount    int64 `json:"probe_success_count"`
 	StateTransitionCount int64 `json:"state_transition_count"`
 }
+
+// CredentialCloneRequest defines model for CredentialCloneRequest.
+type CredentialCloneRequest struct {
+	// IsDefault Mark this clone as the system default (only valid when scope=system)
+	IsDefault *bool `json:"is_default,omitempty"`
+
+	// Name Defaults to '<source name> (clone)' when omitted
+	Name  *string                     `json:"name,omitempty"`
+	Scope CredentialCloneRequestScope `json:"scope"`
+
+	// ScopeId Required when scope=host
+	ScopeId *openapi_types.UUID `json:"scope_id,omitempty"`
+}
+
+// CredentialCloneRequestScope defines model for CredentialCloneRequest.Scope.
+type CredentialCloneRequestScope string
 
 // CredentialCreateRequest defines model for CredentialCreateRequest.
 type CredentialCreateRequest struct {
@@ -927,6 +961,9 @@ type PostAuthRefreshJSONRequestBody = AuthRefreshRequest
 // PostCredentialsJSONRequestBody defines body for PostCredentials for application/json ContentType.
 type PostCredentialsJSONRequestBody = CredentialCreateRequest
 
+// PostCredentialCloneJSONRequestBody defines body for PostCredentialClone for application/json ContentType.
+type PostCredentialCloneJSONRequestBody = CredentialCloneRequest
+
 // PostDiagnosticsEchoJSONRequestBody defines body for PostDiagnosticsEcho for application/json ContentType.
 type PostDiagnosticsEchoJSONRequestBody = EchoRequest
 
@@ -1016,6 +1053,9 @@ type ServerInterface interface {
 	// Fetch a credential's metadata
 	// (GET /api/v1/credentials/{id})
 	GetCredentialByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Clone a credential into a new scope (system → host or host → host)
+	// (POST /api/v1/credentials/{id}:clone)
+	PostCredentialClone(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// Echo the request message; exercises idempotency + audit
 	// (POST /api/v1/diagnostics:echo)
 	PostDiagnosticsEcho(w http.ResponseWriter, r *http.Request, params PostDiagnosticsEchoParams)
@@ -1214,6 +1254,12 @@ func (_ Unimplemented) DeleteCredentialByID(w http.ResponseWriter, r *http.Reque
 // Fetch a credential's metadata
 // (GET /api/v1/credentials/{id})
 func (_ Unimplemented) GetCredentialByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Clone a credential into a new scope (system → host or host → host)
+// (POST /api/v1/credentials/{id}:clone)
+func (_ Unimplemented) PostCredentialClone(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1760,6 +1806,32 @@ func (siw *ServerInterfaceWrapper) GetCredentialByID(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetCredentialByID(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostCredentialClone operation middleware
+func (siw *ServerInterfaceWrapper) PostCredentialClone(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostCredentialClone(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2879,6 +2951,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/credentials/{id}", wrapper.GetCredentialByID)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/credentials/{id}:clone", wrapper.PostCredentialClone)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/v1/diagnostics:echo", wrapper.PostDiagnosticsEcho)
 	})
 	r.Group(func(r chi.Router) {
@@ -2986,127 +3061,133 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H1tbxs31uhfIXQXWBuRZDlOgtZBcJG6ySZ70zaw0+0F6lwtNXMksZ4hpyRHjm5g4Pm0P2Dx/ML9JQ/4",
-	"MjOcGc6LFEtyd/OljTV8OTzvPDw8/DwIWJwwClSKwfnnAQeRMCpA//EdDi/h9xSEVH8FjEqg+p84SSIS",
-	"YEkYPflNMKp+E8ESYqz+9ScO88H54H+dFEOfmK/i5BXnjL+iK4hYAoO7u7vhIAQRcJKowQbng7/hiIR6",
-	"5CFK8IJQ+2/GEQkhTpgEGqwRqHEGd8PBDyCXLPyRyZdRxG4h3B+kv3BGF+jNhw/vUayBGKg2trsa/WUY",
-	"E3rJIhCXFqvq14SzBLgkBsVcfVb/IBJi0QWTGuwVlXytVi7XCQzOB5hzvNZTc/g9JVyh4Fc77se8FZv9",
-	"BoFU3V6mIZGvVhY/ZWhwYNb2OesmJCd0obrhQDI+JRq/NI0iPItgcC55CsOmxuZnz1gB4xwiTRQ7Yq1J",
-	"CBKTSMMUhkS1xNF7B9bSxMXizGhzxmMsB+eDNCXhwAMfC4KUcwinWJbah1jCSJIYfJ04BIyHG3cKDVLL",
-	"RK61KxNT9RMs5QH0xXjePkN6Zw8BK+BErj3gVHhJ47BCs2HGKyVilzHbzn3iPV54BCJHUS+BcJjZg0QK",
-	"n+Q0SLlgXA1UFt+fEvx7Csh8fo4SLATCAv1v88MLJBmagwyWSC4BqZGUOlJL7MBsFXl6GWVY/IiRy3ds",
-	"QaijccuYYTJR/4vxp3dAF3I5OH82HMSEOn/ViKxWdct4WOn4+Gm566mnayqAUxzDxl0rCMjHcaDpQECT",
-	"ssRBAEJMJbsBv5LiMOcgli0tFDTdTCWXP0AORnVBJSiqc9oZmhb4w+uXryhnUdS8yISzFRGEUUIX05ST",
-	"bvms9WiZ/W/AyXx9jzxWgUUN0Dg9vAceE6FAbTGJJAQqrWKqfvHSlIgppoyuY5a6ynXGWASYar5gEfTU",
-	"c7ppZUzfgpJiKZto9tqUdq3lAZsx2Iw2iK3BrOOnn1FsQFJZE/TAoCPwBiY7dNOi3lutcLHEdAGNrKnt",
-	"CpXTkkprV2EUbvs3ryylNl1luKbVXBp10LiMLhVV9eNKzX2TXmAJC8bXxi+szVcyeo3M0YOs7kBeOBil",
-	"EEiyInL9HQd8E7Jb6iEjJ5IEOKob5JRywMFSmVb0CAWKy4NUkhVM55hEKQdxnU4mZ8HZYFgwM6Hy2ZOC",
-	"mwmVsABuPMgFx6HZEJQn6jUNvDjtOY9dZnmOlnF7wk+VfzZNOJv51kAZWjIhpxFZAQUhEGe3CD4RIUW/",
-	"4RmNCIXNkfNi0mf8qlUwkzlEGRaMYFFYWXEXi10sIbi5BJFGHiHTu8PcFS4vUAbJVHnrLJVDtUI9IqNT",
-	"DvNUQDhEM0wp8GlMRIxlsNRbT9VJD/ocKfcPMYpEqv2AbofQKA6LVxIRuZ4KiWVaF8/BeybkaLkWEjgI",
-	"IpBph44EjgGtcJSC9kYT4ISFJEARYwm6ZWkUoltOJBwrnUvT2GgOS0ilkmn5rxuqMP7R5zBq7G+4xcmG",
-	"9ttea7E00qexZ9UThU7LX9285K6kNra7gGa8d/IWo3OyaNZdUwGBh3hqZqTA5iscoTnjyFVpSlwFmkHE",
-	"bjUR5VIpdhaF6OjZZDz+5tmTyeR4jL6HOU4jiU4fT9DR41hRNMafSKyIqttof8z8/WzSpvh6Q1mF8ZbI",
-	"Zati9EN8Npmgo6dbQcxuaW9oDYxYKrHEM7aCXtj8RgF3NtkGuhirPyimAUwXEZv5bNcvS6BISz/SDGgk",
-	"U5LgRqBZKs2PAlmtLQoudwTFncePDOCCCAmhUlGhDyuEImeUBjI9U6h4NomPx+hHJtEaJMKpZCMdKoPw",
-	"OZIcBzcQ6nGtuhmp8Utji4gEsDkyjSW4f9Z8MfGv9lu12NOtuJJjCdOIxETWQf0Bf1JgWCcRXV29cUyJ",
-	"QGGqlCOaRwASiVuARKCj0/H48WRSAuRxCYxTHxTWVDVyxMjw24eL9yNjuJDtoZhBQMBoaOY+K0991jmz",
-	"o7ymuXjVYbgoqJEpcaXm5oxDQb5//eOfri5U8JyW4TntgMfrUWisVDTesKymHe1SF7EyepuWXGIFrz7o",
-	"Z1Ca925BbnDa4hIeE6XVveZ0sU3v6p7H/OyM2bWwq9yRKS8owkIaT866EhXxUdqEQ6BkR7caCYm51Kxr",
-	"PayUShJp9TMnXEitS13P03VJOh0wl2RYge7xC38gyr8TuRyr5U0NRsYekvs0uFlwwFJadp+avXDTw4rN",
-	"Fj2tE7pRT+UEwVRyTIUOrG/QuR54ytfrh8i/wkYYvJTy8iAHHTnB0QUHLJujBjiVy6k9nlEbA+scC7Gc",
-	"3sDajUkOBzMml16nuLKHdqJjp5PHT4beiJQVIb9PvFVctRzN9XjuZKWQqpbV8V1HMZIlx8If8BEBMzun",
-	"HF1qSxIPhgNlhb0o0l2m/khTp3jeV6jZwG3RWwpEuWzQzk/viJAtijpv1/+Mohi7CCl3hAXdadrBbQmW",
-	"3wfnB1q6NtsPZn1m615hx34Bqs5hiHA0e13i+krkwWXB0mc6I9KNJ7v627YIWBzbU9zGUeaELoAnnHS0",
-	"azyqTZNwYwbYMF7cT2pLJHTJ7ZWPVEgWX7IIOsxDs2bvo48NiRMsJXDlQvy/X/Ho/39U/5mMvp1+/Hw6",
-	"fHZ29ycfinqfHsSEvjUfTzuPEipB2u4jhQJNzWpkq/ixps8sJZGcEuoXuPs6P6kt2p25GwWvgiVr5I4Y",
-	"hLCH1DWbv4ldysZpBqBZiYdETmEFVE57KsIeyRUQLBn0iPvbdrUxveugv6eQwgcQ8q9s1rbV6QTvNzbr",
-	"t9gKuLZfP3BL2T3+ALIP+HDfGS25zcrsTxARMD408BVwxeMsIoGy6PBJKaLSfrSYf5nGmE4dlvYEciVf",
-	"NwVya1vFUGnoTB0XXasT1ZFfZTKNai+NVjhKsYSXEXDZKKQiYDwT0SyU4MYSJp3bGDOCD4LXEYB8w4R8",
-	"baPTtdnVxobQxZSn0Wb7N316sw2XZx2HvrkbF/HOnhPVV1A9Z+oBeyni36N9duDQt/Vm47ecD/jPPXqc",
-	"NGmcXeoAhTmWFl+aqaRH/KA2vDZxqtO06VGbgUsj6ORKzSubcKVmpT5HwlnDoW+uRqCvMlmtpLxgIdQQ",
-	"c14kIFYCnaYFUtMKdIKObBf0CNn5jxEOOBMC4SgyweIxmozHp+NS0IilhhUseDSNZzbMyiSOpmA0TuaU",
-	"VAOdKZWIzc3Bq0aADmMgzm4Ful0C19lkOmvAHtwRYfLKGNdgjrc4Oq3hxgdrI8I/sOS1wc8bfe5wH0zs",
-	"6sMvZOICPMXO9wOeKxhfCp4jrnVfQOuF6Q2hpf21jlZOBehcMBPmMi31VsfmXOY/eQ11b8uw43zXRl3Q",
-	"mjxqVm2CwhlSFBNbVaGwcEOSROOjavvbtomF3St0j51pWCJGdxLqG8CRXLbseWZTGwUuecnO7qW+xKUe",
-	"c+3mOPiIuwIu/FupqlOSLa0ETDGAd11MyAsWJxHBNICrNI6xLyUod257GASrXfsGpY2y6huItnzQr7XW",
-	"eltFqS1QxWLqLJgN34jVbcMIDQHikIgkwutpU9SzvmWjK8IZzQI+boKmb/wFZ2mybQhKSdqWEWqSTHEY",
-	"cutoVqDsim4zLkt+/LOnT8+edp6P4kXZQHShppok3hZ87vbEbaTKWXcTC32v939tG+NMcKeikNw2c+cX",
-	"d0vAPp3deHTkbBBwFP00H5z/2j1Cvq24+1i9HvNjGkXKK6KIMpSnqZnT6iUWSFkQxFOK8AITKiSSSyK0",
-	"bzWuMakP83qfX0NZE/bfESHfSoi9If1Dh7ir2qBL+ncn7ltH30tyX/v8sJmrUD091Eu3Ptl9xNyveOwy",
-	"ytzSJg/NumiZbRZ6ud0l+epyuc3QzWA1hSl8ST9+kuncg3IGaKcM1PIVtssz0MPkSYkGcw2dqgC7W4Uv",
-	"gqEh0fRL0kL9EZbOlMqSifmqdw+gd//z9NrPGsoH66h3uMBfxE//9r53jeDvSABUwJXUJG9UNPqUE3jj",
-	"adinhHAQX6R054BlZpH6ixSh0wXHAUxNQn/fUIM9+FbsgnUOrlmBZhI2jQxSlAzRFY6IPw4hibkHmYet",
-	"OOjruwnQWyyD5TSJdPQBqNT5AwK8w6Q6NplwWFXyjprOjfS8TuAmR9zHZvp23Fm0C57+diu79YzbuMeU",
-	"jZft9sYzDcMUPCSmhspe5snI3AnMSi9Y+S7lFJmixS3mlNDFF4FbVfoZ7NX5fZQp7o423HQL7EU4v6lX",
-	"fhVvvCC6ZZZDxk0LLKHvPboczGriQgFi+/LFJSyIkLyFPe0cZIPSEuVrhB5l1ZSw0TZolWa+Qgc7KoDh",
-	"oKAM+7ClNsZ7FpGAgLiEiOGwGb8slQGLbYqG9zS/Wfs3HIPnQzbCtf4eAn3Nuy1ZZ6scg+7UAAtdg5Op",
-	"gGtOIbPfmyPfes8i+gTFMzDKk9amyAf04bJgoT9+rlOZr104fCv/WQDvCGTnl8hb4r5n29eZ+GY/dSay",
-	"a+etl7UVNu53d/rFN/BNFMIC3SMWcIhszRqaG3HLIngpBFk0VzRRith65ZtQOuvWNLNoD26pFfS3OCU2",
-	"6RJRM7Qn5Uk7+3NWTyq4kngBaIJucXRD6GIkbiACqa8X8zkOAP3rv/5bX24EBDRMGKFSILnEEsEn4AER",
-	"+vrjNZ2zlJqyWUhIHNygIyclbeiWzhoinVQ4NCW0ENgcuOPxtc4tIFI5b4OfEqC/qI0AOrIgHjuHj+eD",
-	"yfh0PBnhKFni8am2EAlQnJDB+eBsPBmfaemTS43eE5yQk9XpCQ5jQk+sz3RuPD5NHntcoYik4X0b2rvQ",
-	"uoJWySUfGISDkN+xcH1vxb68O427MnltrLhUIe3xZLIrGPLqM/USaaqFnQMZjxkd2Xs3+rL6OoEwu4t3",
-	"bKqSZSdKg+/5esRTilamzhogjP76ywdkqaIvWJrLg0LiKCJ0gYhxVspUTKyndM61q9SDjGXfarBDRDZ4",
-	"cR5Mvgc+UthCZhUod8LuhoMnk7P91ZK7wFEEHEU4uBHIeDMZZsvkM2tCSq1CaFuiOYlAoDlnsb4wZy6t",
-	"pRxCFBIOgTS7jU+jjJdHhd8wOB/Up8tJrRTFic4+1kRagIfAfwHpFPXScs9xDFIr2V8/D5RTNPg9BQ2D",
-	"MTRF7bACfTWV7+9ZK0O28QilcmUb9xaEBuWOfaxs02j6kuO9jWari22xquxqa9ExvyzzdLLJfeW7jzuU",
-	"62rtOJ9AK1PF5sbEIcu5WpgnTaPn4J445S7LQqf8idKQ6MjgemQrVEI4RBRuQUhzW/W4IkZyeRKxhdke",
-	"tKjJrALajoxcrcTcng1cvcKbh4K6gSmuAqGuRsBugApEhEghNLQ83Z9ifmtiqMi5kadM7A+vX6IccZpZ",
-	"IEhNQtyvH13W+dm6yyeZW480I5hCBiwxW3T04acP770sw1LZi2dUuxrlnnjcTdBaH3FYsRuoGxf1q7Eh",
-	"1vgL06EOnNkwNFsEufwBBjtmplKRvjrpstpq++aZH5nxrjLkKYaZAeY2N83Ft0w5LeE7LwjnQfhJJY7Q",
-	"jvz35ZjXbungK+zn97dsMxSRmpp9NZ/ri/e64kg2XF6FpAeG5vgcdHXFbpnJCzHuHDe1io8+vDgVHNHP",
-	"l28R15zh1GBRC1TrDrBkHOEkqeJOz1FClNqMIkK1clEKy4+wXtswt3bkDo1TrT5lLwPlUXNKPeuFkQOY",
-	"DDW5Qrk9fkO6jE0S4XVN3+oyHDxGmCLDtxBqyyIg4CDRbG0WsVbUxGgBVBEGQuS1FpmBOTdxo26Klusu",
-	"7pCs/gKP29I2Gw3ZYJfj3u1JvcMtyq05h990ZrYilr2Ht29+u7BFiHKYbjmzUTOH1TTua/rhzyLv5uGo",
-	"Qgufc3vm1GV3PMdUO93qt5yKeVCVg1RGzus0itDldy8vULZMdFScHw1dczREOsQ+IhTpYySPp29LdnYL",
-	"oC0VukPJqxQjfYj+vpIm7eKjBBN+KDffIspCYjX3ENnEiqHR4amAUDGGCHAI1oVGkpPFAjiEx637gEum",
-	"r4op+ePuXM9RTKhEWG0fkaks/ShroBBSYq9K9ZEmObxwmu2QvA01U3waKm+JYpA4xBJb/++QYbYCm+cc",
-	"aoE2ved3d31HOeiMRuvjloBabeBhiyKoEuv+FUFTraRe2uB0B2D0ZBV7BLd3++6+QJL5cLpGyVAnkCPK",
-	"JNLHLeZREtvi6uoNugFr/b/do7eZRpIkESBTlwblpdsq9l8jE2GHpftxsK4r26SFTj6T8M64aBFIqHP4",
-	"9/r3gqjfrd9+3xAiTrBcFhFJc9GvxJzeMGnDlfmPfTxJA1yIjvJiMi/mOBJwbIj4ZI96qeD6nLsqBLxi",
-	"czkyaN6CipY+d8MeRuNwNJocTtlkyv0hkv61fobEJfqfRQHwBnbIEeKQ4AVlQpJAnEOwZO3e6vdF61eq",
-	"sZ87loBDnd1p+eNtceg8+j+wbmWWUubH087Mj4YZ/+/oojgfGr1tPx/6uBtz61YU2rPDXaol5OE19b0I",
-	"rW91LqK6PO3uUnuVa99mscJ7mfeuw+4hmc9Bb5lnivCVQJrCkXHT9ZKRTYt7nidciNJDZI/MwVCzcJm6",
-	"SCMJQo5+Y7P+glYqqFR35B/fHzL9pZs8WP0rm+lNSiIhfI5uGb8Bjm5JFKGQY0KrJkviBYwmSI+OQojZ",
-	"c2TRIdSOh41Ygn5jM5RwpjY+JoqicE/oyP5mJ2lGr60RNMIRcNkfuW5poR353d7yRXvWCA2Jo74QtEkl",
-	"CG3TBlImWStNS7tAYSLUaplF1WSRh8MaKJdwiEkajzayPu9NpwdhhP4z7Uemyx/vT5fbxCgUMl1CXyJC",
-	"gygNAVkWmjpsheytitpuXg8x0on6SLHc8+z8VrQOU/Kush/PB54ujYxuu+sS+iPtiPXl9kvT09yj1DlT",
-	"Xzn+EByPjgITODKKTRFSe9THhw1g5XA0KGsd0TaqOuf1vI8T1G7ZQpSn6ORuEyzYgr1/0R2/8vfD4W/7",
-	"ntDhGbwIQG3A4brTBixej3L5eJxDDCExm0v4BEG6ObNfFkO8siN85fr/dD/G4aup4StbIPJwoueAdJ6x",
-	"erMMPsrSxyuy6BkFPfIvt8vj8uOoWaybFpDJt36b58R97ONk5r5aaOOk1YgxJyvQtnNkaj/qEwFd9bLI",
-	"VLoCKQldCPSvf/wTXQWY6rSe63QyefzsmsaMEsn0+0AJXsAYfYdpKFDAYjAp3H/3lTr5+zUt3oU7R+b5",
-	"mxd5+Y5Hps+LyRBl5edqH7PXu4bXNHsh54VTAcRtFZwNkULEi1LPsyFyC6e+oAxxdju+phdm/SKNkWTI",
-	"hNIdzIzRVQIBwgkZaayPXKyPcqybCyi1wLSuxOh/XHKXAWTvhA1XCAwrGC44rNiaQ6Cag1eW3Cc5wMUa",
-	"UU4GdGSY6yRjpJOMW07U5xOXBY49IuXWemo6bCiXJN4hGcsTeXVy/n5mFKXJ3hMPXhZ5fSYvN8spfvBc",
-	"9MbRfLM1cosC2XcrPcxh3nwaBUVN5VYWKVdgrjlK5SW8JpEErjSQLOq2CnS7ZEJpVhzDLeM3Uw5z/ciT",
-	"xIQKUxfsBtboaHU6Ph1Pjse6cEb9ikQ+QNf9il5AqQ6BjNb61oCyGpgaUC5fX5ydnX2rX8ISEsdJAzj3",
-	"ew+l7/2P08lBL4B4eMKby6PfFXPwbV7u3/a446s26KEN6kgX6MiaGUOq4/IVGY9yyCv5t+oEU0O8ty5o",
-	"KNa9R52wc4kwGPGQ8bV5f9J8/srKPVlZY210S0LlIWUFRg0W87rzJ7pcsM/9kSwZ2TrDo7yMYitDV2u0",
-	"/4FY+9/AnFSx7zMomN5AaDY0eenJr9Zkx76lfexXbajjDPPFExBHagqgIaGLLink2dMCPaXQPEXwVQoP",
-	"I4UG+81SqDD9VQr349NpSfNLoXmOu1EKzWsIbUJn3mDY5d6/8sqDByVXwFckAEQEyp5vuBsOnu6TKg4I",
-	"WbwFMY5SileYmEp6bdcK8vDFI7UBD4lTBvsIU0bXMUsrd1Q6nZIGL8SnYtxip1toKIkXB/Oca0WwPcTR",
-	"IY7DX1RoOufVVxSWllo9TnDbriFkRN/FSVD9AY09Xz0ov3XQQOfDXzfIzBo6mmHjbio5GSKSDFHCuBwi",
-	"kMH4eO+5lG8sJAhHipHWCD4Rpf0JRa4CaLhwYN9q2PD4VbP1yWf76M+de+ngnINg0arj6PVN+W7Npe3T",
-	"J6/deWnoD5zcblfslq44XJb7j8wFI7dt+shM76sYr1xgqcWX9GrMBdZiJF0JTSegzgDpDF81YifTtWXG",
-	"W87rdbFFMdnDvNJi4A6nWCIBcv83Wt6Ubkq13mXpoyC676/skxRNUf76ezT3sUF8rDaIKPf0iFDeoS6V",
-	"AeHDjUx6njxqYhNTtRYd2XQIUTzo8siD0gfGy9nlHK3F9F7JCz0CykmwtJ5yP2cNy2DpMW7q570rnt14",
-	"heXXGvacJdTLKzxUkYm6V/iw2N5QDsWp1HbcxEYJRKHY2tfTbp6TknAeLCG4cb28+h7JXD0Qyjl17oyY",
-	"DXCMgyWhwM2VEvPEAglQxFiiXAVxTY8KP2A05wDow8X70QxTChwxqn1u9PjxsS4AIbTLK9k11fo8E/Ih",
-	"wjS05XoMMObuvinLOUaVtL1rmmHGSYrRqbOlnBi9cl8+TO7ZOq0vNJr2Y/buMzXx9PE3vVIT95Dho1F4",
-	"ad4e8JdnmoEl6dYhx4NHD0qBvgPrkj3vYF9alWAy9OxLcMqTyna0hKJ5RBbL6rbjak2DJWeUpQIxOgoh",
-	"NuLu5LoUI2MkCF1YbVjScNmbLC1Rt3f5sy27LjBcfi6nJU9Vu6sVhPwFpNmD2aJDkdsWHUkCfJilcooh",
-	"+j1lEouhTQgqByLzlx+aUHLJzEHM7grUhDGhepbWjTSL4AFEARW6GqOA5aJEbWmxpVFKpDg3EbD2sIrG",
-	"lont7KpciX6uSc1z2HIlORitFQR0K431gwUQnaKK2RN++9avWkRIiCS+AdpYeaTAVReD1n1EExwq52ub",
-	"OtdtGuRK9ypZetNnX36Fnq2dgYweNWtBj/L6LUiks1HxrsGDT//CYVZ7vHBjbao74imVJIZikTN8A6FS",
-	"V0W1muEgST1O/vvc816CrpFlxhjqCujY+v+O659vvoU5WLumkiFTNN246hATmS1qbAYb29f4x+g75Z0I",
-	"hDnk9fHDa4qNyVtiGiq0zPRTC3ytn2ZgqRyx+Yjr6norHKX61oMu6/pkMhlf09zLN1OW/Hyvh5+2c+0O",
-	"FG59oj3vxJsgKLOC2XKGGRcJihOxZH88h9wKVO2KmneD3UOeOvVk8YJgfz15lT3QtxeiX2X54vXyViA5",
-	"CUSF2n9gXejoqtiu7RGKMVFr0YHCeYTLJM3fq2minn7zZpekqj+q4xNPodB0cDdZYavRTU4tppqcD6dz",
-	"22F5gfD718b1R7r27PiWHzxqoPMDOCxnPH/+xA2QHpTvfHeVc/9Xtejivbrjq1m253GkIs1DPI7ce7hJ",
-	"82i/08c+VOk+fTws5id7Ff6HRc3s/K0PHWtxj0K4bAgE6wfr2kMg2eN2wrxu9wc+gvM/07dtYXYdBDAI",
-	"PIBl+NmEPkwohlS5xKwQYfNZsm6G0XEIyw6tLJPSjZjm56z5V7Zx2IZDzFa6FGt2liSPa261apKRUN+U",
-	"35CIOo+Wr/wJ/e9YgCMUguYwe0yf8mhwPlhKmYjzk5NItdCnKd88eXI2uPt49z8BAAD//w==",
+	"7H39bhs3tvirEPotUBuRZDlOgtZB8EPqJpvsTdvATrcXqHO11MyRxHqGnJIcKbqFgfvXPsDiPuE+yQU/",
+	"ZoYzw/mQY0nubv7ZbSwOeXi+ec7h4e+DgMUJo0ClGJz/PuAgEkYF6H98i8NL+C0FIdW/AkYlUP2fOEki",
+	"EmBJGD35VTCq/iaCJcRY/defOMwH54P/d1JMfWJ+FSevOGf8FV1BxBIY3N7eDgchiICTRE02OB/8FUck",
+	"1DMPUYIXhNr/ZhyREOKESaDBBoGaZ3A7HHwPcsnCH5h8GUVsDeH+IP2ZM7pAbz58eI9iDcRAjbGfq9lf",
+	"hjGhlywCcWmxqv6acJYAl8SgmKuf1X8QCbHogklN9opKvlE7l5sEBucDzDne6KU5/JYSrlDwi533Yz6K",
+	"zX6FQKrPXqYhka9WFj9laHBg9vZ79pmQnNCF+gwHkvEp0filaRThWQSDc8lTGDYNNn/2zBUwziHSRLEz",
+	"1oaEIDGJNExhSNRIHL13YC0tXGzOzDZnPMZycD5IUxIOPPCxIEg5h3CKZWl8iCWMJInB9xGHgPFw649C",
+	"g9QykWvjysRU3wmW8gD6YjwfnyG98wsBK+BEbjzgVHhJ47BCs2HGKyVilzHbzn3iPV54BCJHUS+BcJjZ",
+	"g0QKn+Q0SLlgXE1UFt8fE/xbCsj8/BwlWAiEBfr/5g8vkGRoDjJYIrkEpGZS6khtsQOzVeTpbZRh8SNG",
+	"Lt+xBaGOxi1jhslE/V+MP70DupDLwfmz4SAm1PlXjchqV2vGw8qHj5+WPz31fJoK4BTHsPWnFQTk8zjQ",
+	"dCCgSVniIAAhppLdgF9JcZhzEMuWEQqabqaSy+8hB6O6oRIU1TXtCk0b/P71y1eUsyhq3mTC2YoIwiih",
+	"i2nKSbd81r5oWf2vwMl8c488VoFFTdC4PLwHHhOhQG0xiSQEKq1iqv7ipSkRU0wZ3cQsdZXrjLEIMNV8",
+	"wSLoqef00Mqcvg0lxVa20ey1Je1eyxM2Y7AZbRBbg1nHTz+j2ICksibogUFH4A1MduqmTb23WuFiiekC",
+	"GllT2xUqpyWV1q7CKKz7D69spbZcZbqm3VwaddC4jS4VVfXjSsN9i15gCQvGN8YvrK1XMnqNzNGDrO5E",
+	"XjgYpRBIsiJy8y0HfBOyNfWQkRNJAhzVDXJKOeBgqUwreoQCxeVBKskKpnNMopSDuE4nk7PgbDAsmJlQ",
+	"+exJwc2ESlgANx7kguPQHAjKC/VaBl6c9lzHbrO8Rsu8PeGnyj+bJpzNfHugDC2ZkNOIrICCEIizNYJP",
+	"REjRb3pGI0Jhe+S8mPSZv2oVzGIOUYYFI1gUVnbcxWIXSwhuLkGkkUfI9Okwd4XLG5RBMlXeOkvlUO1Q",
+	"z8jolMM8FRAO0QxTCnwaExFjGSz10VN9pCd9jpT7hxhFItV+QLdDaBSHxSuJiNxMhcQyrYvn4D0TcrTc",
+	"CAkcBBHIjENHAseAVjhKQXujCXDCQhKgiLEErVkahWjNiYRjpXNpGhvNYQmpVDIt/+uGKox/9DmMGvtb",
+	"HnGyqf2211osjfRp7Nn1RKHT8lc3L7k7qc3tbqAZ7528xeicLJp111RA4CGeWhkpsPkKR2jOOHJVmhJX",
+	"gWYQsbUmolwqxc6iEB09m4zHXz97Mpkcj9F3MMdpJNHp4wk6ehwrisb4E4kVUfUY7Y+Zfz+btCm+3lBW",
+	"YVwTuWxVjH6IzyYTdPT0ThCzNe0NrYERSyWWeMZW0AubXyvgziZ3gS7G6h8U0wCmi4jNfLbr5yVQpKUf",
+	"aQY0kilJcCPQLJXmjwJZrS0KLncExV3HjwzggggJoVJRoQ8rhCJnlgYyPVOoeDaJj8foBybRBiTCqWQj",
+	"HSqD8DmSHAc3EOp5rboZqflLc4uIBLA9Mo0luH/WfDHx7/YbtdnTO3ElxxKmEYmJrIP6Pf6kwLBOIrq6",
+	"euOYEoHCVClHNI8AJBJrgESgo9Px+PFkUgLkcQmMUx8U1lQ1csTI8NuHi/cjY7iQ/UIxg4CA0dCsfVZe",
+	"+qxzZUd5TXPxqsNwUVAjU+JKzc0Zh4J8//z7P1xdqOA5LcNz2gGP16PQWKlovGFZTTvapS5iZfQ2bbnE",
+	"Cl590M+gNJ/dgtzgtMUlPCZKq3vN6eIuX1fPPObPzpxdG7vKHZnyhiIspPHkrCtRER+lTTgESnb0qJGQ",
+	"mEvNutbDSqkkkVY/c8KF1LrU9Txdl6TTAXNJhhXoHr/we6L8O5HLsdre1GBk7CG5T4ObDQcspWX3qdkL",
+	"N19YsbnDl9YJ3epL5QTBVHJMhQ6sb/FxPfCU79cPkX+HjTB4KeXlQQ46coKji4jR5qABEVPLyz4dzm+Q",
+	"XBKBAjUHwkKzm1Dud4zsZ+iI0WijfG8SorWy8iJgCbwwo469bJDFSsrLWYskkGToK3OSNSF7pMYb1wod",
+	"aVCOvzJLsZhIqQ9LW8ZuNYz6IGQPAwbcwXCgzKjX8def2GxDGfBLS3F3+3qaYS2mtF1o3EDZQV4OWDbT",
+	"F6dyObXZN3e7Yjm9gY0bch4OZkwuvVuvhEgcXJ9OHj8ZegOODlc1M8CWVHNDVZ6DGVkpmVHb6vhdB6mS",
+	"JcfCH8/7TO7Ykuj3l0kwcFv0luKMLhu089M7ImSLHc7H9U9BFXMXGYOOqK+7TDu4LbmQ++D8QEvXdsf9",
+	"7JvZpldUuV/8sXMaIhzDXZe4vhJ5cFmw9JnOiHTTBa55tiMCFsc2Sd84y5zQBfCEk45xjZn4NAm3ZoAt",
+	"0wH9pLZEQpfcXvlIhWTxJYugwzw0a/Y++tiQOMFSAleG8L9+waP//qj+ZzL6Zvrx99Phs7PbP/lQ1Ds5",
+	"FBP61vx42pkpqsTguzNGBZqa1cid0gOaPrOURHJKqF/g7is9Vtu0u3I3Cl4FS9bIHTEIYWsQajZ/G7uU",
+	"zdMMQLMSD4mcwgqonPZUhD1qZyBYMuiR1rHjanN690F/SyGFDyDkX9is7STbCd6vbNZvsxVw7Xf9wC0V",
+	"b/nzAz7gw30XLOU2K7M/QUTAHJGAr4ArHmcRCZRFh09KEZXCDcX6yzTGdOqwtCdOL/mmKU5fiwSESkNn",
+	"6rj4tLpQHflVJtOo9tJohaMUS3gZAZeNQioCxjMRzSJFbqho0nlKNTP4IHgdAcg3TMjXNvlQW12dWwld",
+	"THkabXc818m5u3B59uHQt3bjJt7ZNGB9B9U0Yg/YSwmdHuOzfFLf0dvN35L+8ae1eiQSNc4udfzJVB2I",
+	"zy1E0zN+4JgKWxfXadr0rM3ApRF0cqXmlW24UrNSn4x/NnDoW6sR6KtMVisVTVgINcWcF/WllTi2GYHU",
+	"sgKdoCP7CXqE7PrHCAecCYFwFJlcwBhNxuPTcSkmyFLDChY8msYzG0VnEkdTMBonc0qqceyUSsTmJq+u",
+	"EaCjVIiztUDrJXBdLKiLQmxelghTNsi4BnN8h8x4DTc+WBsR/oElrw1+3ui00n0wsasPP5OJC/AUO98P",
+	"eK5gfC54jrjWfQGtF6Y3hJbO1zoYPRWgS/1MFNOM1EcdW1Kb/8lrqHtbhh2XMzfqgtbaYLNrE/PPkKKY",
+	"2KoKhYUbkiQaH1Xb33ZMLOxeoXvsSsMSMbprjN8AjuSy5cwzm9ogf8lLdk4v9S0u9Zwbt4TFR9wVcOE/",
+	"SlWdkmxrJWCKCbz7YkJesDiJCKYBXKVxjH0VX7lz28MgWO3aN+dglFXfPIPlg36jtda7UxLCAlVsps6C",
+	"2fSNWL1rGKEhQBwSkUR4M22KetaPbHRFOKNZwMetv/XNv+AsTe4aglKSdscINUmmOAy5dTQrUHZFtxmX",
+	"JT/+2dOnZ0870994UTYQXaip3gFoCz53e+I2UuXsu4mFvtPnv7aDcSa4U1FIbpu584u7JWCfj914dOQc",
+	"EHAU/TgfnP/SPUN+rLj9WL399EMaRSYjRBnKqxBNMcISC6QsCOIpRXiBCRXSZNoU6OMak/owr8/5NZQ1",
+	"Yf8dEfKthNgb0j90iLuqDbqkf3fifufoe0nuaz8/bOYqVE8P9dKtT3YfMfcrHruNMre0yUOzLlpmh4Ve",
+	"bndJvrpcbjN1M1hNYQpfTZefZLq0pFzg2ykDtXKUu5WR6GnymlODuYaPqgC7R4XPgqGhjvhzqn79EZbO",
+	"itmSifmidw+gd//99NpPGsoH66h3uMCfxU//8r53jeDvSABUwJXUJG9UNDrLCbwxG/YpIRzEZyndOWCZ",
+	"WaT+IkXodMFxAFNzX6NvqMEmvhW7YF1ibXagmYRNI4MUJUNUV6V54xCSmGuuediKg76dnQBdYxksp0mk",
+	"ow9Apa4fEOCdJtWxyYTDqlJ31JQ30us6gZsccR+b6dtxJdVuePrrWnbrGXdwjyUb71LujWcapil4SEwN",
+	"lb3Mk5G5E5iV3rDyXcolMsWINeaU0MVngVtV+hns1fV9lCmuBjdcZAzsPUe/qVd+FW+8/3vHKoeMmxZY",
+	"Qt9rkjmY1cKFAsT27YtLWBAheQt72jXIFp1DyrdEPcqqqWCjbdIqzXx9LHbU38RBQRn2YUvrk/csIgEB",
+	"cQkRw2EzflkqAxbbEg1vNr9Z+zekwfMpG+HafAeBvsXfVqxzpxqD7tIAC12Dk6mAay4hs783R771mUX0",
+	"CYpnYJQXrS2RT+jDZcFCf/xapzJfu3D4dv6TAN4RyM57BLTEfc/u3kbk6/20Ecm6CrTexVfYuN/T6Wc3",
+	"WDBRCAt0j1jAIao1a2huxC2L4KUQZNHcsEYpYuuVb0Pp7LOmlUV7cEvtoL/FKbFJl4iaqT0lT9rZn7N6",
+	"UcGVxAtAE7TG0Q2hi5G4gQikvj3O5zgA9M//+V99dxUQ0DBhhEqB5BJLBJ+AB0To263XdM5SarqiISFx",
+	"cIOOnJK0odsZbYh0UeHQdEhDYGvgjsfXuraASOW8DX5MgP6sDgLoyIJ47CQfzweT8el4MsJRssTjU20h",
+	"EqA4IYPzwdl4Mj7T0ieXGr0nOCEnq9MTHMaEnlif6dx4fJo8Nl2hiKThfRvaq+66QVrJJR8YhIOQ37Jw",
+	"c2+93LwnjdsyeW2suNQA7/FksisY8uZC9Q54aoRdAxmPGR3Za1W6F8EmgTC7anlsms5lGaXBd3wz4ik1",
+	"F5awBITRX37+gCxV9P1ZczdUSBxFhC4QMc5KmYqJ9ZTOuXaVepCx7FsNdojIBi/Og8n3wEcKW8jsAuVO",
+	"2O1w8GRytr9WgRc4ioCjCAc3AhlvJsNsmXxmT0ipVQjtSDQnEQg05yzWF9TMncSUQ4hCwiGQ5rTxaZTx",
+	"8qjwGwbng/pyOamVojjR1ceaSAvwEPjPIJ2ebVruOY5BaiX7y+8D5RQNfktBw2AMTdEarkBfTeX7v6x1",
+	"mdt6hlI3uq2/FoQG5Q/7WNmm2fQd1nubzTaPu8OuspvLxYf5ZZmnk22uo99+3KFcV1sD+gRamSo2NyYO",
+	"Wc7Vwjxpmj0H98TpZloWOuVPlKZERwbXI9uAFMIhorAGIc1l5OOKGMnlScQW5njQoiazBnc7MnK1DoJ7",
+	"NnD1Bn4eCuoBpncOhLrZBLsBKhARIoXQ0PJ0f4r5rYmhIudGnjKx379+iXLEaWaBIDUFcb98dFnnJ+su",
+	"n2RuPdKMYPpUsMQc0dGHHz+897IMS2UvnlHjapR74nE3QWt9xGHFbqBuXNRfjQ2xxl+YD+rAmQNDs0WQ",
+	"y+9hsGNmKvVgrJMua523b575gdnr4BZ5imFmgLmtTXPxLVNOS/jO+/15EH5SiSO0I/99Oea1Wzr4+jb6",
+	"/S07DEWkpmZfzee6r4JuKJNNlzeZ6YGhOT4H3TyzW2byPps7x02toacPL06DTvTT5VvENWc4LXbUBtW+",
+	"AywZRzhJqrjTa5QQpQ6jiFCtXJTC8iOs1zHMbQ26Q+NUaz/ay0B51JxSz3pj5AAmQy2uUG7Tb0h3KUoi",
+	"vKnpW91lhccIU2T4FkJtWQQEHCSabcwmNoqaGC2AKsJAiLzWIjMw5yZu1E3RclvNHZLV37/zrrTNZkM2",
+	"2OW4d3tS77BGuTXn8KuuzFbEsvfw9s1vF7bHVA7TmjMbNXNYTeO+ph++EvlnHo4qtPA5tzmnLrvjSVPt",
+	"9KjfkhXzoCoHqYyc12kUoctvX16gbJvoqMgfDV1zNEQ6xD4iFOk0ksfTtx1ZuwXQdoLdoeRVes0+RH9f",
+	"SZN28VGCCT+Um28RZSGxmnuIbGHF0OjwVECoGEMEOATrQiPJyWIBHMLj1nPAJdNXxZT8cXet5ygmVCKs",
+	"jo/INA5/lA1QCCmxV6X7SJMcXjjDdkjehp4pPg2Vj0QxSBxiia3/d8gwW4HNcw61QJs+87unvqMcdEaj",
+	"zXFLQK028bBFEVSJdf+KoKlXUi9tcLoDMHqyik3B7d2+uw/MZD6c7lEy1AXkiDKJdLrFvDljR1xdvUE3",
+	"YK3/N3v0NtNIkiSqtiUTVfuvkYmww9L9OFi3DW7SQie/k/DWuGgRSKhz+Hf67wVRv928/a4hRJxguSwi",
+	"kuaiX4k5vWHShivzH/t4kga4EB3lzWRezHEk4NgQ8cke9VLB9Tl3VQh4xeZyZNB8Bypa+twOexiNw9Fo",
+	"cjhlkyn3h0j61/qVGZfoX4kC4C3sUIsQn+u+gq7PWr38nhCw/Q9NU8ISNEADvkmUMNmza4wlcLWpFfAZ",
+	"liRGhEpm/RzO1iYAqhszY74AaTTsSdY6a4x+EuZQpYbM0ugGkThhXKK5bo/NEJYSG6wsmQDqgIMkxEmk",
+	"vS2GQA2isI42dgIIjRbPEp0cRglncSJ1P14bbalswqTG22y3bjK5N6HZqY/gtst8mC6CbsZ5KO/gbadH",
+	"sMr9h7xn/b6VylVVRAsQdVf0SOmDDRKFTQn37rgU7dxeKL5CAYsiEoJt4Y2peaxC5yBKnk3VsTGtWd29",
+	"OppGUwkd2Rn++fd/GILZfuj5H47v6guFBC8oE5IE4hyCJWs/9H9XjH6lBvv1xRJwqIvkrcZ4W9TujP4D",
+	"Nq3qo1RA97SzgK5hxf8cXRRp9tHb9jT7jjSS25htz3GLUks2D+eq34sM5Z3Sy+qTp92f1N6u3LeQVngv",
+	"C4JoEQ3JfA468jhThK/kIxSOTLRDbxnZ6uLned2aKD3X+cjk15uFy7SXG0kQcvQrm/UXtFJfuno85PH9",
+	"IdPfAc+D1b+wmY71KIfpOVozfgMcrUkUoZBjQquev8QLGE2Qnh2FELPnyKJDKDXHRixBv7IZSjgLQDh+",
+	"E6Ej+ze7SDN6bau1EY6Ay/7IdTu07Sh84e0Ct2eN0FB/78vkmYqs0A5tIGWSjdK0tBs03rUmQPG2gMiz",
+	"Cg2USzjEJI1HW1mf9+ajB2GE/j3tR6bLH+9Pl9v6UhQy/dCMRIQGURoCsiw0ddgK2ctptaConmKk7zsh",
+	"xXLPszIY0TpNyb3K/ng+8HzSyOj2c/3QzEifZ/tyu+1Pb66j69LTLxx/CI5HR4GJvxvFpgipAxPHh80D",
+	"5HA0KGudGDSqOuf1/BsnN9hyhigv0cnd5pxxB/b+WX/4hb8fDn/bV/cOz+DF2XULDtcfbcHi7QfkjMc5",
+	"xBASc7iETxCk2zP7ZTHFKzvDF67/d/djHL6aGr6yfXYPJ3oOSOcZqzfL4KPsFk5FFj2zoEf+7XZ5XH4c",
+	"NYt10wYy+dYv2J24T2KdzNy3fW26qZp442QF2naOTAtdHY3TzYOLgs8rkJLQhdBRuqsAU10deZ1OJo+f",
+	"XdOYUSKZfkUvwQsYo28xDQUKWAzmJszffB2j/nZNi9dTz5F5JO5F3gXpkfnmxWSIsi6etR+zNy6H1zR7",
+	"R+6F00jJHRWcDZFCxIvSl2dD5PaffkEZ4mw9vqYXZv8ijXWCw5TCFpgZo6sEAoQTMtJYH7lYH+VY9yUr",
+	"/gxSN7T1P8G8yzycd8GGm1iGFQwXHFZsTby45uCVJfdJDnCxR5STQb8LRiicZIx0knHLifr5xGWBY49I",
+	"uS3zmnK25c7uOyRjeSGvTs5fmY6iNNl7/dbLojzaXG/IrmY8eC5642i+2Qa5vdXs684e5jAvI46CojV9",
+	"K4uUG9nXHKXyFl6TSAJXGkgW7a8FWi+ZUJoVx7Bm/GbKYa6fQpSYUGHaK97ABh2tTsen48nxWPcfqt80",
+	"yyfouqbWCyj1QSCjjb58pawGpgaUy9cXZ2dn3+j3IoXEcdIAzv1e5+t7je50ctB7dB6e8JZE6tc3HXxr",
+	"Q3vndMcXbdBDG9SRLtCRNTOGVMflm4Ye5ZA/iNKqE8xTDL11QcObB3vUCTuXCIMRDxlfm1eazc9fWLkn",
+	"K2usjdYkVB5S1qfZYDF/vuNEd133uT+SJSPbrn2Ud6NtZejqUxd/INb+FzAnVez7DAqmN1n1Vd7B94s1",
+	"2bFvKYpKuzjDfPGSzpFaAmhI6KJLCnn2QktPKTQvunyRwsNIocF+sxQqTH+Rwv34dFrS/FKoTVuzFJpH",
+	"ZdqEzjxls8uzf+WxHF+1IfAVCQARgbJXcG6Hg6f7pIoDQhZvQYyjlOIVJqYhadvtrDx88UgdwEPivCZw",
+	"hCmjm5illat+nU5JgxfiUzFuz+g7aCiJFwfznGtvCXiIo0Mch7/v1ZTn1Te9lpZaPTK4bbe5MqLvIhNU",
+	"f4doz+XZ5SdjGuh8+FtbmVlDRzNs3E0lJ0NEkiFKGJdDBDIYH++9lvKNhSQvv9YFzgIRilwF0HBvyz55",
+	"s2X6VbP1ye/27bRb99rHOQfBolVH6vVN+Yripf2mz00H58G2P/AdIbtjtwPQ4S4L/cBcMHLbplNmWWF7",
+	"a7W83Y3pA+DcmFliaQpQZ4B0ha+asZPp2i4YWc7rdT9QMdnDvBloL0dMsUQC5P4vBr4pXS9pvRLYR0F0",
+	"XwPcJymaovz1Z73u44D4WB0QUe7pEaG8Q91xCMKHG5n0vBzXxCam+Tc6suUQongX65EHpQ+Ml7M7jvnd",
+	"PD/0CCgnwdJ6yv2cNSyDpce4qT/vXfHsxissP3qz5yqhXl7hoXr1/PXwd/Fa2d5QDsWp1HbcxEYJRKG4",
+	"s6+n3TynJOE8WEJw03KzF0eRvdirnFPnzog5AMc4WBIK3FwpMS/VkABFjCXKVRDX9KjwA0ZzDoA+XLwf",
+	"zTClwBGj2udGjx8f6z46Qru8kl1Trc8zIR8iTEPb9cwAY1qgmO7GY1Qp27umGWacohhdOluqidE7b7q8",
+	"a17PLEZfaDTtx+zdZ2ni6eOve5Um7qHCR6Pw0jzh4u9yNwNL0juHHA8ePSgF+g6sS/Z8gn1pVYKp0LMP",
+	"aipPKjvREormEVksq8eOqw0NlpxRlgrE6CiE2Ii7U+tSzIyRIHRhtWFJw2VPW7VE3d7lr1/tuk97+dWx",
+	"ljpV7a5WEPJnkOYMZnu3Re5YdCQJ8GFWyimG6LeUSSyGtiCoHIjMH9BpQsklM4mY3fX5CmNC9SqtB2kW",
+	"wQOIAip0NUYBy73d2spiS7OUSHFuImDtYRWNLRPb2VXXJ/3qnVrnsF2fcjBaWzroURrrBwsgOr1ps5dQ",
+	"961ftYiQEEl8A7SxgVOBqy4GrfuIJjhUrtc2zwW0aZAr/VXJ0ptv9uVX6NXaGcjoUbMX9Chvg4VEOhsV",
+	"z8M8+PIvHGZPOBRurC11RzylksRQbHKGbyBU6qpo+jUcJKnHyX+fe95L0I0xzBxD/ZAEtv6/4/rnh29h",
+	"EmvXVDJk3p4wrjrERGabGpvJxqZCLRyjb5V3IhDmkD8zEl5TbEzeEtNQoWWmX6zhG/3CDUvliM1HXDcp",
+	"XeEo1bcedHfsJ5PJ+JrmXr5ZsuTnez38tJ1rd6Bw6wvt+STeBEGZFcyRM8y4SFCciCX74znkVqBqV9S8",
+	"B+we8tSpJ4uHWPvryavsndO9EP0qqxevdwkEyUkgKtT+A+tCR1fFdm+PUIyJ2osOFM4jXCZp/uxXE/X0",
+	"02G7JFX9bTKfeAqFpoO7yQpbjW5yajHV5Hw4H7clywuE3782rr91uGfHt/xuXAOdH0CynPH8FSk3QHpQ",
+	"vvPdVc79XzWii/fqjq9m2Z7pSEWah5iO3Hu4SfNov+xjH6p0Zx8Pi/nJXoX/YVEzy7/1oWMt7lEIlw2B",
+	"YP3uZ3sIJHsjVJhHQv/AKTj/a6d3fd9CBwEMAg9gGX4yoQ8TiiFVLjE7RNj8rLssdjCMjkNYdmhlmZRu",
+	"xTQ/ZcO/sI3DNhxittIdrbNckjyuudVqSEZCfVN+SyLqOlq+8hf0v2MBjlAImsNsmj7l0eB8sJQyEecn",
+	"J5EaobMpXz95cja4/Xj7fwEAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/app/internal/server/api_credentials_test.go
+++ b/app/internal/server/api_credentials_test.go
@@ -463,6 +463,153 @@ func TestCredentials_Resolve_FallsBackToSystem(t *testing.T) {
 	})
 }
 
+// @ac AC-13
+// AC-13: Clone a system credential into a host scope; new row inherits
+// the source's auth_method + key metadata + username but lives at the
+// new (scope=host, scope_id) coordinates.
+func TestCredentials_Clone_SystemToHost(t *testing.T) {
+	t.Run("api-credentials/AC-13", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+
+		// Source: system credential.
+		srcReq := asRole(t, "POST", url+"/api/v1/credentials", auth.RoleAdmin, map[string]any{
+			"scope":       "system",
+			"name":        "ac13-src",
+			"username":    "operator",
+			"auth_method": "password",
+			"password":    "src-pw-from-template",
+		})
+		srcResp := doReq(t, srcReq)
+		if srcResp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(srcResp.Body)
+			srcResp.Body.Close()
+			t.Fatalf("seed source: status=%d body=%s", srcResp.StatusCode, b)
+		}
+		var src map[string]any
+		_ = json.NewDecoder(srcResp.Body).Decode(&src)
+		srcResp.Body.Close()
+		srcID, _ := src["id"].(string)
+
+		// Target host for the clone.
+		hostID := seedAPIHost(t, pool)
+
+		cloneReq := asRole(t, "POST",
+			url+"/api/v1/credentials/"+srcID+":clone", auth.RoleAdmin, map[string]any{
+				"scope":    "host",
+				"scope_id": hostID.String(),
+				"name":     "ac13-clone",
+			})
+		cloneResp := doReq(t, cloneReq)
+		defer cloneResp.Body.Close()
+		if cloneResp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(cloneResp.Body)
+			t.Fatalf("clone status=%d body=%s", cloneResp.StatusCode, b)
+		}
+		raw, _ := io.ReadAll(cloneResp.Body)
+		// Response must NEVER leak secret material.
+		for _, leaky := range []string{
+			`"password":`, `"private_key":`, `"private_key_passphrase":`,
+			`"encrypted_password":`, `"encrypted_private_key":`,
+		} {
+			if strings.Contains(string(raw), leaky) {
+				t.Errorf("clone response leaks %s: %s", leaky, raw)
+			}
+		}
+		var got map[string]any
+		_ = json.Unmarshal(raw, &got)
+		if got["scope"] != "host" {
+			t.Errorf("scope = %v, want host", got["scope"])
+		}
+		if got["scope_id"] != hostID.String() {
+			t.Errorf("scope_id = %v, want %s", got["scope_id"], hostID.String())
+		}
+		// Source identity inherited: username + auth_method match.
+		if got["username"] != "operator" {
+			t.Errorf("username = %v, want operator (inherited from source)", got["username"])
+		}
+		if got["auth_method"] != "password" {
+			t.Errorf("auth_method = %v, want password", got["auth_method"])
+		}
+		if got["id"] == srcID {
+			t.Errorf("clone reused source id %s; expected fresh id", srcID)
+		}
+		if got["name"] != "ac13-clone" {
+			t.Errorf("name = %v, want ac13-clone", got["name"])
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: Clone with unknown source id returns 404 credentials.not_found.
+func TestCredentials_Clone_UnknownSource(t *testing.T) {
+	t.Run("api-credentials/AC-14", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		hostID := seedAPIHost(t, pool)
+		bogus, _ := uuid.NewV7()
+
+		req := asRole(t, "POST",
+			url+"/api/v1/credentials/"+bogus.String()+":clone", auth.RoleAdmin, map[string]any{
+				"scope":    "host",
+				"scope_id": hostID.String(),
+			})
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status=%d body=%s", resp.StatusCode, b)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(b), "credentials.not_found") {
+			t.Errorf("body lacks credentials.not_found: %s", b)
+		}
+	})
+}
+
+// @ac AC-15
+// AC-15: Clone with scope=host but a non-existent scope_id returns
+// 400 credentials.host_not_found.
+func TestCredentials_Clone_HostNotFound(t *testing.T) {
+	t.Run("api-credentials/AC-15", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+
+		// Real source.
+		srcReq := asRole(t, "POST", url+"/api/v1/credentials", auth.RoleAdmin, map[string]any{
+			"scope":       "system",
+			"name":        "ac15-src",
+			"username":    "operator",
+			"auth_method": "password",
+			"password":    "src-pw",
+		})
+		srcResp := doReq(t, srcReq)
+		if srcResp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(srcResp.Body)
+			srcResp.Body.Close()
+			t.Fatalf("seed source: status=%d body=%s", srcResp.StatusCode, b)
+		}
+		var src map[string]any
+		_ = json.NewDecoder(srcResp.Body).Decode(&src)
+		srcResp.Body.Close()
+		srcID, _ := src["id"].(string)
+
+		ghost, _ := uuid.NewV7()
+		req := asRole(t, "POST",
+			url+"/api/v1/credentials/"+srcID+":clone", auth.RoleAdmin, map[string]any{
+				"scope":    "host",
+				"scope_id": ghost.String(),
+			})
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status=%d body=%s", resp.StatusCode, b)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(b), "credentials.host_not_found") {
+			t.Errorf("body lacks credentials.host_not_found: %s", b)
+		}
+	})
+}
+
 // @ac AC-12
 // AC-12: Resolve returns 404 credentials.none_available when neither
 // host-scope nor system-default is present.

--- a/app/internal/server/credentials_handlers.go
+++ b/app/internal/server/credentials_handlers.go
@@ -140,6 +140,90 @@ func (h *handlers) GetCredentialByID(w http.ResponseWriter, r *http.Request, id 
 	writeJSON(w, http.StatusOK, credentialResponse(m))
 }
 
+// PostCredentialClone copies the source credential's secret material
+// into a new row with the target scope/scope_id. The bulk-import flow
+// uses this to attach a chosen credential template to every newly
+// imported host without re-prompting the operator for the key/password.
+//
+// Spec api-credentials v1.1.0 AC-13, AC-14, AC-15.
+func (h *handlers) PostCredentialClone(w http.ResponseWriter, r *http.Request, srcID openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.CredentialWrite); denied {
+		return
+	}
+	var req api.CredentialCloneRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"scope is required", false)
+		return
+	}
+
+	var scopeID *uuid.UUID
+	if req.ScopeId != nil {
+		u := uuid.UUID(*req.ScopeId)
+		scopeID = &u
+	}
+	params := credential.CloneParams{
+		SourceID: uuid.UUID(srcID),
+		Scope:    credential.Scope(req.Scope),
+		ScopeID:  scopeID,
+	}
+	if req.Name != nil {
+		params.Name = *req.Name
+	}
+	if req.IsDefault != nil {
+		params.IsDefault = *req.IsDefault
+	}
+	if creator := h.identityUUID(r); creator != nil {
+		params.CreatedBy = *creator
+	}
+
+	// Mirror PostCredentials AC-04: when scope=host, the target host MUST exist.
+	if params.Scope == credential.ScopeHost && params.ScopeID != nil {
+		if _, err := h.hosts.GetByID(r.Context(), *params.ScopeID); err != nil {
+			if errors.Is(err, host.ErrHostNotFound) {
+				writeError(w, http.StatusBadRequest, "credentials.host_not_found", "client",
+					"scope_id does not match an active host", false)
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "server.error", "server",
+				"host lookup failed", true)
+			return
+		}
+	}
+
+	newID, err := h.credentials.CloneCredential(r.Context(), params)
+	if err != nil {
+		switch {
+		case errors.Is(err, credential.ErrNotFound):
+			writeError(w, http.StatusNotFound, "credentials.not_found", "client",
+				"source credential not found", false)
+		case errors.Is(err, credential.ErrInvalidScope):
+			writeError(w, http.StatusBadRequest, "credentials.invalid_scope", "client",
+				"scope and scope_id mismatch", false)
+		case errors.Is(err, credential.ErrMultipleSystemDefaults):
+			writeError(w, http.StatusConflict, "credentials.multiple_system_defaults", "client",
+				"another system default already exists", false)
+		default:
+			writeError(w, http.StatusInternalServerError, "server.error", "server",
+				err.Error(), true)
+		}
+		return
+	}
+	emitAudit(r, audit.CredentialCreated, newID.String(), map[string]any{
+		"credential_id": newID.String(),
+		"cloned_from":   uuid.UUID(srcID).String(),
+		"scope":         string(params.Scope),
+	})
+
+	created, err := h.credentials.GetMetadataByID(r.Context(), newID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"clone succeeded but lookup failed", true)
+		return
+	}
+	writeJSON(w, http.StatusCreated, credentialResponse(created))
+}
+
 // DeleteCredentialByID soft-deletes a credential.
 // Spec api-credentials AC-09.
 func (h *handlers) DeleteCredentialByID(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {

--- a/app/specs/api/credentials.spec.yaml
+++ b/app/specs/api/credentials.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-credentials
   title: Credential CRUD + host resolver HTTP surface
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -34,6 +34,7 @@ spec:
         - GET / POST /credentials
         - GET / DELETE /credentials/{id}
         - POST /hosts/{host_id}/credentials:resolve
+        - "POST /credentials/{id}:clone — copies the source row's encrypted secret material into a new scope without re-prompting for the secret (v1.1.0)"
       excludes:
         - "PUT /credentials/{id} (update) — deferred to A.5"
         - "Hard delete — A.5; only soft delete (is_active=false) ships in Slice A"
@@ -55,6 +56,10 @@ spec:
     - id: C-04
       description: DELETE is soft delete only — the row is marked is_active=false; subsequent GET returns 404; the row is NEVER hard-deleted by the HTTP API
       type: technical
+      enforcement: error
+    - id: C-05
+      description: POST /credentials/{id}:clone MUST copy the source row's encrypted_password / encrypted_private_key / encrypted_private_key_passphrase columns verbatim into the new row (no decrypt/re-encrypt round-trip). The HTTP request body MUST NOT carry plaintext secret material. The clone target scope/scope_id MUST be validated the same way POST /credentials validates them — host scope requires scope_id pointing at an existing host
+      type: security
       enforcement: error
 
   acceptance_criteria:
@@ -99,3 +104,15 @@ spec:
     - id: AC-12
       description: POST /hosts/{host_id}/credentials:resolve returns 404 credentials.none_available when neither a host-scope nor a system-default credential is available for host_id.
       priority: critical
+    - id: AC-13
+      description: POST /credentials/{id}:clone with admin caller, an existing source credential, and a valid {scope=host, scope_id=<existing host>} body returns 201 with a new credential's metadata. The new row's username, auth_method, ssh_key_fingerprint, ssh_key_type, and ssh_key_bits match the source row exactly. The new row has scope=host and scope_id set to the request body's host id.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-14
+      description: POST /credentials/{id}:clone with an unknown source id returns 404 credentials.not_found; no row inserted.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-15
+      description: POST /credentials/{id}:clone with scope=host but scope_id pointing at a non-existent host id returns 400 credentials.host_not_found; no row inserted.
+      priority: high
+      references_constraints: [C-05]


### PR DESCRIPTION
## Summary

Closes the bulk-import credential gap by adding a server-side credential **clone** endpoint and wiring the bulk-import wizard to it.

### Backend
- New `credential.CloneCredential` does a single-tx `SELECT FOR UPDATE` on the source + `INSERT` with the source's encrypted ciphertext columns copied verbatim. No decrypt/re-encrypt round-trip; the DEK never leaves the credential package.
- `POST /api/v1/credentials/{id}:clone` returns 201 with metadata (no leaked secret keys). 404 on unknown source, 400 on scope/host mismatch, 409 on multi-default conflict.
- Audits as `credential.created` with `cloned_from` in the detail map.

### Frontend
- BulkImportWizard seeds `credentialMode='system_default'`.
- PreviewImportStep adds a **Credentials** fieldset with two radios:
  - **Use system default** — POST `/hosts`, no follow-up. Each host falls back to the system-default at scan time.
  - **Clone an existing credential** — POST `/hosts`, then `POST /credentials/{srcId}:clone` with `{scope: 'host', scope_id: newHostId}`. Operator picks the template from a `<select>` populated by `GET /credentials`.
- Failed clone surfaces as a per-row note ("Host created but credential attach failed…") so the host record isn't lost.

### Spec / tests
- `api-credentials` v1.0.0 → v1.1.0 with new C-05 and AC-13/14/15.
- 3 backend integration tests (`api-credentials/AC-13`, `AC-14`, `AC-15`).
- Frontend `frontend-add-host/AC-18` source-inspection test covers the wizard wiring.

## Why
Bulk import had no way to attach a credential to each new host. The naive client-side "clone" approach wasn't possible because `GET /credentials` returns metadata only (C-01 invariant — no key material on the wire). Doing the clone server-side keeps the ciphertext-only contract intact while letting operators bulk-import 100 hosts with one credential template instead of 100 manual paste-the-key-again ops.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/server/...` passes (clone tests skipped without DSN, run in CI)
- [x] Frontend build clean (`npm run build`)
- [x] All 28 frontend tests pass (new AC-18)
- [x] `specter coverage` 100% across all 42 specs; api-credentials at 15/15
- [ ] CI integration tests for `api-credentials/AC-13..15` with `OPENWATCH_TEST_DSN`
