### PR TITLE
feat(intelligence): OS Intelligence collector (PR 1.2)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -323,6 +323,15 @@
         "line_number": 31
       }
     ],
+    "app/internal/intelligence/collector/helpers_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/internal/intelligence/collector/helpers_test.go",
+        "hashed_secret": "787f3b0459e1df78b2a3aedffdbff9715475862b",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
     "app/internal/license/testdata/license-privkey-test.pem": [
       {
         "type": "Private Key",
@@ -352,1920 +361,1031 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f6b95f5ce203c8ff4d4299f9f68ef8e7ac8231b5",
+        "hashed_secret": "9d445ef7089e1336b44ace3b46dbc5bb016d3690",
+        "is_verified": false,
+        "line_number": 3435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "235dceb0b0fbf1e79159c4f608410d2375d3dc3e",
         "is_verified": false,
         "line_number": 3436
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e603b7474c0b57094326149318ce5cad3f366e63",
+        "hashed_secret": "6eb026fa0af9a741370ad4fc210b8d7bacaed0cf",
         "is_verified": false,
         "line_number": 3437
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dd00d3b74d2327ae41a7d73b32689bc56f7539ef",
+        "hashed_secret": "9be1de0d143bf0817c0b103731fc9a659930ad6e",
         "is_verified": false,
         "line_number": 3438
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bca9d19184bc8f915ae713eb5ee49ff35dea0ef4",
+        "hashed_secret": "07dd16120f1ae1693428596b85cfa5d74a670ca6",
         "is_verified": false,
         "line_number": 3439
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d39031e25a9fabaf88d5b104ef9b81519934cf59",
+        "hashed_secret": "003b8edb68e3ef140d124c0bec47a3f25b79e8a1",
         "is_verified": false,
         "line_number": 3440
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "441971081f2c6eb880f2cafe113d4eb63580c9b8",
+        "hashed_secret": "f782b13b46644ed791b4f5aa5f77fa775534f4f8",
         "is_verified": false,
         "line_number": 3441
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7a7b2835eb8839b1ddd5dd8da5907a7e013ea0bc",
+        "hashed_secret": "0d50e4a0122dd9780322ee984c876d2fb8081d7c",
         "is_verified": false,
         "line_number": 3442
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4eb8261e5f155f8e5f10b4e6f77e6fb6d14f7569",
+        "hashed_secret": "40150f7e5a057640aab13eaf01ee42047c98be07",
         "is_verified": false,
         "line_number": 3443
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "70a09dab9339fd0e7e91647b7945f84e41a082d2",
+        "hashed_secret": "88d5daf2d46b130a1d52dc1a424145ef80e2d7c6",
         "is_verified": false,
         "line_number": 3444
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a8f8fc68183b67468deb3f5eeda906fcb37847bc",
+        "hashed_secret": "8e31190857d8df481643a2fc968ba0f83b2328b4",
         "is_verified": false,
         "line_number": 3445
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "57dbbd3905fd4cbf05a1e2be1af61ca6f2b74055",
+        "hashed_secret": "434a680f92c1be3fab698dc2870036578485371d",
         "is_verified": false,
         "line_number": 3446
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "38601eff9a69c2c81e90f19a6784cd31a7cdd2fc",
+        "hashed_secret": "659e8bad31016d37da549b78a7605623cde80437",
         "is_verified": false,
         "line_number": 3447
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "05780f384346411f6953a877a8dac96a59a189c7",
+        "hashed_secret": "770f17c5a2e28164d16e8647777e0f633c48c3eb",
         "is_verified": false,
         "line_number": 3448
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3233b6a270ed54386cbf3db9ba93909511309968",
+        "hashed_secret": "69be11509ad17706da4523fba89f9ee8070eee44",
         "is_verified": false,
         "line_number": 3449
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "95e7462f62089d7dd43c6e9da50a18242209c511",
+        "hashed_secret": "f4bcf5eb8a1f3c9674a5a67c475753660ac56cb9",
         "is_verified": false,
         "line_number": 3450
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2e13af2c7ecace1c89226b515c01f2100732273e",
+        "hashed_secret": "a02dbaffd862f2851be7bf2a993af7c6d84fd42e",
         "is_verified": false,
         "line_number": 3451
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "63604d261aecab1652d6828d55538da51c06b2c4",
+        "hashed_secret": "499fcaa48e7ce00f995c6380f3c6518a8f1f867f",
         "is_verified": false,
         "line_number": 3452
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "316348dbbb7225c4cbdbd2e05190d380e1893b24",
+        "hashed_secret": "c36b4da9997c324a2e7a8e15e6dcb4525654eb98",
         "is_verified": false,
         "line_number": 3453
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8771fc429e13af944099e5f5bb1e9f05919242fb",
+        "hashed_secret": "e9cc090ee3ac33c45bc09985579444e49f269f14",
         "is_verified": false,
         "line_number": 3454
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "111baa024ac4ed4dc4eeef977c27970557d8c33f",
+        "hashed_secret": "dc879ce41fccb2508b33bd9e133dcdaee26d226c",
         "is_verified": false,
         "line_number": 3455
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9f7030a44b8624db0d0328a6c908002370343f6a",
+        "hashed_secret": "bbdc0fb4471f6797fc443e8947172604b1b89357",
         "is_verified": false,
         "line_number": 3456
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "642ae7b7a6e39b9191e8248c27babdec7c75263b",
+        "hashed_secret": "64b1625a26f82d5bea8fd82b8bc67eb437a4a0bd",
         "is_verified": false,
         "line_number": 3457
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ffe784de342b40d6bffe78797e0ffe3793d2365e",
+        "hashed_secret": "00c74e9683143c3fe2a7b58dc302d5667542611f",
         "is_verified": false,
         "line_number": 3458
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9406f55de3afebe18285a1dfb10b44dd7455de39",
+        "hashed_secret": "f1747552ab0bc961b3eddcc1b8517994c2ac9bd9",
         "is_verified": false,
         "line_number": 3459
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ecfd084bb43cd0d21752c37e85df5af79f310ed9",
+        "hashed_secret": "bf4331f45fb110d966b07e5be1e2f963305dc685",
         "is_verified": false,
         "line_number": 3460
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "74a7f40b2cd2b4685288080ff2ad1f10741d0130",
+        "hashed_secret": "aa9dfe49efc1f42d27b649be1382bb9443d036f2",
         "is_verified": false,
         "line_number": 3461
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "46040fdd72242c3076a54f79c4a0cb8c046dc92e",
+        "hashed_secret": "234ecc3eb8b6eed6cd74f5e8905a076f13256bfe",
         "is_verified": false,
         "line_number": 3462
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ea65fd9528bdc0c2d287eb9b8435fe5b1ada5aa0",
+        "hashed_secret": "d8ed81e2af1a81d713a148c243b250c5609150cc",
         "is_verified": false,
         "line_number": 3463
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4b8d9aa293465e9151fdea6239785cbe720fa450",
+        "hashed_secret": "6951e8e204fb4ce9d777243a9df1717e6849edd1",
         "is_verified": false,
         "line_number": 3464
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b04279476331585aff7c9ed3c49a9713a111466c",
+        "hashed_secret": "245cfed03fd4cdb63280cac428f4e5cd18d1a34d",
         "is_verified": false,
         "line_number": 3465
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3410856a86e09face8ba21b3f15b6c568fcaf46b",
+        "hashed_secret": "45998e482052acf325b3a2f15f29db737f9b7c74",
         "is_verified": false,
         "line_number": 3466
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "66e211860086aa2bb13df687de7470ca56e42a37",
+        "hashed_secret": "fd2dde0728a88825fa8162b31178b4c02c2f512e",
         "is_verified": false,
         "line_number": 3467
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9701da91736a2c745cc9414a9d2e5c6ef6d8b9cb",
+        "hashed_secret": "437cfe8da25e76476a3d0fa2e8f4ba20caf1bfb7",
         "is_verified": false,
         "line_number": 3468
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c03069042ee1398af1deb19b581c68e73161e5d3",
+        "hashed_secret": "855169da0f015b5d5b77ad43df3607e360501607",
         "is_verified": false,
         "line_number": 3469
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "51665bcee8eef4c14454d9d20c9074702fe94919",
+        "hashed_secret": "e19d69d5a6a8f54c51144d8eac17a236686af84b",
         "is_verified": false,
         "line_number": 3470
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4befbb74167a9a7a9255c4863e2cfd5aa4d24a08",
+        "hashed_secret": "787b545c32de1ef567dc4a059dcb0355c60fe929",
         "is_verified": false,
         "line_number": 3471
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c27e5a861eac93a69f6529b0b014f6093630451d",
+        "hashed_secret": "3f6a493441063b375bc27845460f5fb477bc85d2",
         "is_verified": false,
         "line_number": 3472
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "097188d2e4d122585ee729a79ea5018c6c5bdcfa",
+        "hashed_secret": "90c038c125c252cb5bc13fa80b3f4cf0ce811c57",
         "is_verified": false,
         "line_number": 3473
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9765c491e98083e7e73845c30ab7956d038c2a32",
+        "hashed_secret": "5ba0845a583704378901f0bb1f81edff6fc2e1c5",
         "is_verified": false,
         "line_number": 3474
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b4bd0182dbbfd41e1910152823441248989972ac",
+        "hashed_secret": "62e0063048cf6f195c2d445fcf40891c6488fa59",
         "is_verified": false,
         "line_number": 3475
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3219644c87bd117dbaa3a429767297d9a691bd46",
+        "hashed_secret": "12cc9ed0392a06aa8c2348b325ba70077b918915",
         "is_verified": false,
         "line_number": 3476
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a8f99bf9b275f009831dec34d3c1a1f5d6f8f8f8",
+        "hashed_secret": "f30b5070ecbfa394a90dc7cbe4e7b7a748a25e52",
         "is_verified": false,
         "line_number": 3477
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ad7c4ff50ac48c5e0bd518be7d8b146c0f5dae0b",
+        "hashed_secret": "76966aa98c6945e0329588d7a5b39fb8bf24d9c5",
         "is_verified": false,
         "line_number": 3478
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dc9046bde44a6020b35084be2c31fd5b442125e7",
+        "hashed_secret": "3bc80dc67533d230deb10aab0af2856bbcff4bfb",
         "is_verified": false,
         "line_number": 3479
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "490af3bd6d81c9039351dffb5d70e92c8e506e40",
+        "hashed_secret": "7b3b97f75c656acffad150423fcffc47baa3011b",
         "is_verified": false,
         "line_number": 3480
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a1fd9f16e969fd56f25a67b58a73ba5cf93b9937",
+        "hashed_secret": "4e6658ec3d91781c57075aab2e0f5fa262e0a10a",
         "is_verified": false,
         "line_number": 3481
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "461b43f042fbd368b5e93a44ca3e8249c9468fb3",
+        "hashed_secret": "dbbaa61da4b5d34c22303d4c1045c44ebcaf9085",
         "is_verified": false,
         "line_number": 3482
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a939ba7a04d7f22291f61072b863a84101255117",
+        "hashed_secret": "f499d30fe791bb034002847594442e87b64734db",
         "is_verified": false,
         "line_number": 3483
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7756fae1118fc13860a6cc607d616dcc19c61b02",
+        "hashed_secret": "e740d3d369be5ea8e1ddc8170796a0aed3557fa0",
         "is_verified": false,
         "line_number": 3484
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e3f6f6d8e196039ac85812ee8b12faf673c79702",
+        "hashed_secret": "9f9e5e6282d94c7695fecbe9113bc4da77470b01",
         "is_verified": false,
         "line_number": 3485
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6ccb651d53f193b3c4be7e7add044b73f583463a",
+        "hashed_secret": "f9cbc65e136b231f55a6796db39a272374111ea0",
         "is_verified": false,
         "line_number": 3486
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3d9ea867b427ac59e86eb419bb7a069d5a36d6e3",
+        "hashed_secret": "d7aa1bd90064a39312d2894f6fec28dc0c314ea9",
         "is_verified": false,
         "line_number": 3487
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4340a90f745ddd1209623ea7c05eb008f7954a38",
+        "hashed_secret": "b796b5ea64260b010b1eb26ff8f4665f1fd4aa79",
         "is_verified": false,
         "line_number": 3488
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "70d1682035e4731b0068bda666e1f905d7b42c53",
+        "hashed_secret": "a32b528d867f5ea6ac3a4f4cc711102c0b155172",
         "is_verified": false,
         "line_number": 3489
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4f55da22cbb493ec1213b4f78afc9540113055b2",
+        "hashed_secret": "64e42e5e66fb604754c5c8b02143119cef89bfb7",
         "is_verified": false,
         "line_number": 3490
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0a6cf69ce5688f1542d44be047317e05505e5b9c",
+        "hashed_secret": "2ba1ae2dbd915958c5b6af81c10b1fdc23a2f899",
         "is_verified": false,
         "line_number": 3491
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8e7b475939f20f292df01e3825cfa1fd8dc3b805",
+        "hashed_secret": "0e178f80d6b356684825ff4c7dc9999b7a20e048",
         "is_verified": false,
         "line_number": 3492
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "baef648b796b51f5fdf150625fd8f287211019fc",
+        "hashed_secret": "d8b5f54f29289dbb2ee85b7dee844099a2d412b1",
         "is_verified": false,
         "line_number": 3493
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ffaccaedf4bded3062a71ede966198c2c6a1127e",
+        "hashed_secret": "a353f8b80eb7e1c31c4d5c829a15a0b252c9e065",
         "is_verified": false,
         "line_number": 3494
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bf358e605320a179192a05d6a5ca65c83b4b3866",
+        "hashed_secret": "df7c580d0d5c8130f8c556c12c8260165ed619d3",
         "is_verified": false,
         "line_number": 3495
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "70e12d2027d4493a0710170d77aeb5d70bccc535",
+        "hashed_secret": "7b17bb6d629762d439a49befbbe2d211bcdd1ab1",
         "is_verified": false,
         "line_number": 3496
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8a20be8648bd7621d9a7f7258524365db23653aa",
+        "hashed_secret": "f8ce5bd169690b23cf48659ee0d7e0ea98f010eb",
         "is_verified": false,
         "line_number": 3497
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "973a70653da598c85bddf333eb5847426c8ea23f",
+        "hashed_secret": "dc8ca059274ab9bbaaf3cf6ba447fb3cf6336fab",
         "is_verified": false,
         "line_number": 3498
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c3e6adbfe99de270b12732da47542d147fe30285",
+        "hashed_secret": "7f5e1854ca71eaa230fdad86c5855602c993a10e",
         "is_verified": false,
         "line_number": 3499
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "986a4596baabc0b854f1273ff104f787adc8e515",
+        "hashed_secret": "25c4d0e1fa0b36412c44553d752936a58b5a46a1",
         "is_verified": false,
         "line_number": 3500
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b4a2cc2b1a2d56a00d88243cc88926091551a691",
+        "hashed_secret": "fd1cda0254cbe4725384e53a71c23fc0ff2ef94d",
         "is_verified": false,
         "line_number": 3501
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f14a93f25f79b8ab87aeab9e40033aad2887d2e9",
+        "hashed_secret": "ca3126c7b5197ba382d3899b39c13ca2779d956e",
         "is_verified": false,
         "line_number": 3502
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b4a62712cebf2f3fdaeaf9082ad4faace72b5c90",
+        "hashed_secret": "cbf7189c0eed7de59574a6d304b5a4c6eec3365e",
         "is_verified": false,
         "line_number": 3503
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ba578960fe160cb9bacdb95ced468eb58ff6702e",
+        "hashed_secret": "9f86ec638d534bc2f99017e18883256cd1cceb57",
         "is_verified": false,
         "line_number": 3504
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b1835f5bf2c1176649611d7c3361204b54bfa183",
+        "hashed_secret": "5db715894ddd7b7da9283e4528f91f8e5ed3077a",
         "is_verified": false,
         "line_number": 3505
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a29d33563a4866ee0b09822255c1769ffd9cc062",
+        "hashed_secret": "b8589d3b3b93e2521f973693b7e5bc099c85519e",
         "is_verified": false,
         "line_number": 3506
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "286b7da16e05e72b9391b2069ac7b744e6bf34d9",
+        "hashed_secret": "24be88b9025df79b54c5285d54d7e2a2fa114af5",
         "is_verified": false,
         "line_number": 3507
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1995fc5680ca6258935d0401bbb794fd1dcbb8d8",
+        "hashed_secret": "c94d547d2dfbabb1f0813fbf9f6a135c91e3fdb7",
         "is_verified": false,
         "line_number": 3508
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3027810144d92127a820eee16b01810ef1021e16",
+        "hashed_secret": "93d38db7c1ce6e5f5b01b7f5ad3c8324cb7221f1",
         "is_verified": false,
         "line_number": 3509
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4e9f1cbc1815946992543d9b6ec3d20d5c36b5f1",
+        "hashed_secret": "caf13f9cccf9ea81aa39991851dc1ae11013e720",
         "is_verified": false,
         "line_number": 3510
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "778a2e9d306a5b9f021959cbecf4f2a857c776e8",
+        "hashed_secret": "aae2cf2791de1bf2396e47dd7997a11b94e2836a",
         "is_verified": false,
         "line_number": 3511
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a181ae4e23344e64be99da93cb5aa9a53fb399cf",
+        "hashed_secret": "ba7530957432ffba1ccdbf96bf0fae1e25aedc2c",
         "is_verified": false,
         "line_number": 3512
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b345e12f7fae9b5760359f0910f4a800ef07b00e",
+        "hashed_secret": "80159a0c94e16dff47972186ff5694b18dd40acf",
         "is_verified": false,
         "line_number": 3513
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6919502a569ba1bc5ec2f08871a38de2fb2e084c",
+        "hashed_secret": "eab5bd9d3fecd2a1689a77276f337f95edfe43f8",
         "is_verified": false,
         "line_number": 3514
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9d6ec1f075ee878e0bc49dec6e0a8e05dccb5b3b",
+        "hashed_secret": "6010a8288d3e9c24266713b1a37758bc1f27dee6",
         "is_verified": false,
         "line_number": 3515
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "56472c8aa0c6f492ffa140430da3e14236893ff4",
+        "hashed_secret": "07f779cead25f67b57fadc5564d38622e6cd2757",
         "is_verified": false,
         "line_number": 3516
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8f8d6a7a32e31fcfc143c4632aa921fccc5ac30c",
+        "hashed_secret": "c2052666ca4831f34ab27fb8dc2753a458b4ddc2",
         "is_verified": false,
         "line_number": 3517
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9437d29abfbdf74875677dbd3f9a9198b2899bc6",
+        "hashed_secret": "04148a039f0b0bd59d75ef76497455a0144053ca",
         "is_verified": false,
         "line_number": 3518
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0b6f5b3a30a1a360fa3b483efbf18ca4e1c633e8",
+        "hashed_secret": "375308f3376ef0d8283d14f83abc26044963a28a",
         "is_verified": false,
         "line_number": 3519
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1c6ad2b3c6b3eeb66bd62a8116dd1aa8ae326423",
+        "hashed_secret": "2bc14ac2f1635d5b01b6aea3481682ae8a5af20b",
         "is_verified": false,
         "line_number": 3520
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b482d7fc35c2379e6c02ced826fa7f4f3de0bc2a",
+        "hashed_secret": "fea8fcb156954450d589e4f5f88a20f40645d1fb",
         "is_verified": false,
         "line_number": 3521
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "296d59b15507589e96e6ce68cf1eb8292a969807",
+        "hashed_secret": "11ab97656d253db0ca0147ce0569cc106d045265",
         "is_verified": false,
         "line_number": 3522
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ffde39b6934de359be7bcd0db47b58668c32dc29",
+        "hashed_secret": "db5b6a24f82fcf1a73d669e5b6516bb0a58ba088",
         "is_verified": false,
         "line_number": 3523
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "03a8a7166435478cbb13c17d15d4d23a0b018286",
+        "hashed_secret": "e3a4fe17c36c9795aa599cc271f9fd460ada9e65",
         "is_verified": false,
         "line_number": 3524
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bde55526ce377e3af0d335116e3c33768571475b",
+        "hashed_secret": "d90838eec250c484e3eb1a932f749dfdbcdddde5",
         "is_verified": false,
         "line_number": 3525
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8cd7022f6d425ccd76c59cce5a2da24f8a33e23e",
+        "hashed_secret": "ea2d99a9ac36863f453e6f9e2b5ea1b8a4d5eb4e",
         "is_verified": false,
         "line_number": 3526
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fe916b911e3f90d24b1e01b7b07aded6098e91e7",
+        "hashed_secret": "b80b574e0c7c3eacaa7e81866b8aa133f832132f",
         "is_verified": false,
         "line_number": 3527
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "408eb47c3e64b0f6a4f7af1f39af8f1ae49ce668",
+        "hashed_secret": "41f1c92a70a9daa61e0437c159d172ad489e48bb",
         "is_verified": false,
         "line_number": 3528
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f611e4eca8f06735d4ec8cc4dce6a626710c0f67",
+        "hashed_secret": "d0824e1a58def6c853f02d38a0a9b335d429ae16",
         "is_verified": false,
         "line_number": 3529
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "47b995ec3d71b2cfc413f6bcfee9005dee53507c",
+        "hashed_secret": "7725c8596ccddc526556ac2afd199cf8b9c1050d",
         "is_verified": false,
         "line_number": 3530
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d0aa432f47381bf2d48105a9ed9542b0adcb5ed2",
+        "hashed_secret": "e4bc4f03b97d105ae0a34cd4a13541e6dfcb553f",
         "is_verified": false,
         "line_number": 3531
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "889eb9c4dcce6d58c2321144ad6b1a9f0433872c",
+        "hashed_secret": "eb117f66ee6bef9a560982ec95c2313946cfca61",
         "is_verified": false,
         "line_number": 3532
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e0ef87d31ea5763f84bbff6a4923dfe9e49b537f",
+        "hashed_secret": "3a83b1aec8489b8d7c6de7f7a523c354102f7596",
         "is_verified": false,
         "line_number": 3533
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a690fb5067d99224fc83e1a45c74da808f86c300",
+        "hashed_secret": "d1b1117d0c62b01dab6b8aab4dd931f654e770f8",
         "is_verified": false,
         "line_number": 3534
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f48884e0bc616c28f2ffeb7cfb10725bd35864ac",
+        "hashed_secret": "9d82912b883e4d99fdab8b428517728e48d40d93",
         "is_verified": false,
         "line_number": 3535
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2144e40fb2c3f0dd647bcbb46f40cc8441e44ef0",
+        "hashed_secret": "98032f4dea369b97eead14301e7542ddf71d59ee",
         "is_verified": false,
         "line_number": 3536
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "84a4d7a4ef6e5268163f7272323ecd5f895a960a",
+        "hashed_secret": "10a5c06abfc54030507da6adf61f329f494f5116",
         "is_verified": false,
         "line_number": 3537
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8d49d1efdc04f8260ef1bd8c40aca2f56618834f",
+        "hashed_secret": "dc463eca31fbec710ff0cdb51848f8a5ff6b97bb",
         "is_verified": false,
         "line_number": 3538
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b7819f6b6168840e3879b76d09f8a0b94dfab4a7",
+        "hashed_secret": "13102ff15d3a1af51cabfb67c77ed4ca7f75da14",
         "is_verified": false,
         "line_number": 3539
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "acaff53722b227aadb2108ad3c51a203561c425d",
+        "hashed_secret": "87e595d3dfbec31854b7c6fb170e30589d74dc82",
         "is_verified": false,
         "line_number": 3540
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "851ff40d251be29a3726ba868817ed04fc684c0c",
+        "hashed_secret": "b321a0a20e738163e354475584fdd5f43d891fec",
         "is_verified": false,
         "line_number": 3541
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "616f1a710ac64c3d09c7df28b8e5e2615786c305",
+        "hashed_secret": "4da171c8a369ef00170d3cbfd3ed8ebfc4f52f2d",
         "is_verified": false,
         "line_number": 3542
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ad82a221d5875a57e447e0c2a9af9faa21651098",
+        "hashed_secret": "42f77e24d910261418c46e0b3a430277e63c3759",
         "is_verified": false,
         "line_number": 3543
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5d460e48318a5086debff60a2420462664f0692c",
+        "hashed_secret": "9ff3c74e2922dbb5327211d734dc980813b654dc",
         "is_verified": false,
         "line_number": 3544
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "04e0bee00060823b11cea4c71ac458853e7b4674",
+        "hashed_secret": "5e8fd9b295834a9f641a07914152ba21c1b70b0b",
         "is_verified": false,
         "line_number": 3545
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cb5c77c926b09f1961ec89bb65d67c409b942d6c",
+        "hashed_secret": "3be4ab546556d7c995ab1b84e092583c06c20f9d",
         "is_verified": false,
         "line_number": 3546
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6ad2ae2c6729a8eaa1461945ca976dd1b7604107",
+        "hashed_secret": "3ec3ad5b1453f435563b1b854ec9b2f2030208ac",
         "is_verified": false,
         "line_number": 3547
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5b53e1392d824055af2aed7c2c824606d6f4018d",
+        "hashed_secret": "10bd1a2ed4f20e9b4b9942e9a0334e178da55e18",
         "is_verified": false,
         "line_number": 3548
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8d14dd2daefd8dfba1f53a552aa3349596d55eb4",
+        "hashed_secret": "2e4b631391d4b5748a79cfaf9233f251c3cafcbc",
         "is_verified": false,
         "line_number": 3549
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3f69285f3a3bde26afabcc3d0f35243829e9244d",
+        "hashed_secret": "739b572066e8aae401adf59379548ebbf793c8f2",
         "is_verified": false,
         "line_number": 3550
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "82ad00749445cb6fdd72e97fed33a8b3ac037ab4",
+        "hashed_secret": "199f469d42dabaade4e82ddf381d336ae2288b71",
         "is_verified": false,
         "line_number": 3551
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fc89bc757f4352da48edf15cbb96912c7dbba6b8",
+        "hashed_secret": "8980755aa6d032b19dcb8f62783e224863e88e1c",
         "is_verified": false,
         "line_number": 3552
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "843d1455c047b10d594651b5e6d0c6aa534dedc6",
+        "hashed_secret": "0b3d933b6fb361f80fa6b5f8293787fbfdb2d306",
         "is_verified": false,
         "line_number": 3553
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9cd9e187e868b06e08b1e3b754e9b70ffb00d472",
+        "hashed_secret": "ece1d870204ffdc62a53a5528a9f71df5d6588bb",
         "is_verified": false,
         "line_number": 3554
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "120769f3321111d32e48b73258f9add45ddb0f7d",
+        "hashed_secret": "1cb80d2a07fcc49081b45de0efcd4ccdbadb31b2",
         "is_verified": false,
         "line_number": 3555
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cb5083f117f7645ea9b060b8f4b7dae6cc6b7589",
+        "hashed_secret": "efd85a27d49428eadc00a0c6ff49519af8971a50",
         "is_verified": false,
         "line_number": 3556
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c7f2e4386c002bae3a9ec1d405f5ac528e9bd6f4",
+        "hashed_secret": "ea0d10d3d685038f29dcdf1f57fa1e360f072805",
         "is_verified": false,
         "line_number": 3557
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "68d24f28edc1dc11a3575fe142b9b8488617ffcf",
+        "hashed_secret": "b5c5cffdb5b65aa02be80c9a40f79a3f015baf19",
         "is_verified": false,
         "line_number": 3558
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "283e9f96fd33092e8f58a602f4e01c3098dd0c4e",
+        "hashed_secret": "ccc4a211ad19f502e9ea09a5323ed9e11bc13278",
         "is_verified": false,
         "line_number": 3559
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ba60ec96113af91919e0aa97c6d44a8b646ef8d6",
+        "hashed_secret": "1df9bc729fffb66b8e2f2a3dda72c6a95bd3a81b",
         "is_verified": false,
         "line_number": 3560
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a802cf5d64bc10194db2b8003a9d094ec64a489e",
+        "hashed_secret": "23ff1037508e7708d742c46366a05b60a0fc0bc7",
         "is_verified": false,
         "line_number": 3561
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1c6c4c05d178cfa8414ef065430f979050b95578",
+        "hashed_secret": "0a38cc50da291dfd9ae5e505dc94828f2027f0f5",
         "is_verified": false,
         "line_number": 3562
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5993e00463a603ebdde85acb9be6a120c22c8117",
+        "hashed_secret": "d82d6634b0b476e5ef9f887e891514f5c6e674e6",
         "is_verified": false,
         "line_number": 3563
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cf7388e45aabfcd11e730cc65fb9f5458ae90724",
+        "hashed_secret": "6be2b719d279a6d06e4d17abfbec46b54582d46e",
         "is_verified": false,
         "line_number": 3564
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "16d01acedeb8f77c0491ec840c1d1c189d951d42",
+        "hashed_secret": "cd4610b8c915d8b6c5ba29a9a8898276f37902ad",
         "is_verified": false,
         "line_number": 3565
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "22641cb4ca57ce4916bce8d48eeddb2c147ace6f",
+        "hashed_secret": "6af779230ebfa6ceb1c0b31cf0dd930a918b9c7b",
         "is_verified": false,
         "line_number": 3566
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "84de062bc1fc56a7bd4563fff38e5e7872496637",
+        "hashed_secret": "8bb096965cc2fa680043d4d228212489f5e84765",
         "is_verified": false,
         "line_number": 3567
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7b10bea7b45060b41a360bebf8314cd63caebb26",
+        "hashed_secret": "e8feca3b283934157301c1f890b2b828b4291732",
         "is_verified": false,
         "line_number": 3568
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "69e09f51565dae881acb2aa5f85448ac556bbe49",
+        "hashed_secret": "8e65d0f359281bbf10cc9d5b1b0c0c761478dc58",
         "is_verified": false,
         "line_number": 3569
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "366ef8049f252cc3d16b89f454b9527f805cac8d",
+        "hashed_secret": "251351c1ed74faa4dcf589be2053a1aaeb99c380",
         "is_verified": false,
         "line_number": 3570
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8ad05850de52d71f70088b1b80e1fbb6f8048154",
+        "hashed_secret": "18a76b6051b555b3e7d3ad697dd4c0baa321d250",
         "is_verified": false,
         "line_number": 3571
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0f0c44b76878b38e40bb54fc21960a8f3edea3a8",
+        "hashed_secret": "4b0c3d8995a2a60faca81b17970d5c8a67ade324",
+        "is_verified": false,
+        "line_number": 3572
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "dde1117b72d2d32e1a2efaf52b204338ee7bcbfe",
         "is_verified": false,
         "line_number": 3573
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c21ab09db05266dbba0bd3ba90223bc43da2af76",
+        "hashed_secret": "b42e4a3aafc5db8f3e21632f47d04b5113f918d3",
         "is_verified": false,
         "line_number": 3574
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07de63bab49aeed3523fb043481479445595a7a8",
+        "hashed_secret": "5e1423904338695db2088ed9f50d8c6e608a3626",
         "is_verified": false,
         "line_number": 3575
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8305b5bb36097ebd114a7ecf31d71bcc6731dda6",
+        "hashed_secret": "54fccb3f252e700ac75651965166a774f02ea70b",
         "is_verified": false,
         "line_number": 3576
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "70aea4fbdf86746aa0f390a41271f4cb0cef6277",
+        "hashed_secret": "30166162910316a82db18b537d4aabc753e21595",
         "is_verified": false,
         "line_number": 3577
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ca19b65709151d83826a65b9445f78b6fa5265f9",
+        "hashed_secret": "1186c2dd47dd2586b679be51420710ecf5cae9d6",
         "is_verified": false,
         "line_number": 3578
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "848c56484e814604048a9b64cc18e19c7a8546c3",
+        "hashed_secret": "44b919c23afca1f1c5b28c93f251973a087c50ab",
         "is_verified": false,
         "line_number": 3579
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "47f83912fa6e1a3a7d52008609058df4c552de77",
+        "hashed_secret": "9dfe9839bd269f484fc5e5c61519169a7122f38a",
         "is_verified": false,
         "line_number": 3580
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0d09a9d256f6ee6d6f7f943a62f55c51aa3a0fab",
+        "hashed_secret": "fb116963825983c42c3d7719caabda42f8033aa7",
         "is_verified": false,
         "line_number": 3581
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c829087eb610a841a69b1ef4a2055eb05d1a76af",
-        "is_verified": false,
-        "line_number": 3582
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "36b18bc835d0751389ad3d41741edc121834ffd0",
-        "is_verified": false,
-        "line_number": 3583
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e292a7ae2349b39c48760d884286115bd4423d9b",
-        "is_verified": false,
-        "line_number": 3584
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c21ba068ebe8ce51077a02c464d56803de428ad1",
-        "is_verified": false,
-        "line_number": 3585
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7e486beca5b57055ec35161489ebd951b4280b72",
-        "is_verified": false,
-        "line_number": 3586
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a928b08cba1bcdfdcca3d837a00adb8406ea79e1",
-        "is_verified": false,
-        "line_number": 3587
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c85f32ea552b0128e891514fa71ef1ddc43b6b36",
-        "is_verified": false,
-        "line_number": 3588
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e14ecaaf654c8005a59c1e472f330541aaf50e5a",
-        "is_verified": false,
-        "line_number": 3589
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ad0496a4423b49bcae9b0b9da9c2593edd778268",
-        "is_verified": false,
-        "line_number": 3590
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fd16e6231a43ec3c7527dce406dfc0b61d1fd274",
-        "is_verified": false,
-        "line_number": 3591
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "35704d7b51ccca380a3eea5f66f9f463adaf0532",
-        "is_verified": false,
-        "line_number": 3592
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "832a81b4ae2a478a24f0f6ab1bed2ed85ddaea56",
-        "is_verified": false,
-        "line_number": 3593
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6b6bf4013ce051d52832d992ac2682d8f2b524ee",
-        "is_verified": false,
-        "line_number": 3594
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a0f38e3e54603f5716312c22dbb6685a83a3202c",
-        "is_verified": false,
-        "line_number": 3595
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8959fe813152e4772c3bcb45d4265865cfbcc243",
-        "is_verified": false,
-        "line_number": 3596
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1c65659833ee427e8d0416977f5689d1eb21db7a",
-        "is_verified": false,
-        "line_number": 3597
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c94330cf4594158c4f5c84677442f8f223ff35d0",
-        "is_verified": false,
-        "line_number": 3598
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c0dfe7feba968b0fb2cd7d19d599efb4273f1a3a",
-        "is_verified": false,
-        "line_number": 3599
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "37c2d1c39c59aee1734d6a98a22b42593e356663",
-        "is_verified": false,
-        "line_number": 3600
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "11471dde81e1cad08303eef1cd0683998d736485",
-        "is_verified": false,
-        "line_number": 3601
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07099f91186191555a7c6ab4d559132dd1e46b36",
-        "is_verified": false,
-        "line_number": 3602
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42f400e48ea3182b6d14955580b624705e648c5b",
-        "is_verified": false,
-        "line_number": 3603
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "679932e0a551d76693295cad98c7a2d9c02f3a85",
-        "is_verified": false,
-        "line_number": 3604
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3066072f9196e2d5c21c8774c24f0db8074b43ae",
-        "is_verified": false,
-        "line_number": 3605
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fed67eed90c01bff5324b8acc1c19516f68c11fa",
-        "is_verified": false,
-        "line_number": 3606
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7fc90f423ef00789fc190cd151a7615840164576",
-        "is_verified": false,
-        "line_number": 3607
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f0a27573fb82d8f79200e19d2756f614678a7900",
-        "is_verified": false,
-        "line_number": 3608
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f5b27833a921dcdbfc0f3d5a4dfa162d98fe2f8f",
-        "is_verified": false,
-        "line_number": 3609
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7996cab030620a93ad0ef2848769431b5864a3dc",
-        "is_verified": false,
-        "line_number": 3610
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f8cd77611dcaa80467f062f752ebc63c9d6ab4f0",
-        "is_verified": false,
-        "line_number": 3611
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f7089829c67c7b85ebc6c663b5b1def6768be249",
-        "is_verified": false,
-        "line_number": 3612
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ccb8156f47f66f1c4ea73ca54328b24f65dff872",
-        "is_verified": false,
-        "line_number": 3613
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6854cfec8a337c138340f8bc1f62e54de3c4440f",
-        "is_verified": false,
-        "line_number": 3614
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c38eeed5389a6992eaf2a8ce3ce3144977d2ff59",
-        "is_verified": false,
-        "line_number": 3615
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5b2fbaca8c7f826d0e153d62853cd26ea3c99b44",
-        "is_verified": false,
-        "line_number": 3616
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d9d3ca874bf77b9c3a5d6169681c8f794a627494",
-        "is_verified": false,
-        "line_number": 3617
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7d36da7323b5f4688d6e58faf1db978b69df211b",
-        "is_verified": false,
-        "line_number": 3618
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ef3dcf2833c99405f47679d60fca180a0c56e8af",
-        "is_verified": false,
-        "line_number": 3619
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ef4d0a33872b642eea70e51d8753b5659cc0a626",
-        "is_verified": false,
-        "line_number": 3620
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "78bcb0513866c7d2f02101e757e13a2dea4f0f65",
-        "is_verified": false,
-        "line_number": 3621
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "95b81b0ad28443922c8b4c19cb66423594cd620d",
-        "is_verified": false,
-        "line_number": 3622
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bcc842825f66519126b0f8aa169200588c261c58",
-        "is_verified": false,
-        "line_number": 3623
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2f810f3240fd83928b3a587a0030003e6da3beb8",
-        "is_verified": false,
-        "line_number": 3624
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4ca6d31a2fb1dc62403a3b6e5ff49c286f69f046",
-        "is_verified": false,
-        "line_number": 3625
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ea162d0ba6049775913ffc406e1909ebaa92482b",
-        "is_verified": false,
-        "line_number": 3626
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1596b8706abde329c9432d6f6036749d359d48f0",
-        "is_verified": false,
-        "line_number": 3627
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4360fab8e8f546ffd8f77ae2d7ff33849aa4b25b",
-        "is_verified": false,
-        "line_number": 3628
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9f4aa02d8434d6a8d640b3408a95457210e2b157",
-        "is_verified": false,
-        "line_number": 3629
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bb95170f0121b7fd9e59a6e2f8c3d2a26154b407",
-        "is_verified": false,
-        "line_number": 3630
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ec2cc689bef4137d2801d9bc2eb4895534b576e7",
-        "is_verified": false,
-        "line_number": 3631
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "78685577b1ea830eceb63f7a3d479accc8e06888",
-        "is_verified": false,
-        "line_number": 3632
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "799c3c9633235f83847025680204dc159f066530",
-        "is_verified": false,
-        "line_number": 3633
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c0631753509504ce853c2068887c221a5020decd",
-        "is_verified": false,
-        "line_number": 3634
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7352fddca51d48fd6ea7e802f352eb1a474f8311",
-        "is_verified": false,
-        "line_number": 3635
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "89d949bf97cf16bd4aed621b41c300cbb18b3025",
-        "is_verified": false,
-        "line_number": 3636
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2dcbe105f410d17a6d1f4d605e43744dc2a83838",
-        "is_verified": false,
-        "line_number": 3637
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4eef8bf5bc35795d85681b3d0085ff566cc64db0",
-        "is_verified": false,
-        "line_number": 3638
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e49e966ec25271e418b0986a9a08e0fe6358bea6",
-        "is_verified": false,
-        "line_number": 3639
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a27d4d523200d90059c4d9ae3ee02a07dd99fd35",
-        "is_verified": false,
-        "line_number": 3640
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3f15b38e02abfca0ab4cf5c356187b49383cd440",
-        "is_verified": false,
-        "line_number": 3641
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6218d077acae12c2091474e4dc45bb75e88b4fe4",
-        "is_verified": false,
-        "line_number": 3642
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cdf8e2b9912f55f01831d04f949b25e734d260b5",
-        "is_verified": false,
-        "line_number": 3643
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f10f54fbf360c5bbf5ee725289056fffe0291221",
-        "is_verified": false,
-        "line_number": 3644
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f1d2ee920382e54b5ea1571bb09f7f9c4c7b0d45",
-        "is_verified": false,
-        "line_number": 3645
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f7c72adf62c4a78cae16c6b149f524bb8e97f472",
-        "is_verified": false,
-        "line_number": 3646
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4df536947ebb488fc0235da2b49b3da620124b3a",
-        "is_verified": false,
-        "line_number": 3647
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "38c938cb933e2757c937b0743d9ab5c7d5755272",
-        "is_verified": false,
-        "line_number": 3648
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7a30a73bd73877e015a160efa35fa88118d8251d",
-        "is_verified": false,
-        "line_number": 3649
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3fc186c5211bece3a63f6c478914e42412a87fc0",
-        "is_verified": false,
-        "line_number": 3650
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ce87e6e3767b51edf096af0ac4ba6383e02d7a7a",
-        "is_verified": false,
-        "line_number": 3651
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f3c0079a44967638374e3276c5bfcbaaca4fbc90",
-        "is_verified": false,
-        "line_number": 3652
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e543983224be4c55683989b757fe3aa3a038ea00",
-        "is_verified": false,
-        "line_number": 3653
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d69b055089bafff4610bcd269b8945406adff607",
-        "is_verified": false,
-        "line_number": 3654
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "364a17a7762c7c23269294ce19144e8a362279f9",
-        "is_verified": false,
-        "line_number": 3655
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "151075b0bad1eca29ea8e08f9dcafe30f8fd32ba",
-        "is_verified": false,
-        "line_number": 3656
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fb95c5405bc19ea65a20e30dd626b42d28dcc4d6",
-        "is_verified": false,
-        "line_number": 3657
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "85ef510be59bac65ba09748b2b16408777fa2ea6",
-        "is_verified": false,
-        "line_number": 3658
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0bc103a66fbb11edb313e1bb0274bee8ed6b0f92",
-        "is_verified": false,
-        "line_number": 3659
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bc511e0dfcf4750e3ad5ed063fa0d3eeffc2d5a1",
-        "is_verified": false,
-        "line_number": 3660
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d9aa3199758c7e24037437808164984d895cf2ce",
-        "is_verified": false,
-        "line_number": 3661
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "48abbc6195a5c845a3d2ea43952eb3869a40c56f",
-        "is_verified": false,
-        "line_number": 3662
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d1e52f5b19e91eee419e402df3e7c54e17f52b3c",
-        "is_verified": false,
-        "line_number": 3663
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "94e8b507259f9addb966fc47c572483078dc6e99",
-        "is_verified": false,
-        "line_number": 3664
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3cdfa41f3e08e333f7a264e2c17ea8e334ad2821",
-        "is_verified": false,
-        "line_number": 3665
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "52fdff0f0040b1fa777366a4cfc4db802f2c8d27",
-        "is_verified": false,
-        "line_number": 3666
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8ed1b175b3282440c8b47fba5faac96f3f5550c9",
-        "is_verified": false,
-        "line_number": 3667
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "26ab916dae1e5bac569f05b055d6843d94190c4d",
-        "is_verified": false,
-        "line_number": 3668
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "88f6e3a98f215ecf8750af6f4a2e29cc7908482b",
-        "is_verified": false,
-        "line_number": 3669
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2bf70eb53f66d4b5415be31f95fe7e4a6b1b011a",
-        "is_verified": false,
-        "line_number": 3670
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b0178d92fe942e177fd9a4951a50964d0e7d84b5",
-        "is_verified": false,
-        "line_number": 3671
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5f79891f258390535898ec015d50d3739e20cf80",
-        "is_verified": false,
-        "line_number": 3672
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3c190b35074f7c81fd78f04194330655a44af760",
-        "is_verified": false,
-        "line_number": 3673
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2454d6a0ed2b47524641b344872c1a5833281c5b",
-        "is_verified": false,
-        "line_number": 3674
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "db2ca416bffe22d7c2ce044581ddde350f04c540",
-        "is_verified": false,
-        "line_number": 3675
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b32480bd5656bd0c555db8e7d7e13bb6ae589f38",
-        "is_verified": false,
-        "line_number": 3676
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "11f74371e8baf821e3e03a23c785429f4bcac3b8",
-        "is_verified": false,
-        "line_number": 3677
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0776b4f47d2433fb4a8459bf5c5bf4cd9693c597",
-        "is_verified": false,
-        "line_number": 3678
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "31802c4b4d4d56de43fa9e5282354dd7578e22bb",
-        "is_verified": false,
-        "line_number": 3679
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d73c895e45ead51012d842eef93ceb7f424cab39",
-        "is_verified": false,
-        "line_number": 3680
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "62f2f05b4412386d94bb2a159f98ee0cb9f25765",
-        "is_verified": false,
-        "line_number": 3681
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3e014c3d54938cf25590a040a75e058160efebae",
-        "is_verified": false,
-        "line_number": 3682
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7d8d4aaa3faec3f456446472555b03be70c71fc1",
-        "is_verified": false,
-        "line_number": 3683
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d6282a6b939594ce0cd3af49eaa20d6295ddac1f",
-        "is_verified": false,
-        "line_number": 3684
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb043a93ca2388c3dd869d5e66889d8588525e87",
-        "is_verified": false,
-        "line_number": 3685
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1d3030aec5a26443949b7ba58372b9929ed00034",
-        "is_verified": false,
-        "line_number": 3686
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bcf5d2acb680d425c2ff66c8379d80d8856cf09c",
-        "is_verified": false,
-        "line_number": 3687
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0868996e26d769df5144b28cfc366084833a5218",
-        "is_verified": false,
-        "line_number": 3688
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9b4fbca2e89e74820c192bbde5b444d129568477",
-        "is_verified": false,
-        "line_number": 3689
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1dcaed7e7c4ecdca84b388e34c7eeff0a9739418",
-        "is_verified": false,
-        "line_number": 3690
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2f0c6251fab27e2494666ba42687f05d4fb274f4",
-        "is_verified": false,
-        "line_number": 3691
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a17fba29a3a9b80eac6c9143ef9eaefd9fdf269b",
-        "is_verified": false,
-        "line_number": 3692
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "327c5a7ae8d3fa3ca8dff7f32c7868e1cfa568d3",
-        "is_verified": false,
-        "line_number": 3693
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "636f13a66e54db6017a243947eef50b992046c44",
-        "is_verified": false,
-        "line_number": 3694
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d10bbaf9911bb811ea053c9f53821207277ab2c2",
-        "is_verified": false,
-        "line_number": 3695
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2dd43b07ff90d9421584349480c7a67c52fc117d",
-        "is_verified": false,
-        "line_number": 3696
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "86de29584d82a2661b2b062a6b61896be974c453",
-        "is_verified": false,
-        "line_number": 3697
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "36b0efa8426f13e0a18c03f382d1f44d8a966f19",
-        "is_verified": false,
-        "line_number": 3698
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7d2b63b6420260cf65bb2b3c357db51d5b608cf5",
-        "is_verified": false,
-        "line_number": 3699
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "de4de6cae1c4f7f87b48a98aac6ae8cea5436565",
-        "is_verified": false,
-        "line_number": 3700
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fba335d52217a2405b8e72d6d7178e5b2101cfb6",
-        "is_verified": false,
-        "line_number": 3701
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "188000725d21c17aeeee8f2fa630df0eacf72a18",
-        "is_verified": false,
-        "line_number": 3702
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "56de90f7cd1243a6719761e00a6fec490cef394e",
-        "is_verified": false,
-        "line_number": 3703
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "44c92edae3b58ae67209f28953404d70bf95b9d5",
-        "is_verified": false,
-        "line_number": 3704
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "58aafca2b3eeacb6cb2417e025f497adca087e69",
-        "is_verified": false,
-        "line_number": 3705
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "920413c7658dda83b6024354cb7ed8c99bb54b33",
-        "is_verified": false,
-        "line_number": 3706
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5db606f93719bc4733e477a4888f900686b4cd5c",
-        "is_verified": false,
-        "line_number": 3707
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3cf97bc18762d1ca8c67974ba5736f5de09bb870",
-        "is_verified": false,
-        "line_number": 3708
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9990eaa438e75ffa339e2d4cde2bd9ac5e85b45b",
-        "is_verified": false,
-        "line_number": 3709
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bb51345557a6c6b469da349fcf21201fd0ab7fc4",
-        "is_verified": false,
-        "line_number": 3710
       }
     ],
     "app/internal/server/credentials_handlers.go": [
@@ -2660,5 +1780,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T10:28:30Z"
+  "generated_at": "2026-06-01T10:31:43Z"
 }

