### PR TITLE
fix(liveness): strip /N CIDR prefix from inet before dialing

### DIFF
--- a/app/internal/liveness/band_test.go
+++ b/app/internal/liveness/band_test.go
@@ -5,11 +5,13 @@
 //	AC-24  TestBandIntervalFor_MapsStateAndConsecutiveToBand
 //	AC-25  TestPersist_WritesNextProbeAtFromBand
 //	AC-26  TestListProbeTargets_FiltersByNextProbeAt
+//	AC-27  TestListProbeTargets_StripsCIDRPrefixFromIP
 
 package liveness
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -142,6 +144,41 @@ func TestListProbeTargets_FiltersByNextProbeAt(t *testing.T) {
 		}
 		if ids[hFuture] {
 			t.Errorf("expected hFuture (next_probe_at in future) to be skipped, got it back")
+		}
+	})
+}
+
+// @ac AC-27
+// AC-27: listProbeTargets MUST strip PostgreSQL inet's /N prefix length
+// before handing the IP to the dialer. inet::text yields "1.2.3.4/32"
+// which net.Dial rejects as malformed — every probe would fail and every
+// host would be misclassified unreachable.
+func TestListProbeTargets_StripsCIDRPrefixFromIP(t *testing.T) {
+	t.Run("system-liveness-loop/AC-27", func(t *testing.T) {
+		pool := freshPool(t)
+		userID := seedUser(t, pool)
+		hostID := seedHost(t, pool, userID)
+
+		svc := NewService(pool, noopEmit, nil)
+		targets, err := svc.listProbeTargets(context.Background())
+		if err != nil {
+			t.Fatalf("listProbeTargets: %v", err)
+		}
+		var seen bool
+		for _, tgt := range targets {
+			if tgt.HostID != hostID {
+				continue
+			}
+			seen = true
+			if strings.Contains(tgt.Addr, "/") {
+				t.Errorf("Addr=%q contains '/'; inet prefix not stripped — dialer will fail", tgt.Addr)
+			}
+			if tgt.Addr != "192.0.2.10:22" {
+				t.Errorf("Addr=%q, want 192.0.2.10:22", tgt.Addr)
+			}
+		}
+		if !seen {
+			t.Errorf("seeded host %s not present in probe targets", hostID)
 		}
 	})
 }

--- a/app/internal/liveness/service.go
+++ b/app/internal/liveness/service.go
@@ -296,8 +296,12 @@ type probeTarget struct {
 // tick scales to large fleets without re-walking every host.
 func (s *Service) listProbeTargets(ctx context.Context) ([]probeTarget, error) {
 	now := s.clock()
+	// host(inet) strips the /N prefix length that PostgreSQL's inet type
+	// renders via ::text — "192.168.1.10/32" → "192.168.1.10". The
+	// `/32` slipping through here would yield "192.168.1.10/32:22"
+	// which net.Dial rejects, marking every host unreachable.
 	const q = `
-		SELECT h.id, h.ip_address::text, COALESCE(h.port, 22)
+		SELECT h.id, host(h.ip_address), COALESCE(h.port, 22)
 		  FROM hosts h
 		  LEFT JOIN host_backoff_state b
 		    ON b.host_id = h.id AND b.probe_type = 'scan'

--- a/app/specs/system/liveness-loop.spec.yaml
+++ b/app/specs/system/liveness-loop.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-liveness-loop
   title: Host liveness probe loop
-  version: "1.2.0"
+  version: "1.2.1"
   status: approved
   tier: 1
 
@@ -115,6 +115,10 @@ spec:
       description: Service.Run tick cadence MUST be a short polling interval (default 30s) — per-host effective cadence comes from the band, not from the tick rate. The 30s tick discovers due hosts; the 60..86400s band intervals decide per-host probe spacing. v1.2.0 NEW
       type: technical
       enforcement: error
+    - id: C-17
+      description: listProbeTargets MUST select hosts.ip_address via host(ip_address) (not ::text). PostgreSQL's inet type renders via ::text with a CIDR prefix length appended (192.0.2.10/32) which net.Dial rejects as malformed. v1.2.1 — regression hardening
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -220,3 +224,7 @@ spec:
       description: listProbeTargets seeded with three hosts — H1 with next_probe_at=NULL, H2 with next_probe_at in the past, H3 with next_probe_at in the future — returns exactly H1 and H2. The short Run-tick (Service.effectiveInterval defaulting to 30s) drives this query — per-host effective cadence comes from the band, not the tick rate.
       priority: critical
       references_constraints: [C-15, C-16]
+    - id: AC-27
+      description: listProbeTargets returns probeTarget.Addr of the form "<ip>:<port>" — never "<ip>/<prefix>:<port>". A host seeded as ip_address='192.0.2.10' MUST produce Addr="192.0.2.10:22". Regression hardening for the inet::text bug that marked every host unreachable in v1.2.0.
+      priority: critical
+      references_constraints: [C-17]


### PR DESCRIPTION
## Summary
Fix the liveness loop's IP cast. `inet::text` rendered every host's address with its CIDR prefix (`192.168.1.10/32`), and `net.Dial("tcp", "192.168.1.10/32:22")` rejected every probe — so every host got marked `unreachable` after two boot ticks and parked in the 30-min Down band.

The host CRUD code already used `host(ip_address)` to strip the prefix; the liveness loop was the lone holdout.

## Why this mattered

Operator reported "added 9 hosts, all show down — that's not true." Raw TCP to one of them returned the SSH banner in 65ms while openwatch's periodic loop kept marking it unreachable.

After the fix, against the user's live fleet:
- **8 reachable** (sub-70ms SSH banner times)
- **1 truly unreachable** (raw TCP also times out — the real outlier)

## Spec
- `system-liveness-loop` v1.2.0 → v1.2.1
- New C-17: `listProbeTargets MUST use host(ip_address)`
- New AC-27: regression test asserting `probeTarget.Addr` does not contain `/`

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/liveness/... -count=1` passes (AC-27 covered)
- [x] Live verification against fleet — 8/9 now correctly reachable
- [x] `specter coverage` — system-liveness-loop at 27/27
- [ ] CI integration test for AC-27 with `OPENWATCH_TEST_DSN`