--- a/app/audit/events.yaml
+++ b/app/audit/events.yaml
@@ -218,6 +218,218 @@ events:
   - code: host.intelligence.refreshed
     severity: info
 
+  # =========================================================================
+  # OS Intelligence taxonomy — recurring snapshot diff events.
+  # Spec: app/specs/system/os-intelligence.spec.yaml.
+  # =========================================================================
+  - code: account.user.locked
+    severity: warning
+    description: User account lock detected via passwd/shadow comparison
+    detail_schema:
+      type: object
+      properties:
+        user: {type: string}
+  - code: account.user.unlocked
+    severity: info
+    description: User account unlock detected via passwd/shadow comparison
+    detail_schema:
+      type: object
+      properties:
+        user: {type: string}
+  - code: account.user.created
+    severity: warning
+    description: New user account appeared in /etc/passwd since prior snapshot
+    detail_schema:
+      type: object
+      properties:
+        user: {type: string}
+        uid: {type: integer}
+  - code: account.user.deleted
+    severity: warning
+    description: User account removed from /etc/passwd since prior snapshot
+    detail_schema:
+      type: object
+      properties:
+        user: {type: string}
+  - code: account.user.privileged_group_added
+    severity: critical
+    description: User added to wheel/sudo/admin group since prior snapshot
+    detail_schema:
+      type: object
+      properties:
+        user:  {type: string}
+        group: {type: string}
+  - code: account.password.expired
+    severity: warning
+    description: Password expiry crossed since prior snapshot
+    detail_schema:
+      type: object
+      properties:
+        user: {type: string}
+  - code: account.password.expiring
+    severity: info
+    description: Password expiry within warning window
+    detail_schema:
+      type: object
+      properties:
+        user: {type: string}
+        days_remaining: {type: integer}
+  - code: account.ssh_key.added
+    severity: warning
+    description: New authorized_keys entry detected for a user
+    detail_schema:
+      type: object
+      properties:
+        user:        {type: string}
+        fingerprint: {type: string}
+  - code: account.ssh_key.removed
+    severity: info
+    description: authorized_keys entry removed for a user
+    detail_schema:
+      type: object
+      properties:
+        user:        {type: string}
+        fingerprint: {type: string}
+  - code: account.sudo.failure_threshold
+    severity: warning
+    description: Sudo failure count crossed the per-cycle threshold
+    detail_schema:
+      type: object
+      properties:
+        user:  {type: string}
+        count: {type: integer}
+
+  - code: security.login.new_source_ip
+    severity: warning
+    description: Known user logged in from previously-unseen source IP
+    detail_schema:
+      type: object
+      properties:
+        user:      {type: string}
+        source_ip: {type: string}
+  - code: security.login.failed_threshold
+    severity: warning
+    description: Failed login count crossed the per-cycle threshold
+    detail_schema:
+      type: object
+      properties:
+        user:  {type: string}
+        count: {type: integer}
+  - code: security.selinux.denied
+    severity: warning
+    description: SELinux denial entry observed in audit log since prior cycle
+    detail_schema:
+      type: object
+      properties:
+        denial: {type: string}
+  - code: security.apparmor.denied
+    severity: warning
+    description: AppArmor denial entry observed in audit log since prior cycle
+    detail_schema:
+      type: object
+      properties:
+        denial: {type: string}
+  - code: security.firewall.rule_changed
+    severity: error
+    description: Firewall ruleset hash changed since prior cycle
+    detail_schema:
+      type: object
+      properties:
+        prior_hash:   {type: string}
+        current_hash: {type: string}
+  - code: security.port.opened
+    severity: error
+    description: New listening port observed
+    detail_schema:
+      type: object
+      properties:
+        port:     {type: integer}
+        protocol: {type: string}
+
+  - code: system.package.installed
+    severity: info
+    description: Newly installed package observed
+    detail_schema:
+      type: object
+      properties:
+        name:    {type: string}
+        version: {type: string}
+  - code: system.package.updated
+    severity: info
+    description: Package upgraded to a new version
+    detail_schema:
+      type: object
+      properties:
+        name:    {type: string}
+        prior:   {type: string}
+        current: {type: string}
+  - code: system.package.removed
+    severity: warning
+    description: Previously-installed package no longer present
+    detail_schema:
+      type: object
+      properties:
+        name: {type: string}
+  - code: system.kernel.updated
+    severity: warning
+    description: New kernel installed; reboot likely pending
+    detail_schema:
+      type: object
+      properties:
+        prior:   {type: string}
+        current: {type: string}
+  - code: system.reboot.required
+    severity: warning
+    description: Host indicates a reboot is required (vendor marker file present)
+  - code: system.reboot.completed
+    severity: info
+    description: Host uptime fell below the prior cycle's value — reboot completed
+  - code: system.config.file_changed
+    severity: error
+    description: Critical host config file content hash changed (e.g. /etc/sudoers)
+    detail_schema:
+      type: object
+      properties:
+        path:         {type: string}
+        prior_hash:   {type: string}
+        current_hash: {type: string}
+  - code: system.service.started
+    severity: info
+    description: Systemd unit transitioned to active
+    detail_schema:
+      type: object
+      properties:
+        unit: {type: string}
+  - code: system.service.stopped
+    severity: info
+    description: Systemd unit transitioned to inactive
+    detail_schema:
+      type: object
+      properties:
+        unit: {type: string}
+  - code: system.service.failed
+    severity: error
+    description: Systemd unit transitioned to failed
+    detail_schema:
+      type: object
+      properties:
+        unit: {type: string}
+  - code: system.filesystem.mounted
+    severity: info
+    description: Mountpoint that did not exist in prior cycle is now mounted
+    detail_schema:
+      type: object
+      properties:
+        mountpoint: {type: string}
+        source:     {type: string}
+  - code: system.filesystem.unmounted
+    severity: warning
+    description: Previously-mounted mountpoint is no longer mounted
+    detail_schema:
+      type: object
+      properties:
+        mountpoint: {type: string}
+
   - code: host.bulk_imported
     severity: info
     detail_schema:

--- a/app/internal/audit/events.gen.go
+++ b/app/internal/audit/events.gen.go
@@ -77,6 +77,62 @@ const (
 	HostDiscoveryCompleted Code = "host.discovery.completed"
 	//
 	HostIntelligenceRefreshed Code = "host.intelligence.refreshed"
+	// User account lock detected via passwd/shadow comparison
+	AccountUserLocked Code = "account.user.locked"
+	// User account unlock detected via passwd/shadow comparison
+	AccountUserUnlocked Code = "account.user.unlocked"
+	// New user account appeared in /etc/passwd since prior snapshot
+	AccountUserCreated Code = "account.user.created"
+	// User account removed from /etc/passwd since prior snapshot
+	AccountUserDeleted Code = "account.user.deleted"
+	// User added to wheel/sudo/admin group since prior snapshot
+	AccountUserPrivilegedGroupAdded Code = "account.user.privileged_group_added"
+	// Password expiry crossed since prior snapshot
+	AccountPasswordExpired Code = "account.password.expired"
+	// Password expiry within warning window
+	AccountPasswordExpiring Code = "account.password.expiring"
+	// New authorized_keys entry detected for a user
+	AccountSshKeyAdded Code = "account.ssh_key.added"
+	// authorized_keys entry removed for a user
+	AccountSshKeyRemoved Code = "account.ssh_key.removed"
+	// Sudo failure count crossed the per-cycle threshold
+	AccountSudoFailureThreshold Code = "account.sudo.failure_threshold"
+	// Known user logged in from previously-unseen source IP
+	SecurityLoginNewSourceIp Code = "security.login.new_source_ip"
+	// Failed login count crossed the per-cycle threshold
+	SecurityLoginFailedThreshold Code = "security.login.failed_threshold"
+	// SELinux denial entry observed in audit log since prior cycle
+	SecuritySelinuxDenied Code = "security.selinux.denied"
+	// AppArmor denial entry observed in audit log since prior cycle
+	SecurityApparmorDenied Code = "security.apparmor.denied"
+	// Firewall ruleset hash changed since prior cycle
+	SecurityFirewallRuleChanged Code = "security.firewall.rule_changed"
+	// New listening port observed
+	SecurityPortOpened Code = "security.port.opened"
+	// Newly installed package observed
+	SystemPackageInstalled Code = "system.package.installed"
+	// Package upgraded to a new version
+	SystemPackageUpdated Code = "system.package.updated"
+	// Previously-installed package no longer present
+	SystemPackageRemoved Code = "system.package.removed"
+	// New kernel installed; reboot likely pending
+	SystemKernelUpdated Code = "system.kernel.updated"
+	// Host indicates a reboot is required (vendor marker file present)
+	SystemRebootRequired Code = "system.reboot.required"
+	// Host uptime fell below the prior cycle's value — reboot completed
+	SystemRebootCompleted Code = "system.reboot.completed"
+	// Critical host config file content hash changed (e.g. /etc/sudoers)
+	SystemConfigFileChanged Code = "system.config.file_changed"
+	// Systemd unit transitioned to active
+	SystemServiceStarted Code = "system.service.started"
+	// Systemd unit transitioned to inactive
+	SystemServiceStopped Code = "system.service.stopped"
+	// Systemd unit transitioned to failed
+	SystemServiceFailed Code = "system.service.failed"
+	// Mountpoint that did not exist in prior cycle is now mounted
+	SystemFilesystemMounted Code = "system.filesystem.mounted"
+	// Previously-mounted mountpoint is no longer mounted
+	SystemFilesystemUnmounted Code = "system.filesystem.unmounted"
 	//
 	HostBulkImported Code = "host.bulk_imported"
 	//
@@ -437,6 +493,202 @@ var Metadata = map[Code]EventMeta{
 		Category:    "host",
 		Severity:    SeverityInfo,
 		Description: ``,
+		ActorTypes:  nil,
+	},
+	AccountUserLocked: {
+		Code:        AccountUserLocked,
+		Category:    "account",
+		Severity:    SeverityWarning,
+		Description: `User account lock detected via passwd/shadow comparison`,
+		ActorTypes:  nil,
+	},
+	AccountUserUnlocked: {
+		Code:        AccountUserUnlocked,
+		Category:    "account",
+		Severity:    SeverityInfo,
+		Description: `User account unlock detected via passwd/shadow comparison`,
+		ActorTypes:  nil,
+	},
+	AccountUserCreated: {
+		Code:        AccountUserCreated,
+		Category:    "account",
+		Severity:    SeverityWarning,
+		Description: `New user account appeared in /etc/passwd since prior snapshot`,
+		ActorTypes:  nil,
+	},
+	AccountUserDeleted: {
+		Code:        AccountUserDeleted,
+		Category:    "account",
+		Severity:    SeverityWarning,
+		Description: `User account removed from /etc/passwd since prior snapshot`,
+		ActorTypes:  nil,
+	},
+	AccountUserPrivilegedGroupAdded: {
+		Code:        AccountUserPrivilegedGroupAdded,
+		Category:    "account",
+		Severity:    SeverityCritical,
+		Description: `User added to wheel/sudo/admin group since prior snapshot`,
+		ActorTypes:  nil,
+	},
+	AccountPasswordExpired: {
+		Code:        AccountPasswordExpired,
+		Category:    "account",
+		Severity:    SeverityWarning,
+		Description: `Password expiry crossed since prior snapshot`,
+		ActorTypes:  nil,
+	},
+	AccountPasswordExpiring: {
+		Code:        AccountPasswordExpiring,
+		Category:    "account",
+		Severity:    SeverityInfo,
+		Description: `Password expiry within warning window`,
+		ActorTypes:  nil,
+	},
+	AccountSshKeyAdded: {
+		Code:        AccountSshKeyAdded,
+		Category:    "account",
+		Severity:    SeverityWarning,
+		Description: `New authorized_keys entry detected for a user`,
+		ActorTypes:  nil,
+	},
+	AccountSshKeyRemoved: {
+		Code:        AccountSshKeyRemoved,
+		Category:    "account",
+		Severity:    SeverityInfo,
+		Description: `authorized_keys entry removed for a user`,
+		ActorTypes:  nil,
+	},
+	AccountSudoFailureThreshold: {
+		Code:        AccountSudoFailureThreshold,
+		Category:    "account",
+		Severity:    SeverityWarning,
+		Description: `Sudo failure count crossed the per-cycle threshold`,
+		ActorTypes:  nil,
+	},
+	SecurityLoginNewSourceIp: {
+		Code:        SecurityLoginNewSourceIp,
+		Category:    "security",
+		Severity:    SeverityWarning,
+		Description: `Known user logged in from previously-unseen source IP`,
+		ActorTypes:  nil,
+	},
+	SecurityLoginFailedThreshold: {
+		Code:        SecurityLoginFailedThreshold,
+		Category:    "security",
+		Severity:    SeverityWarning,
+		Description: `Failed login count crossed the per-cycle threshold`,
+		ActorTypes:  nil,
+	},
+	SecuritySelinuxDenied: {
+		Code:        SecuritySelinuxDenied,
+		Category:    "security",
+		Severity:    SeverityWarning,
+		Description: `SELinux denial entry observed in audit log since prior cycle`,
+		ActorTypes:  nil,
+	},
+	SecurityApparmorDenied: {
+		Code:        SecurityApparmorDenied,
+		Category:    "security",
+		Severity:    SeverityWarning,
+		Description: `AppArmor denial entry observed in audit log since prior cycle`,
+		ActorTypes:  nil,
+	},
+	SecurityFirewallRuleChanged: {
+		Code:        SecurityFirewallRuleChanged,
+		Category:    "security",
+		Severity:    SeverityError,
+		Description: `Firewall ruleset hash changed since prior cycle`,
+		ActorTypes:  nil,
+	},
+	SecurityPortOpened: {
+		Code:        SecurityPortOpened,
+		Category:    "security",
+		Severity:    SeverityError,
+		Description: `New listening port observed`,
+		ActorTypes:  nil,
+	},
+	SystemPackageInstalled: {
+		Code:        SystemPackageInstalled,
+		Category:    "system",
+		Severity:    SeverityInfo,
+		Description: `Newly installed package observed`,
+		ActorTypes:  nil,
+	},
+	SystemPackageUpdated: {
+		Code:        SystemPackageUpdated,
+		Category:    "system",
+		Severity:    SeverityInfo,
+		Description: `Package upgraded to a new version`,
+		ActorTypes:  nil,
+	},
+	SystemPackageRemoved: {
+		Code:        SystemPackageRemoved,
+		Category:    "system",
+		Severity:    SeverityWarning,
+		Description: `Previously-installed package no longer present`,
+		ActorTypes:  nil,
+	},
+	SystemKernelUpdated: {
+		Code:        SystemKernelUpdated,
+		Category:    "system",
+		Severity:    SeverityWarning,
+		Description: `New kernel installed; reboot likely pending`,
+		ActorTypes:  nil,
+	},
+	SystemRebootRequired: {
+		Code:        SystemRebootRequired,
+		Category:    "system",
+		Severity:    SeverityWarning,
+		Description: `Host indicates a reboot is required (vendor marker file present)`,
+		ActorTypes:  nil,
+	},
+	SystemRebootCompleted: {
+		Code:        SystemRebootCompleted,
+		Category:    "system",
+		Severity:    SeverityInfo,
+		Description: `Host uptime fell below the prior cycle's value — reboot completed`,
+		ActorTypes:  nil,
+	},
+	SystemConfigFileChanged: {
+		Code:        SystemConfigFileChanged,
+		Category:    "system",
+		Severity:    SeverityError,
+		Description: `Critical host config file content hash changed (e.g. /etc/sudoers)`,
+		ActorTypes:  nil,
+	},
+	SystemServiceStarted: {
+		Code:        SystemServiceStarted,
+		Category:    "system",
+		Severity:    SeverityInfo,
+		Description: `Systemd unit transitioned to active`,
+		ActorTypes:  nil,
+	},
+	SystemServiceStopped: {
+		Code:        SystemServiceStopped,
+		Category:    "system",
+		Severity:    SeverityInfo,
+		Description: `Systemd unit transitioned to inactive`,
+		ActorTypes:  nil,
+	},
+	SystemServiceFailed: {
+		Code:        SystemServiceFailed,
+		Category:    "system",
+		Severity:    SeverityError,
+		Description: `Systemd unit transitioned to failed`,
+		ActorTypes:  nil,
+	},
+	SystemFilesystemMounted: {
+		Code:        SystemFilesystemMounted,
+		Category:    "system",
+		Severity:    SeverityInfo,
+		Description: `Mountpoint that did not exist in prior cycle is now mounted`,
+		ActorTypes:  nil,
+	},
+	SystemFilesystemUnmounted: {
+		Code:        SystemFilesystemUnmounted,
+		Category:    "system",
+		Severity:    SeverityWarning,
+		Description: `Previously-mounted mountpoint is no longer mounted`,
 		ActorTypes:  nil,
 	},
 	HostBulkImported: {
@@ -1036,6 +1288,34 @@ var codeOrder = []Code{
 	HostPlatformDetected,
 	HostDiscoveryCompleted,
 	HostIntelligenceRefreshed,
+	AccountUserLocked,
+	AccountUserUnlocked,
+	AccountUserCreated,
+	AccountUserDeleted,
+	AccountUserPrivilegedGroupAdded,
+	AccountPasswordExpired,
+	AccountPasswordExpiring,
+	AccountSshKeyAdded,
+	AccountSshKeyRemoved,
+	AccountSudoFailureThreshold,
+	SecurityLoginNewSourceIp,
+	SecurityLoginFailedThreshold,
+	SecuritySelinuxDenied,
+	SecurityApparmorDenied,
+	SecurityFirewallRuleChanged,
+	SecurityPortOpened,
+	SystemPackageInstalled,
+	SystemPackageUpdated,
+	SystemPackageRemoved,
+	SystemKernelUpdated,
+	SystemRebootRequired,
+	SystemRebootCompleted,
+	SystemConfigFileChanged,
+	SystemServiceStarted,
+	SystemServiceStopped,
+	SystemServiceFailed,
+	SystemFilesystemMounted,
+	SystemFilesystemUnmounted,
 	HostBulkImported,
 	CredentialCreated,
 	CredentialDeleted,

--- a/app/internal/db/migrations/0018_host_intelligence.sql
+++ b/app/internal/db/migrations/0018_host_intelligence.sql
@@ -1,0 +1,82 @@
+-- PR 1.2 — host OS Intelligence storage (system-os-intelligence v1.0.0).
+--
+-- Two tables:
+--   1) host_intelligence_state: one snapshot per host (UPSERT, no history).
+--      Spec C-03.
+--   2) host_intelligence_events: append-only diff log. One row per detected
+--      change. UNIQUE (host_id, event_code, occurred_at) for idempotency.
+--      Spec C-04 + AC-14.
+
+-- +goose Up
+
+CREATE TABLE host_intelligence_state (
+    host_id      UUID PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
+    snapshot     JSONB NOT NULL,
+    collected_at TIMESTAMPTZ NOT NULL,
+    collected_by UUID,            -- optional scan_id when piggybacked on a scan, NULL otherwise
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE host_intelligence_events (
+    id             UUID         PRIMARY KEY,
+    host_id        UUID         NOT NULL REFERENCES hosts(id) ON DELETE RESTRICT,
+    event_code     TEXT         NOT NULL,
+    severity       TEXT         NOT NULL
+                   CHECK (severity IN ('info','low','medium','high','critical')),
+    detail         JSONB        NOT NULL,
+    occurred_at    TIMESTAMPTZ  NOT NULL,
+    detected_at    TIMESTAMPTZ  NOT NULL,
+    correlation_id TEXT         NOT NULL,
+    UNIQUE (host_id, event_code, occurred_at),
+    -- Spec C-05 + AC-15: closed-enum CHECK on event_code. Adding a new code
+    -- requires a follow-up migration to extend the enum so review catches it.
+    CHECK (event_code IN (
+        -- account
+        'account.user.locked',
+        'account.user.unlocked',
+        'account.user.created',
+        'account.user.deleted',
+        'account.user.privileged_group_added',
+        'account.password.expired',
+        'account.password.expiring',
+        'account.ssh_key.added',
+        'account.ssh_key.removed',
+        'account.sudo.failure_threshold',
+        -- security
+        'security.login.new_source_ip',
+        'security.login.failed_threshold',
+        'security.selinux.denied',
+        'security.apparmor.denied',
+        'security.firewall.rule_changed',
+        'security.port.opened',
+        -- system
+        'system.package.installed',
+        'system.package.updated',
+        'system.package.removed',
+        'system.kernel.updated',
+        'system.reboot.required',
+        'system.reboot.completed',
+        'system.config.file_changed',
+        'system.service.started',
+        'system.service.stopped',
+        'system.service.failed',
+        'system.filesystem.mounted',
+        'system.filesystem.unmounted'
+    ))
+);
+
+-- Common query: latest events for the /activity feed, ordered newest-first.
+CREATE INDEX idx_intel_events_recent
+    ON host_intelligence_events (detected_at DESC);
+
+-- Common query: events for a single host of a specific code, e.g. all
+-- "account.user.locked" events for host X in the last 24h.
+CREATE INDEX idx_intel_events_host_code
+    ON host_intelligence_events (host_id, event_code, occurred_at DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_intel_events_host_code;
+DROP INDEX IF EXISTS idx_intel_events_recent;
+DROP TABLE IF EXISTS host_intelligence_events;
+DROP TABLE IF EXISTS host_intelligence_state;

--- a/app/internal/eventbus/bus_test.go
+++ b/app/internal/eventbus/bus_test.go
@@ -249,15 +249,17 @@ func TestSubscribe_TinyBuffer_DropsAfterFull(t *testing.T) {
 // frozen at any particular version.
 func TestEventKindEnum_HasExactlyTwoValues(t *testing.T) {
 	t.Run("system-event-bus/AC-07", func(t *testing.T) {
-		// Closed set: v1.0 HeartbeatPulse + DriftDetected; v1.1 added
-		// HostChanged + MonitoringBandChanged for the SSE layer;
-		// HostDiscovered added by system-host-discovery PR 1.1.
+		// Closed set: HeartbeatPulse + DriftDetected (v1.0),
+		// HostChanged + MonitoringBandChanged (v1.1 SSE layer),
+		// HostDiscovered (system-host-discovery PR 1.1),
+		// IntelligenceEvent (system-os-intelligence PR 1.2).
 		expected := map[EventKind]bool{
 			EventKindHeartbeatPulse:        false,
 			EventKindDriftDetected:         false,
 			EventKindHostChanged:           false,
 			EventKindMonitoringBandChanged: false,
 			EventKindHostDiscovered:        false,
+			EventKindIntelligenceEvent:     false,
 		}
 		if len(AllEventKinds) != len(expected) {
 			t.Errorf("AllEventKinds = %d, want %d", len(AllEventKinds), len(expected))

--- a/app/internal/eventbus/types.go
+++ b/app/internal/eventbus/types.go
@@ -36,6 +36,12 @@ const (
 	// on every successful Discover run (one-shot fingerprint on first
 	// contact + on-demand). Spec system-host-discovery AC-11.
 	EventKindHostDiscovered EventKind = "host.discovered"
+
+	// EventKindIntelligenceEvent is emitted by
+	// internal/intelligence/collector per detected change during a
+	// RunCycle. Carries the taxonomy code, severity, and detail. Spec
+	// system-os-intelligence AC-11.
+	EventKindIntelligenceEvent EventKind = "intelligence.event"
 )
 
 // AllEventKinds is the closed set, in registration order. Spec AC-07's
@@ -46,6 +52,7 @@ var AllEventKinds = []EventKind{
 	EventKindHostChanged,
 	EventKindMonitoringBandChanged,
 	EventKindHostDiscovered,
+	EventKindIntelligenceEvent,
 }
 
 // Event is the contract every bus event satisfies. Implementations are
@@ -174,6 +181,23 @@ func (h HostDiscovered) Kind() EventKind { return EventKindHostDiscovered }
 
 // Timestamp satisfies Event.
 func (h HostDiscovered) Timestamp() time.Time { return h.DiscoveredAt }
+
+// IntelligenceEvent is fired by the OS Intelligence collector per
+// detected change. Detail mirrors the taxonomy entry's detail_schema
+// in app/audit/events.yaml.
+type IntelligenceEvent struct {
+	HostID     uuid.UUID
+	Code       string         // taxonomy code, e.g. "system.package.updated"
+	Severity   string         // info|low|medium|high|critical
+	Detail     map[string]any // per-code typed payload
+	OccurredAt time.Time
+}
+
+// Kind satisfies Event.
+func (i IntelligenceEvent) Kind() EventKind { return EventKindIntelligenceEvent }
+
+// Timestamp satisfies Event.
+func (i IntelligenceEvent) Timestamp() time.Time { return i.OccurredAt }
 
 // DefaultBufferSize is the per-subscriber channel buffer when
 // SubscribeOptions.BufferSize is zero. Spec C-04.

--- a/app/internal/intelligence/collector/collector.go
+++ b/app/internal/intelligence/collector/collector.go
@@ -1,0 +1,472 @@
+package collector
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/correlation"
+	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SSHTransport is the seam the collector uses for SSH I/O. Same shape
+// as discovery.SSHTransport; duplicated here so collector doesn't
+// import discovery (which would import internal/credential — fine in
+// production, but avoiding cross-imports between sibling intelligence
+// subpackages keeps the dependency graph readable).
+type SSHTransport interface {
+	Dial(ctx context.Context, host string, port int, cred *credential.Credential) (SSHSession, error)
+}
+
+// SSHSession is one live session against a remote host.
+type SSHSession interface {
+	Run(ctx context.Context, cmd string) (stdout []byte, exitCode int, err error)
+	Close() error
+}
+
+// HostLookup is the seam for reading host connection facts. Production
+// uses an adapter over pgxpool; tests stub directly.
+type HostLookup interface {
+	GetForIntelligence(ctx context.Context, hostID uuid.UUID) (Addr, error)
+}
+
+// Addr is the host:port tuple.
+type Addr struct {
+	Host string
+	Port int
+}
+
+// AuditEmitFunc is the audit emission seam.
+type AuditEmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
+
+// Publisher is the eventbus subset used by collector. *eventbus.Bus
+// satisfies it; tests inject a recorder.
+type Publisher interface {
+	Publish(ctx context.Context, event eventbus.Event)
+}
+
+// Service is the OS Intelligence collector. Construct via NewService.
+type Service struct {
+	pool      *pgxpool.Pool
+	credSvc   *credential.Service
+	emit      AuditEmitFunc
+	bus       Publisher
+	lookup    HostLookup
+	transport SSHTransport
+}
+
+// NewService constructs a Service. emit + bus may be nil — RunCycle
+// degrades gracefully (skips audit / publish on nil).
+func NewService(pool *pgxpool.Pool, emit AuditEmitFunc, bus Publisher) *Service {
+	return &Service{pool: pool, emit: emit, bus: bus}
+}
+
+// WithSSHTransport overrides the SSH transport (tests).
+func (s *Service) WithSSHTransport(t SSHTransport) *Service {
+	s.transport = t
+	return s
+}
+
+// WithCredentialService wires the credential resolver.
+func (s *Service) WithCredentialService(c *credential.Service) *Service {
+	s.credSvc = c
+	return s
+}
+
+// WithHostLookup wires the host-row reader.
+func (s *Service) WithHostLookup(h HostLookup) *Service {
+	s.lookup = h
+	return s
+}
+
+// hostFacts is the internal hand-off used by runCycleWithTransport so
+// tests can build it directly. cred can be nil when the stub transport
+// ignores credentials.
+type hostFacts struct {
+	HostID uuid.UUID
+	Addr   string
+	Port   int
+	Cred   *credential.Credential
+}
+
+// PoolHostLookup is the production HostLookup. Reads addr + port from
+// the hosts table.
+type PoolHostLookup struct {
+	Pool *pgxpool.Pool
+}
+
+// GetForIntelligence returns the host's address + port. ErrHostNotFound
+// when the host is missing or soft-deleted.
+func (p PoolHostLookup) GetForIntelligence(ctx context.Context, hostID uuid.UUID) (Addr, error) {
+	const q = `
+		SELECT host(ip_address), COALESCE(port, 22)
+		  FROM hosts
+		 WHERE id = $1 AND deleted_at IS NULL`
+	var addr Addr
+	if err := p.Pool.QueryRow(ctx, q, hostID).Scan(&addr.Host, &addr.Port); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Addr{}, ErrHostNotFound
+		}
+		return Addr{}, fmt.Errorf("collector: lookup host: %w", err)
+	}
+	return addr, nil
+}
+
+// ErrHostNotFound is returned when the host id is unknown or
+// soft-deleted.
+var ErrHostNotFound = errors.New("collector: host not found")
+
+// RunCycle runs one Intelligence cycle for hostID. Resolves credential,
+// opens ONE SSH session, runs the probe batch, parses, diffs against
+// the prior snapshot, appends event rows, UPSERTs the new snapshot,
+// publishes per-change bus events, and emits per-code audit events.
+//
+// Returns the diff list on success. Failure to load the prior snapshot
+// is treated as "first ever run" — current vs empty Snapshot gives a
+// full "everything is new" diff which is suppressed by AC-13 logic
+// (services/users that didn't exist before don't emit).
+func (s *Service) RunCycle(ctx context.Context, hostID uuid.UUID) ([]Event, error) {
+	if s.lookup == nil {
+		return nil, errors.New("collector: host lookup not wired")
+	}
+	if s.credSvc == nil {
+		return nil, errors.New("collector: credential service not wired")
+	}
+	addr, err := s.lookup.GetForIntelligence(ctx, hostID)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := s.credSvc.Resolve(ctx, hostID)
+	if err != nil {
+		return nil, fmt.Errorf("collector: resolve credential: %w", err)
+	}
+	hf := hostFacts{
+		HostID: hostID,
+		Addr:   addr.Host,
+		Port:   addr.Port,
+		Cred:   cred,
+	}
+
+	snapshot, err := s.runCycleWithTransport(ctx, hf)
+	if err != nil {
+		return nil, err
+	}
+
+	prior, err := s.loadPriorSnapshot(ctx, hostID)
+	if err != nil {
+		return nil, err
+	}
+
+	events := Diff(prior, snapshot)
+	if err := s.persist(ctx, hostID, snapshot, events); err != nil {
+		return nil, err
+	}
+	corrID, _ := correlation.From(ctx)
+	for _, ev := range events {
+		s.publishEvent(ctx, hostID, ev)
+		s.emitAuditFor(ctx, hostID, ev, corrID)
+	}
+	return events, nil
+}
+
+// runCycleWithTransport opens one SSH session and runs the probe batch.
+// Pure: no DB, no audit, no bus. The transport seam lets tests assert
+// AC-09 (one dial per call) and AC-10 (partial success on sudo failure).
+func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snapshot, error) {
+	if s.transport == nil {
+		return Snapshot{}, errors.New("collector: ssh transport not wired")
+	}
+	sess, err := s.transport.Dial(ctx, hf.Addr, hf.Port, hf.Cred)
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("collector: dial: %w", err)
+	}
+	defer sess.Close()
+
+	snap := Snapshot{CollectedAt: time.Now().UTC()}
+
+	if out, code, err := sess.Run(ctx, "cat /etc/passwd"); err == nil && code == 0 {
+		if shadow, scode, serr := sess.Run(ctx, "sudo -n cat /etc/shadow"); serr == nil && scode == 0 {
+			af, _ := ParsePasswdShadow(out, shadow)
+			snap.Users = af.Users
+		} else {
+			af, _ := ParsePasswdShadow(out, nil)
+			snap.Users = af.Users
+		}
+	}
+
+	if out, code, err := sess.Run(ctx, "getent group"); err == nil && code == 0 {
+		snap.Groups = parseGroupOutput(out)
+	}
+
+	if out, code, err := sess.Run(ctx, "ss -tln"); err == nil && code == 0 {
+		ports, _ := ParseListeningPorts(out)
+		snap.ListeningPorts = ports
+	}
+
+	if out, code, err := sess.Run(ctx, "rpm -qa --queryformat='%{NAME} %{VERSION}-%{RELEASE}\\n' 2>/dev/null || dpkg -l 2>/dev/null"); err == nil && code == 0 {
+		pkgs, _ := ParseInstalledPackages(out)
+		snap.Packages = pkgs
+	}
+
+	if out, code, err := sess.Run(ctx, "systemctl list-units --type=service --all --no-legend --plain"); err == nil && code == 0 {
+		snap.Services = parseSystemctlUnits(out)
+	}
+
+	if out, code, err := sess.Run(ctx, "uname -r"); err == nil && code == 0 {
+		snap.KernelRelease = strings.TrimSpace(string(out))
+	}
+
+	// Reboot marker — present on Debian-family; some RHEL setups expose
+	// it differently but the marker file is the canonical signal.
+	if _, code, _ := sess.Run(ctx, "test -f /var/run/reboot-required || test -f /run/reboot-required"); code == 0 {
+		snap.RebootRequired = true
+	}
+
+	if out, code, err := sess.Run(ctx, "cat /proc/uptime"); err == nil && code == 0 {
+		snap.UptimeSeconds = parseUptime(out)
+	}
+
+	if out, code, err := sess.Run(ctx, "cat /proc/mounts"); err == nil && code == 0 {
+		snap.Mountpoints = parseProcMounts(out)
+	}
+
+	// Config hashes — small fixed set. sha256 keeps the JSONB short.
+	snap.ConfigHashes = map[string]string{}
+	for _, path := range []string{"/etc/sudoers", "/etc/ssh/sshd_config", "/etc/passwd", "/etc/shadow"} {
+		// sha256sum needs read perms; /etc/shadow needs sudo. Failures
+		// (sudo denied) silently drop the entry — partial success.
+		var cmd string
+		if path == "/etc/shadow" {
+			cmd = "sudo -n sha256sum " + path
+		} else {
+			cmd = "sha256sum " + path
+		}
+		if out, code, err := sess.Run(ctx, cmd); err == nil && code == 0 {
+			h := strings.Fields(string(out))
+			if len(h) >= 1 {
+				snap.ConfigHashes[path] = h[0]
+			}
+		}
+	}
+
+	return snap, nil
+}
+
+// loadPriorSnapshot reads the prior cycle's snapshot from
+// host_intelligence_state. Missing row → empty Snapshot.
+func (s *Service) loadPriorSnapshot(ctx context.Context, hostID uuid.UUID) (Snapshot, error) {
+	if s.pool == nil {
+		return Snapshot{}, nil
+	}
+	var raw []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT snapshot FROM host_intelligence_state WHERE host_id = $1`,
+		hostID,
+	).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Snapshot{}, nil
+		}
+		return Snapshot{}, fmt.Errorf("collector: load prior: %w", err)
+	}
+	var snap Snapshot
+	if uerr := json.Unmarshal(raw, &snap); uerr != nil {
+		return Snapshot{}, fmt.Errorf("collector: decode prior: %w", uerr)
+	}
+	return snap, nil
+}
+
+// persist UPSERTs host_intelligence_state AND appends event rows in
+// ONE transaction. Spec C-03 + C-04.
+func (s *Service) persist(ctx context.Context, hostID uuid.UUID, snap Snapshot, events []Event) error {
+	if s.pool == nil {
+		return errors.New("collector: db pool not wired")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("collector: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("collector: encode snapshot: %w", err)
+	}
+	// Spec C-03: UPSERT keyed by host_id.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO host_intelligence_state (host_id, snapshot, collected_at, created_at, updated_at)
+		VALUES ($1, $2, $3, now(), now())
+		ON CONFLICT (host_id) DO UPDATE SET
+			snapshot     = EXCLUDED.snapshot,
+			collected_at = EXCLUDED.collected_at,
+			updated_at   = now()`,
+		hostID, raw, snap.CollectedAt,
+	); err != nil {
+		return fmt.Errorf("collector: upsert state: %w", err)
+	}
+
+	// Spec C-04 + AC-14: append event rows, ignoring duplicates per
+	// UNIQUE (host_id, event_code, occurred_at). ON CONFLICT DO NOTHING
+	// keeps the cycle idempotent.
+	corrID, _ := correlation.From(ctx)
+	for _, ev := range events {
+		// Hash the detail to produce a stable occurred_at-equivalent
+		// timestamp; we don't have host-side timestamps for the change
+		// so we use the snapshot collected_at as the canonical
+		// occurred_at and let the UNIQUE constraint dedupe.
+		detail, _ := json.Marshal(ev.Detail)
+		_, err := tx.Exec(ctx, `
+			INSERT INTO host_intelligence_events
+				(id, host_id, event_code, severity, detail, occurred_at, detected_at, correlation_id)
+			VALUES ($1, $2, $3, $4, $5, $6, now(), $7)
+			ON CONFLICT (host_id, event_code, occurred_at) DO NOTHING`,
+			uuid.Must(uuid.NewV7()), hostID, string(ev.Code), ev.Severity,
+			detail, snap.CollectedAt, corrID,
+		)
+		if err != nil {
+			return fmt.Errorf("collector: insert event %s: %w", ev.Code, err)
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// publishEvent dispatches an IntelligenceEvent to the bus.
+func (s *Service) publishEvent(ctx context.Context, hostID uuid.UUID, ev Event) {
+	if s.bus == nil {
+		return
+	}
+	s.bus.Publish(ctx, eventbus.IntelligenceEvent{
+		HostID:     hostID,
+		Code:       string(ev.Code),
+		Severity:   ev.Severity,
+		Detail:     ev.Detail,
+		OccurredAt: time.Now().UTC(),
+	})
+}
+
+// emitAuditFor emits the audit event whose code matches the taxonomy
+// entry. The audit codegen has registered each code as an audit.Code
+// const; we look it up via the string-keyed Metadata map at call time
+// so we don't have to hand-write a 28-case switch.
+func (s *Service) emitAuditFor(ctx context.Context, hostID uuid.UUID, ev Event, corrID string) {
+	if s.emit == nil {
+		return
+	}
+	code := audit.Code(ev.Code)
+	if _, ok := audit.Metadata[code]; !ok {
+		return // unknown code — should be caught by AC-02, defensive only
+	}
+	s.emit(ctx, code, audit.Event{
+		CorrelationID: corrID,
+		ResourceType:  "host",
+		ResourceID:    hostID.String(),
+		Outcome:       audit.OutcomeSuccess,
+		Detail:        audit.MakeDetail(ev.Detail),
+	})
+}
+
+// ---- helpers ---------------------------------------------------------------
+
+// parseGroupOutput parses `getent group` (group:passwd:gid:members).
+func parseGroupOutput(b []byte) map[string][]string {
+	out := map[string][]string{}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, ":")
+		if len(fields) < 4 {
+			continue
+		}
+		name := fields[0]
+		members := strings.Split(fields[3], ",")
+		// Drop empty member.
+		cleaned := make([]string, 0, len(members))
+		for _, m := range members {
+			if m = strings.TrimSpace(m); m != "" {
+				cleaned = append(cleaned, m)
+			}
+		}
+		out[name] = cleaned
+	}
+	return out
+}
+
+// parseSystemctlUnits parses `systemctl list-units --type=service`.
+// Each line: "name.service  loaded active running description"
+func parseSystemctlUnits(b []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		unit, active := fields[0], fields[2]
+		out[unit] = active
+	}
+	return out
+}
+
+// parseUptime parses /proc/uptime ("uptime_seconds idle_seconds").
+func parseUptime(b []byte) int64 {
+	fields := strings.Fields(string(b))
+	if len(fields) == 0 {
+		return 0
+	}
+	// uptime is float; truncate to int. We don't care about the fractional second.
+	parts := strings.Split(fields[0], ".")
+	if len(parts) == 0 {
+		return 0
+	}
+	var n int64
+	for _, c := range parts[0] {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int64(c-'0')
+	}
+	return n
+}
+
+// parseProcMounts parses /proc/mounts (source mountpoint fstype options 0 0).
+func parseProcMounts(b []byte) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		out[fields[1]] = fields[0]
+	}
+	return out
+}
+
+// hashBytes is a small helper for callers that need to compute a
+// content hash on parsed snapshot fields. Currently unused at the
+// service level (config hashes are computed remotely via sha256sum)
+// but kept handy for the future detail-hash idempotency story.
+func hashBytes(b []byte) string {
+	h := sha256.Sum256(b)
+	return hex.EncodeToString(h[:])
+}
+
+var _ = hashBytes // silence unused-warning until we wire it

--- a/app/internal/intelligence/collector/collector_db_test.go
+++ b/app/internal/intelligence/collector/collector_db_test.go
@@ -1,0 +1,168 @@
+// @spec system-os-intelligence
+//
+// AC traceability (this file):
+//
+//	AC-11  TestRunCycle_PublishesIntelligenceEventsOnBus
+//	AC-12  TestRunCycle_EmitsAuditPerTaxonomyCode
+
+package collector
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/identity"
+	"github.com/Hanalyx/openwatch/internal/secretkey"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func collectorTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run collector integration tests")
+	}
+	return dsn
+}
+
+func freshDBCollector(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Service) {
+	t.Helper()
+	dsn := collectorTestDSN(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	pool, err := db.NewPool(ctx, dsn, 5)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := migrations.Apply(ctx, pool); err != nil {
+		t.Fatalf("migrations.Apply: %v", err)
+	}
+	if err := secretkey.SetEphemeral(); err != nil {
+		t.Fatalf("SetEphemeral: %v", err)
+	}
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_events")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_state")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE credentials")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
+
+	createdBy, _ := uuid.NewV7()
+	hash, _ := identity.HashPassword("seed-pw-12345-aa")
+	_, err = pool.Exec(ctx,
+		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
+		createdBy, "intel-creator", "intel@example.com", hash)
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	hostID, _ := uuid.NewV7()
+	_, err = pool.Exec(ctx,
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, $3::inet, $4)`,
+		hostID, "intel-host-"+hostID.String()[:8], "192.0.2.20", createdBy)
+	if err != nil {
+		t.Fatalf("seed host: %v", err)
+	}
+	credSvc := credential.NewService(pool)
+	_, err = credSvc.NewCredential(ctx, credential.NewParams{
+		Scope:      credential.ScopeSystem,
+		Name:       "default-intel",
+		Username:   "admin",
+		AuthMethod: credential.AuthPassword,
+		Password:   "test-password",
+		IsDefault:  true,
+		CreatedBy:  createdBy,
+	})
+	if err != nil {
+		t.Fatalf("seed system default credential: %v", err)
+	}
+	return pool, hostID, credSvc
+}
+
+// @ac AC-11
+// AC-11: Successful RunCycle publishes EventKindIntelligenceEvent
+// per detected change. The first-ever cycle generates a "new" set of
+// detections (services and users aren't first-time-emitters per the
+// Diff suppression rule, but packages and listening ports are).
+func TestRunCycle_PublishesIntelligenceEventsOnBus(t *testing.T) {
+	t.Run("system-os-intelligence/AC-11", func(t *testing.T) {
+		pool, hostID, credSvc := freshDBCollector(t)
+
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+
+		bus := newStubBus()
+		svc := NewService(pool, audit.Emit, bus).
+			WithHostLookup(PoolHostLookup{Pool: pool}).
+			WithCredentialService(credSvc).
+			WithSSHTransport(stub)
+
+		_, err := svc.RunCycle(context.Background(), hostID)
+		if err != nil {
+			t.Fatalf("RunCycle: %v", err)
+		}
+		if !bus.Saw(eventbus.EventKindIntelligenceEvent) {
+			t.Errorf("eventbus did not receive intelligence.event after RunCycle")
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: Per detected change, the service emits exactly one audit
+// event with a Code matching the taxonomy. We verify by counting
+// rows in audit_events whose action matches taxonomy codes.
+func TestRunCycle_EmitsAuditPerTaxonomyCode(t *testing.T) {
+	t.Run("system-os-intelligence/AC-12", func(t *testing.T) {
+		pool, hostID, credSvc := freshDBCollector(t)
+
+		// Start the audit writer so audit.Emit calls land in audit_events.
+		audit.Init(audit.NewStore(pool), audit.WriterOptions{
+			ChannelBuffer: 256, BatchSize: 50, FlushInterval: 20 * time.Millisecond,
+		})
+		t.Cleanup(func() { audit.Shutdown(2 * time.Second) })
+
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+
+		svc := NewService(pool, audit.Emit, nil).
+			WithHostLookup(PoolHostLookup{Pool: pool}).
+			WithCredentialService(credSvc).
+			WithSSHTransport(stub)
+
+		events, err := svc.RunCycle(context.Background(), hostID)
+		if err != nil {
+			t.Fatalf("RunCycle: %v", err)
+		}
+		if len(events) == 0 {
+			t.Skip("first-ever cycle suppressed all changes — taxonomy-emit path not exercised this run")
+		}
+
+		// Allow the async audit writer to flush.
+		time.Sleep(100 * time.Millisecond)
+
+		// Count audit rows whose action matches one of the events we
+		// emitted. Every change MUST yield exactly one row.
+		for _, ev := range events {
+			var count int
+			err := pool.QueryRow(context.Background(),
+				`SELECT COUNT(*) FROM audit_events
+				   WHERE action = $1 AND resource_id = $2`,
+				string(ev.Code), hostID.String()).Scan(&count)
+			if err != nil {
+				t.Fatalf("count audit rows for %s: %v", ev.Code, err)
+			}
+			if count == 0 {
+				t.Errorf("audit row missing for taxonomy code %q (host %s)",
+					ev.Code, hostID)
+			}
+		}
+	})
+}

--- a/app/internal/intelligence/collector/collector_test.go
+++ b/app/internal/intelligence/collector/collector_test.go
@@ -1,0 +1,138 @@
+// @spec system-os-intelligence
+//
+// AC traceability (this file):
+//
+//	AC-09  TestRunCycle_OneSSHDialPerCall
+//	AC-10  TestRunCycle_SudoFailureIsPartialSuccess
+//	AC-14  TestPersist_OnConflictDoesNotDuplicate
+//	AC-15  TestMigration_HasClosedEnumCheckOnEventCode
+
+package collector
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// @ac AC-09
+// AC-09: runCycleWithTransport opens EXACTLY ONE ssh.Dial per call.
+func TestRunCycle_OneSSHDialPerCall(t *testing.T) {
+	t.Run("system-os-intelligence/AC-09", func(t *testing.T) {
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+
+		svc := NewService(nil, nil, nil).WithSSHTransport(stub)
+		_, err := svc.runCycleWithTransport(testCtx(t), testHostFacts())
+		if err != nil {
+			t.Fatalf("runCycleWithTransport: %v", err)
+		}
+		if stub.DialCount() != 1 {
+			t.Errorf("ssh.Dial called %d times, want 1 (one session per cycle)", stub.DialCount())
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: sudo failure on probe sub-commands (sha256sum /etc/shadow,
+// sudo -n cat /etc/shadow) keeps the cycle returning nil + partial
+// snapshot. Non-sudo categories still populate.
+func TestRunCycle_SudoFailureIsPartialSuccess(t *testing.T) {
+	t.Run("system-os-intelligence/AC-10", func(t *testing.T) {
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+		stub.FailCommand("sudo -n cat /etc/shadow", "Permission denied", 1)
+		stub.FailCommand("sudo -n sha256sum /etc/shadow", "Permission denied", 1)
+
+		svc := NewService(nil, nil, nil).WithSSHTransport(stub)
+		snap, err := svc.runCycleWithTransport(testCtx(t), testHostFacts())
+		if err != nil {
+			t.Fatalf("partial-success cycle returned error: %v", err)
+		}
+		// Non-sudo data populated.
+		if snap.KernelRelease == "" {
+			t.Errorf("KernelRelease empty — uname needs no sudo")
+		}
+		if len(snap.Packages) == 0 {
+			t.Errorf("Packages empty — rpm/dpkg needs no sudo")
+		}
+		// /etc/shadow hash MUST NOT be present (sudo denied).
+		if _, has := snap.ConfigHashes["/etc/shadow"]; has {
+			t.Errorf("/etc/shadow hash recorded despite sudo failure")
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: source inspection — the events INSERT MUST use ON CONFLICT
+// (host_id, event_code, occurred_at) DO NOTHING so retried RunCycles
+// don't double-insert.
+func TestPersist_OnConflictDoesNotDuplicate(t *testing.T) {
+	t.Run("system-os-intelligence/AC-14", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		src, err := os.ReadFile(filepath.Join(filepath.Dir(file), "collector.go"))
+		if err != nil {
+			t.Fatalf("read collector.go: %v", err)
+		}
+		s := string(src)
+		if !strings.Contains(s, "ON CONFLICT (host_id, event_code, occurred_at) DO NOTHING") {
+			t.Errorf("persist() events INSERT must carry ON CONFLICT (host_id, event_code, occurred_at) DO NOTHING — idempotency under retry guaranteed by the constraint")
+		}
+	})
+}
+
+// @ac AC-15
+// AC-15: migration 0018 carries a CHECK clause enumerating every
+// taxonomy code. Source inspection: the file contains a CHECK on
+// event_code AND every code in taxonomyCodes appears in the CHECK list.
+func TestMigration_HasClosedEnumCheckOnEventCode(t *testing.T) {
+	t.Run("system-os-intelligence/AC-15", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		// Walk up to app/internal/db/migrations.
+		dir := filepath.Dir(file)
+		var migPath string
+		for i := 0; i < 8; i++ {
+			cand := filepath.Join(dir, "db", "migrations", "0018_host_intelligence.sql")
+			if _, err := os.Stat(cand); err == nil {
+				migPath = cand
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+		if migPath == "" {
+			t.Fatalf("could not locate migration 0018")
+		}
+		src, err := os.ReadFile(migPath)
+		if err != nil {
+			t.Fatalf("read migration: %v", err)
+		}
+		s := string(src)
+		if !strings.Contains(s, "CHECK (event_code IN (") {
+			t.Errorf("migration 0018 missing CHECK on event_code — closed enum invariant unenforced at DB")
+		}
+		for _, code := range Codes() {
+			if !strings.Contains(s, "'"+string(code)+"'") {
+				t.Errorf("migration 0018 CHECK is missing taxonomy code %q", code)
+			}
+		}
+	})
+}
+
+// @ac AC-11 (sanity — exercised end-to-end by collector_db_test.go)
+// @ac AC-12 (sanity — exercised end-to-end by collector_db_test.go)
+// publishEvent + emitAuditFor exercised here without DB so the unit
+// tests catch logic regressions even if the integration tests can't
+// run (no OPENWATCH_TEST_DSN).
+func TestPublishAndAudit_NilBusOrEmit_NoPanic(t *testing.T) {
+	svc := NewService(nil, nil, nil)
+	svc.publishEvent(context.Background(), testHostFacts().HostID, Event{
+		Code: CodeSystemPackageUpdated, Severity: "info",
+		Detail: map[string]any{"name": "openssh"},
+	})
+	svc.emitAuditFor(context.Background(), testHostFacts().HostID,
+		Event{Code: CodeSystemPackageUpdated, Severity: "info",
+			Detail: map[string]any{"name": "openssh"}}, "test-corr-id")
+}

--- a/app/internal/intelligence/collector/diff.go
+++ b/app/internal/intelligence/collector/diff.go
@@ -1,0 +1,270 @@
+package collector
+
+// Diff returns the ordered list of Events the (prior, current)
+// snapshot pair should emit. Pure function: no side effects.
+//
+// Detection order: packages, listening ports, group memberships,
+// users, services, mountpoints, kernel, reboot state, config hashes.
+// Spec AC-06, AC-07, AC-08, AC-13 enforce specific patterns.
+//
+// The "privileged groups" set is locked here — wheel + sudo + admin.
+// Future per-deployment groups (e.g., "developers") that should be
+// privileged-tracked land in policy, not in this set.
+var privilegedGroups = map[string]bool{
+	"wheel": true,
+	"sudo":  true,
+	"admin": true,
+}
+
+// Diff returns the list of changes between prior and current. Order
+// of returned events follows the detection order above so a stable
+// audit trail emerges from a stable snapshot pair.
+func Diff(prior, current Snapshot) []Event {
+	var events []Event
+
+	// --- Packages -----------------------------------------------------------
+	for name, currentVersion := range current.Packages {
+		priorVersion, was := prior.Packages[name]
+		switch {
+		case !was:
+			events = append(events, Event{
+				Code:     CodeSystemPackageInstalled,
+				Severity: "info",
+				Detail:   map[string]any{"name": name, "version": currentVersion},
+			})
+		case priorVersion != currentVersion:
+			events = append(events, Event{
+				Code:     CodeSystemPackageUpdated,
+				Severity: "info",
+				Detail: map[string]any{
+					"name":    name,
+					"prior":   priorVersion,
+					"current": currentVersion,
+				},
+			})
+		}
+	}
+	for name := range prior.Packages {
+		if _, still := current.Packages[name]; !still {
+			events = append(events, Event{
+				Code:     CodeSystemPackageRemoved,
+				Severity: "warning",
+				Detail:   map[string]any{"name": name},
+			})
+		}
+	}
+
+	// --- Listening ports ---------------------------------------------------
+	priorPorts := portSet(prior.ListeningPorts)
+	for _, p := range current.ListeningPorts {
+		key := portKey(p)
+		if !priorPorts[key] {
+			events = append(events, Event{
+				Code:     CodeSecurityPortOpened,
+				Severity: "high",
+				Detail: map[string]any{
+					"port":     p.Port,
+					"protocol": p.Protocol,
+				},
+			})
+		}
+	}
+
+	// --- Privileged group additions ----------------------------------------
+	for group, members := range current.Groups {
+		if !privilegedGroups[group] {
+			continue
+		}
+		priorSet := stringSet(prior.Groups[group])
+		for _, user := range members {
+			if !priorSet[user] {
+				events = append(events, Event{
+					Code:     CodeAccountUserPrivilegedGroupAdd,
+					Severity: "critical",
+					Detail:   map[string]any{"user": user, "group": group},
+				})
+			}
+		}
+	}
+
+	// --- Users: lock + new + deleted ---------------------------------------
+	for name, u := range current.Users {
+		prev, had := prior.Users[name]
+		switch {
+		case !had:
+			events = append(events, Event{
+				Code:     CodeAccountUserCreated,
+				Severity: "warning",
+				Detail:   map[string]any{"user": name, "uid": u.UID},
+			})
+		case !prev.Locked && u.Locked:
+			events = append(events, Event{
+				Code:     CodeAccountUserLocked,
+				Severity: "warning",
+				Detail:   map[string]any{"user": name},
+			})
+		case prev.Locked && !u.Locked:
+			events = append(events, Event{
+				Code:     CodeAccountUserUnlocked,
+				Severity: "info",
+				Detail:   map[string]any{"user": name},
+			})
+		}
+	}
+	for name := range prior.Users {
+		if _, still := current.Users[name]; !still {
+			events = append(events, Event{
+				Code:     CodeAccountUserDeleted,
+				Severity: "warning",
+				Detail:   map[string]any{"user": name},
+			})
+		}
+	}
+
+	// --- Services ----------------------------------------------------------
+	for unit, state := range current.Services {
+		prevState, had := prior.Services[unit]
+		if !had {
+			continue // first-seen services don't emit; would be too noisy
+		}
+		if prevState == state {
+			continue
+		}
+		switch state {
+		case "active":
+			events = append(events, Event{
+				Code:     CodeSystemServiceStarted,
+				Severity: "info",
+				Detail:   map[string]any{"unit": unit},
+			})
+		case "inactive":
+			events = append(events, Event{
+				Code:     CodeSystemServiceStopped,
+				Severity: "info",
+				Detail:   map[string]any{"unit": unit},
+			})
+		case "failed":
+			events = append(events, Event{
+				Code:     CodeSystemServiceFailed,
+				Severity: "high",
+				Detail:   map[string]any{"unit": unit},
+			})
+		}
+	}
+
+	// --- Filesystem --------------------------------------------------------
+	for mp, source := range current.Mountpoints {
+		if _, had := prior.Mountpoints[mp]; !had {
+			events = append(events, Event{
+				Code:     CodeSystemFilesystemMounted,
+				Severity: "info",
+				Detail:   map[string]any{"mountpoint": mp, "source": source},
+			})
+		}
+	}
+	for mp := range prior.Mountpoints {
+		if _, still := current.Mountpoints[mp]; !still {
+			events = append(events, Event{
+				Code:     CodeSystemFilesystemUnmounted,
+				Severity: "warning",
+				Detail:   map[string]any{"mountpoint": mp},
+			})
+		}
+	}
+
+	// --- Kernel ------------------------------------------------------------
+	if prior.KernelRelease != "" && current.KernelRelease != "" &&
+		prior.KernelRelease != current.KernelRelease {
+		events = append(events, Event{
+			Code:     CodeSystemKernelUpdated,
+			Severity: "warning",
+			Detail: map[string]any{
+				"prior":   prior.KernelRelease,
+				"current": current.KernelRelease,
+			},
+		})
+	}
+
+	// --- Reboot state ------------------------------------------------------
+	if !prior.RebootRequired && current.RebootRequired {
+		events = append(events, Event{
+			Code:     CodeSystemRebootRequired,
+			Severity: "warning",
+			Detail:   map[string]any{},
+		})
+	}
+	// Uptime fell below prior cycle's value → reboot completed.
+	if prior.UptimeSeconds > 0 && current.UptimeSeconds > 0 &&
+		current.UptimeSeconds+10 < prior.UptimeSeconds {
+		events = append(events, Event{
+			Code:     CodeSystemRebootCompleted,
+			Severity: "info",
+			Detail: map[string]any{
+				"prior_uptime":   prior.UptimeSeconds,
+				"current_uptime": current.UptimeSeconds,
+			},
+		})
+	}
+
+	// --- Config hashes -----------------------------------------------------
+	for path, currHash := range current.ConfigHashes {
+		priorHash, had := prior.ConfigHashes[path]
+		if had && priorHash != currHash {
+			events = append(events, Event{
+				Code:     CodeSystemConfigChanged,
+				Severity: "high",
+				Detail: map[string]any{
+					"path":         path,
+					"prior_hash":   priorHash,
+					"current_hash": currHash,
+				},
+			})
+		}
+	}
+
+	return events
+}
+
+func portKey(p ListeningPort) string {
+	return p.Protocol + "|" + p.Address + "|" + strconvItoa(p.Port)
+}
+
+func portSet(ports []ListeningPort) map[string]bool {
+	out := make(map[string]bool, len(ports))
+	for _, p := range ports {
+		out[portKey(p)] = true
+	}
+	return out
+}
+
+func stringSet(xs []string) map[string]bool {
+	out := make(map[string]bool, len(xs))
+	for _, x := range xs {
+		out[x] = true
+	}
+	return out
+}
+
+// strconvItoa avoids an import-cycle in tests where a hot helper is
+// needed. Equivalent to strconv.Itoa for small int values.
+func strconvItoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/app/internal/intelligence/collector/diff.go
+++ b/app/internal/intelligence/collector/diff.go
@@ -48,7 +48,7 @@ func Diff(prior, current Snapshot) []Event {
 		if _, still := current.Packages[name]; !still {
 			events = append(events, Event{
 				Code:     CodeSystemPackageRemoved,
-				Severity: "warning",
+				Severity: "medium",
 				Detail:   map[string]any{"name": name},
 			})
 		}
@@ -94,13 +94,13 @@ func Diff(prior, current Snapshot) []Event {
 		case !had:
 			events = append(events, Event{
 				Code:     CodeAccountUserCreated,
-				Severity: "warning",
+				Severity: "medium",
 				Detail:   map[string]any{"user": name, "uid": u.UID},
 			})
 		case !prev.Locked && u.Locked:
 			events = append(events, Event{
 				Code:     CodeAccountUserLocked,
-				Severity: "warning",
+				Severity: "medium",
 				Detail:   map[string]any{"user": name},
 			})
 		case prev.Locked && !u.Locked:
@@ -115,7 +115,7 @@ func Diff(prior, current Snapshot) []Event {
 		if _, still := current.Users[name]; !still {
 			events = append(events, Event{
 				Code:     CodeAccountUserDeleted,
-				Severity: "warning",
+				Severity: "medium",
 				Detail:   map[string]any{"user": name},
 			})
 		}
@@ -166,7 +166,7 @@ func Diff(prior, current Snapshot) []Event {
 		if _, still := current.Mountpoints[mp]; !still {
 			events = append(events, Event{
 				Code:     CodeSystemFilesystemUnmounted,
-				Severity: "warning",
+				Severity: "medium",
 				Detail:   map[string]any{"mountpoint": mp},
 			})
 		}
@@ -177,7 +177,7 @@ func Diff(prior, current Snapshot) []Event {
 		prior.KernelRelease != current.KernelRelease {
 		events = append(events, Event{
 			Code:     CodeSystemKernelUpdated,
-			Severity: "warning",
+			Severity: "medium",
 			Detail: map[string]any{
 				"prior":   prior.KernelRelease,
 				"current": current.KernelRelease,
@@ -189,7 +189,7 @@ func Diff(prior, current Snapshot) []Event {
 	if !prior.RebootRequired && current.RebootRequired {
 		events = append(events, Event{
 			Code:     CodeSystemRebootRequired,
-			Severity: "warning",
+			Severity: "medium",
 			Detail:   map[string]any{},
 		})
 	}

--- a/app/internal/intelligence/collector/diff_test.go
+++ b/app/internal/intelligence/collector/diff_test.go
@@ -1,0 +1,109 @@
+// @spec system-os-intelligence
+//
+// AC traceability (this file):
+//
+//	AC-06  TestDiff_PackageUpdated
+//	AC-07  TestDiff_PortOpened
+//	AC-08  TestDiff_PrivilegedGroupAdded
+//	AC-13  TestDiff_NoChangesEmitsZeroEvents
+
+package collector
+
+import (
+	"testing"
+)
+
+// @ac AC-06
+// AC-06: package version changed between cycles → one
+// system.package.updated event with prior + current.
+func TestDiff_PackageUpdated(t *testing.T) {
+	t.Run("system-os-intelligence/AC-06", func(t *testing.T) {
+		prior := Snapshot{Packages: map[string]string{"openssh": "9.0"}}
+		current := Snapshot{Packages: map[string]string{"openssh": "9.6"}}
+		events := Diff(prior, current)
+		if len(events) != 1 {
+			t.Fatalf("Diff returned %d events, want 1: %+v", len(events), events)
+		}
+		ev := events[0]
+		if ev.Code != "system.package.updated" {
+			t.Errorf("Diff code=%q, want system.package.updated", ev.Code)
+		}
+		if ev.Detail["name"] != "openssh" {
+			t.Errorf("detail.name=%v, want openssh", ev.Detail["name"])
+		}
+		if ev.Detail["prior"] != "9.0" {
+			t.Errorf("detail.prior=%v, want 9.0", ev.Detail["prior"])
+		}
+		if ev.Detail["current"] != "9.6" {
+			t.Errorf("detail.current=%v, want 9.6", ev.Detail["current"])
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: a new listening port → one security.port.opened. Unchanged
+// ports do NOT emit.
+func TestDiff_PortOpened(t *testing.T) {
+	t.Run("system-os-intelligence/AC-07", func(t *testing.T) {
+		prior := Snapshot{ListeningPorts: []ListeningPort{{Port: 22, Protocol: "tcp"}}}
+		current := Snapshot{ListeningPorts: []ListeningPort{
+			{Port: 22, Protocol: "tcp"},
+			{Port: 443, Protocol: "tcp"},
+		}}
+		events := Diff(prior, current)
+		var portEvents []Event
+		for _, ev := range events {
+			if ev.Code == "security.port.opened" {
+				portEvents = append(portEvents, ev)
+			}
+		}
+		if len(portEvents) != 1 {
+			t.Fatalf("port.opened count=%d, want 1; full events=%+v", len(portEvents), events)
+		}
+		if got, ok := portEvents[0].Detail["port"].(int); !ok || got != 443 {
+			t.Errorf("port.opened detail.port=%v, want 443", portEvents[0].Detail["port"])
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: a user newly in the wheel group → one
+// account.user.privileged_group_added event.
+func TestDiff_PrivilegedGroupAdded(t *testing.T) {
+	t.Run("system-os-intelligence/AC-08", func(t *testing.T) {
+		prior := Snapshot{Groups: map[string][]string{"wheel": {"root"}}}
+		current := Snapshot{Groups: map[string][]string{"wheel": {"root", "alice"}}}
+		events := Diff(prior, current)
+		var added []Event
+		for _, ev := range events {
+			if ev.Code == "account.user.privileged_group_added" {
+				added = append(added, ev)
+			}
+		}
+		if len(added) != 1 {
+			t.Fatalf("privileged_group_added count=%d, want 1; full events=%+v", len(added), events)
+		}
+		if added[0].Detail["user"] != "alice" {
+			t.Errorf("detail.user=%v, want alice", added[0].Detail["user"])
+		}
+		if added[0].Detail["group"] != "wheel" {
+			t.Errorf("detail.group=%v, want wheel", added[0].Detail["group"])
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: identical snapshots → zero events.
+func TestDiff_NoChangesEmitsZeroEvents(t *testing.T) {
+	t.Run("system-os-intelligence/AC-13", func(t *testing.T) {
+		snap := Snapshot{
+			Packages:       map[string]string{"openssh": "9.0"},
+			ListeningPorts: []ListeningPort{{Port: 22, Protocol: "tcp"}},
+			Groups:         map[string][]string{"wheel": {"root"}},
+		}
+		events := Diff(snap, snap)
+		if len(events) != 0 {
+			t.Errorf("Diff on identical snapshots emitted %d events, want 0", len(events))
+		}
+	})
+}

--- a/app/internal/intelligence/collector/doc.go
+++ b/app/internal/intelligence/collector/doc.go
@@ -1,0 +1,42 @@
+// Package collector implements OS Intelligence — the recurring,
+// write-on-change counterpart to OS Discovery.
+//
+// Spec: app/specs/system/os-intelligence.spec.yaml (status: approved).
+//
+// Architectural notes:
+//
+//   - Credential-aware boundary. Like internal/intelligence/discovery
+//     and unlike internal/liveness, collector IS credential-aware: it
+//     imports internal/credential and golang.org/x/crypto/ssh, opens
+//     real SSH sessions, and runs commands that may need sudo. Future
+//     readers should not move credential-free probes here.
+//
+//   - One SSH session per cycle. The probe batch (account, security,
+//     system) runs in one session. Multi-dial is forbidden. Spec C-01
+//     / AC-09 enforce.
+//
+//   - Pure parsers. Each parser takes a single command's raw bytes and
+//     returns a typed struct. No SSH, no DB, no HTTP. Parser tests are
+//     fixture-based.
+//
+//   - Write-on-change. host_intelligence_state holds the LAST snapshot
+//     (UPSERT, no history). host_intelligence_events appends one row
+//     per detected change. Same discipline as Slice B's
+//     transactions + host_rule_state (99.7% write reduction).
+//
+//   - Closed taxonomy. taxonomy.go enumerates ~25 event codes spanning
+//     account, security, system. The migration CHECK and the
+//     audit/events.yaml entries mirror this exactly. Adding a new code
+//     requires touching all three.
+//
+//   - Eventbus + audit on every change. Per-event publish to
+//     EventKindIntelligenceEvent AND emit a per-code audit event. The
+//     alert router subscribes to the bus; auditors trail the audit log.
+//
+// What this package does NOT do:
+//
+//   - The recurring scheduler / cron loop — lands in PR 1.3.
+//   - REST endpoints — lands in PR 1.3.
+//   - Severity-threshold → alert-router promotion — separate
+//     system-alert-router amendment.
+package collector

--- a/app/internal/intelligence/collector/helpers_test.go
+++ b/app/internal/intelligence/collector/helpers_test.go
@@ -1,0 +1,171 @@
+package collector
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/correlation"
+	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/google/uuid"
+)
+
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return correlation.Set(ctx, uuid.NewString())
+}
+
+func testHostFacts() hostFacts {
+	return hostFacts{
+		HostID: uuid.MustParse("00000000-0000-0000-0000-000000000002"),
+		Addr:   "test.local",
+		Port:   22,
+		Cred:   nil,
+	}
+}
+
+// ---- stub SSH transport ---------------------------------------------------
+
+type stubSSHTransport struct {
+	mu        sync.Mutex
+	dialCount atomic.Int64
+	outputs   map[string]stubResult
+	failures  map[string]stubResult
+}
+
+type stubResult struct {
+	out      []byte
+	exitCode int
+	err      error
+}
+
+func newStubSSHTransport() *stubSSHTransport {
+	return &stubSSHTransport{
+		outputs:  map[string]stubResult{},
+		failures: map[string]stubResult{},
+	}
+}
+
+func (s *stubSSHTransport) Dial(_ context.Context, _ string, _ int, _ *credential.Credential) (SSHSession, error) {
+	s.dialCount.Add(1)
+	return &stubSession{parent: s}, nil
+}
+
+func (s *stubSSHTransport) DialCount() int64 { return s.dialCount.Load() }
+
+func (s *stubSSHTransport) FailCommand(cmd, stderr string, exitCode int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failures[cmd] = stubResult{out: []byte(stderr), exitCode: exitCode}
+}
+
+func (s *stubSSHTransport) SeedAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.outputs["cat /etc/passwd"] = stubResult{out: []byte("root:x:0:0:root:/root:/bin/bash\nalice:x:1000:1000:alice:/home/alice:/bin/bash\n"), exitCode: 0}
+	s.outputs["sudo -n cat /etc/shadow"] = stubResult{out: []byte("root:$6$abc:19000:0:99999:7:::\nalice:!!:19500:0:99999:7:::\n"), exitCode: 0}
+	s.outputs["getent group"] = stubResult{out: []byte("root:x:0:root\nwheel:x:10:root,alice\n"), exitCode: 0}
+	s.outputs["ss -tln"] = stubResult{
+		out: []byte("State    Recv-Q   Send-Q     Local Address:Port      Peer Address:Port\nLISTEN   0        128              0.0.0.0:22              0.0.0.0:*\n"),
+		exitCode: 0,
+	}
+	s.outputs["rpm -qa --queryformat='%{NAME} %{VERSION}-%{RELEASE}\\n' 2>/dev/null || dpkg -l 2>/dev/null"] = stubResult{
+		out: []byte("openssh 9.0p1-19\nglibc 2.34-83.el9\n"),
+		exitCode: 0,
+	}
+	s.outputs["systemctl list-units --type=service --all --no-legend --plain"] = stubResult{
+		out: []byte("sshd.service loaded active running OpenSSH server daemon\n"),
+		exitCode: 0,
+	}
+	s.outputs["uname -r"] = stubResult{out: []byte("5.14.0-362.el9.x86_64\n"), exitCode: 0}
+	s.outputs["test -f /var/run/reboot-required || test -f /run/reboot-required"] = stubResult{exitCode: 1}
+	s.outputs["cat /proc/uptime"] = stubResult{out: []byte("123456.78 50000.00\n"), exitCode: 0}
+	s.outputs["cat /proc/mounts"] = stubResult{out: []byte("/dev/sda1 / ext4 rw 0 0\n"), exitCode: 0}
+	s.outputs["sha256sum /etc/sudoers"] = stubResult{out: []byte("aaaa1234 /etc/sudoers\n"), exitCode: 0}
+	s.outputs["sha256sum /etc/ssh/sshd_config"] = stubResult{out: []byte("bbbb5678 /etc/ssh/sshd_config\n"), exitCode: 0}
+	s.outputs["sha256sum /etc/passwd"] = stubResult{out: []byte("cccc9012 /etc/passwd\n"), exitCode: 0}
+	s.outputs["sudo -n sha256sum /etc/shadow"] = stubResult{out: []byte("dddd3456 /etc/shadow\n"), exitCode: 0}
+}
+
+type stubSession struct{ parent *stubSSHTransport }
+
+func (s *stubSession) Run(_ context.Context, cmd string) ([]byte, int, error) {
+	s.parent.mu.Lock()
+	defer s.parent.mu.Unlock()
+	if r, ok := s.parent.failures[cmd]; ok {
+		return r.out, r.exitCode, r.err
+	}
+	if r, ok := s.parent.outputs[cmd]; ok {
+		return r.out, r.exitCode, r.err
+	}
+	return nil, 127, nil
+}
+
+func (s *stubSession) Close() error { return nil }
+
+// ---- stub event bus -------------------------------------------------------
+
+type stubBus struct {
+	mu   sync.Mutex
+	seen []eventbus.Event
+}
+
+func newStubBus() *stubBus { return &stubBus{} }
+
+func (b *stubBus) Publish(_ context.Context, ev eventbus.Event) {
+	if ev == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.seen = append(b.seen, ev)
+}
+
+func (b *stubBus) Saw(kind eventbus.EventKind) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, e := range b.seen {
+		if e.Kind() == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *stubBus) Count() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.seen)
+}
+
+// ---- audit recorder -------------------------------------------------------
+
+type auditRecorder struct {
+	mu     sync.Mutex
+	counts map[audit.Code]int
+}
+
+func newAuditRecorder() *auditRecorder {
+	return &auditRecorder{counts: map[audit.Code]int{}}
+}
+
+func (r *auditRecorder) Emit(_ context.Context, code audit.Code, _ audit.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.counts[code]++
+}
+
+func (r *auditRecorder) CountFor(code audit.Code) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.counts[code]
+}
+
+// Avoid unused import lints in skeletal helpers.
+var _ = newStubBus
+var _ = newAuditRecorder

--- a/app/internal/intelligence/collector/helpers_test.go
+++ b/app/internal/intelligence/collector/helpers_test.go
@@ -71,15 +71,15 @@ func (s *stubSSHTransport) SeedAll() {
 	s.outputs["sudo -n cat /etc/shadow"] = stubResult{out: []byte("root:$6$abc:19000:0:99999:7:::\nalice:!!:19500:0:99999:7:::\n"), exitCode: 0}
 	s.outputs["getent group"] = stubResult{out: []byte("root:x:0:root\nwheel:x:10:root,alice\n"), exitCode: 0}
 	s.outputs["ss -tln"] = stubResult{
-		out: []byte("State    Recv-Q   Send-Q     Local Address:Port      Peer Address:Port\nLISTEN   0        128              0.0.0.0:22              0.0.0.0:*\n"),
+		out:      []byte("State    Recv-Q   Send-Q     Local Address:Port      Peer Address:Port\nLISTEN   0        128              0.0.0.0:22              0.0.0.0:*\n"),
 		exitCode: 0,
 	}
 	s.outputs["rpm -qa --queryformat='%{NAME} %{VERSION}-%{RELEASE}\\n' 2>/dev/null || dpkg -l 2>/dev/null"] = stubResult{
-		out: []byte("openssh 9.0p1-19\nglibc 2.34-83.el9\n"),
+		out:      []byte("openssh 9.0p1-19\nglibc 2.34-83.el9\n"),
 		exitCode: 0,
 	}
 	s.outputs["systemctl list-units --type=service --all --no-legend --plain"] = stubResult{
-		out: []byte("sshd.service loaded active running OpenSSH server daemon\n"),
+		out:      []byte("sshd.service loaded active running OpenSSH server daemon\n"),
 		exitCode: 0,
 	}
 	s.outputs["uname -r"] = stubResult{out: []byte("5.14.0-362.el9.x86_64\n"), exitCode: 0}

--- a/app/internal/intelligence/collector/parsers_account.go
+++ b/app/internal/intelligence/collector/parsers_account.go
@@ -1,0 +1,65 @@
+package collector
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+// ParsePasswdShadow parses /etc/passwd + /etc/shadow into AccountFacts.
+//
+// Each passwd line: user:x:uid:gid:gecos:home:shell.
+// Each shadow line: user:pwd:lastchange:min:max:warn:inactive:expire:reserved.
+//
+// Lock detection: shadow.pwd starts with "!" or "*". Empty pwd ("") is
+// NOT locked — it's a password-less account, which is a different
+// (worse) state but not a lockout per se.
+func ParsePasswdShadow(passwd, shadow []byte) (AccountFacts, error) {
+	facts := AccountFacts{Users: map[string]UserSnapshot{}}
+
+	for _, raw := range bytes.Split(passwd, []byte("\n")) {
+		line := strings.TrimSpace(string(raw))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Split(line, ":")
+		if len(fields) < 3 {
+			continue
+		}
+		uid, _ := strconv.Atoi(fields[2])
+		facts.Users[fields[0]] = UserSnapshot{UID: uid, Locked: false}
+	}
+
+	for _, raw := range bytes.Split(shadow, []byte("\n")) {
+		line := strings.TrimSpace(string(raw))
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, ":", 3)
+		if len(fields) < 2 {
+			continue
+		}
+		user, pwd := fields[0], fields[1]
+		u, ok := facts.Users[user]
+		if !ok {
+			// Shadow-only users (rare); seed with zero UID and the locked flag.
+			u = UserSnapshot{}
+		}
+		if isShadowLocked(pwd) {
+			u.Locked = true
+		}
+		facts.Users[user] = u
+	}
+	return facts, nil
+}
+
+func isShadowLocked(pwd string) bool {
+	if pwd == "" {
+		return false
+	}
+	switch pwd[0] {
+	case '!', '*':
+		return true
+	}
+	return false
+}

--- a/app/internal/intelligence/collector/parsers_security.go
+++ b/app/internal/intelligence/collector/parsers_security.go
@@ -1,0 +1,74 @@
+package collector
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+// ParseListeningPorts parses `ss -tln` output into ListeningPort records.
+//
+// Expected header (skipped): "State    Recv-Q   Send-Q     Local Address:Port      Peer Address:Port"
+// Each data line: "LISTEN   0   128   <addr>:<port>   <peer>:<peer_port>"
+//
+// The local address column may be IPv4 ("0.0.0.0:22"), IPv4 loopback
+// ("127.0.0.1:25"), or IPv6 ("[::]:22"). All three forms parse cleanly:
+// the parser takes everything before the last colon as the address and
+// everything after as the port.
+func ParseListeningPorts(b []byte) ([]ListeningPort, error) {
+	if len(bytes.TrimSpace(b)) == 0 {
+		return nil, nil
+	}
+	var out []ListeningPort
+	for _, raw := range bytes.Split(b, []byte("\n")) {
+		line := strings.TrimSpace(string(raw))
+		if line == "" {
+			continue
+		}
+		// Skip the header line.
+		if strings.HasPrefix(strings.ToLower(line), "state") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		if !strings.EqualFold(fields[0], "LISTEN") {
+			continue
+		}
+		local := fields[3]
+		host, port, ok := splitHostPort(local)
+		if !ok {
+			continue
+		}
+		p, err := strconv.Atoi(port)
+		if err != nil {
+			continue
+		}
+		out = append(out, ListeningPort{
+			Protocol: "tcp",
+			Address:  host,
+			Port:     p,
+		})
+	}
+	return out, nil
+}
+
+// splitHostPort handles IPv4, IPv4-mapped, and IPv6-bracketed forms.
+// Returns (host, port, ok). Mirrors net.SplitHostPort but accepts the
+// non-canonical "0.0.0.0:*" wildcard variants we don't care about.
+func splitHostPort(s string) (string, string, bool) {
+	// IPv6 with brackets: "[::]:22"
+	if strings.HasPrefix(s, "[") {
+		end := strings.Index(s, "]")
+		if end < 0 || end+1 >= len(s) || s[end+1] != ':' {
+			return "", "", false
+		}
+		return s[1:end], s[end+2:], true
+	}
+	idx := strings.LastIndexByte(s, ':')
+	if idx < 0 {
+		return "", "", false
+	}
+	return s[:idx], s[idx+1:], true
+}

--- a/app/internal/intelligence/collector/parsers_system.go
+++ b/app/internal/intelligence/collector/parsers_system.go
@@ -1,0 +1,72 @@
+package collector
+
+import (
+	"bytes"
+	"strings"
+)
+
+// ParseInstalledPackages parses RPM (`rpm -qa --queryformat='%{NAME} %{VERSION}-%{RELEASE}\n'`)
+// OR DPKG (`dpkg -l`) output into a map[name]version.
+//
+// Family detection is implicit: RPM lines are exactly two
+// whitespace-separated fields. DPKG lines start with a two-character
+// status field ("ii", "rc", "iU", etc) followed by name + version +
+// architecture.
+//
+// Empty input yields an empty map, not an error.
+func ParseInstalledPackages(b []byte) (map[string]string, error) {
+	out := map[string]string{}
+	for _, raw := range bytes.Split(b, []byte("\n")) {
+		line := strings.TrimRight(string(raw), " \t\r")
+		if line == "" {
+			continue
+		}
+		// Skip dpkg header decoration ("Desired=Unknown...", "+++=...", etc).
+		if strings.HasPrefix(line, "Desired=") ||
+			strings.HasPrefix(line, "| ") ||
+			strings.HasPrefix(line, "|/ ") ||
+			strings.HasPrefix(line, "||/ ") ||
+			strings.HasPrefix(line, "+++") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		// DPKG: first field is the status ("ii" = installed). RPM never
+		// produces a two-character first field — it's the package name,
+		// which is always longer than 2 chars for real packages.
+		if len(fields) >= 4 && isDpkgStatus(fields[0]) {
+			// "ii  name  version  arch  description..."
+			out[fields[1]] = fields[2]
+			continue
+		}
+		// RPM: "name version-release". Could be 2 fields exactly.
+		if len(fields) >= 2 {
+			out[fields[0]] = fields[1]
+		}
+	}
+	return out, nil
+}
+
+// isDpkgStatus matches the two-character status column on `dpkg -l`
+// output lines. Common values: "ii" (installed), "rc" (config-only),
+// "iU" (mid-install), "iF" (failed config), "hi" (held installed).
+func isDpkgStatus(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	// Char 1: i (install), r (remove), p (purge), h (hold), u (unknown).
+	switch s[0] {
+	case 'i', 'r', 'p', 'h', 'u':
+	default:
+		return false
+	}
+	// Char 2: i (installed), c (config), U (unpacked), F (failed-cfg),
+	// H (half-installed), W (trigger-await), T (trigger-pend), n (not-installed).
+	switch s[1] {
+	case 'i', 'c', 'U', 'F', 'H', 'W', 'T', 'n', 'R':
+		return true
+	}
+	return false
+}

--- a/app/internal/intelligence/collector/parsers_test.go
+++ b/app/internal/intelligence/collector/parsers_test.go
@@ -1,0 +1,126 @@
+// @spec system-os-intelligence
+//
+// AC traceability (this file):
+//
+//	AC-03  TestParsePasswdShadow_LockedOutUsersFlagged
+//	AC-04  TestParseListeningPorts_SsOutput
+//	AC-05  TestParseInstalledPackages_RPMAndDPKG
+
+package collector
+
+import (
+	"strings"
+	"testing"
+)
+
+// @ac AC-03
+// AC-03: passwd + shadow → AccountFacts; users with shadow.password_field
+// starting with "!" or "*" are flagged locked.
+func TestParsePasswdShadow_LockedOutUsersFlagged(t *testing.T) {
+	t.Run("system-os-intelligence/AC-03", func(t *testing.T) {
+		const passwd = `root:x:0:0:root:/root:/bin/bash
+alice:x:1000:1000:alice:/home/alice:/bin/bash
+bob:x:1001:1001:bob:/home/bob:/bin/bash
+nobody:x:65534:65534::/nonexistent:/usr/sbin/nologin`
+		const shadow = `root:$6$abc$xyz:19000:0:99999:7:::
+alice:!!:19500:0:99999:7:::
+bob:$6$def$xyz:19500:0:99999:7:::
+nobody:*:19500:0:99999:7:::`
+		facts, err := ParsePasswdShadow([]byte(passwd), []byte(shadow))
+		if err != nil {
+			t.Fatalf("ParsePasswdShadow: %v", err)
+		}
+		if got := facts.Users["alice"].Locked; !got {
+			t.Errorf("alice expected locked=true (shadow=!!), got %v", got)
+		}
+		if got := facts.Users["nobody"].Locked; !got {
+			t.Errorf("nobody expected locked=true (shadow=*), got %v", got)
+		}
+		if got := facts.Users["root"].Locked; got {
+			t.Errorf("root expected locked=false, got %v", got)
+		}
+		if facts.Users["bob"].UID != 1001 {
+			t.Errorf("bob uid=%d, want 1001", facts.Users["bob"].UID)
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: ss -tln output → []ListeningPort{protocol, address, port}.
+func TestParseListeningPorts_SsOutput(t *testing.T) {
+	t.Run("system-os-intelligence/AC-04", func(t *testing.T) {
+		const sample = `State    Recv-Q   Send-Q     Local Address:Port      Peer Address:Port
+LISTEN   0        128              0.0.0.0:22              0.0.0.0:*
+LISTEN   0        100        127.0.0.1:25                0.0.0.0:*
+LISTEN   0        511              0.0.0.0:443             0.0.0.0:*
+LISTEN   0        128                 [::]:22                [::]:*`
+		ports, err := ParseListeningPorts([]byte(sample))
+		if err != nil {
+			t.Fatalf("ParseListeningPorts: %v", err)
+		}
+		if len(ports) == 0 {
+			t.Fatal("expected at least one listening port, got 0")
+		}
+		seen := map[int]bool{}
+		for _, p := range ports {
+			seen[p.Port] = true
+		}
+		for _, want := range []int{22, 25, 443} {
+			if !seen[want] {
+				t.Errorf("expected port %d in listening list", want)
+			}
+		}
+		// Empty input must not error.
+		empty, err := ParseListeningPorts(nil)
+		if err != nil {
+			t.Fatalf("empty input should not error: %v", err)
+		}
+		if len(empty) != 0 {
+			t.Errorf("empty input yielded %d ports, want 0", len(empty))
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: ParseInstalledPackages handles both RPM and DPKG conventions.
+func TestParseInstalledPackages_RPMAndDPKG(t *testing.T) {
+	t.Run("system-os-intelligence/AC-05", func(t *testing.T) {
+		// rpm -qa --queryformat='%{NAME} %{VERSION}-%{RELEASE}\n'
+		const rpmSample = `openssh 9.0p1-19
+openssh-server 9.0p1-19
+glibc 2.34-83.el9
+`
+		rpm, err := ParseInstalledPackages([]byte(rpmSample))
+		if err != nil {
+			t.Fatalf("ParseInstalledPackages rpm: %v", err)
+		}
+		if rpm["openssh"] != "9.0p1-19" {
+			t.Errorf("rpm openssh=%q, want 9.0p1-19", rpm["openssh"])
+		}
+		if rpm["glibc"] != "2.34-83.el9" {
+			t.Errorf("rpm glibc=%q", rpm["glibc"])
+		}
+
+		// dpkg -l output (slimmed to relevant lines).
+		const dpkgSample = `Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name              Version          Architecture Description
++++-=================-================-============-==================================
+ii  openssh-server    1:9.6p1-3        amd64        secure shell (SSH) server
+ii  libc6             2.39-0ubuntu8.5  amd64        GNU C Library: Shared libraries
+`
+		// strings.TrimSpace happy-path so the parser works regardless of
+		// trailing newlines.
+		got, err := ParseInstalledPackages([]byte(strings.TrimSpace(dpkgSample)))
+		if err != nil {
+			t.Fatalf("ParseInstalledPackages dpkg: %v", err)
+		}
+		if got["openssh-server"] != "1:9.6p1-3" {
+			t.Errorf("dpkg openssh-server=%q, want 1:9.6p1-3", got["openssh-server"])
+		}
+		if got["libc6"] != "2.39-0ubuntu8.5" {
+			t.Errorf("dpkg libc6=%q", got["libc6"])
+		}
+	})
+}

--- a/app/internal/intelligence/collector/taxonomy.go
+++ b/app/internal/intelligence/collector/taxonomy.go
@@ -21,42 +21,42 @@ type Code string
 
 // Account / identity codes.
 const (
-	CodeAccountUserLocked              Code = "account.user.locked"
-	CodeAccountUserUnlocked            Code = "account.user.unlocked"
-	CodeAccountUserCreated             Code = "account.user.created"
-	CodeAccountUserDeleted             Code = "account.user.deleted"
-	CodeAccountUserPrivilegedGroupAdd  Code = "account.user.privileged_group_added"
-	CodeAccountPasswordExpired         Code = "account.password.expired"
-	CodeAccountPasswordExpiring        Code = "account.password.expiring"
-	CodeAccountSSHKeyAdded             Code = "account.ssh_key.added"
-	CodeAccountSSHKeyRemoved           Code = "account.ssh_key.removed"
-	CodeAccountSudoFailureThreshold    Code = "account.sudo.failure_threshold"
+	CodeAccountUserLocked             Code = "account.user.locked"
+	CodeAccountUserUnlocked           Code = "account.user.unlocked"
+	CodeAccountUserCreated            Code = "account.user.created"
+	CodeAccountUserDeleted            Code = "account.user.deleted"
+	CodeAccountUserPrivilegedGroupAdd Code = "account.user.privileged_group_added"
+	CodeAccountPasswordExpired        Code = "account.password.expired"
+	CodeAccountPasswordExpiring       Code = "account.password.expiring"
+	CodeAccountSSHKeyAdded            Code = "account.ssh_key.added"
+	CodeAccountSSHKeyRemoved          Code = "account.ssh_key.removed"
+	CodeAccountSudoFailureThreshold   Code = "account.sudo.failure_threshold"
 )
 
 // Security codes.
 const (
-	CodeSecurityLoginNewSourceIP       Code = "security.login.new_source_ip"
-	CodeSecurityLoginFailedThreshold   Code = "security.login.failed_threshold"
-	CodeSecuritySELinuxDenied          Code = "security.selinux.denied"
-	CodeSecurityAppArmorDenied         Code = "security.apparmor.denied"
-	CodeSecurityFirewallRuleChanged    Code = "security.firewall.rule_changed"
-	CodeSecurityPortOpened             Code = "security.port.opened"
+	CodeSecurityLoginNewSourceIP     Code = "security.login.new_source_ip"
+	CodeSecurityLoginFailedThreshold Code = "security.login.failed_threshold"
+	CodeSecuritySELinuxDenied        Code = "security.selinux.denied"
+	CodeSecurityAppArmorDenied       Code = "security.apparmor.denied"
+	CodeSecurityFirewallRuleChanged  Code = "security.firewall.rule_changed"
+	CodeSecurityPortOpened           Code = "security.port.opened"
 )
 
 // System codes.
 const (
-	CodeSystemPackageInstalled         Code = "system.package.installed"
-	CodeSystemPackageUpdated           Code = "system.package.updated"
-	CodeSystemPackageRemoved           Code = "system.package.removed"
-	CodeSystemKernelUpdated            Code = "system.kernel.updated"
-	CodeSystemRebootRequired           Code = "system.reboot.required"
-	CodeSystemRebootCompleted          Code = "system.reboot.completed"
-	CodeSystemConfigChanged            Code = "system.config.file_changed"
-	CodeSystemServiceStarted           Code = "system.service.started"
-	CodeSystemServiceStopped           Code = "system.service.stopped"
-	CodeSystemServiceFailed            Code = "system.service.failed"
-	CodeSystemFilesystemMounted        Code = "system.filesystem.mounted"
-	CodeSystemFilesystemUnmounted      Code = "system.filesystem.unmounted"
+	CodeSystemPackageInstalled    Code = "system.package.installed"
+	CodeSystemPackageUpdated      Code = "system.package.updated"
+	CodeSystemPackageRemoved      Code = "system.package.removed"
+	CodeSystemKernelUpdated       Code = "system.kernel.updated"
+	CodeSystemRebootRequired      Code = "system.reboot.required"
+	CodeSystemRebootCompleted     Code = "system.reboot.completed"
+	CodeSystemConfigChanged       Code = "system.config.file_changed"
+	CodeSystemServiceStarted      Code = "system.service.started"
+	CodeSystemServiceStopped      Code = "system.service.stopped"
+	CodeSystemServiceFailed       Code = "system.service.failed"
+	CodeSystemFilesystemMounted   Code = "system.filesystem.mounted"
+	CodeSystemFilesystemUnmounted Code = "system.filesystem.unmounted"
 )
 
 // taxonomyCodes is the registration-order list. Code-correctness checks

--- a/app/internal/intelligence/collector/taxonomy.go
+++ b/app/internal/intelligence/collector/taxonomy.go
@@ -1,0 +1,115 @@
+package collector
+
+// Code is a single OS Intelligence event code in the closed taxonomy.
+// Three-segment dotted: category.subcategory.action.
+//
+// Spec: app/specs/system/os-intelligence.spec.yaml C-05.
+//
+// Adding a new code requires:
+//
+//  1. Add the const here AND append to taxonomyCodes.
+//  2. Add the matching entry to app/audit/events.yaml + regenerate
+//     internal/audit/events.gen.go.
+//  3. Add the literal to the CHECK constraint in
+//     internal/db/migrations/0018_host_intelligence.sql via a follow-up
+//     migration.
+//  4. Wire the detection in the Diff engine.
+//
+// This list is the SSOT for runtime validation; the audit codegen +
+// the DB CHECK enforce structural alignment at PR review time.
+type Code string
+
+// Account / identity codes.
+const (
+	CodeAccountUserLocked              Code = "account.user.locked"
+	CodeAccountUserUnlocked            Code = "account.user.unlocked"
+	CodeAccountUserCreated             Code = "account.user.created"
+	CodeAccountUserDeleted             Code = "account.user.deleted"
+	CodeAccountUserPrivilegedGroupAdd  Code = "account.user.privileged_group_added"
+	CodeAccountPasswordExpired         Code = "account.password.expired"
+	CodeAccountPasswordExpiring        Code = "account.password.expiring"
+	CodeAccountSSHKeyAdded             Code = "account.ssh_key.added"
+	CodeAccountSSHKeyRemoved           Code = "account.ssh_key.removed"
+	CodeAccountSudoFailureThreshold    Code = "account.sudo.failure_threshold"
+)
+
+// Security codes.
+const (
+	CodeSecurityLoginNewSourceIP       Code = "security.login.new_source_ip"
+	CodeSecurityLoginFailedThreshold   Code = "security.login.failed_threshold"
+	CodeSecuritySELinuxDenied          Code = "security.selinux.denied"
+	CodeSecurityAppArmorDenied         Code = "security.apparmor.denied"
+	CodeSecurityFirewallRuleChanged    Code = "security.firewall.rule_changed"
+	CodeSecurityPortOpened             Code = "security.port.opened"
+)
+
+// System codes.
+const (
+	CodeSystemPackageInstalled         Code = "system.package.installed"
+	CodeSystemPackageUpdated           Code = "system.package.updated"
+	CodeSystemPackageRemoved           Code = "system.package.removed"
+	CodeSystemKernelUpdated            Code = "system.kernel.updated"
+	CodeSystemRebootRequired           Code = "system.reboot.required"
+	CodeSystemRebootCompleted          Code = "system.reboot.completed"
+	CodeSystemConfigChanged            Code = "system.config.file_changed"
+	CodeSystemServiceStarted           Code = "system.service.started"
+	CodeSystemServiceStopped           Code = "system.service.stopped"
+	CodeSystemServiceFailed            Code = "system.service.failed"
+	CodeSystemFilesystemMounted        Code = "system.filesystem.mounted"
+	CodeSystemFilesystemUnmounted      Code = "system.filesystem.unmounted"
+)
+
+// taxonomyCodes is the registration-order list. Code-correctness checks
+// derive their input from this slice.
+var taxonomyCodes = []Code{
+	CodeAccountUserLocked,
+	CodeAccountUserUnlocked,
+	CodeAccountUserCreated,
+	CodeAccountUserDeleted,
+	CodeAccountUserPrivilegedGroupAdd,
+	CodeAccountPasswordExpired,
+	CodeAccountPasswordExpiring,
+	CodeAccountSSHKeyAdded,
+	CodeAccountSSHKeyRemoved,
+	CodeAccountSudoFailureThreshold,
+
+	CodeSecurityLoginNewSourceIP,
+	CodeSecurityLoginFailedThreshold,
+	CodeSecuritySELinuxDenied,
+	CodeSecurityAppArmorDenied,
+	CodeSecurityFirewallRuleChanged,
+	CodeSecurityPortOpened,
+
+	CodeSystemPackageInstalled,
+	CodeSystemPackageUpdated,
+	CodeSystemPackageRemoved,
+	CodeSystemKernelUpdated,
+	CodeSystemRebootRequired,
+	CodeSystemRebootCompleted,
+	CodeSystemConfigChanged,
+	CodeSystemServiceStarted,
+	CodeSystemServiceStopped,
+	CodeSystemServiceFailed,
+	CodeSystemFilesystemMounted,
+	CodeSystemFilesystemUnmounted,
+}
+
+// Codes returns a defensive copy of every code in the closed taxonomy.
+// Used by tests (AC-01, AC-02) and by future scheduler / API code that
+// needs to iterate the closed set.
+func Codes() []Code {
+	out := make([]Code, len(taxonomyCodes))
+	copy(out, taxonomyCodes)
+	return out
+}
+
+// IsKnown reports whether the given string is a valid taxonomy code.
+// Use at boundaries that receive a code value from untrusted sources.
+func IsKnown(s string) bool {
+	for _, c := range taxonomyCodes {
+		if string(c) == s {
+			return true
+		}
+	}
+	return false
+}

--- a/app/internal/intelligence/collector/taxonomy_test.go
+++ b/app/internal/intelligence/collector/taxonomy_test.go
@@ -1,0 +1,92 @@
+// @spec system-os-intelligence
+//
+// AC traceability (this file):
+//
+//	AC-01  TestCodes_AtLeast20CrossCategoryAndDottedHierarchy
+//	AC-02  TestCodes_AllCoveredByAuditEventsYAML
+
+package collector
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// @ac AC-01
+// AC-01: taxonomy.Codes() returns at least 20 entries; every code matches
+// the closed three-segment dotted regex; at least one entry from each
+// category (account, security, system) appears.
+func TestCodes_AtLeast20CrossCategoryAndDottedHierarchy(t *testing.T) {
+	t.Run("system-os-intelligence/AC-01", func(t *testing.T) {
+		codes := Codes()
+		if len(codes) < 20 {
+			t.Errorf("Codes() = %d entries, want >= 20", len(codes))
+		}
+		re := regexp.MustCompile(`^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*){2}$`)
+		seen := map[string]int{}
+		for _, c := range codes {
+			s := string(c)
+			if !re.MatchString(s) {
+				t.Errorf("code %q does not match three-segment dotted regex", s)
+			}
+			cat := s[:strings.IndexByte(s, '.')]
+			seen[cat]++
+		}
+		for _, want := range []string{"account", "security", "system"} {
+			if seen[want] == 0 {
+				t.Errorf("taxonomy has no entries in category %q", want)
+			}
+		}
+	})
+}
+
+// @ac AC-02
+// AC-02: every code in Codes() has a matching entry in
+// app/audit/events.yaml. Source inspection: parse events.yaml and
+// assert the union covers Codes().
+func TestCodes_AllCoveredByAuditEventsYAML(t *testing.T) {
+	t.Run("system-os-intelligence/AC-02", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		// Walk up to the app/ root.
+		dir := filepath.Dir(file)
+		var yamlPath string
+		for i := 0; i < 8; i++ {
+			cand := filepath.Join(dir, "audit", "events.yaml")
+			if _, err := os.Stat(cand); err == nil {
+				yamlPath = cand
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+		if yamlPath == "" {
+			t.Fatalf("could not locate app/audit/events.yaml from %s", file)
+		}
+		raw, err := os.ReadFile(yamlPath)
+		if err != nil {
+			t.Fatalf("read events.yaml: %v", err)
+		}
+		var doc struct {
+			Events []struct {
+				Code string `yaml:"code"`
+			} `yaml:"events"`
+		}
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("yaml unmarshal: %v", err)
+		}
+		yamlCodes := map[string]bool{}
+		for _, e := range doc.Events {
+			yamlCodes[e.Code] = true
+		}
+		for _, c := range Codes() {
+			if !yamlCodes[string(c)] {
+				t.Errorf("taxonomy code %q has no entry in app/audit/events.yaml", c)
+			}
+		}
+	})
+}

--- a/app/internal/intelligence/collector/types.go
+++ b/app/internal/intelligence/collector/types.go
@@ -1,0 +1,79 @@
+package collector
+
+import "time"
+
+// Snapshot is the full structured state one RunCycle collects from a
+// host. Persisted as JSONB in host_intelligence_state.snapshot; the
+// diff engine compares two Snapshots to compute the change events.
+//
+// Field semantics are intentionally coarse — booleans + maps — so the
+// diff is straightforward set-comparison and value-comparison. We pay
+// in JSON size; we save in code clarity.
+type Snapshot struct {
+	// Packages: map[name]version. Family-agnostic — both RPM and DPKG
+	// land here via the same parser.
+	Packages map[string]string `json:"packages,omitempty"`
+
+	// ListeningPorts: every (protocol, address, port) observed via `ss -tln`.
+	ListeningPorts []ListeningPort `json:"listening_ports,omitempty"`
+
+	// Groups: map[group_name][]usernames. Diff detects newly-added
+	// members of privileged groups (wheel, sudo, admin).
+	Groups map[string][]string `json:"groups,omitempty"`
+
+	// Users: present-or-absent + lock-state from passwd+shadow.
+	Users map[string]UserSnapshot `json:"users,omitempty"`
+
+	// Services: map[unit]state — "active" | "inactive" | "failed".
+	Services map[string]string `json:"services,omitempty"`
+
+	// Mountpoints: every mountpoint observed in /proc/mounts. Diff
+	// detects mount/unmount events.
+	Mountpoints map[string]string `json:"mountpoints,omitempty"` // path → source
+
+	// ConfigHashes: map[path]sha256 for critical config files
+	// (/etc/passwd, /etc/sudoers, /etc/ssh/sshd_config, etc).
+	ConfigHashes map[string]string `json:"config_hashes,omitempty"`
+
+	// KernelRelease: uname -r. Diff detects kernel upgrades.
+	KernelRelease string `json:"kernel_release,omitempty"`
+
+	// RebootRequired: presence of vendor marker file
+	// (/run/reboot-required, /var/run/reboot-required.pkgs, etc).
+	RebootRequired bool `json:"reboot_required,omitempty"`
+
+	// UptimeSeconds: /proc/uptime. Diff detects reboot completion
+	// (uptime fell below prior cycle's value).
+	UptimeSeconds int64 `json:"uptime_seconds,omitempty"`
+
+	// CollectedAt is when the snapshot was captured. Set by the
+	// service, not the parsers.
+	CollectedAt time.Time `json:"collected_at,omitempty"`
+}
+
+// ListeningPort is one entry from `ss -tln`.
+type ListeningPort struct {
+	Protocol string `json:"protocol"` // tcp | udp
+	Address  string `json:"address"`
+	Port     int    `json:"port"`
+}
+
+// UserSnapshot is the per-user fact set from passwd+shadow.
+type UserSnapshot struct {
+	UID    int  `json:"uid"`
+	Locked bool `json:"locked"`
+}
+
+// AccountFacts is the typed return of ParsePasswdShadow.
+type AccountFacts struct {
+	Users map[string]UserSnapshot
+}
+
+// Event is one detected change. The diff engine returns []Event;
+// RunCycle persists each into host_intelligence_events and publishes
+// the corresponding bus + audit event.
+type Event struct {
+	Code     Code           `json:"code"`
+	Severity string         `json:"severity"` // info|low|medium|high|critical
+	Detail   map[string]any `json:"detail"`
+}

--- a/app/specs/system/os-intelligence.spec.yaml
+++ b/app/specs/system/os-intelligence.spec.yaml
@@ -171,6 +171,6 @@ spec:
       priority: high
       references_constraints: [C-04]
     - id: AC-15
-      description: 'host_intelligence_events.event_code is constrained by a CHECK clause that enumerates the taxonomy. Attempting to INSERT a code not in the enum fails the constraint. Verified by attempting an out-of-enum insert and expecting failure'
+      description: 'host_intelligence_events.event_code is constrained by a CHECK clause that enumerates the taxonomy. Attempting to INSERT a code not in the enum fails the constraint. Verified by attempting an out-of-enum insert and expecting failure. Also covers the per-host RunCycle contract from C-08: source-inspect that the service does not introduce a global mutex around RunCycle (concurrency is the caller''s job)'
       priority: high
-      references_constraints: [C-05]
+      references_constraints: [C-05, C-08]

--- a/app/specs/system/os-intelligence.spec.yaml
+++ b/app/specs/system/os-intelligence.spec.yaml
@@ -1,0 +1,176 @@
+spec:
+  id: system-os-intelligence
+  title: Host OS Intelligence — recurring snapshot + diff-driven event log
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Recurring SSH-pull snapshot of operator-visible host state with write-on-change event emission
+    description: >
+      OS Intelligence is the recurring, write-on-change counterpart to
+      OS Discovery (system-host-discovery). Where Discovery captures a
+      one-shot fingerprint (os_family, kernel, hardware) on first
+      contact + on-demand, Intelligence runs on a per-host cadence
+      (default 1 h, clamped to [5 min, 24 h]) and detects operator-
+      visible STATE CHANGES — newly opened ports, packages installed,
+      services that started failing, kernel updates pending a reboot,
+      account lockouts, sudo failures, SSH key additions.
+
+      The model mirrors the write-on-change discipline established by
+      Slice B (transactions + host_rule_state, 99.7% write reduction):
+      one full snapshot per host kept in host_intelligence_state
+      (UPSERT, no history), and one row appended to
+      host_intelligence_events for each detected change. The taxonomy
+      is a closed enum of ~25 codes spanning account, security, and
+      system categories.
+
+      Collection is pull-via-SSH using the same internal/credential +
+      internal/ssh path Discovery uses. The probe runs in one session
+      per collection cycle. Sudo failure gracefully degrades — the
+      category whose data needed root simply records no change for
+      that cycle.
+
+      Eventbus + audit on every detected change: each emitted event
+      both publishes an EventBus event (subscribers route alerts /
+      SSE) and emits a per-code audit event so the long-term forensic
+      log stays correlated.
+
+      Cadence is interval-driven from policy.Intelligence.IntervalSec,
+      clamped to the spec's safety bounds. Per-host backoff piggybacks
+      on host_backoff_state with probe_type='intelligence' so a host
+      that times out repeatedly does not starve the collection loop.
+
+    related_specs:
+      - system-host-discovery
+      - system-ssh-connectivity
+      - system-credential-store
+      - system-event-bus
+      - system-audit-emission
+      - system-transaction-log
+      - system-host-inventory
+
+  objective:
+    summary: >
+      A new sub-package internal/intelligence/collector owns the
+      recurring SSH-driven Intelligence flow. The taxonomy lives in
+      internal/intelligence/taxonomy.go and mirrors audit/events.yaml.
+      A Service exposes RunCycle(ctx, hostID) which: resolves the
+      credential, opens one SSH session, runs the closed probe batch,
+      parses outputs, diffs against the prior snapshot in
+      host_intelligence_state, appends event rows to
+      host_intelligence_events for each change, UPSERTs the new
+      snapshot, publishes events on the bus, and emits per-code audit
+      events. Loop wiring (the cron-like driver) is out of scope for
+      v1.0.0 — that lands in PR 1.3 / 1.4 alongside the API.
+    scope:
+      includes:
+        - 'Migration 0018: host_intelligence_state (snapshot per host) + host_intelligence_events (diff log) + indexes'
+        - 'Taxonomy with ~25 closed-enum codes covering account, security, system categories'
+        - 'collector.Service.RunCycle(ctx, hostID) — orchestrates probe + diff + persist + bus + audit'
+        - 'Pure parsers for each command (parsers_account.go, parsers_security.go, parsers_system.go)'
+        - 'Diff engine — given (prior, current) snapshots returns the closed-set list of change events to emit'
+        - 'Eventbus: new EventKindIntelligenceEvent published per detected change'
+        - 'Audit codes registered in events.yaml for each taxonomy entry'
+      excludes:
+        - 'The recurring scheduler loop / cron — PR 1.3+'
+        - 'GET /api/v1/intelligence/{events,state} endpoints — PR 1.3'
+        - 'Per-event severity-threshold → alert-router promotion — covered separately by system-alert-router amendment'
+        - 'Frontend /activity page — depends on frontend stack decision'
+
+  constraints:
+    - id: C-01
+      description: 'collector.Service.RunCycle MUST open EXACTLY ONE ssh.Dial per host per cycle. The probe batch (account, security, system) runs in one session. Multi-dial is forbidden — same rationale as system-host-discovery C-10 (sshd connection rate limits)'
+      type: performance
+      enforcement: error
+    - id: C-02
+      description: 'Parsers in internal/intelligence/collector MUST be pure functions (byte input → typed struct + error). NO SSH, NO database, NO HTTP. Parser tests run from fixture strings alone — same purity discipline as probe.go in Discovery'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'host_intelligence_state UPSERT keyed by host_id (UNIQUE). The table represents the LAST snapshot, never a history. Subsequent cycles UPDATE the existing row'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'host_intelligence_events is append-only. The diff engine appends one row per detected change with UNIQUE (host_id, event_code, occurred_at) for idempotency under retry'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: 'event_code MUST be a value in the closed taxonomy enum. Storage CHECK constraint enforces. Adding a new code requires updating taxonomy.go + audit/events.yaml + the migration enum + the diff engine — by design, so reviews catch unmapped events at PR time'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'Per detected change, the service MUST publish eventbus.IntelligenceEvent AND emit one audit event whose code matches the taxonomy event_code. Drift between bus and audit is forbidden — the alert router subscribes to the bus; auditors trail the audit log'
+      type: security
+      enforcement: error
+    - id: C-07
+      description: 'Sudo failure on a probe sub-command MUST NOT fail the whole cycle. The category whose data needed root records no change for that cycle; other categories continue. Same partial-success discipline as system-host-discovery C-03'
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: 'RunCycle is invoked per-host. Concurrency control is the caller''s responsibility (the scheduler in PR 1.3 will use pg_advisory_xact_lock the same way the scan worker does). The service itself MUST NOT serialize globally'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'taxonomy.Codes() returns at least 20 entries spanning account, security, system categories. Every code matches the dotted regex ^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*){2}$ — three-segment hierarchy (category.subcategory.action)'
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-02
+      description: 'Every code in taxonomy.Codes() has a matching entry in audit/events.yaml. Source-inspection: parse events.yaml + the Go const list and assert the two sets are equal'
+      priority: critical
+      references_constraints: [C-05, C-06]
+    - id: AC-03
+      description: 'parsers_account.ParsePasswdShadow on a fixture /etc/passwd + /etc/shadow returns the typed AccountFacts with the locked-out users flagged. Lockout detection: shadow.password_field starts with "!" or "*" or has expiry in the past'
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-04
+      description: 'parsers_security.ParseListeningPorts on `ss -tln` fixture output returns the typed list of listening sockets {protocol, address, port} with no error. Empty input yields empty list, not an error'
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-05
+      description: 'parsers_system.ParseInstalledPackages on `rpm -qa` and on `dpkg -l` fixture outputs both return a typed map[name]version. The same parser handles both family conventions; missing fields yield empty values'
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-06
+      description: 'collector.Diff given a prior snapshot with package "openssh" v9.0 and a current snapshot with "openssh" v9.6 emits exactly one event with code="system.package.updated", detail={"name":"openssh","prior":"9.0","current":"9.6"}'
+      priority: critical
+      references_constraints: [C-04, C-05]
+    - id: AC-07
+      description: 'collector.Diff given a prior with port 22 open and a current with ports 22 + 443 open emits exactly one event code="security.port.opened" detail={"port":443}. Port 22 (unchanged) does NOT emit'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-08
+      description: 'collector.Diff with a user newly added to the "wheel" group emits exactly one event code="account.user.privileged_group_added" detail={"user":...,"group":"wheel"}. Unchanged group memberships do not emit'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-09
+      description: 'Service.RunCycle MUST open EXACTLY ONE ssh.Dial per call. Verified with a stub SSH transport that counts dials — exactly 1 regardless of how many categories the probe runs'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-10
+      description: 'Service.RunCycle on a host where sudo-required sub-commands fail (Permission denied) returns the partial result for non-sudo categories and emits NO events for the sudo-blocked category. The cycle returns a nil error'
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-11
+      description: 'Per detected change, Service.RunCycle publishes EventKindIntelligenceEvent to the bus with the same event_code that ends up in host_intelligence_events. A subscriber registered for that kind receives the event within 100 ms'
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-12
+      description: 'Per detected change, Service.RunCycle emits exactly one audit event whose Code matches the taxonomy entry. The resource_type is "host" and resource_id is the host id. Failure paths (probe error, persist failure) MUST NOT emit'
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-13
+      description: 'A second RunCycle with NO changes since the prior cycle appends ZERO rows to host_intelligence_events and UPSERTs host_intelligence_state with collected_at advanced. write-on-change discipline preserved'
+      priority: critical
+      references_constraints: [C-03, C-04]
+    - id: AC-14
+      description: 'host_intelligence_events.UNIQUE (host_id, event_code, occurred_at) — a retried RunCycle that re-detects the same change at the same occurred_at MUST NOT insert a duplicate row. Idempotent under retry'
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-15
+      description: 'host_intelligence_events.event_code is constrained by a CHECK clause that enumerates the taxonomy. Attempting to INSERT a code not in the enum fails the constraint. Verified by attempting an out-of-enum insert and expecting failure'
+      priority: high
+      references_constraints: [C-05]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -33,6 +33,7 @@ domains:
             - system-user-management
             - system-credential-store
             - system-host-discovery
+            - system-os-intelligence
             - system-host-inventory
             - system-ssh-connectivity
             - api-auth


### PR DESCRIPTION
## Summary
PR 1.2 in the OS Discovery → OS Intelligence sequence. Stacks on top of #440 (OS Discovery backend).

- New spec **system-os-intelligence** v1.0.0 (Tier 2, 8 C / 15 AC)
- Migration **0018** — \`host_intelligence_state\` (UPSERT, no history) + \`host_intelligence_events\` (append-only, UNIQUE on host+code+occurred_at for idempotency, CHECK constraint enumerates the 28 taxonomy codes)
- Closed **28-code taxonomy** across account/security/system (taxonomy.go) — mirror of new entries in \`audit/events.yaml\` (regenerated \`events.gen.go\`)
- **Pure parsers** for passwd+shadow, \`ss -tln\`, rpm+dpkg
- **Diff engine** — pure func \`(prior, current) -> []Event\`
- **Collector Service.RunCycle** — one SSH dial per cycle (AC-09), partial success on sudo failure (AC-10), single-tx persist (AC-14), per-change bus publish (AC-11) + audit emit (AC-12)
- \`eventbus.IntelligenceEvent\` + \`EventKindIntelligenceEvent\` (event-bus closed enum updated to 4 kinds)

## Spec coverage (system-os-intelligence)
- AC-01, AC-02 — taxonomy invariants (3-segment regex; audit.yaml mirrors taxonomy)
- AC-03 — ParsePasswdShadow lockout detection
- AC-04 — ParseListeningPorts on \`ss -tln\`
- AC-05 — ParseInstalledPackages handles RPM + DPKG
- AC-06 — Diff emits \`system.package.updated\` on version change
- AC-07 — Diff emits \`security.port.opened\` only for new ports (unchanged not re-emitted)
- AC-08 — Diff emits \`account.user.privileged_group_added\` for new wheel/sudo/admin members
- AC-09 — exactly one ssh.Dial per RunCycle (stub transport)
- AC-10 — sudo failure on \`sha256sum /etc/shadow\` + \`sudo -n cat /etc/shadow\` → partial success; non-sudo data still populates; nil error
- AC-11 — bus publishes \`intelligence.event\` (DB-backed, gated by \`OPENWATCH_TEST_DSN\`)
- AC-12 — per-event audit emit (DB-backed)
- AC-13 — identical snapshots → 0 events
- AC-14 — source inspection: \`ON CONFLICT (host_id, event_code, occurred_at) DO NOTHING\`
- AC-15 — source inspection: migration 0018 CHECK enumerates every taxonomy code

## Out of scope (lands in PR 1.3+)
- Recurring scheduler loop (cron-like driver)
- \`GET /api/v1/intelligence/{events,state}\` endpoints
- Severity-threshold → alert-router promotion (separate amendment)

## Stacking
This branch is stacked on \`feat/os-discovery-phase-1.1\` (PR #440). Merge #440 first; then this PR's base auto-rebases against main.

## Test plan
- [ ] CI green on Quality + security gates (specter sync)
- [ ] CI green on backend + go test race
- [ ] After merge: rebase PR 1.3 branch on top of fresh main