### PR TITLE
feat(intelligence): OS Intelligence read API (PR 1.3)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -356,1036 +356,1099 @@
         "filename": "app/internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 1166
+        "line_number": 1266
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9d445ef7089e1336b44ace3b46dbc5bb016d3690",
+        "hashed_secret": "72e3bfe9c6166ac4c914a9c01feb17daa102bc36",
         "is_verified": false,
-        "line_number": 3435
+        "line_number": 3696
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "235dceb0b0fbf1e79159c4f608410d2375d3dc3e",
+        "hashed_secret": "6ef7786f32670c202c54aea87cfdf05113cc3ffe",
         "is_verified": false,
-        "line_number": 3436
+        "line_number": 3697
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6eb026fa0af9a741370ad4fc210b8d7bacaed0cf",
+        "hashed_secret": "86ccab9657f1dca59db61781ed479a804acff3bc",
         "is_verified": false,
-        "line_number": 3437
+        "line_number": 3698
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9be1de0d143bf0817c0b103731fc9a659930ad6e",
+        "hashed_secret": "c54f36bf355a8bc02d5935abc95d9eec4e8b0cc7",
         "is_verified": false,
-        "line_number": 3438
+        "line_number": 3699
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07dd16120f1ae1693428596b85cfa5d74a670ca6",
+        "hashed_secret": "71843dbc2ae8889e62ac5c42a003e445968a406b",
         "is_verified": false,
-        "line_number": 3439
+        "line_number": 3700
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "003b8edb68e3ef140d124c0bec47a3f25b79e8a1",
+        "hashed_secret": "9671219fce29e2368674079e528e153e2ce1b7b1",
         "is_verified": false,
-        "line_number": 3440
+        "line_number": 3701
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f782b13b46644ed791b4f5aa5f77fa775534f4f8",
+        "hashed_secret": "afed986ef80b2ac643d1c377adc353a2dd072f9f",
         "is_verified": false,
-        "line_number": 3441
+        "line_number": 3702
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0d50e4a0122dd9780322ee984c876d2fb8081d7c",
+        "hashed_secret": "c1ea81e3c5ceae95818e63ddca15e50a41b04643",
         "is_verified": false,
-        "line_number": 3442
+        "line_number": 3703
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "40150f7e5a057640aab13eaf01ee42047c98be07",
+        "hashed_secret": "10b1e2620e95c65a3a1cdcd3f088a1d440b59437",
         "is_verified": false,
-        "line_number": 3443
+        "line_number": 3704
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "88d5daf2d46b130a1d52dc1a424145ef80e2d7c6",
+        "hashed_secret": "85a5a000f37fff8207d356baf16dc68b1aad3ad8",
         "is_verified": false,
-        "line_number": 3444
+        "line_number": 3705
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8e31190857d8df481643a2fc968ba0f83b2328b4",
+        "hashed_secret": "ee766dbe6737f20798d2907f668e3ccdc8adfa05",
         "is_verified": false,
-        "line_number": 3445
+        "line_number": 3706
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "434a680f92c1be3fab698dc2870036578485371d",
+        "hashed_secret": "ee432fc4db6fe7cf6d4f9c1df4bd616cd1ef8347",
         "is_verified": false,
-        "line_number": 3446
+        "line_number": 3707
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "659e8bad31016d37da549b78a7605623cde80437",
+        "hashed_secret": "69af827cedf9814ce90a6701ad3c3a8ca73d8e45",
         "is_verified": false,
-        "line_number": 3447
+        "line_number": 3708
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "770f17c5a2e28164d16e8647777e0f633c48c3eb",
+        "hashed_secret": "2e4a6670ebb4b46a24f09d5b23b670e7aa30f7e0",
         "is_verified": false,
-        "line_number": 3448
+        "line_number": 3709
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "69be11509ad17706da4523fba89f9ee8070eee44",
+        "hashed_secret": "3300b1ed2d6d90773c5d69bf35a98ba089fdb7c8",
         "is_verified": false,
-        "line_number": 3449
+        "line_number": 3710
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f4bcf5eb8a1f3c9674a5a67c475753660ac56cb9",
+        "hashed_secret": "703a5fa2dfe95eb476ec40a6e9b1c507a65cecab",
         "is_verified": false,
-        "line_number": 3450
+        "line_number": 3711
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a02dbaffd862f2851be7bf2a993af7c6d84fd42e",
+        "hashed_secret": "c1607bc05bfe42a6e547b4c550a5d236f5cacd45",
         "is_verified": false,
-        "line_number": 3451
+        "line_number": 3712
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "499fcaa48e7ce00f995c6380f3c6518a8f1f867f",
+        "hashed_secret": "a155f54fa1ac2db556c1ae1a50c2d6e1aa77e212",
         "is_verified": false,
-        "line_number": 3452
+        "line_number": 3713
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c36b4da9997c324a2e7a8e15e6dcb4525654eb98",
+        "hashed_secret": "4579281a93869323bee95ea5eb1e152e18846f00",
         "is_verified": false,
-        "line_number": 3453
+        "line_number": 3714
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e9cc090ee3ac33c45bc09985579444e49f269f14",
+        "hashed_secret": "5bb7380658b4fdb90584895b3d520e8a26bf8bd9",
         "is_verified": false,
-        "line_number": 3454
+        "line_number": 3715
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dc879ce41fccb2508b33bd9e133dcdaee26d226c",
+        "hashed_secret": "0ce12a6fbde3bf344c50449819c08e0acf951434",
         "is_verified": false,
-        "line_number": 3455
+        "line_number": 3716
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bbdc0fb4471f6797fc443e8947172604b1b89357",
+        "hashed_secret": "0f544f3319d5a8adc0f6222ef6bc7a0f3c1c8842",
         "is_verified": false,
-        "line_number": 3456
+        "line_number": 3717
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "64b1625a26f82d5bea8fd82b8bc67eb437a4a0bd",
+        "hashed_secret": "3c7a9f5e132d781d92b58a017b40bed1dac0e139",
         "is_verified": false,
-        "line_number": 3457
+        "line_number": 3718
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "00c74e9683143c3fe2a7b58dc302d5667542611f",
+        "hashed_secret": "b83aa13552c1ee1d65ef2b6aad87f3336eae2e75",
         "is_verified": false,
-        "line_number": 3458
+        "line_number": 3719
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f1747552ab0bc961b3eddcc1b8517994c2ac9bd9",
+        "hashed_secret": "68b73513cba329f38f36b18307fa7c59d7b526b0",
         "is_verified": false,
-        "line_number": 3459
+        "line_number": 3720
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "bf4331f45fb110d966b07e5be1e2f963305dc685",
+        "hashed_secret": "747fc2c2c2dbd9f71e8a31a1538d3691abe2fcdb",
         "is_verified": false,
-        "line_number": 3460
+        "line_number": 3721
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "aa9dfe49efc1f42d27b649be1382bb9443d036f2",
+        "hashed_secret": "fd354a4e9cddb60127ab0eb50624eea4cfbd0348",
         "is_verified": false,
-        "line_number": 3461
+        "line_number": 3722
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "234ecc3eb8b6eed6cd74f5e8905a076f13256bfe",
+        "hashed_secret": "be7b9a4716db2bc804ce23434ad41207330cb2d9",
         "is_verified": false,
-        "line_number": 3462
+        "line_number": 3723
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d8ed81e2af1a81d713a148c243b250c5609150cc",
+        "hashed_secret": "4db5849acf1f7b4d262ed8f4ca49ef00c59fb809",
         "is_verified": false,
-        "line_number": 3463
+        "line_number": 3724
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6951e8e204fb4ce9d777243a9df1717e6849edd1",
+        "hashed_secret": "c09d2debfd8a8e9e43c7cadc22583abfcee82858",
         "is_verified": false,
-        "line_number": 3464
+        "line_number": 3725
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "245cfed03fd4cdb63280cac428f4e5cd18d1a34d",
+        "hashed_secret": "84e06e2669ae469aab6edcdbe4fac12afa22ce8f",
         "is_verified": false,
-        "line_number": 3465
+        "line_number": 3726
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "45998e482052acf325b3a2f15f29db737f9b7c74",
+        "hashed_secret": "f274e8f5a8f48d86850df3f111e22503a3c80dd8",
         "is_verified": false,
-        "line_number": 3466
+        "line_number": 3727
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fd2dde0728a88825fa8162b31178b4c02c2f512e",
+        "hashed_secret": "7cb3739f9d4152b2802579b10350f8b9d4e634c8",
         "is_verified": false,
-        "line_number": 3467
+        "line_number": 3728
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "437cfe8da25e76476a3d0fa2e8f4ba20caf1bfb7",
+        "hashed_secret": "07a0278352a18727fd47ae0a50c9d93e67da09b6",
         "is_verified": false,
-        "line_number": 3468
+        "line_number": 3729
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "855169da0f015b5d5b77ad43df3607e360501607",
+        "hashed_secret": "c1fcd9f83adce749cad474f5dd127bcd5a492411",
         "is_verified": false,
-        "line_number": 3469
+        "line_number": 3730
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e19d69d5a6a8f54c51144d8eac17a236686af84b",
+        "hashed_secret": "e9f746830aa82345091c63ac524052b5ab80e286",
         "is_verified": false,
-        "line_number": 3470
+        "line_number": 3731
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "787b545c32de1ef567dc4a059dcb0355c60fe929",
+        "hashed_secret": "db3d12df052570e864ef393e21d683542a3d25c2",
         "is_verified": false,
-        "line_number": 3471
+        "line_number": 3732
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3f6a493441063b375bc27845460f5fb477bc85d2",
+        "hashed_secret": "48cfc36b2d836d4c92293a67ad4cef9bdb256fc9",
         "is_verified": false,
-        "line_number": 3472
+        "line_number": 3733
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "90c038c125c252cb5bc13fa80b3f4cf0ce811c57",
+        "hashed_secret": "fb20128f4a2ba4d2c17db6d7407cb730cb44d2df",
         "is_verified": false,
-        "line_number": 3473
+        "line_number": 3734
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5ba0845a583704378901f0bb1f81edff6fc2e1c5",
+        "hashed_secret": "51184d242675a95c2e72d1bec3c6ab9fd67bf19b",
         "is_verified": false,
-        "line_number": 3474
+        "line_number": 3735
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "62e0063048cf6f195c2d445fcf40891c6488fa59",
+        "hashed_secret": "6e944d3b8c6cd5dac06068666d533c12e7500965",
         "is_verified": false,
-        "line_number": 3475
+        "line_number": 3736
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "12cc9ed0392a06aa8c2348b325ba70077b918915",
+        "hashed_secret": "5d460d7a72a568938d030543cc4fea4b70246422",
         "is_verified": false,
-        "line_number": 3476
+        "line_number": 3737
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f30b5070ecbfa394a90dc7cbe4e7b7a748a25e52",
+        "hashed_secret": "42c1fac1937a95b7011a158115c307a6b47e3b81",
         "is_verified": false,
-        "line_number": 3477
+        "line_number": 3738
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "76966aa98c6945e0329588d7a5b39fb8bf24d9c5",
+        "hashed_secret": "dd4b105853bdfd34e40c535849bac7d0b1f663ca",
         "is_verified": false,
-        "line_number": 3478
+        "line_number": 3739
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3bc80dc67533d230deb10aab0af2856bbcff4bfb",
+        "hashed_secret": "d9eb1dad228237eec6847934d0576ff7a994600e",
         "is_verified": false,
-        "line_number": 3479
+        "line_number": 3740
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7b3b97f75c656acffad150423fcffc47baa3011b",
+        "hashed_secret": "167da25410bdacd7a45e526290ee224fc37e8ad5",
         "is_verified": false,
-        "line_number": 3480
+        "line_number": 3741
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4e6658ec3d91781c57075aab2e0f5fa262e0a10a",
+        "hashed_secret": "9bab3814f32c25ba49e737f0987eacebaf673d37",
         "is_verified": false,
-        "line_number": 3481
+        "line_number": 3742
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dbbaa61da4b5d34c22303d4c1045c44ebcaf9085",
+        "hashed_secret": "c76d0e2d664c5a590bcb1ffdcd039babb00a82f2",
         "is_verified": false,
-        "line_number": 3482
+        "line_number": 3743
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f499d30fe791bb034002847594442e87b64734db",
+        "hashed_secret": "7c6d9e3a77758c19e198984d80962550784a0ade",
         "is_verified": false,
-        "line_number": 3483
+        "line_number": 3744
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e740d3d369be5ea8e1ddc8170796a0aed3557fa0",
+        "hashed_secret": "1b7b13e8ed10eedcd91ca201b445511f7e281542",
         "is_verified": false,
-        "line_number": 3484
+        "line_number": 3745
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9f9e5e6282d94c7695fecbe9113bc4da77470b01",
+        "hashed_secret": "6d1999c236ea993d6d9bf8eda6b344fc6efb31e2",
         "is_verified": false,
-        "line_number": 3485
+        "line_number": 3746
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f9cbc65e136b231f55a6796db39a272374111ea0",
+        "hashed_secret": "3f0d4ae9b649cfac2a8e97a7459aaaa75067a9f6",
         "is_verified": false,
-        "line_number": 3486
+        "line_number": 3747
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d7aa1bd90064a39312d2894f6fec28dc0c314ea9",
+        "hashed_secret": "5fe34f22c7ff6bde84095164192b98fe99df5de6",
         "is_verified": false,
-        "line_number": 3487
+        "line_number": 3748
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b796b5ea64260b010b1eb26ff8f4665f1fd4aa79",
+        "hashed_secret": "10f7eab7df07c32ada0dfce8af071e0570bde2b5",
         "is_verified": false,
-        "line_number": 3488
+        "line_number": 3749
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a32b528d867f5ea6ac3a4f4cc711102c0b155172",
+        "hashed_secret": "7ed6e0f40600a76507e8742e9e4bcea26ec52e01",
         "is_verified": false,
-        "line_number": 3489
+        "line_number": 3750
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "64e42e5e66fb604754c5c8b02143119cef89bfb7",
+        "hashed_secret": "1581853940822412287889ad374721af1b7bb69b",
         "is_verified": false,
-        "line_number": 3490
+        "line_number": 3751
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2ba1ae2dbd915958c5b6af81c10b1fdc23a2f899",
+        "hashed_secret": "6bcec2339d7fb28321fff3aa8eac3fcd2294b437",
         "is_verified": false,
-        "line_number": 3491
+        "line_number": 3752
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0e178f80d6b356684825ff4c7dc9999b7a20e048",
+        "hashed_secret": "f494b9dca74e5e5abd9857581593c2ac91499fd9",
         "is_verified": false,
-        "line_number": 3492
+        "line_number": 3753
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d8b5f54f29289dbb2ee85b7dee844099a2d412b1",
+        "hashed_secret": "eb9b61397546b029f17e39e0502a11a19064c10d",
         "is_verified": false,
-        "line_number": 3493
+        "line_number": 3754
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a353f8b80eb7e1c31c4d5c829a15a0b252c9e065",
+        "hashed_secret": "52d5b54b7daddd818aa4c113d62ba873065e54b5",
         "is_verified": false,
-        "line_number": 3494
+        "line_number": 3755
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "df7c580d0d5c8130f8c556c12c8260165ed619d3",
+        "hashed_secret": "59955d359d7036299839019c537dba5ff5b4242d",
         "is_verified": false,
-        "line_number": 3495
+        "line_number": 3756
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7b17bb6d629762d439a49befbbe2d211bcdd1ab1",
+        "hashed_secret": "978f28ca873fccb2f7f32ea4b1293c8aac63fec7",
         "is_verified": false,
-        "line_number": 3496
+        "line_number": 3757
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f8ce5bd169690b23cf48659ee0d7e0ea98f010eb",
+        "hashed_secret": "52a27035190e6daef58de1456d674e792ec30a2d",
         "is_verified": false,
-        "line_number": 3497
+        "line_number": 3758
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dc8ca059274ab9bbaaf3cf6ba447fb3cf6336fab",
+        "hashed_secret": "6560d38de0e9b067b51363f2bb0aee3944ac7fcb",
         "is_verified": false,
-        "line_number": 3498
+        "line_number": 3759
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7f5e1854ca71eaa230fdad86c5855602c993a10e",
+        "hashed_secret": "ba1227e71a404a17e5164330a3288d6a2d5791c1",
         "is_verified": false,
-        "line_number": 3499
+        "line_number": 3760
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "25c4d0e1fa0b36412c44553d752936a58b5a46a1",
+        "hashed_secret": "8d7b6a2a6d4cbdb47a86206e2d9c7a06599cb2b9",
         "is_verified": false,
-        "line_number": 3500
+        "line_number": 3761
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fd1cda0254cbe4725384e53a71c23fc0ff2ef94d",
+        "hashed_secret": "929f5bd02d170f54b2235477df888100a85b802a",
         "is_verified": false,
-        "line_number": 3501
+        "line_number": 3762
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ca3126c7b5197ba382d3899b39c13ca2779d956e",
+        "hashed_secret": "c7693bca443a91e60bfb71f48fcab31681588777",
         "is_verified": false,
-        "line_number": 3502
+        "line_number": 3763
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cbf7189c0eed7de59574a6d304b5a4c6eec3365e",
+        "hashed_secret": "a7cd2150a2ce7a704b5d6f4705c1c731900603b3",
         "is_verified": false,
-        "line_number": 3503
+        "line_number": 3764
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9f86ec638d534bc2f99017e18883256cd1cceb57",
+        "hashed_secret": "f9c7fdd828e92070fd8edef94b8efb2fde7597c8",
         "is_verified": false,
-        "line_number": 3504
+        "line_number": 3765
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5db715894ddd7b7da9283e4528f91f8e5ed3077a",
+        "hashed_secret": "e2be11bf9a8b2aaee2259e7709fc56e80c43596c",
         "is_verified": false,
-        "line_number": 3505
+        "line_number": 3766
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b8589d3b3b93e2521f973693b7e5bc099c85519e",
+        "hashed_secret": "fe593b6a0d04dae498e9a4b1a7ad8986643ed184",
         "is_verified": false,
-        "line_number": 3506
+        "line_number": 3767
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "24be88b9025df79b54c5285d54d7e2a2fa114af5",
+        "hashed_secret": "f652e8367cee3d7adee4b49e0edee4f063143c5e",
         "is_verified": false,
-        "line_number": 3507
+        "line_number": 3768
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c94d547d2dfbabb1f0813fbf9f6a135c91e3fdb7",
+        "hashed_secret": "f9d01455c672a83ebee214cf3837d6c3d34056f5",
         "is_verified": false,
-        "line_number": 3508
+        "line_number": 3769
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "93d38db7c1ce6e5f5b01b7f5ad3c8324cb7221f1",
+        "hashed_secret": "63965dd4ba214689c87551231f41c172a4f4ae5a",
         "is_verified": false,
-        "line_number": 3509
+        "line_number": 3770
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "caf13f9cccf9ea81aa39991851dc1ae11013e720",
+        "hashed_secret": "c10c4155f793cddce478a4398c77d5ffe56677eb",
         "is_verified": false,
-        "line_number": 3510
+        "line_number": 3771
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "aae2cf2791de1bf2396e47dd7997a11b94e2836a",
+        "hashed_secret": "366d462f5415e022d4470b59dd7336235912d0e1",
         "is_verified": false,
-        "line_number": 3511
+        "line_number": 3772
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ba7530957432ffba1ccdbf96bf0fae1e25aedc2c",
+        "hashed_secret": "1ab8a5197a178c15c0d1fe548dffc0799a329cb9",
         "is_verified": false,
-        "line_number": 3512
+        "line_number": 3773
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "80159a0c94e16dff47972186ff5694b18dd40acf",
+        "hashed_secret": "1be058d1392649551558b82c0801ff1333b6069e",
         "is_verified": false,
-        "line_number": 3513
+        "line_number": 3774
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eab5bd9d3fecd2a1689a77276f337f95edfe43f8",
+        "hashed_secret": "569350ad80633404a9513e0deb22d602c6548da1",
         "is_verified": false,
-        "line_number": 3514
+        "line_number": 3775
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6010a8288d3e9c24266713b1a37758bc1f27dee6",
+        "hashed_secret": "37095ba8f49885f3246e50cbed40280698aa49f3",
         "is_verified": false,
-        "line_number": 3515
+        "line_number": 3776
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07f779cead25f67b57fadc5564d38622e6cd2757",
+        "hashed_secret": "f463fa838d0f9eb797012cf9429d74f68eec0514",
         "is_verified": false,
-        "line_number": 3516
+        "line_number": 3777
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c2052666ca4831f34ab27fb8dc2753a458b4ddc2",
+        "hashed_secret": "317e364d7f3a80cc2445fc0eb3da408ed07fdfa6",
         "is_verified": false,
-        "line_number": 3517
+        "line_number": 3778
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "04148a039f0b0bd59d75ef76497455a0144053ca",
+        "hashed_secret": "4600e96fa38df8442a90e235b6d5d1a9c66d1b80",
         "is_verified": false,
-        "line_number": 3518
+        "line_number": 3779
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "375308f3376ef0d8283d14f83abc26044963a28a",
+        "hashed_secret": "b0f14876e3a2eae39310d185cfd4150cc673c328",
         "is_verified": false,
-        "line_number": 3519
+        "line_number": 3780
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2bc14ac2f1635d5b01b6aea3481682ae8a5af20b",
+        "hashed_secret": "b1f83af6db2a94ba936b190c2fccf49161258266",
         "is_verified": false,
-        "line_number": 3520
+        "line_number": 3781
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fea8fcb156954450d589e4f5f88a20f40645d1fb",
+        "hashed_secret": "47e19adb933c198667471fd970808235374745ff",
         "is_verified": false,
-        "line_number": 3521
+        "line_number": 3782
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "11ab97656d253db0ca0147ce0569cc106d045265",
+        "hashed_secret": "5c9f322bd6501a703a69871ef953469da335639b",
         "is_verified": false,
-        "line_number": 3522
+        "line_number": 3783
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "db5b6a24f82fcf1a73d669e5b6516bb0a58ba088",
+        "hashed_secret": "2c2cce4bddee9b888ba2c47457433487bc75615c",
         "is_verified": false,
-        "line_number": 3523
+        "line_number": 3784
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e3a4fe17c36c9795aa599cc271f9fd460ada9e65",
+        "hashed_secret": "c2ddeea3bbdc8623c3a89c21551fbe794396ca4a",
         "is_verified": false,
-        "line_number": 3524
+        "line_number": 3785
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d90838eec250c484e3eb1a932f749dfdbcdddde5",
+        "hashed_secret": "50ca990754754ae2e756723b459b085baafc97f8",
         "is_verified": false,
-        "line_number": 3525
+        "line_number": 3786
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ea2d99a9ac36863f453e6f9e2b5ea1b8a4d5eb4e",
+        "hashed_secret": "8cdc824a0bfcc4b030fd212575f981af3ba72620",
         "is_verified": false,
-        "line_number": 3526
+        "line_number": 3787
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b80b574e0c7c3eacaa7e81866b8aa133f832132f",
+        "hashed_secret": "6d801dfebf092cdd1d0cb618a2afbbb24ab93095",
         "is_verified": false,
-        "line_number": 3527
+        "line_number": 3788
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "41f1c92a70a9daa61e0437c159d172ad489e48bb",
+        "hashed_secret": "121bac336c90613ddb6e07fa08495986c28bbc09",
         "is_verified": false,
-        "line_number": 3528
+        "line_number": 3789
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d0824e1a58def6c853f02d38a0a9b335d429ae16",
+        "hashed_secret": "95b7b6e1e01374981a2df173e795b0d60ac157b0",
         "is_verified": false,
-        "line_number": 3529
+        "line_number": 3790
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7725c8596ccddc526556ac2afd199cf8b9c1050d",
+        "hashed_secret": "119c26cf4f62cf8c20845b83e38b69c3c1f259e5",
         "is_verified": false,
-        "line_number": 3530
+        "line_number": 3791
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e4bc4f03b97d105ae0a34cd4a13541e6dfcb553f",
+        "hashed_secret": "b7df59204656c0c44bef39dd7c9fa8ed73ff0e48",
         "is_verified": false,
-        "line_number": 3531
+        "line_number": 3792
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb117f66ee6bef9a560982ec95c2313946cfca61",
+        "hashed_secret": "dd1d531ee7ce87632a58db6da17d8fcfb7fbcc4e",
         "is_verified": false,
-        "line_number": 3532
+        "line_number": 3793
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3a83b1aec8489b8d7c6de7f7a523c354102f7596",
+        "hashed_secret": "a7fb7186ff43a9ed01fd7b081b86e09db6bb4f0e",
         "is_verified": false,
-        "line_number": 3533
+        "line_number": 3794
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d1b1117d0c62b01dab6b8aab4dd931f654e770f8",
+        "hashed_secret": "30d78981c86fc4c2809eba9d3b2d057beae943af",
         "is_verified": false,
-        "line_number": 3534
+        "line_number": 3795
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9d82912b883e4d99fdab8b428517728e48d40d93",
+        "hashed_secret": "7aac9a0c69f9eac1fe3e81a58298d50b386e1205",
         "is_verified": false,
-        "line_number": 3535
+        "line_number": 3796
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "98032f4dea369b97eead14301e7542ddf71d59ee",
+        "hashed_secret": "7721742608b2f2987dafcf2f344b38dd4417732e",
         "is_verified": false,
-        "line_number": 3536
+        "line_number": 3797
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10a5c06abfc54030507da6adf61f329f494f5116",
+        "hashed_secret": "f7da5cc1baa30b87858647d3fbfe69caa14d1983",
         "is_verified": false,
-        "line_number": 3537
+        "line_number": 3798
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dc463eca31fbec710ff0cdb51848f8a5ff6b97bb",
+        "hashed_secret": "051d8b6047ff8e7250667b9518cefc22f6fbd220",
         "is_verified": false,
-        "line_number": 3538
+        "line_number": 3799
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "13102ff15d3a1af51cabfb67c77ed4ca7f75da14",
+        "hashed_secret": "68e0e441a65c2d890b94784d34e98cfa6bbdfa60",
         "is_verified": false,
-        "line_number": 3539
+        "line_number": 3800
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "87e595d3dfbec31854b7c6fb170e30589d74dc82",
+        "hashed_secret": "42c43f5d7c49890377725de96c4ee383651bcb48",
         "is_verified": false,
-        "line_number": 3540
+        "line_number": 3801
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b321a0a20e738163e354475584fdd5f43d891fec",
+        "hashed_secret": "fa272ad3231289d0fe74d3fa1779608915327290",
         "is_verified": false,
-        "line_number": 3541
+        "line_number": 3802
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4da171c8a369ef00170d3cbfd3ed8ebfc4f52f2d",
+        "hashed_secret": "db7bd757118d0533a81ccfda68c2878cb5616425",
         "is_verified": false,
-        "line_number": 3542
+        "line_number": 3803
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42f77e24d910261418c46e0b3a430277e63c3759",
+        "hashed_secret": "fcb382375a96edb4dff409e483ae7086cd1c808a",
         "is_verified": false,
-        "line_number": 3543
+        "line_number": 3804
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9ff3c74e2922dbb5327211d734dc980813b654dc",
+        "hashed_secret": "f3e6153ddd8cebe4378abef6ffe3df8d16a88f36",
         "is_verified": false,
-        "line_number": 3544
+        "line_number": 3805
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5e8fd9b295834a9f641a07914152ba21c1b70b0b",
+        "hashed_secret": "6a4116db9a3774ec0a1226941f1a3ad86d60a953",
         "is_verified": false,
-        "line_number": 3545
+        "line_number": 3806
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3be4ab546556d7c995ab1b84e092583c06c20f9d",
+        "hashed_secret": "d5d6ab3e82edf205bf010abe1d417a8d5371a94c",
         "is_verified": false,
-        "line_number": 3546
+        "line_number": 3807
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3ec3ad5b1453f435563b1b854ec9b2f2030208ac",
+        "hashed_secret": "95faac95e471b53b94b6cb6a4cb7e09637452044",
         "is_verified": false,
-        "line_number": 3547
+        "line_number": 3808
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10bd1a2ed4f20e9b4b9942e9a0334e178da55e18",
+        "hashed_secret": "3a343a5e676fc43589e1c2982188e29fe5d76d79",
         "is_verified": false,
-        "line_number": 3548
+        "line_number": 3809
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2e4b631391d4b5748a79cfaf9233f251c3cafcbc",
+        "hashed_secret": "7cb7f88b5f76c4a0d4ec6993b0fd557eb60f495d",
         "is_verified": false,
-        "line_number": 3549
+        "line_number": 3810
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "739b572066e8aae401adf59379548ebbf793c8f2",
+        "hashed_secret": "0bb78e25247f1e2e71c32d132edf999d36efd87e",
         "is_verified": false,
-        "line_number": 3550
+        "line_number": 3811
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "199f469d42dabaade4e82ddf381d336ae2288b71",
+        "hashed_secret": "3b40808cc2b35eee26807b37cba122a2be4d2d11",
         "is_verified": false,
-        "line_number": 3551
+        "line_number": 3812
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8980755aa6d032b19dcb8f62783e224863e88e1c",
+        "hashed_secret": "68d303b0f090c741b347437076a940950a57fb28",
         "is_verified": false,
-        "line_number": 3552
+        "line_number": 3813
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0b3d933b6fb361f80fa6b5f8293787fbfdb2d306",
+        "hashed_secret": "a223db0481e84ed16c499ada626f551c765490d4",
         "is_verified": false,
-        "line_number": 3553
+        "line_number": 3814
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ece1d870204ffdc62a53a5528a9f71df5d6588bb",
+        "hashed_secret": "ba146e702d94218263d4d389daac4d7c9275a74a",
         "is_verified": false,
-        "line_number": 3554
+        "line_number": 3815
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1cb80d2a07fcc49081b45de0efcd4ccdbadb31b2",
+        "hashed_secret": "a6eb771ac3d0a0546d71201802120de475c1e6a5",
         "is_verified": false,
-        "line_number": 3555
+        "line_number": 3816
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "efd85a27d49428eadc00a0c6ff49519af8971a50",
+        "hashed_secret": "50af18355c25aa99d17768f2e559d6fc8ce18616",
         "is_verified": false,
-        "line_number": 3556
+        "line_number": 3817
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ea0d10d3d685038f29dcdf1f57fa1e360f072805",
+        "hashed_secret": "9a49835f25021496bcdb09d157e9294382fe1994",
         "is_verified": false,
-        "line_number": 3557
+        "line_number": 3818
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b5c5cffdb5b65aa02be80c9a40f79a3f015baf19",
+        "hashed_secret": "a81d39d1c391c66eac7fa5421a1fd59feca16b46",
         "is_verified": false,
-        "line_number": 3558
+        "line_number": 3819
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ccc4a211ad19f502e9ea09a5323ed9e11bc13278",
+        "hashed_secret": "2be7c7baad7edcc019526e2ecf9dbeb13ea47ace",
         "is_verified": false,
-        "line_number": 3559
+        "line_number": 3820
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1df9bc729fffb66b8e2f2a3dda72c6a95bd3a81b",
+        "hashed_secret": "7ef95bcab5b5e92e972a8791dd6f2706c27ddc11",
         "is_verified": false,
-        "line_number": 3560
+        "line_number": 3821
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "23ff1037508e7708d742c46366a05b60a0fc0bc7",
+        "hashed_secret": "4a777a75776c1a3dbe2cf9b0d03859fc233f9d07",
         "is_verified": false,
-        "line_number": 3561
+        "line_number": 3822
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0a38cc50da291dfd9ae5e505dc94828f2027f0f5",
+        "hashed_secret": "3907909f1cd55a330347c139e72782f11350836b",
         "is_verified": false,
-        "line_number": 3562
+        "line_number": 3823
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d82d6634b0b476e5ef9f887e891514f5c6e674e6",
+        "hashed_secret": "25d2a9d2d29c08a6acf76c245c6f307fb4b9ac12",
         "is_verified": false,
-        "line_number": 3563
+        "line_number": 3824
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6be2b719d279a6d06e4d17abfbec46b54582d46e",
+        "hashed_secret": "c835eb04f83c01c8679b1c3a05a43661d35e0814",
         "is_verified": false,
-        "line_number": 3564
+        "line_number": 3825
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cd4610b8c915d8b6c5ba29a9a8898276f37902ad",
+        "hashed_secret": "f96301c858950830bdee8d8f5fdfa2b660ead6b2",
         "is_verified": false,
-        "line_number": 3565
+        "line_number": 3826
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6af779230ebfa6ceb1c0b31cf0dd930a918b9c7b",
+        "hashed_secret": "42948c52e1a86bc52456f7995fc863a0c1791f4d",
         "is_verified": false,
-        "line_number": 3566
+        "line_number": 3827
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8bb096965cc2fa680043d4d228212489f5e84765",
+        "hashed_secret": "038b97c7520d13c600ecad3393f831f6c1c53e72",
         "is_verified": false,
-        "line_number": 3567
+        "line_number": 3828
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e8feca3b283934157301c1f890b2b828b4291732",
+        "hashed_secret": "cb91aa7aa5488783dc455b629b9c8f5d130d83bd",
         "is_verified": false,
-        "line_number": 3568
+        "line_number": 3829
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8e65d0f359281bbf10cc9d5b1b0c0c761478dc58",
+        "hashed_secret": "2450a89bb622f7e25321b66c6ff5837be9fbb333",
         "is_verified": false,
-        "line_number": 3569
+        "line_number": 3830
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "251351c1ed74faa4dcf589be2053a1aaeb99c380",
+        "hashed_secret": "7c3c462109bd2fe10d9f706490ccc4d3f2d1d826",
         "is_verified": false,
-        "line_number": 3570
+        "line_number": 3831
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "18a76b6051b555b3e7d3ad697dd4c0baa321d250",
+        "hashed_secret": "ac7e1b04ebbff6d028a0dfdea8d7b67b3785c515",
         "is_verified": false,
-        "line_number": 3571
+        "line_number": 3832
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4b0c3d8995a2a60faca81b17970d5c8a67ade324",
+        "hashed_secret": "34482a92383d48e9f508c4789a37da13bf72333f",
         "is_verified": false,
-        "line_number": 3572
+        "line_number": 3833
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dde1117b72d2d32e1a2efaf52b204338ee7bcbfe",
+        "hashed_secret": "8996219c94725b68b30deb4a00e8a67b96932e47",
         "is_verified": false,
-        "line_number": 3573
+        "line_number": 3834
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b42e4a3aafc5db8f3e21632f47d04b5113f918d3",
+        "hashed_secret": "05063f22057841b05f62bd49a9ad19e1a07962ab",
         "is_verified": false,
-        "line_number": 3574
+        "line_number": 3835
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5e1423904338695db2088ed9f50d8c6e608a3626",
+        "hashed_secret": "f5bdb563f7d8727a8936b1220465490816da1f76",
         "is_verified": false,
-        "line_number": 3575
+        "line_number": 3836
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "54fccb3f252e700ac75651965166a774f02ea70b",
+        "hashed_secret": "fbddd867f082e9511f37acdba2ff79d93323441c",
         "is_verified": false,
-        "line_number": 3576
+        "line_number": 3837
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "30166162910316a82db18b537d4aabc753e21595",
+        "hashed_secret": "49ae219c88060fddcee2f29881a9db24eb750105",
         "is_verified": false,
-        "line_number": 3577
+        "line_number": 3838
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1186c2dd47dd2586b679be51420710ecf5cae9d6",
+        "hashed_secret": "56efcb65c112f6542d6ab4dfabedf9ef6527e16d",
         "is_verified": false,
-        "line_number": 3578
+        "line_number": 3839
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "44b919c23afca1f1c5b28c93f251973a087c50ab",
+        "hashed_secret": "66b35440dc968f787dd38317c92a51ba9f1a6366",
         "is_verified": false,
-        "line_number": 3579
+        "line_number": 3840
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9dfe9839bd269f484fc5e5c61519169a7122f38a",
+        "hashed_secret": "2e30f5139123bf91ad42005362d6203308887440",
         "is_verified": false,
-        "line_number": 3580
+        "line_number": 3841
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fb116963825983c42c3d7719caabda42f8033aa7",
+        "hashed_secret": "d07564a106ac8c73c15c3f2d9f9faaea2ad18be1",
         "is_verified": false,
-        "line_number": 3581
+        "line_number": 3842
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1fa900a954867f4c8020aef670a1b6fcfc50dda9",
+        "is_verified": false,
+        "line_number": 3843
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c16acb9704b26933251d98fe225a7b391bc7fb81",
+        "is_verified": false,
+        "line_number": 3844
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "573e30c456992b38cbdf133d4ce59086898d205a",
+        "is_verified": false,
+        "line_number": 3845
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "f7e624a9d13d8db311a90c5d69fe55bc0321aaa6",
+        "is_verified": false,
+        "line_number": 3846
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "a82e58fa78bbf4092e5045c75e450c08b117e912",
+        "is_verified": false,
+        "line_number": 3847
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "66929d3cd2245f657eee56953f2a2a208cdf6a25",
+        "is_verified": false,
+        "line_number": 3848
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "3cacb6d5882c30a76451f0bff1ef23b8b96dff9c",
+        "is_verified": false,
+        "line_number": 3849
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7b5c0d8d25129a14a8feef0c8075765f05d2a924",
+        "is_verified": false,
+        "line_number": 3850
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "eee127f034102fab460bb3d828f0d7ab64628138",
+        "is_verified": false,
+        "line_number": 3851
       }
     ],
     "app/internal/server/credentials_handlers.go": [
@@ -1780,5 +1843,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T10:31:43Z"
+  "generated_at": "2026-06-01T10:32:32Z"
 }

--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -1158,6 +1158,83 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/intelligence/events:
+    get:
+      operationId: getIntelligenceEvents
+      summary: List OS Intelligence change events
+      description: |
+        Returns the change events the OS Intelligence collector
+        recorded — newly opened ports, package updates, service
+        failures, etc. Cursor pagination on detected_at DESC. Filter
+        by host_id, event_code, severity, since/until. Spec
+        api-os-intelligence.
+      parameters:
+        - name: host_id
+          in: query
+          schema: {type: string, format: uuid}
+        - name: event_code
+          in: query
+          schema: {type: string, minLength: 1, maxLength: 64}
+        - name: severity
+          in: query
+          schema: {type: string, enum: [info, low, medium, high, critical]}
+        - name: since
+          in: query
+          schema: {type: string, format: date-time}
+        - name: until
+          in: query
+          schema: {type: string, format: date-time}
+        - name: cursor
+          in: query
+          schema: {type: string}
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, maximum: 200, default: 50}
+      responses:
+        '200':
+          description: Events page
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/IntelligenceEventsPage'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '403':
+          description: Caller lacks host:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/intelligence/state/{host_id}:
+    get:
+      operationId: getIntelligenceState
+      summary: Last full Intelligence snapshot for one host
+      description: |
+        Returns the most recent host_intelligence_state row for the
+        given host. 404 hosts.not_found if the host is unknown OR if
+        no Intelligence cycle has populated the row yet (operators
+        cannot probe host existence via this endpoint). Spec
+        api-os-intelligence.
+      parameters:
+        - name: host_id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      responses:
+        '200':
+          description: Last snapshot
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/IntelligenceState'}
+        '403':
+          description: Caller lacks host:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Host unknown OR no snapshot yet
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/hosts/{id}/discovery:run:
     post:
       operationId: postHostDiscoveryRun
@@ -1766,6 +1843,43 @@ components:
           type: string
           enum: [reachable, unreachable, unknown]
           description: Post-hysteresis status (same value the periodic loop would write)
+
+    IntelligenceEvent:
+      type: object
+      required: [id, host_id, event_code, severity, occurred_at, detected_at]
+      properties:
+        id:             {type: string, format: uuid}
+        host_id:        {type: string, format: uuid}
+        event_code:     {type: string, description: 'Closed taxonomy: e.g. system.package.updated'}
+        severity:       {type: string, enum: [info, low, medium, high, critical]}
+        detail:
+          type: object
+          additionalProperties: true
+        occurred_at:    {type: string, format: date-time}
+        detected_at:    {type: string, format: date-time}
+        correlation_id: {type: string}
+
+    IntelligenceEventsPage:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: {$ref: '#/components/schemas/IntelligenceEvent'}
+        next_cursor:
+          type: string
+          nullable: true
+
+    IntelligenceState:
+      type: object
+      required: [host_id, snapshot, collected_at]
+      properties:
+        host_id:      {type: string, format: uuid}
+        snapshot:
+          type: object
+          additionalProperties: true
+          description: Free-form host_intelligence_state.snapshot — mirrors collector.Snapshot
+        collected_at: {type: string, format: date-time}
 
     HostSystemInfo:
       type: object

--- a/app/internal/server/api/server.gen.go
+++ b/app/internal/server/api/server.gen.go
@@ -357,6 +357,33 @@ func (e HostMonitoringHistoryEntryPreviousState) Valid() bool {
 	}
 }
 
+// Defines values for IntelligenceEventSeverity.
+const (
+	IntelligenceEventSeverityCritical IntelligenceEventSeverity = "critical"
+	IntelligenceEventSeverityHigh     IntelligenceEventSeverity = "high"
+	IntelligenceEventSeverityInfo     IntelligenceEventSeverity = "info"
+	IntelligenceEventSeverityLow      IntelligenceEventSeverity = "low"
+	IntelligenceEventSeverityMedium   IntelligenceEventSeverity = "medium"
+)
+
+// Valid indicates whether the value is a known member of the IntelligenceEventSeverity enum.
+func (e IntelligenceEventSeverity) Valid() bool {
+	switch e {
+	case IntelligenceEventSeverityCritical:
+		return true
+	case IntelligenceEventSeverityHigh:
+		return true
+	case IntelligenceEventSeverityInfo:
+		return true
+	case IntelligenceEventSeverityLow:
+		return true
+	case IntelligenceEventSeverityMedium:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for LicenseStateResponseStatus.
 const (
 	Active    LicenseStateResponseStatus = "active"
@@ -399,6 +426,33 @@ func (e LicenseStateResponseTier) Valid() bool {
 	case Free:
 		return true
 	case OpenwatchPlus:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetIntelligenceEventsParamsSeverity.
+const (
+	GetIntelligenceEventsParamsSeverityCritical GetIntelligenceEventsParamsSeverity = "critical"
+	GetIntelligenceEventsParamsSeverityHigh     GetIntelligenceEventsParamsSeverity = "high"
+	GetIntelligenceEventsParamsSeverityInfo     GetIntelligenceEventsParamsSeverity = "info"
+	GetIntelligenceEventsParamsSeverityLow      GetIntelligenceEventsParamsSeverity = "low"
+	GetIntelligenceEventsParamsSeverityMedium   GetIntelligenceEventsParamsSeverity = "medium"
+)
+
+// Valid indicates whether the value is a known member of the GetIntelligenceEventsParamsSeverity enum.
+func (e GetIntelligenceEventsParamsSeverity) Valid() bool {
+	switch e {
+	case GetIntelligenceEventsParamsSeverityCritical:
+		return true
+	case GetIntelligenceEventsParamsSeverityHigh:
+		return true
+	case GetIntelligenceEventsParamsSeverityInfo:
+		return true
+	case GetIntelligenceEventsParamsSeverityLow:
+		return true
+	case GetIntelligenceEventsParamsSeverityMedium:
 		return true
 	default:
 		return false
@@ -955,6 +1009,38 @@ type HostUpdateRequest struct {
 	Username    *string             `json:"username,omitempty"`
 }
 
+// IntelligenceEvent defines model for IntelligenceEvent.
+type IntelligenceEvent struct {
+	CorrelationId *string                 `json:"correlation_id,omitempty"`
+	Detail        *map[string]interface{} `json:"detail,omitempty"`
+	DetectedAt    time.Time               `json:"detected_at"`
+
+	// EventCode Closed taxonomy: e.g. system.package.updated
+	EventCode  string                    `json:"event_code"`
+	HostId     openapi_types.UUID        `json:"host_id"`
+	Id         openapi_types.UUID        `json:"id"`
+	OccurredAt time.Time                 `json:"occurred_at"`
+	Severity   IntelligenceEventSeverity `json:"severity"`
+}
+
+// IntelligenceEventSeverity defines model for IntelligenceEvent.Severity.
+type IntelligenceEventSeverity string
+
+// IntelligenceEventsPage defines model for IntelligenceEventsPage.
+type IntelligenceEventsPage struct {
+	Items      []IntelligenceEvent `json:"items"`
+	NextCursor *string             `json:"next_cursor,omitempty"`
+}
+
+// IntelligenceState defines model for IntelligenceState.
+type IntelligenceState struct {
+	CollectedAt time.Time          `json:"collected_at"`
+	HostId      openapi_types.UUID `json:"host_id"`
+
+	// Snapshot Free-form host_intelligence_state.snapshot — mirrors collector.Snapshot
+	Snapshot map[string]interface{} `json:"snapshot"`
+}
+
 // LicenseStateResponse defines model for LicenseStateResponse.
 type LicenseStateResponse struct {
 	CustomerId    *string                    `json:"customer_id,omitempty"`
@@ -1153,6 +1239,20 @@ type PostHostDiscoveryRunParams struct {
 	IdempotencyKey string `json:"Idempotency-Key"`
 }
 
+// GetIntelligenceEventsParams defines parameters for GetIntelligenceEvents.
+type GetIntelligenceEventsParams struct {
+	HostId    *openapi_types.UUID                  `form:"host_id,omitempty" json:"host_id,omitempty"`
+	EventCode *string                              `form:"event_code,omitempty" json:"event_code,omitempty"`
+	Severity  *GetIntelligenceEventsParamsSeverity `form:"severity,omitempty" json:"severity,omitempty"`
+	Since     *time.Time                           `form:"since,omitempty" json:"since,omitempty"`
+	Until     *time.Time                           `form:"until,omitempty" json:"until,omitempty"`
+	Cursor    *string                              `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Limit     *int                                 `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetIntelligenceEventsParamsSeverity defines parameters for GetIntelligenceEvents.
+type GetIntelligenceEventsParamsSeverity string
+
 // PostAdminLicenseVerifyJSONRequestBody defines body for PostAdminLicenseVerify for application/json ContentType.
 type PostAdminLicenseVerifyJSONRequestBody = LicenseVerifyRequest
 
@@ -1341,6 +1441,12 @@ type ServerInterface interface {
 	// Synchronous on-demand OS fingerprint discovery for a single host
 	// (POST /api/v1/hosts/{id}/discovery:run)
 	PostHostDiscoveryRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params PostHostDiscoveryRunParams)
+	// List OS Intelligence change events
+	// (GET /api/v1/intelligence/events)
+	GetIntelligenceEvents(w http.ResponseWriter, r *http.Request, params GetIntelligenceEventsParams)
+	// Last full Intelligence snapshot for one host
+	// (GET /api/v1/intelligence/state/{host_id})
+	GetIntelligenceState(w http.ResponseWriter, r *http.Request, hostId openapi_types.UUID)
 	// Get the current license state (tier, features, quotas, status)
 	// (GET /api/v1/license)
 	GetLicense(w http.ResponseWriter, r *http.Request)
@@ -1626,6 +1732,18 @@ func (_ Unimplemented) PostHostConnectivityCheck(w http.ResponseWriter, r *http.
 // Synchronous on-demand OS fingerprint discovery for a single host
 // (POST /api/v1/hosts/{id}/discovery:run)
 func (_ Unimplemented) PostHostDiscoveryRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params PostHostDiscoveryRunParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List OS Intelligence change events
+// (GET /api/v1/intelligence/events)
+func (_ Unimplemented) GetIntelligenceEvents(w http.ResponseWriter, r *http.Request, params GetIntelligenceEventsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Last full Intelligence snapshot for one host
+// (GET /api/v1/intelligence/state/{host_id})
+func (_ Unimplemented) GetIntelligenceState(w http.ResponseWriter, r *http.Request, hostId openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2935,6 +3053,143 @@ func (siw *ServerInterfaceWrapper) PostHostDiscoveryRun(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// GetIntelligenceEvents operation middleware
+func (siw *ServerInterfaceWrapper) GetIntelligenceEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetIntelligenceEventsParams
+
+	// ------------- Optional query parameter "host_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "host_id", r.URL.Query(), &params.HostId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "host_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "host_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "event_code" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "event_code", r.URL.Query(), &params.EventCode, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "event_code"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "event_code", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "severity" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "severity", r.URL.Query(), &params.Severity, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "severity"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "severity", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "since", r.URL.Query(), &params.Since, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "since"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "since", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "until" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "until", r.URL.Query(), &params.Until, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "until"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "until", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetIntelligenceEvents(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetIntelligenceState operation middleware
+func (siw *ServerInterfaceWrapper) GetIntelligenceState(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "host_id" -------------
+	var hostId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "host_id", chi.URLParam(r, "host_id"), &hostId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "host_id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetIntelligenceState(w, r, hostId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetLicense operation middleware
 func (siw *ServerInterfaceWrapper) GetLicense(w http.ResponseWriter, r *http.Request) {
 
@@ -3388,6 +3643,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/api/v1/hosts/{id}/discovery:run", wrapper.PostHostDiscoveryRun)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/intelligence/events", wrapper.GetIntelligenceEvents)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/intelligence/state/{host_id}", wrapper.GetIntelligenceState)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/license", wrapper.GetLicense)
 	})
 	r.Group(func(r chi.Router) {
@@ -3432,154 +3693,163 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H3tchs3suiroHhPVaRrkqIs25VVynXLcey198aJS3I2tyr25YIzTRIRBpgAGNI8iavur/MAp+4T7pOc",
-	"wsfMYGYwH5QlSjnrP7uxiAEa/YVGd6P791HEk5QzYEqOzn8fCZApZxLMP77F8QX8loFU+l8RZwqY+U+c",
-	"ppREWBHOTn6VnOm/yWgNCdb/9W8ClqPz0f84Kac+sb/KkxdCcPGCbYDyFEafPn0aj2KQkSCpnmx0Pvo7",
-	"piQ2M49RileEuf/mApEYkpQrYNEOgZ5n9Gk8egNqzeMfuHpGKd9CfDhIfxacrdCrd+/eosQAMdJj3Od6",
-	"9mdxQtgFpyAvHFb1X1PBUxCKWBQL/bP+D6IgkX0w6cleMCV2eudql8LofISFwDuztIDfMiI0Cn5x834o",
-	"RvHFrxAp/dmzLCbqxcbhpwoNjuzefs8/k0oQttKf4UhxMScGvyyjFC8ojM6VyGDcNtj+OTBXxIUAaoji",
-	"ZmwMiUFhQg1McUz0SEzferBWFi43Z2dbcpFgNTofZRmJRwH4eBRlQkA8x6oyPsYKJookEPpIQMRFvPdH",
-	"sUVqlciNcVVi6u8kz0QEQzFejM+R3vuFhA0IonYBcGq8ZHBYo9k455UKsauY7eY++RavAgJRoGiQQHjM",
-	"HEAig49qHmVCcqEnqorvjyn+LQNkf/4GpVhKhCX6X/YPT5HiaAkqWiO1BqRn0upIb7EHs3XkmW1UYQkj",
-	"Rq2/5yvCPI1bxQxXqf6/BH/8HthKrUfnT8ajhDDvXw0i611tuYhrHz58XP30NPBpJkEwnMDen9YQUMzj",
-	"QdODgDZliaMIpJwrfgVhJSVgKUCuO0ZoaPqZSq3fQAFGfUMVKOpruhXaNvjm5bMXTHBK2zeZCr4hknBG",
-	"2GqeCdIvn40vOlb/Owiy3N0gj9Vg0RO0Lg9vQSREalA7jkQSA1NOMdV/CdKUyDlmnO0SnvnKdcE5BcwM",
-	"X3AKA/WcGVqbM7ShtNzKPpq9saTba3XCdgy2ow0Sd2A28TPsUGxBUlUTDMCgJ/AWJjd126beOq3wfI3Z",
-	"ClpZ05wrTM0rKq1bhTHYDh9e20pjudp0bbu5sOqgdRt9Kqpux1WGhxZ9jhWsuNhZu7CxXuXQa2WOAWT1",
-	"JwrCwRmDSJENUbtvBeCrmG9ZgIyCKBJh2jyQMyYAR2t9tKIHKNJcHmWKbGC+xIRmAuT7bDY7i85G45KZ",
-	"CVNPHpXcTJiCFQhrQa4Eju2FoLrQoGXg6enAddw2q2t0zDsQfqbts3kq+CK0B8bRmks1p2QDDKREgm8R",
-	"fCRSyWHTc0YJg/2R83Q2ZP76qWAX84gyLhnBobC24z4We76G6OoCZEYDQmZuh4UpXN2gitK5ttZ5psZ6",
-	"h2ZGzuYClpmEeIwWmDEQ84TIBKtoba6e+iMz6TdIm3+IMyQzYwf0G4RWcTi8EkrUbi4VVllTPEdvuVST",
-	"9U4qECCJRHYcOpI4AbTBNANjjaYgCI9JhCjnKdryjMZoK4iCY61zWZZYzeEIqVUyq/7rimmMfwgZjAb7",
-	"e15x8qnDZ687sQzS50lg1zONTsdf/bzk76Qxt7+Bdrz38hZnS7Jq111zCVGAeHplpMEWG0zRkgvkqzQt",
-	"rhItgPKtIaJaa8XOaYyOnsym06+fPJrNjqfoO1jijCp0+nCGjh4mmqIJ/kgSTVQzxthj9t9PZl2KbzCU",
-	"dRi3RK07FWMY4rPZDB09vhbEfMsGQ2thxEqLJV7wDQzC5tcauLPZdaBLsP4HwyyC+YryRejs+nkNDBnp",
-	"R4YBrWQqEl1JtMiU/aNETmvLkss9QfHXCSMDhCRSQaxVVBzCCmHIm6WFTE80Kp7MkuMp+oErtAOFcKb4",
-	"xLjKIP4GKYGjK4jNvE7dTPT8lbklJRHsj0x7Etw8az6dhXf7F73Z02txpcAK5pQkRDVBfYM/ajCckYgu",
-	"L195R4lEcaaVI1pSAIXkFiCV6Oh0On04m1UAeVgB4zQEhTuqWjliYvnt3fO3E3twIfeFZgYJEWexXfus",
-	"uvRZ78qe8poX4tWE4XlJjVyJazW35AJK8v3zP/7T14UantMqPKc98AQtCoOVmsYbV9W0p12aIlZFb9uW",
-	"K6wQ1AfDDpT2u1tUHDhdfonAEWXUveF0eZ2v63ce+2dvzr6NXRaGTHVDFEtlLTlnStTER2sTAZGWHTNq",
-	"IhUWyrCus7Aypgg16mdJhFRGl/qWp2+S9BpgPsmwBj1gF74h2r6ThRzr7c0tRqYBkoc0uN1wxDNWNZ/a",
-	"rXD7hROba3zpjNC9vtRGEMyVwEwax/oeHzcdT8V+wxCFd9gKQ5BSQR4UYDwnmD6nnLU7DYicO14O6XBx",
-	"hdSaSBTpORCWht2kNr8T5D5DR5zRnba9SYy2+pSXEU/hqR11HGSD3FdSXc6dSBIpjr6yN1nrskd6vDWt",
-	"0JEB5fgruxRPiFLmsrSn79bAaC5C7jJgwR2NR/oYDRr+5hMXbagCfuEo7m/fTDNu+JT2c41bKHvIKwCr",
-	"dvriTK3nLvrmb1eu51ew813O49GCq3Vw6zUXiYfr09nDR+Ogw9HjqnYG2JNqvqsqcDEjGy0zels9vxsn",
-	"VboWWIb9eZ/JHXsS/eYiCRZuh96Kn9Fng25++p5I1XEOF+OGh6DKucuIQY/X11+mG9yOWMhNcH5kpGu/",
-	"637+zWI3yKs8zP/YOw2R3sHdlLihEnnnsuDoM18Q5YcL/OPZjYh4krggfessS8JWIFJBesa1RuKzNN6b",
-	"AfYMBwyT2goJfXIH5SOTiicXnELP8dCu2YfoY0viFCsFQh+E//cXPPn3D/p/ZpO/zD/8fjp+cvbp30Io",
-	"GhwcSgh7bX887Y0U1Xzw/RGjEk3tauRa4QFDn0VGqJoTFha4mwqPNTbtr9yPghfRmrdyRwJSuhyExpm/",
-	"z7mUz9MOQLsSj4mawwaYmg9UhANyZyBacxgQ1nHjGnMG98F+yyCDdyDV3/ii6ybbC96vfDFsszVw3XfD",
-	"wK0kb4XjAyHg40MnLBVnVn7+RJSAvSKB2IDQPM4pifSJDh+1Iqq4G8r111mC2dxj6YCfXoldm5++4QmI",
-	"tYbO1XH5aX2hJvLrTGZQHaTRBtMMK3hGQahWIZURF7mI5p4i31U0672l2hlCELykAOoVl+qlCz40Vtf3",
-	"VsJWc5HR/a7nJjh3HS7PPxyH1m7dxPcuDNjcQT2MOAD2SkBnwPg8njR09H7zd4R/wmGtAYFEg7ML43+y",
-	"WQfycxPRzIzvBGbS5cX1Hm1m1nbgMgq9XGl4ZR+uNKw0JOKfDxyH1moF+jKX1VpGE5ZST7EUZX5pzY9t",
-	"RyC9rEQn6Mh9gh4gt/4xwpHgUiJMqY0FTNFsOj2dVnyCPLOs4MBjWbJwXnSuMJ2D1Ti5UVL3Y2dMIb60",
-	"cXWDAOOlQoJvJdquQZhkQZMU4uKyRNq0QS4MmNNrRMYbuAnB2orwdzx9afHzyoSVboKJfX34mUxcgqfZ",
-	"+WbA8wXjc8HzxLVpCxi9ML8irHK/Ns7ouQST6me9mHakueq4lNriT8GDevDJcMvpzK26oDM32O7a+vxz",
-	"pGgmdqpCY+GKpKnBR/3s77omludeqXvcSuMKMfpzjF8BpmrdcedZzJ2Tv2Ile7eX5hbXZs6dn8ISIu4G",
-	"hAxfpepGSb61CjDlBMF9came8ySlBLMILrMkwaGMr8K4HXAgOO06NOZgldXQOIPjg2Gjjda7VhDCAVVu",
-	"psmC+fStWL2uG6HFQRwTmVK8m7d5PZtXNrYhgrPc4ePn34bmXwmepdd1QWlJu6aHmqRzHMfCGZo1KPu8",
-	"21yoih3/5PHjs8e94W+8qh4QfaipvwHocj73W+LOU+Xtu42FvjP3v66LcS64c1lKbtdxFxZ3R8AhH/v+",
-	"aOpdEDClPy5H57/0z1BcKz59qL9++iGj1EaEGEdFFqJNRlhjifQJgkTGEF5hwqSykTYN+rTBpCHMm3t+",
-	"A2Vt2P+eSPVaQRI6xyG6mqeC8PxAG5xycC/843VV0qc6bk9XXNt1X1EajZ9NqoCMMOvCci+g95u/q3Ht",
-	"pOpm8r2mTkcO0IP9iu/2XfthDem2UeXMLsFtV5rr/FYz6H5QUQR9dwM7dTtYbf6UUPJZmGSGsauZyP1s",
-	"XM+buaY06GmK5FiLuZaP6gD7d5rPgiHhjCiu/2Xn9K3pYfngnsz0ZS3rVYZTpjHcJa20jhdkQyisYJ81",
-	"gt/0LNSSJP55Kd1SrveAuz66E+Kwb64311pL2JuSuK12NzC9vUBKimY59BSlOJPgcmu/QUtMpf6rAJn5",
-	"6q3Nx53P3gphwcCviFTtL2yshWHEYrCitWrB89b3itOeikQTGeI5xTv73rG4qrsLklyPPB7VOBhkC1zT",
-	"cdF+7Tu4luBXHfir5PLBhvBM3jhYvXguNcdQWENPLPrVvZb0YSt0+2s8/g/Qc7B0dbxsZEoQ2M8OaBHe",
-	"gJ10A5GaHMC2vXbcCr/cTu737eSL3R5m6UuTJvWaLXkoYVRm1IRSMPqOyIhvQOz0XWmK8iRrtbYvOuY2",
-	"3WpO2JIjpYn9nkWcZgmbLLmY2P+cossUIpeYa16iTOJ82ul7ZpOM/ayKNMUi4WLu2Q/9ShSLaE0URMqF",
-	"3Hq5L+KUGrftXqSKibyaLwXAfLUYpqfNFzYotNcnmYR48BdLImCLKZ1LEBsSBfKX8xEx+gNlyy36A7Gl",
-	"oZhEfyCSFv8JSWres/ebKMWShaHb/81vMRs0cB9jxVcjvRNfgWBA5/uOF0DB5eMO/cSLJfRftiCZ4w0m",
-	"ZtQ8GUh0/ZVlrKFfcDlf4oTQXUDqOaVZiuzP6J//7/8jsQY6RjEsCGZjJDMJY4RpSpj+fxGtx2gFTHE+",
-	"RlytTapL7z65HFoQx4ycU3IFQ4cPJimX81SAUru9PtmHnOXw+TKjdNA3KcVKs/rc1pRYEmv4D6gDRAnL",
-	"Pra+SX7BllxEhK3QHyiv37EB9IdW7Ua95jKPyBIxrlAqQNoUpv61tzjdiwNbTbCKMm47tH4yR+u9DfP0",
-	"BFA+y1T6bx+5aRD8exIBk3CpDMlbDXCTIwuiNZfyY0oEyM/yhC0Bq9zhMtwOJGy+EjiCuX3tPzRQ7dKm",
-	"Nbtgc/W0OzBMwufUIkUbfsy8aQpelBWpOg20uTIaj3gKbItVtJ6n1MSugSmTfS4hOE1mMlv0Rbr2aqXt",
-	"YmnW9cL+BeI+tNO3p6CR2/D8163qN479wQOWbL2vHoxnWqYpeUjOLZWDzKOGHhEbs+G5KKptNEZssWCE",
-	"rT4L3PpNJYe9vn6IMmVhqTYnnauSE77FYrYC0Vo96po58jk3rbCCoUV2CjDrae8liN3blxewIlJ1uVPc",
-	"Gvt4VKo1hgLKqi3dv2vSOs1CVRBvqTqmh4Iq7OOOwplvOSURAXkBlOO4Hb88UxFP3FU0mAverv1bkqiL",
-	"KVvh2n0HkakB1/XU41oZ6v2J5Q668LNEA1z7AyT3e3velAmKyCEpVTkY1UUbSxQThnBZstCf/6VMla99",
-	"OEI7/0mC6EmDKirMdWQNnV2/COXXhylCmdek66zkprHR+Ux0bxfdZ5fns6FhB/SAAO1dvPVroLkVt5zC",
-	"MynJqr3cqVbEzirfh9L5Z20ry+6MA72D4SdOhU36RNROHXgwY4z9kCP1UuEVoBnaYnpF2Goir4CCMrXH",
-	"xBJHYLwsai0AELA45YQpidQaKwQfQUREmtpI79mSZ8zW1EZS4egKHXkPmsZ+Xe0xMk/Sxra+NgL3gurY",
-	"ulkVUdp4G/2YAvtZXwTQkQPx2EtdPR/NpqfT2QTTdI2np+aESIHhlIzOR2fT2fTMSJ9aG/Se4JScbE5P",
-	"cJwQduJspnNr8RnyuGQ3TSQD7+vYFUoz5bUrJvnIIhyk+pbHuxurBB68aXyqktel+VTKpz+czW4LhqI0",
-	"bbN+uh7h1kDWYkZHLohvKtntUojzQj3HtmR5no84+k7sJiJjttwFVoAw+tvP75Cjiqm+ZCsLSYUpJWyF",
-	"iDVWqlRMnaV0LoypNICMVdtqdIuIbLHiAph8C2KisYXsLlBhhH0ajx7Nzg5XaP45phQEoji6kshaMzlm",
-	"q+Sze0JarULsRqIloSDRUvDERF1sRZtMQIxiIiBS9rbxcZLz8qS0G0bno+ZyBam1ojgxb1cNkVYQIPBf",
-	"QXkVv43cC5yAMkr2l99H2iga/ZaBgcEeNGVh8RJ9DZUf/rJRo3zvGSq1zPf+WhIb7S8/HHLKts1mKiDd",
-	"2Gyu9Pg1dpXXvSo/LEotPJ7tU8zs04dblOt6YfmQQOujii/tEYcc5xphnrXNXoB74vXCqAqdticqU6Ij",
-	"i+uJa18B8Rgx2IJUtpTVcU2M1PqE8pW9HnSoybw8+i0dco368wc+4Jrl3wMUNANs5VWITalCfgVMIiJl",
-	"BrGl5enhFPNr60NFXj0XfcS+efkMFYgzzAJRZvM7fvngs85Pzlw+yc16ZBjBVjnkqb2io3c/vnsbZBme",
-	"qUE8o8c1KPcoYG6C0fpIwIZfQfNw0X+1Z4g7/KX9oAmcvTC0nwhq/QZGt8xMlQr+TdLlhdcPzTM/cFdM",
-	"zCFPM8wCsHDRLR/fKhOsgu+iWnwA4Sc1P0I38t9WfV63S4dQ1f+wveWGIUoaavbFcmmq8plypPl0RYnS",
-	"ARha4nMwrRf6Zabo0nDruGm0gwjhxWvvgH66eI2E4QyvQKveoN53hBUXCKdpHXdmjQqi9GUUEWaUi1ZY",
-	"YYQNuob5jSVu8XBqNK8YdEAF1JxWz2Zj5A6ODL24RrkLvyFT4zaleNfQt6ZGp0gQZsjyLcTmZJEQCVBo",
-	"sbOb2GlqYrQCpgkDMQqeFvkBc279Rv0UrTZluEWyhrs/XJe2+WzIObs88+5A6h22qDjNBfxqchI0sVwV",
-	"l0Pz23NXobiAaSu485p5rGZw39APX8niswBHlVr4XLiYU9+5EwhT3epVvyMqFkBVAVIVOS8zStHFt8+e",
-	"o3yb6KiMH43942iMjIt9QhgyYaSApe/6efQLoOsjcouSV+tUch/tfS1NxsRHKSbirsx8hygHidPcY+QS",
-	"K8ZWh2cSYs0YMsIxOBMaKUFWKxAQH3feAy64KTSi5U/4a32DEsIUwvr6iGzbqQf5AI2QCnvVale2yeFz",
-	"b9gtkrel4mZIQxUjUQIKx1hhZ//dpZutxOa5gIajzdz5/VvfUQE6Z3R33OFQa0w87lAEdWLdvCJoq7Q7",
-	"SBuc3gIYA1nFheAOfr777UlzG85UuBybfHaTAGnCLbZjqRtxefkKXYE7/f9yQGszo4qktF7UWtbPf4NM",
-	"hD2WHsbBpulMmxY6+Z3En6yJRsE+oapy+Hfm7yVRv929/q7FRZxitS49krZMTIU5g27Slmc8H4ZYkha4",
-	"GB0VpUifmgeGx5aIjw6ol0quL7irRsBLvlQTi+ZrUNHR59N4wKFxdzSa3Z2yyZX7fST9S9Oj1Cf6V7IE",
-	"eI9zqEOIz01Vet9mrZdOSwm46vm2pH0FGmCR2KVamNzdNcEKhN7UBsQCK5IgwhR3do7gW+sANW19sFiB",
-	"shr2JC+8PEU/SXup0kMWGb1CJEm5UGhpmitxhJXCFitrLoF54CAFSUqNtcUR6EEMtnTnJoDYavE80Clg",
-	"kgqepMp0c3HeltombGi86+w2LQoOJjS3aiP4zRbup4lgWjnclXXwutci2BT2Q9Hx7NBK5bIuoiWIpqcW",
-	"1fpgh2R5psQHN1zKYuBPzVv/iFNKYnANoDCzrQ5NDKJi2dQNG9vYw9+rp2kMldCRm+Gf//GflmCum1bx",
-	"h+Pr2kIxwSvGpSKRPIdozbsv/d+Vo1/owWF9sQYc26dSVmO8LnN3Jv8bdp3qo5JA97g3ga5lxf8zeV6G",
-	"2Sevu8Pst6SR/LLeB/ZbVAp6BzhX/15GKK8VXtafPO7/5I2pnP8DV88o5ds7ENIa7+VOECOiMVkuwXge",
-	"F5rwtXiExpH1dpgtI5dd/E2Rtyb9pDT0wMbX24XLFiefKJBq8itfDBe0SlXzpj/k4c0hM1w/PYDVv/GF",
-	"8fVog+kbtOXiCgTaEkpRLDBhdctf4RVMZsjMjmJI+DfIoUNqNccnPEW/8gVKBTd1XAq7ibCJ+5tbpB29",
-	"rlD3BFMQajhy/fret+S+CNYQP7BGaMm/D0XybEZW7Ia2kDLNRxlaug1a69oQoOxMJ4uoQgvlUgEJyZLJ",
-	"XqfPW/vRvTiE/jXPj1yXPzycLnf5pSjmpk2pQoRFNIsBORaae2yF3OO0hlPUTDEx752QZrlv8jQY2TlN",
-	"xbzK/3g+CnzSyujuc1scwtxnh3K7625my7SY1NMvHH8XHI+OIut/t4pNE9I4Jo7vNg5QwNGirE1g0Krq",
-	"gteLb7zYYMcdorpEL3fbe8Y12Ptn8+EX/r4//O16tt89g5d31z043Hy0B4t3X5BzHheQQEzs5RI+QpTt",
-	"z+wX5RQv3AxfuP5f3Y7x+Gpu+cp1abk70fNAOs9ZvV0GH+SvcGqyGJgFPQhvt8/iCuOoXazbNpDLt+l/",
-	"fuI3VD5ZCMBXsesW5MJN9cCbIBswZ+fENmAx3jjTeqZM+LwEpQhbSeOlu4wwM9mR77PZ7OGT96ysQohS",
-	"vIIp+hazWKKIJ2BfwvwjVBD1H+/ZeicVCJBEniNb5/FpUWb1gf3m6WyM8sqPjR9tG9+np+P3LC8J+dSr",
-	"1OqPis7GSCPiaeXLszHyuxc9ZRwJvp2+Z8/t/mWWmACHTYUtMeNqpOGUTAzWJz7WJwXWQ8GKv4Iy7VD8",
-	"vt7fFmS6zThccMGWl1iWFSwX3K3YWn9xw8CrSu6jAuByj6ggg+kqTRic5Ix0knPLif75xGeB44BI+dXO",
-	"22K21b5gt0jG6kJBneyqpwtTIuzg+VvPyvRo+7whf5px77nolaf5Fjvk11dGrkpOkzlsX/1JVDY262SR",
-	"ahu0hqFU3cJLQhUIrYFU2TxJou2aS61ZcQJbLq7mApamkb7ChElbGf8Kduhoczo9nc6Op6b+UPOlWTFB",
-	"3zO1QUDpDyJFd+bxlT41MLOgXLx8fnZ29hekSAJS4SRtAedmn/MNfUZ3OrvTd3QBngimROoBPr7NQXvt",
-	"cMcXbTBAGzSRLtGRO2YsqY6rLw0DyqFop9mpE2wjv8G6oKVj3gF1wq1LhMVIgIzmV2TR+oWVh7Kywdpk",
-	"S2JtIeVdfiwWi+aPJ6YwZMj8UTyduGZfk6JFSCdD1xsl/olY+7/BcVLHfuhAwewqz74qGlR8OU1u2baU",
-	"ZaZdkmO+7MN6pJcAFhO26pNCkff3HCiFth/oFym8Gym02G+XQo3pL1J4GJvOSFpYCs3R1i6FtiVpl9DZ",
-	"Rqi3efevtVoNZRvaevKISJT3UP00Hj0+JFU8EHJ/C+ICZayomN75OqtwXzzQF/CYeI3gjjDjbJfwrPbU",
-	"r9coabFCQirGrxl9DQ2l8OrOLOdGg7cAcYyL4+7fe7XFec1Lr7Wj1oAIbtdrrpzotxEJanaxPXB6drXh",
-	"aAud7/7VVn6soaMFtuamlpMxIukYpVyoMQIVTY8Pnkv5ykFSpF+bBGeJCEO+Amh5t+Uapu4ZfjVsffK7",
-	"K6L/yX/2cS5AcrrpCb2+qj5RvHDfDHnp4LX7/hO/EXI79isA3d1joR+4D0ZxtpmQWZ7Y3pkt73Zj6wB4",
-	"L2bWWNkE1AUgk+GrZ+xluq4HRnXO85ulaY7LAnHBd3y1MmZRvSWTeyGAMwnSnCRv9dn8zrwckvr2IK9I",
-	"WnQcQpyZ3q07JLOF1LqSKaRIdDVF7/KmRLQMWGy11UBhqVDGFM+iNcRjJLltMliDBqVEHyVZWlbbo1gq",
-	"JCDiQhsd5vIyRZvT6dl0Fnw3lKlab8TDCtPtnEuBVo8HTlboO5xsYxB7Hhxcbl9VXgnVZPKtZusT29Ky",
-	"1oZYOjmUhK0o3NAZUEbOT9a2cV5roN4WqDL8rjj6h7kK/8PcYCY2BGWFyesI6Ga013cNvJcANEUvcLQ2",
-	"Ehfh1PQ+MBKUgpiYLpamFsmJPr7RkuKV/TXJqCL578Ykz4WtS8ycAd7oEXgwYftMb8LjO3UmdHdvDDG4",
-	"T3Ybn5i4+MR9ErV3mrXyY+IriUrGnVQY98hc0h2Lu4qO+2Z3OrEb9EBeA30/n8a714FzrJAEdXy/yFl9",
-	"Ez9EO/a/gz8kKdrC3GW8ZO42exMe0ofT2fEUFa4OIlHGsCm5B/H9Dc1penxn2lr0Xj1t9wt05PIBZXmY",
-	"Pgig9J7xcv7Iv3icHoYeARMkWjtX0TBvBVbROnC7038+uOK5HfOz2vXtnlmehux3Vazu73f/GL2T7S3l",
-	"UJKZ5qIuOEiAxvLahq7xc3g5eeemA3NHaQtMqatsgZPKo0lrbiY4WhOmr5POWCU8JhGinKf6rizfs6Py",
-	"IjxZCgD07vnbyQIzBkLfRU3diocPj00hOWl8Poq/Z5V76BhhFruynxYYWwPMlvefolre+nuWY8bLCjVv",
-	"RypJoWbnbdUrjGvHG/3coOkwx95N5uafPvx6UG7+AVJcDQptb+SWMq/m+mJ/v2bM7c7d55VI1x3rkgO7",
-	"cJ85lWBT1IlFirakcpcuYWhJyWpd97td7li0FpzxTCLOJjEkVty9ZM9y5up9v0XDFe2xz0XG2pXbjykw",
-	"vSSYAmV5QWq80uahKj1mpo8jIkoi5xWO37NSqY2RyJxWiiiXEE8kKAfwwjaJ4XLi+h+PtVmZwPg9SyAh",
-	"bMnHKF6OPT/8ChSYhrMwRhhPbJLrGOW9orWaxMLoVb0gz1SaKTlGWSpBKNnsKf4AxcC0yqHk352DR065",
-	"nP/PvM+4cbEXSPVy68YozRaUyLVezFT2X2RyaixOh12IrWKGhKiypfm07E1uLDN9Q3rPvAYB/e3Mw+q4",
-	"aKV+kbEvmvg6hpjXtD4gv16rets2x3ZXgtwfFSP7/UscKfnn1NCNJ3t3r6IfH/J1mLW2y/c4hsRa98UE",
-	"U8SFH/Zwus5YxhAfPGmh5EbXkd+gbavFTJuNthCZ2DTaBoQPkx8v0ZKwlenWyxQq9E3PkZK3C+7IZPi+",
-	"6Ch8272vqp2cO97+GQ9IDS1/BXugRa4eNvXHoiNFQIzz53FyjH7LuMJy7B5ZVJM7iqakbSi54Da57fZq",
-	"J8cJYWaVzuAkp3APMis0ulozK6r1srueGlZmqZDi3GYVdIeqDbZsvPy2KumaTuJ6nbutpFuA0Vkmz4wy",
-	"WL+zpAyv30fGrph5+3dgk92ICImRwlfAWovilrjqY9Cm28FaedU3sLYFW5cGsYZG5fJovznUVdWs1s1A",
-	"Vo/avRgz25YWRjJbTMqWm/f+SQ2O87Z4pWfERX70xUaRBMpNLvAVxFpdlYWUx+FshbeFM2cNptignWNs",
-	"mvNh51LyvEmFP9ed9u+Z4sj28/MvGXZTUzvZ1L76iafoW21NSYQFFK0b9Z3D3eEwizVaFqYLqNgZo4dn",
-	"asKXE2EaP2wwzcxLctNx6NFsNn3PCseRu6f4CGpJXejk2ltQuM2FDuzcbYMgnFzguEgynMo1//P5eJxA",
-	"Ne8QIZ/tAHnq1ZPuheteevLSfnMgol/mb3CblddBCRLJGrX/xLrQ01WJ29uDSvLTkuIqSYtWym3UM+2Y",
-	"b5NUzX7PIfGUGk13biZrbLWayZnDVJvx4X3clYBcIvzmtXGzf/yBDd9qL+4WOt+DBGQuis68fsztTvku",
-	"VP+psH/1iD7eaxq+hmUHZrho0tzHDJeDu8cMjw5LaBlClf6ElrvF/Oygwn+/qJmndAyhY8PvUQqXc4Fg",
-	"qe8V3S4QgyM9+pkd/OfN6sh3YjfyuT0DjRPAIvAOToafrOvDumJInUvsDhG2P5vK9T0MY/wQjh06WSZj",
-	"ezHNT/nwL2zjsY2AhG9Ml6A8KObae/tmtR6Sk9C8DNiTiOZtotiEH0l/zyNMUQyGw1zmVybo6Hy0ViqV",
-	"5ycnVI8w4Z+vHz06G3368Om/AgAA//8=",
+	"7H1rcxs3suhfQfGeqkjXJEX5VVmlXLccP9bem4dLcja3KvLlgjNNEtEMMAEwpHkSV91P5wecur9wf8kp",
+	"NDBvzIOyRCl7/GU3FjFAo19odDe6fx8FIk4EB67V6Oz3kQSVCK4A//EtDc/htxSUNv8KBNfA8T9pkkQs",
+	"oJoJfvKrEtz8TQVriKn5r3+TsBydjf7HSTH1if1VnbySUshXfAORSGD06dOn8SgEFUiWmMlGZ6O/04iF",
+	"OPOYJHTFuPtvIQkLIU6EBh7sCJh5Rp/Go+9Br0X4g9DPo0hsITwcpD9LwVfkzfv370iMQIzMGPe5mf15",
+	"GDN+LiJQ5w6r5q+JFAlIzSyKpfnZ/AfTEKs+mMxkr7iWO7NzvUtgdDaiUtIdLi3ht5RJg4Jf3Lwf8lFi",
+	"8SsE2nz2PA2ZfrVx+KlCQwO7t9+zz5SWjK/MZzTQQs4Z4penUUQXEYzOtExh3DbY/tkzVyCkhAiJ4mZs",
+	"DAlBUxYhTGHIzEgavSvBWlm42JydbSlkTPXobJSmLBx54BNBkEoJ4ZzqyviQaphoFoPvIwmBkOHeH4UW",
+	"qVUiN8ZViWm+UyKVAQzFeD4+Q3rvFwo2IJneecCp8RLisEazccYrFWJXMdvNfeodXXkEIkfRIIEoMbMH",
+	"iRw+6nmQSiWkmagqvj8m9LcUiP35G5JQpQhV5H/ZPzwjWpAl6GBN9BqImcmoI7PFHszWkYfbqMLiR4xe",
+	"fydWjJc0bhUzQifm/2L68TvgK70enT0dj2LGS/9qENnsaitkWPvw4ZPqp6eeT1MFktMY9v60hoB8nhI0",
+	"PQhoU5Y0CECpuRZX4FdSEpYS1LpjhIGmn6n0+nvIwahvqAJFfU23QtsGv3/9/BWXIoraN5lIsWGKCc74",
+	"ap5K1i+fjS86Vv87SLbc3SCP1WAxE7QuD+9AxkwZUDuORBYC104x1X/x0pSpOeWC72KRlpXrQogIKEe+",
+	"EBEM1HM4tDanb0NJsZV9NHtjSbfX6oTtGGxHG8TuwGziZ9ih2IKkqiYYgMGSwFuY3NRtm3rntMKLNeUr",
+	"aGVNPFe4nldUWrcK47AdPry2lcZytenadnNu1UHrNvpUVN2Oqwz3LfqCalgJubN2YWO9yqHXyhwDyFqe",
+	"yAuH4BwCzTZM776VQK9CseUeMkqmWUCj5oGccgk0WJujlTwggeHyINVsA/MlZVEqQV2ms9mj4NFoXDAz",
+	"4/rp44KbGdewAmktyJWkob0QVBcatAw8Ox24jttmdY2OeQfCz419Nk+kWPj2wAVZC6XnEdsAB6WIFFsC",
+	"H5nSatj0gkeMw/7IeTYbMn/9VLCLlYgyLhjBobC24z4We7GG4OocVBp5hAxvh7kpXN2gDpK5sdZFqsdm",
+	"hzij4HMJy1RBOCYLyjnIecxUTHWwxqun+Qgn/YYY848ITlSKdkC/QWgVh8Mri5jezZWmOm2K5+idUHqy",
+	"3ikNEhRTxI4jR4rGQDY0SgGt0QQkEyELSCREQrYijUKylUzDsdG5PI2t5nCENCqZV/91xQ3GP/gMRsT+",
+	"nlecbGr/2etOLET6PPbsembQ6firn5fKO2nMXd5AO957eUvwJVu16665gsBDPLMyMWDLDY3IUkhSVmlG",
+	"XBVZQCS2SES9NopdRCE5ejqbTr9++ng2O56Sl7CkaaTJ6cMZOXoYG4rG9COLDVFxDNpj9t9PZ12KbzCU",
+	"dRi3TK87FaMf4kezGTl6ci2IxZYPhtbCSLURS7oQGxiEza8NcI9m14EupuYfnPIA5qtILHxn189r4ASl",
+	"nyADWsnULLhSZJFq+0dFnNZWBZeXBKW8jh8ZIBVTGkKjokIfVhgnpVlayPTUoOLpLD6ekh+EJjvQhKZa",
+	"TNBVBuE3REsaXEGI8zp1MzHzV+ZWEQtgf2Tak+DmWfPZzL/bv5jNnl6LKyXVMI9YzHQT1O/pRwOGMxLJ",
+	"xcWb0lGiSJga5UiWEYAmaguQKHJ0Op0+nM0qgDysgHHqg8IdVa0cMbH89v7Fu4k9uIj7wjCDgkDw0K79",
+	"qLr0o96VS8prnotXE4YXBTUyJW7U3FJIKMj3z//4z7IuNPCcVuE57YHHa1EgVmoab1xV0yXt0hSxKnrb",
+	"tlxhBa8+GHagtN/dgvzA6fJLeI4oVPfI6eo6X9fvPPbPpTn7NnaRGzLVDUVUaWvJOVOiJj5Gm0gIjOzg",
+	"qInSVGpkXWdhpVyzCNXPkkmlUZeWLc+ySdJrgJVJRg3oHrvwe2bsO5XLsdne3GJk6iG5T4PbDQci5VXz",
+	"qd0Kt184sbnGl84I3etLYwTBXEvKFTrW9/i46XjK9+uHyL/DVhi8lPLyoAT0nNDoRSR4u9OAqbnjZZ8O",
+	"l1dEr5kigZmDUIXspoz5HRP3GTkSPNoZ25uFZGtOeRWIBJ7ZUcdeNsh8JdXl3ImkiBbkK3uTtS57YsZb",
+	"04ocISjHX9mlRMy0xsvSnr5bhBEvQu4yYMEdjUfmGPUa/viJizZUAT93FC9vH6cZN3xK+7nGLZQ95JVA",
+	"dTt9aarXcxd9K29XredXsCu7nMejhdBr79ZrLpISrk9nDx+PvQ7HEle1M8CeVCu7qjwXM7YxMmO21fM7",
+	"OqmStaTK78/7TO7Yk+g3F0mwcDv0VvyMZTbo5qfvmNId53A+bngIqpi7iBj0eH3Ly3SD2xELuQnOD1C6",
+	"9rvuZ98sdoO8ysP8j73TMFU6uJsSN1Qi71wWHH3mC6bL4YLy8exGBCKOXZC+dZYl4yuQiWQ941oj8WkS",
+	"7s0Ae4YDhklthYRlcnvlI1VaxOcigp7joV2zD9HHlsQJ1RqkOQj/7y908u8fzP/MJn+Zf/j9dPz00ad/",
+	"86FocHAoZvyt/fG0N1JU88H3R4wKNLWrkWuFB5A+i5RFes64X+BuKjzW2HR55X4UvArWopU7YlDK5SA0",
+	"zvx9zqVsnnYA2pV4yPQcNsD1fKAiHJA7A8FawICwjhvXmNO7D/5bCim8B6X/JhZdN9le8H4Vi2GbrYHr",
+	"vhsGbiV5yx8f8AEfHjphKT+zsvMniBjYKxLIDUjD4yJigTnR4aNRRBV3Q7H+Oo0pn5dY2uOn13LX5qdv",
+	"eAJCo6EzdVx8Wl+oifw6kyGqvTTa0CilGp5HIHWrkKpAyExEM09R2VU0672l2hl8ELyOAPQbofRrF3xo",
+	"rG7urYyv5jKN9rueY3DuOlyefTj2rd26ie9cGLC5g3oYcQDslYDOgPFZPGno6P3m7wj/+MNaAwKJiLNz",
+	"9D/ZrAP1uYloOON7SblyeXG9RxvO2g5cGkEvVyKv7MOVyEpDIv7ZwLFvrVagLzJZrWU0UaXMFEtZ5JfW",
+	"/Nh2BDHLKnJCjtwn5AFx6x8TGkihFKFRZGMBUzKbTk+nFZ+gSC0rOPB4Gi+cF11oGs3BapzMKKn7sVOu",
+	"iVjauDoiAL1URIqtIts1SEwWxKQQF5dlyqYNColgTq8RGW/gxgdrK8Lfi+S1xc8bDCvdBBOX9eFnMnEB",
+	"nmHnmwGvLBifC15JXJu2AOqF+RXjlfs1OqPnCjDVz3ox7Ui86riU2vxP3oN68Mlwy+nMrbqgMzfY7tr6",
+	"/DOkGCZ2qsJg4YolCeKjfvZ3XROLc6/QPW6lcYUY/TnGb4BGet1x51nMnZO/YiWXbi/NLa5xzl05hcVH",
+	"3A1I5b9K1Y2SbGsVYIoJvPsSSr8QcRIxygO4SOOY+jK+cuN2wIHgtOvQmINVVkPjDI4Pho1GrXetIIQD",
+	"qthMkwWz6Vuxel03QouDOGQqiehu3ub1bF7Z+IZJwTOHTzn/1jf/Soo0ua4LykjaNT3ULJnTMJTO0KxB",
+	"2efdFlJX7PinT548etIb/qar6gHRh5r6G4Au53O/Je48VaV9t7HQS7z/dV2MM8Gdq0Jyu447v7g7Ag75",
+	"uOyPjkoXBBpFPy5HZ7/0z5BfKz59qL9++iGNIhsR4oLkWYg2GWFNFTEnCJEpJ3RFGVfaRtoM6NMGk/ow",
+	"j/f8BsrasP8dU/qthth3jkNwNU8kE9mBNjjl4F74x+uqpE913J6uuLbrvqI0Gj9jqoAKKO/Cci+g95u/",
+	"q3HtuOpmKntNnY4coAf7Fd/tu/b9GtJto8qZXYLbrjTX2a1m0P2gogj67gZ26naw2vwpvuQzP8mQsauZ",
+	"yP1sXM+buaY0mGny5FiLuZaP6gCX7zSfBUMsONPC/MvOWbamh+WDl2SmL2vZrDKcMo3hLmmldbxkGxbB",
+	"CvZZw/tNz0ItSeKfl9Kt1HoPuOujOyH2++Z6c62NhH1fELfV7gZutudJSTEsR56RhKYKXG7tN2RJI2X+",
+	"KkGlZfXW5uPOZm+FMGfgN0zp9hc21sJAsRisaK1aKHnre8VpT0ViiAzhPKI7+94xv6q7C5Jaj0o8anAw",
+	"yBa4puOi/dp3cC0hrjrwV8nlgw0TqbpxsHrxXGiOobD6nlj0q3sj6cNW6PbXlPjfQ8/B0tXxspFryWA/",
+	"O6BFeD120g1EajIA2/bacSv8cju537eTL3a7n6UvME3qLV8KX8KoSiMMpVDykqlAbEDuzF1pSrIka722",
+	"LzrmNt1qzvhSEG2IfckDEaUxnyyFnNj/nJKLBAKXmIsvUSZhNu30ktsk43JWRZJQGQs5L9kP/UqUymDN",
+	"NATahdx6uS8QUYRu271IFTJ1NV9KgPlqMUxP4xc2KLTXJ6mCcPAXSyZhS6NorkBuWODJX85GhOQPki63",
+	"5A/Cl0gxRf4gLMn/E+IE37P3myj5krmh2//NbyEfNHAfY6WsRnonvgLJIZrvO15CBC4fd+gnpVhC/2UL",
+	"4jndUIaj5vFAopuvLGMN/UKo+ZLGLNp5pF5EUZoQ+zP55//7/0SuIRqTEBaM8jFRqYIxoVHCuPl/GazH",
+	"ZAVcCzEmQq8x1aV3n0INLYiDI+cRu4KhwweTVKh5IkHr3V6f7EPOYvh8mUbRoG+SiGrD6nNbU2LJrOE/",
+	"oA5QxHj6sfVN8iu+FDJgfEX+IFn9jg2QP4xqR/WayTxhS8KFJokEZVOY+tfe0mQvDmw1wSrKuO3Q+gmP",
+	"1nsb5ukJoHyWqfQvH7lpEPwt1xBFbAU8gJZyZ7eX1heC3t80sHmgWRJiLTslEgpCoulHwUW8OyMwXU2d",
+	"STRNaHBFVzB1puPoHmcdlDMLsgu1Mf5G41EktuYCCSFLMf+erdblm/W+aQQlbJaWrYJdJdSHIVx0I2XL",
+	"mrzZX73sOmXH+nZ0kfk26nJxHct2HxZTnCZqLXSfYFWF4LUEMPeC2N4dWGkn1tswzeZF+yPOX3TidoSc",
+	"XmTL9mWtFmykik96z5jvWABcWax23PkxLR9ka/r2x4RJUJ/lfF8C1ZmPd/jVk/H5StIA5rbAyNDcGPdS",
+	"w5xQFL1ddgd4Lol5ZJFi7pocn1F6fXOaVf2U5oZkhDUBvqU6WM+TCNNlgGt88KLAO02KyXSJhE3toVyb",
+	"LwvXLWUa5YjroG9PDTW34fmvW91/Hy8PHrBkq4vsYDzTMk3BQ2puqexlHj3UKt3ghucyL/DTGLGlkjO+",
+	"+ixw60ozg72+vo8yRS27triAK8zltysoX4FsLVh3zWc5GTetqIahdb1yMOsvbQoQu7evzmHFlO7y4Lo1",
+	"9nHiVsuaeZRV2wujrknrNPMVXr2lgrwlFFRhH3fU6n0nIhYwUOcQCRq241ekOhCx8355j9N27d9yAuZT",
+	"tsK1ewkBlp3sel12Leu5/y2Lg87/EhqBa3/z6H5vT9XEOKwaksWZgVFdtLFEPqEPlwUL/fkf51X5ugyH",
+	"b+c/KZA9mZd5UcuORMVH1697+/Vh6t5mZTA7i0cabHS+TN87KvDZFUFtNooDekBOyF08L26guRW3IoLn",
+	"SrFVe4Vlo4idVb4PpbPP2lZW3UlOZgfDT5wKm/SJqJ3a80YPjX1f7OZC0xWQGdnS6Irx1URdQQQayx3K",
+	"JQ0AL1Z6LQEI8DARjGtF9JpqAh9BBkxhObZLvhQpt2X8idI0uCJHJWfLuFzKf0zwFezYlvQn4B5tHtvI",
+	"jmbaGG+jHxPgP5uLADlyIB6XsuXPRrPp6XQ2oVGyptNTPCES4DRho7PRo+ls+gilT68RvSc0YSeb0xMa",
+	"xoyfOJvpzFp8SB6XX2uIhPC+DV1tRqzoXzHJRxbhoPS3ItzdWPMB703jU5W8LrOw0rHh4Wx2WzDk1bCb",
+	"LRvMCLcGsRYzOXJ5Q1g8c5dAmNUGO7ZdErIU6NFLuZvIlNsKO1QDoeRvP78njipY8M0WM1OaRhHjK8Ks",
+	"sVKlYuIspTOJptIAMlZtq9EtIrLFivNg8h3IicEWsbsguRH2aTx6PHt0uN4WL2gUgSQRDa4UsdZMhtkq",
+	"+eyeiFGrELqRZMkiUGQpRYyBXltEK5UQkpBJ9MQYufk4yXh5UtgNo7NRc7mc1EZRnKBjD4m0Ag+B/wq6",
+	"1GQA5V7SGDQq2V9+HxmjaPRbCgiDPWiKXgYF+hoq3/9loy3C3jNU2ifs/bViNsGo+HDIKds2GxZdu7HZ",
+	"nO/yGrvKSu0VH+bVXZ7M9qmf+OnDLcp1vZeFT6DNUSWW9ogjjnNRmGdts+fgnpTa71SFztgTlSnJkcX1",
+	"xHXMgXBMOGxBaVs977gmRnp9EomVvR50qMmsI8MtHXKNlhcHPuCaHSc8FMQBttgzhFgdVVwBV4QplUJo",
+	"aXl6OMX81vpQSamElDliv3/9nOSIQ2aBILVxll8+lFnnJ2cun2RmPUFGsIVVRWKv6OT9j+/feVlGpHoQ",
+	"z5hxDco99pibgFqfSNiIK2geLuav9gxxh7+yHzSBsxeG9hNBr7+H0S0zU6VpSJN0Wa+HQ/PMD8LVL3TI",
+	"MwyzACpdQL2Mb51KXsF33qDCg/CTmh+hG/nvqj6v26WDr9GI395yw0jEGmr21XKJhUCxAnI2XV4VeQCG",
+	"lvQMsNtLv8zkjWFuHTeNDjQ+vJQ6ypCfzt8SiZxRqgltNmj2HVAtJKFJUscdrlFBlLmMEsZRuRiF5UfY",
+	"oGtYuZfNLR5OjX45gw4oj5oz6hk3xu7gyDCLG5S78BvBstpJRHcNfYtlgWVMKCeWbyHEk0VBIEGTxc5u",
+	"YmeoSckKuCEMhMR7WmQHzJn1G/VTtNoH5hbJ6m84c13aZrORLPuiMO8OpN5hS/LTXMKvGKI2xHKFow7N",
+	"by9cUfQcpq0UzmtWYjXEfUM/fKXyzzwcVWjhM+liTn3njidMdatX/Y6omAdVOUhV5LxOo4icf/v8Bcm2",
+	"SY6K+NG4fByNCbrYJ4wTDCN5LH3XQqhfAF3roluUvFpzpPto7xtpQhOfJJTJuzLzHaIcJE5zj4lLrBhb",
+	"HZ4qCA1jqICG4ExooiVbrUBCeNx5DzgXWNvIyJ8sr/UNiRnXhJrrI7Gd7h5kAwxCKuxVK5fbJocvSsNu",
+	"kbwtRX59GiofSWLQNKSaOvvvLt1sBTbPJDQcbXjnL9/6jnLQBY92xx0OtcbE4w5FUCfWzSuCtuLeg7TB",
+	"6S2AMZBVXAju4Od7uSNyZsNhUd0xpsFhzjWGW2yTZDfi4uINuQJ3+v/lgNZmGmmWRPU6+qp+/iMyCS2x",
+	"9DAOxj5XbVro5HcWfrImWgQ2s7HK4S/x7wVRv929fdniIk6oXhceSVuZqsKcXjdpy8vBD0MsSQtcSI7y",
+	"6sfP8E3zsSXi4wPqpYLrc+6qEfBCLPXEovkaVHT0+TQecGjcHY1md6dsMuV+H0n/Gtsil4n+lSoA3uMc",
+	"6hDiM2yEUbZZ69UaEwauYYftolGBBnggd4kRJnd3jakGaTa1AbmgmsWEcS2cnSPF1jpAsZMYlSvQVsOe",
+	"ZLXep+QnZS9VZsgija4IixMhNVliPzdBqNbUYmUtFPASOERDnERobQkCZhCHbbRzE0BotXgW6JQwSaSI",
+	"E40NpJy3pbYJGxrvOruxK8rBhOZWbYRyf5f7aSJg95i7sg7e9loEm9x+yJssHlqpXNRFtAAR2/hFRh/s",
+	"iCrOlPDghkvRf+AZlhcJRBSxEFzPOcptd1WMQVQsm7phY3sJlfda0jRIJXLkZvjnf/ynJZhr4Jf/4fi6",
+	"tlDI6IoLpVmgziBYi+5L/8ti9Csz2K8v1kBD+zrTaoy3Re7O5H/DrlN9VBLonvQm0LWs+H8mL4ow++Rt",
+	"d5j9ljRSuZPAgf0WlR4CHs41vxcRymuFl80nT/o/+R6bdfwg9PMoEts7ENIa72VOEBTRkC2XgJ7HhSF8",
+	"LR5hcGS9Hbhl4rKLv8nz1lQ5KY08sPH1duGy/RAmGpSe/CoWwwWt0kih6Q95eHPI9Lds8GD1b2KBvh5j",
+	"MH1DtkJegSRbFkUklJTxuuWv6QomM4KzkxBi8Q1x6FBGzYmJSMivYkESKbB0VG43MT5xf3OLtKPX9QaY",
+	"0AikHo7cckuBW3JfeNsWHFgjtOTf+yJ5NiMrdENbSJlko5CWboPWukYCFM0wVR5VaKFcIiFmaTzZ6/R5",
+	"Zz+6F4fQf8/zI9PlDw+ny11+KQkFdkbWhPEgSkMgjoXmJbYi7nFawymKU0zwvRMxLPdNlgajOqepmFfZ",
+	"H89Gnk9aGd19buvR4H12KLe7hoq2MhSmnn7h+LvgeHIUWP+7VWyGkOiYOL7bOEAOR4uyxsCgVdU5r+ff",
+	"lGKDHXeI6hK93G3vGddg75/xwy/8fX/4G0l5Hxi8uLvuweH40R4s3n1BznhcQgwhs5dL+AhBuj+znxdT",
+	"vHIzfOH6/+52TImv5pavXGOouxO9EkhnGau3y+CD7BVOTRY9s5AH/u32WVx+HLWLddsGMvleRgD6pNzD",
+	"/WQhgV6FrkGZCzfVA2+SbQDPzont+YTeOOx2VSR8XoDWjK8UeukuAsoxO/Iync0ePr3kReFTktAVTMm3",
+	"lIeKBCIG+xLmH74azP+45Oud0iBBMXVGbGnZZ3ll5wf2m2ezMcmKzTZ+tJ3Dn52OL3lWK+dZqTh0eVTw",
+	"aEwMIp5Vvnw0JuWGac+4IFJsp5f8hd2/SmMMcNhU2AIzriwjTdgEsT4pY32SY90XrPgraOzA9KL0xbc5",
+	"mW4zDuddsOUllmUFywV3K7bWX9ww8KqS+zgHuNgjycmAjewZh5OMkU4ybjkxP5+UWeDYI1LlBgttMdtq",
+	"K8JbJGN1Ia9Odg0bJFYlPHj+1vMiPdo+b8ieZtx7LnpT0nyLHSmXdCeuSk6TOSS2UpwERS/FThapdl5s",
+	"GEq1ok8s0iCNBtJFvzZFtmuhjGalMWyFvJpLWBptyzVlXNlmHFewI0eb0+npdHY8xfpDzZdm+QR9z9QG",
+	"AWU+CHS0w8dX5tSg3IJy/vrFo0eP/kI0i0FpGict4Nzsc76hz+hOZ3f6js7DE96USDOgjG88aK8d7vii",
+	"DQZogybSFTlyx4wl1XH1paFHOeQdfDt1gu0dOlgXtDTpPKBOuHWJsBjxkBF/JRatX1h5KCsj1iZbFhoL",
+	"KWssZrGY95s9wVq0PvNHi2Ti+gtO8q5EnQxd7836J2Ltf4HjpI5934FC+VWWfZX3xPlymtyybamKTLs4",
+	"w3zR+vnILAE8ZHzVJ4Uyayk8UAptC+IvUng3Umix3y6FBtNfpPAwNh1Kml8K8Whrl0LbBblL6Gzv5du8",
+	"+9e6O/uyDW0LC8IUydo2fxqPnhySKiUQMn8LEZKkPG/S0Pk6K3dfPDAX8JCVek8eUS74LhZp7alfr1HS",
+	"YoX4VEy5TP01NJSmqzuznBs9JT3EQRfH3b/3aovz4kuvtaPWgAhu12uujOi3EQlqNs4+cHp2tcdxC53v",
+	"/tVWdqyRowW15qaRkzFhyZgkQuoxAR1Mjw+eS/nGQZKnX2OCsyKMk7ICaHm35Xo07xl+RbY++d2VV/9U",
+	"fvZxJkGJaNMTen1TfaJ47r4Z8tKhqOn+Z34j5HZcrgB0d4+FfhBlMPKzDUNmWWJ7Z7a8242tA1B6MbOm",
+	"2iagLoBghq+ZsZfpuh4Y1Tmv3J/RcFzqiQu+F6sVmkX1LnDuhQBNFSg8Sd6Zs/k9vhxS5vagrliSNzkj",
+	"gmO76B1R6UIZXck10Sy4mpL3WR+0qAhYbI3VEMFSk5RrkQZrCMdECdvXtAYNSZg5StKkqLYXUaWJhEBI",
+	"Y3TYtghkczp9NJ153w2lutaO9bDCdDvnkqe77IGTFfoOJ9uLyJ4HB5fbN5VXQjWZfGfY+sR20a11PldO",
+	"DhXjqwhu6AwoIucna9urszVQbwtUIb9rQf6BV+F/4A1mYkNQVphKTUjdjPb6boAvJQBNySsarFHiAppg",
+	"7wOUoATkBBvnYi2SE3N8k2VEV/bXOI00y35HkzwTti4xcwZ4oy3pwYTtM70JT+7UmdDdMNbH4GWy2/jE",
+	"xMUn7pOovTeslR0TXylSMO6kwrhHeEl3LO4qOu6b3enEbtADeQP0/Xwa714HzqkmCvTx/SJn9U38EO3Y",
+	"/w7+kKRoC3MX8ZK52+xNeEgfTmfHU5K7OpgiKadYcg/C+xuaM/R4iW0teq+etvsFOXL5gKo4TB94UHrP",
+	"eDl75J8/TvdDT4BLFqydq2iYt4LqYO253Zk/H1zx3I75WW00ec8sTyT7XRWr+/vdP0bvZHtLORKn2M/Y",
+	"BQcZRKG6tqGLfo5STt4ZNn3vKG1Bo8hVtqBx5dGkNTdjGqwZN9dJZ6wyEbKAREIk5q6sLvlRcRGeLCUA",
+	"ef/i3WRBOQdp7qJYt+Lhw2MsJKfQ56PFJa/cQ8eE8tCV/bTA2Bpgtrz/lNTy1i95hplSVii+HakkheLO",
+	"26pXoGunNPoFoukwx95N5uafPvx6UG7+AVJcEYW2HXtLmVe8vtjfrxlzu3P3eSXSdce65MAu3OdOJdgU",
+	"dWaRYiypzKXLOFlGbLWu+90udjxYS8FFqojgkxBiK+6lZM9i5up9v0XD5R35z2TK25XbjwlwsyRggbKs",
+	"IDVdGfNQFx4z7ONImFbEeYXDS14otTGRqdNKAfbFnSjQDuCFbRIj1MS1XB8bszKG8SWPIWZ8KcYkXI5L",
+	"fvgVaMAe1zAmlE5skuuYZO3pjZqkEvWqWVCkOkm1GpM0USC1RfncOjnnZnrygITAjcqJ2L87B4+aCjX/",
+	"n5c8EFEac3Sx50gt5daNSZIuIqbWZjGs7L9I1RQtToddCK1ihphplaNrmiN/ipaZuSFd8lKDAKeULZRW",
+	"LxefdKjjbNndecq/aOLrGGIXiPK3fCl88pvjN2ubY7srQeaPCon9/jUNtPpzaujGk727V9FPDvk6zFrb",
+	"xXscJLHRfSGjERGyHPZwug4tYwgPnrRQcKNy6QsGbVsjZsZstIXI5KbRNsB/mPx4QZaMr7BbL9ck1zc9",
+	"R0q5qXOz1Y/fHYwSYwtKu34o5i8/XpByr+uiDbQxVl14xBDDVmMTCdgORtIod9dR3V2T1DjDyCXPcpRs",
+	"1Ja8wL4rxPVdweYKnJSaipOXry5eTIl1pFzyxc61rg7HpGhQbqa3/cnHBF8AnGAjHqu1L7mxpYWalDHT",
+	"4mJudisflvBRanf9uQ7latt1n1Z++nhoHaj644iiiXsx8ec3kf/SWOm+NVZqabrve/Jrxf2zHoLcrwtM",
+	"MxWoocfKmq5dd6JTtgizDVKi5TBDS4t9DJe5J7GXfMU2wK0NSh7PHjtjlws9t8X92LKw6dHBe8XFlpMf",
+	"zwlbXnIuajvbBeZIoIokIkkjjI9izS6xJTvQ5MgqPCHVJQ8oN6eTNfpxfkxfwXk2jNrrUNai8vjzVCk2",
+	"9P+XyDFp7sr3eJIqTRSniVqLL5f83ITLWZeLHDuGLesya7C3TKOoytv5F0Z2zP23Yfm4x/ZdOZyu1MDo",
+	"9rt+InN09kVzpQGU46IyCv4K9iofuE4gUXksOdIM5DgrDKDG5LdUaGpsLLx5V9Na83bsbSg5Fzat//a6",
+	"RoQx47hKZ1qWiOAe5JQadLXmlFY7hXQVWajMUiHFmc2n7E7SQ2zZTMHb6iGQKi1is87d9hDIwegsEIyj",
+	"EOt3lo5a6nTmNNnBnZUoIiwkml4Bb20HUOCqj0GbARfr36pW/7DNZ7s0iHWxVNzm9ptDOelxtW4GsnrU",
+	"7gUdjLapAlHpYlI0G7/3j4lpmDUELmJCLueFSHNHiqHY5IJeQWjUVdFCYuzP03yXh7HWgGWW7RxjbEtM",
+	"XTCtFEfLI9n5rV4LYjsZl92rdlNTO9nUmt3hlHxrLFtFqIS8aXV4yanzXlMeGrQssP+53KGHQaR6IpYT",
+	"iXb7hkYp1tDBXouPZ7PpJc9DZs5DW0ZQS9JmJ9fegsJtLnTgsHYbBP60SsdFVSv2T3Q5dALV9J76otUD",
+	"5KlXT7raHnvpyQv7zYGIfpFVH2n2nAEtWaDuyZ3lBnRhSVfFbm8PKmnfy4hWSZoqvJW2U+8nHHCLpMIF",
+	"+p5emUH3wEw22Go1k1OHqTbjo/Rx19OrAuE3r43N3Hdq+BoAeul8D55eCZnVtq5kG90p3/kqX+b2rxnR",
+	"x3tNwxdZdmBuryHNfcztPbhbB3l0WCrvEKr0p/LeLeZnBxX++0XNLJl1CB0bfo9CuJwLhCpzr+h2gSCO",
+	"zOjndvCfN58124ndyOd2S0YngEXgHZwMPzknrrSuiBqX2B0San/Gnj09DIN+CMcOnSyT8r2Y5qds+Be2",
+	"KbGNhFhssD9ilg6kjxtmtRmSkRDfRO5JRKzKIDf+8jDfiYBGJATkMJfznspodDZaa52os5OTyIzAqMXX",
+	"jx8/Gn368Om/AgAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/app/internal/server/api_intelligence_test.go
+++ b/app/internal/server/api_intelligence_test.go
@@ -63,10 +63,14 @@ func seedHostForIntel(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 	t.Helper()
 	creator := firstSeededUserID(t, pool)
 	id, _ := uuid.NewV7()
+	// Use the full id in the hostname — UUIDv7's leading bytes are a
+	// millisecond timestamp, so id.String()[:8] would collide when two
+	// hosts are seeded in the same ms (idx_hosts_hostname_environment_active
+	// UNIQUE breaks).
 	_, err := pool.Exec(context.Background(),
 		`INSERT INTO hosts (id, hostname, ip_address, created_by)
 		 VALUES ($1, $2, $3::inet, $4)`,
-		id, "intel-"+id.String()[:8], "192.0.2.30", creator)
+		id, "intel-"+id.String(), "192.0.2.30", creator)
 	if err != nil {
 		t.Fatalf("seed host: %v", err)
 	}

--- a/app/internal/server/api_intelligence_test.go
+++ b/app/internal/server/api_intelligence_test.go
@@ -1,0 +1,330 @@
+// @spec api-os-intelligence
+//
+// AC traceability (this file):
+//
+//	AC-01  TestAPI_Intelligence_Events_ViewerCanList
+//	AC-02  TestAPI_Intelligence_Events_Anonymous_Forbidden
+//	AC-03  TestAPI_Intelligence_Events_LimitTooHigh_Returns400
+//	AC-04  TestAPI_Intelligence_Events_FilterByHostAndCode
+//	AC-05  TestAPI_Intelligence_Events_CursorPagination
+//	AC-06  TestAPI_Intelligence_State_UnknownHost_Returns404
+//	AC-07  TestAPI_Intelligence_State_NoSnapshotYet_Returns404
+//	AC-08  TestAPI_Intelligence_State_WithSnapshot_Returns200
+//	AC-09  TestAPI_Intelligence_Events_UnknownSeverity_Returns400
+//	AC-10  TestAPI_Intelligence_Events_TimeRangeFilter
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// seedIntelEvent inserts one host_intelligence_events row.
+func seedIntelEvent(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, code, severity string, detectedAt time.Time) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO host_intelligence_events
+		   (id, host_id, event_code, severity, detail, occurred_at, detected_at, correlation_id)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, 'seed-corr')`,
+		id, hostID, code, severity, []byte(`{"sample":"detail"}`), detectedAt, detectedAt)
+	if err != nil {
+		t.Fatalf("seed intel event: %v", err)
+	}
+	return id
+}
+
+func seedIntelState(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, snapshot map[string]any, collectedAt time.Time) {
+	t.Helper()
+	raw, _ := json.Marshal(snapshot)
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO host_intelligence_state (host_id, snapshot, collected_at, created_at, updated_at)
+		 VALUES ($1, $2::jsonb, $3, now(), now())
+		 ON CONFLICT (host_id) DO UPDATE SET snapshot = EXCLUDED.snapshot, collected_at = EXCLUDED.collected_at`,
+		hostID, raw, collectedAt)
+	if err != nil {
+		t.Fatalf("seed intel state: %v", err)
+	}
+}
+
+func seedHostForIntel(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	creator := firstSeededUserID(t, pool)
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, $3::inet, $4)`,
+		id, "intel-"+id.String()[:8], "192.0.2.30", creator)
+	if err != nil {
+		t.Fatalf("seed host: %v", err)
+	}
+	return id
+}
+
+// @ac AC-01
+func TestAPI_Intelligence_Events_ViewerCanList(t *testing.T) {
+	t.Run("api-os-intelligence/AC-01", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		seedIntelEvent(t, pool, hostID, "system.package.updated", "info",
+			time.Now().UTC().Add(-1*time.Minute))
+
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/events", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+		}
+		var page api.IntelligenceEventsPage
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(page.Items) == 0 {
+			t.Errorf("expected at least one item")
+		}
+	})
+}
+
+// @ac AC-02
+func TestAPI_Intelligence_Events_Anonymous_Forbidden(t *testing.T) {
+	t.Run("api-os-intelligence/AC-02", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req, _ := http.NewRequest("GET", srv+"/api/v1/intelligence/events", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected 403 anon, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-03
+func TestAPI_Intelligence_Events_LimitTooHigh_Returns400(t *testing.T) {
+	t.Run("api-os-intelligence/AC-03", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/events?limit=300", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-04
+func TestAPI_Intelligence_Events_FilterByHostAndCode(t *testing.T) {
+	t.Run("api-os-intelligence/AC-04", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		hostA := seedHostForIntel(t, pool)
+		hostB := seedHostForIntel(t, pool)
+		base := time.Now().UTC().Add(-5 * time.Minute)
+		seedIntelEvent(t, pool, hostA, "system.package.updated", "info", base)
+		seedIntelEvent(t, pool, hostA, "security.port.opened", "high", base.Add(time.Second))
+		seedIntelEvent(t, pool, hostB, "system.package.updated", "info", base.Add(2*time.Second))
+
+		q := url.Values{}
+		q.Set("host_id", hostA.String())
+		q.Set("event_code", "system.package.updated")
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/events?"+q.Encode(),
+			auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, b)
+		}
+		var page api.IntelligenceEventsPage
+		_ = json.NewDecoder(resp.Body).Decode(&page)
+		if len(page.Items) != 1 {
+			t.Errorf("expected 1 filtered item, got %d", len(page.Items))
+		}
+		if len(page.Items) > 0 && page.Items[0].EventCode != "system.package.updated" {
+			t.Errorf("filter leak: event_code=%q", page.Items[0].EventCode)
+		}
+	})
+}
+
+// @ac AC-05
+func TestAPI_Intelligence_Events_CursorPagination(t *testing.T) {
+	t.Run("api-os-intelligence/AC-05", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		base := time.Now().UTC().Add(-1 * time.Hour)
+		for i := 0; i < 5; i++ {
+			seedIntelEvent(t, pool, hostID, "system.package.updated", "info",
+				base.Add(time.Duration(i)*time.Minute))
+		}
+
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/events?limit=2", auth.RoleViewer, nil)
+		resp, _ := http.DefaultClient.Do(req)
+		defer resp.Body.Close()
+		var page1 api.IntelligenceEventsPage
+		_ = json.NewDecoder(resp.Body).Decode(&page1)
+		if len(page1.Items) != 2 {
+			t.Fatalf("page1 items=%d, want 2", len(page1.Items))
+		}
+		if page1.NextCursor == nil || *page1.NextCursor == "" {
+			t.Fatalf("page1 next_cursor missing")
+		}
+
+		q := url.Values{}
+		q.Set("limit", "2")
+		q.Set("cursor", *page1.NextCursor)
+		req2 := asRole(t, "GET", srv+"/api/v1/intelligence/events?"+q.Encode(),
+			auth.RoleViewer, nil)
+		resp2, _ := http.DefaultClient.Do(req2)
+		defer resp2.Body.Close()
+		var page2 api.IntelligenceEventsPage
+		_ = json.NewDecoder(resp2.Body).Decode(&page2)
+		if len(page2.Items) != 2 {
+			t.Errorf("page2 items=%d, want 2", len(page2.Items))
+		}
+	})
+}
+
+// @ac AC-06
+func TestAPI_Intelligence_State_UnknownHost_Returns404(t *testing.T) {
+	t.Run("api-os-intelligence/AC-06", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		missing, _ := uuid.NewV7()
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/state/"+missing.String(),
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-07
+func TestAPI_Intelligence_State_NoSnapshotYet_Returns404(t *testing.T) {
+	t.Run("api-os-intelligence/AC-07", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/state/"+hostID.String(),
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("expected 404 (no snapshot yet), got %d", resp.StatusCode)
+		}
+		var env api.ErrorEnvelope
+		_ = json.NewDecoder(resp.Body).Decode(&env)
+		if env.Error.Code != "hosts.not_found" {
+			t.Errorf("error.code=%q, want hosts.not_found", env.Error.Code)
+		}
+	})
+}
+
+// @ac AC-08
+func TestAPI_Intelligence_State_WithSnapshot_Returns200(t *testing.T) {
+	t.Run("api-os-intelligence/AC-08", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		collected := time.Now().UTC().Add(-1 * time.Minute).Truncate(time.Microsecond)
+		seedIntelState(t, pool, hostID, map[string]any{
+			"kernel_release": "5.14.0-test",
+			"packages":       map[string]any{"openssh": "9.0"},
+		}, collected)
+
+		req := asRole(t, "GET", srv+"/api/v1/intelligence/state/"+hostID.String(),
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, b)
+		}
+		var state api.IntelligenceState
+		if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if state.Snapshot == nil {
+			t.Errorf("snapshot is nil")
+		} else if state.Snapshot["kernel_release"] != "5.14.0-test" {
+			t.Errorf("snapshot.kernel_release=%v", state.Snapshot["kernel_release"])
+		}
+	})
+}
+
+// @ac AC-09
+func TestAPI_Intelligence_Events_UnknownSeverity_Returns400(t *testing.T) {
+	t.Run("api-os-intelligence/AC-09", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req := asRole(t, "GET",
+			srv+"/api/v1/intelligence/events?severity=panic", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		// oapi-codegen's request-validator rejects out-of-enum BEFORE
+		// the handler runs; either path returns 400.
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-10
+func TestAPI_Intelligence_Events_TimeRangeFilter(t *testing.T) {
+	t.Run("api-os-intelligence/AC-10", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		base := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
+		seedIntelEvent(t, pool, hostID, "system.package.updated", "info", base)
+		seedIntelEvent(t, pool, hostID, "system.package.updated", "info", base.Add(30*time.Minute))
+		seedIntelEvent(t, pool, hostID, "system.package.updated", "info", base.Add(50*time.Minute))
+
+		q := url.Values{}
+		q.Set("since", base.Add(20*time.Minute).Format(time.RFC3339Nano))
+		q.Set("until", base.Add(40*time.Minute).Format(time.RFC3339Nano))
+		req := asRole(t, "GET",
+			srv+"/api/v1/intelligence/events?"+q.Encode(), auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		var page api.IntelligenceEventsPage
+		_ = json.NewDecoder(resp.Body).Decode(&page)
+		if len(page.Items) != 1 {
+			t.Errorf("time-range filter returned %d items, want 1", len(page.Items))
+		}
+	})
+}

--- a/app/internal/server/api_intelligence_test.go
+++ b/app/internal/server/api_intelligence_test.go
@@ -181,7 +181,10 @@ func TestAPI_Intelligence_Events_CursorPagination(t *testing.T) {
 		}
 
 		req := asRole(t, "GET", srv+"/api/v1/intelligence/events?limit=2", auth.RoleViewer, nil)
-		resp, _ := http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET page1: %v", err)
+		}
 		defer resp.Body.Close()
 		var page1 api.IntelligenceEventsPage
 		_ = json.NewDecoder(resp.Body).Decode(&page1)
@@ -197,7 +200,10 @@ func TestAPI_Intelligence_Events_CursorPagination(t *testing.T) {
 		q.Set("cursor", *page1.NextCursor)
 		req2 := asRole(t, "GET", srv+"/api/v1/intelligence/events?"+q.Encode(),
 			auth.RoleViewer, nil)
-		resp2, _ := http.DefaultClient.Do(req2)
+		resp2, err := http.DefaultClient.Do(req2)
+		if err != nil {
+			t.Fatalf("GET page2: %v", err)
+		}
 		defer resp2.Body.Close()
 		var page2 api.IntelligenceEventsPage
 		_ = json.NewDecoder(resp2.Body).Decode(&page2)

--- a/app/internal/server/intelligence_handlers.go
+++ b/app/internal/server/intelligence_handlers.go
@@ -1,0 +1,202 @@
+// OS Intelligence read API — GET /intelligence/events + /intelligence/state.
+//
+// Spec: app/specs/api/os-intelligence.spec.yaml.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	openapitypes "github.com/oapi-codegen/runtime/types"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/host"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// GetIntelligenceEvents implements api.ServerInterface.
+// Spec api-os-intelligence AC-01, AC-02, AC-03, AC-04, AC-05, AC-09, AC-10.
+func (h *handlers) GetIntelligenceEvents(
+	w http.ResponseWriter,
+	r *http.Request,
+	params api.GetIntelligenceEventsParams,
+) {
+	if denied := auth.EnforcePermission(w, r, auth.HostRead); denied {
+		return
+	}
+
+	limit := int32(50)
+	if params.Limit != nil {
+		v := *params.Limit
+		if v < 1 || v > 200 {
+			writeError(w, http.StatusBadRequest, "pagination.limit_exceeded", "client",
+				"limit must be between 1 and 200", false)
+			return
+		}
+		limit = int32(v)
+	}
+	if params.Severity != nil {
+		if !params.Severity.Valid() {
+			writeError(w, http.StatusBadRequest, "validation.field_range", "client",
+				"severity must be one of info/low/medium/high/critical", false)
+			return
+		}
+	}
+
+	rows, err := h.queryIntelligenceEvents(r.Context(), params, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.internal", "server",
+			"failed to query intelligence events", true)
+		return
+	}
+
+	resp := api.IntelligenceEventsPage{Items: rows}
+	if len(rows) == int(limit) {
+		last := rows[len(rows)-1].DetectedAt.Format(time.RFC3339Nano)
+		resp.NextCursor = &last
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// queryIntelligenceEvents reads host_intelligence_events with the given
+// filters, newest-first.
+func (h *handlers) queryIntelligenceEvents(
+	ctx context.Context,
+	p api.GetIntelligenceEventsParams,
+	limit int32,
+) ([]api.IntelligenceEvent, error) {
+	q := `
+SELECT id, host_id, event_code, severity, detail,
+       occurred_at, detected_at, correlation_id
+  FROM host_intelligence_events
+ WHERE 1=1
+`
+	args := []any{}
+	idx := 1
+	addArg := func(condition string, val any) {
+		q += " AND " + strings.Replace(condition, "$N", "$"+itoa(idx), 1)
+		args = append(args, val)
+		idx++
+	}
+
+	if p.HostId != nil {
+		addArg("host_id = $N", uuid.UUID(*p.HostId))
+	}
+	if p.EventCode != nil && *p.EventCode != "" {
+		addArg("event_code = $N", *p.EventCode)
+	}
+	if p.Severity != nil {
+		addArg("severity = $N", string(*p.Severity))
+	}
+	if p.Since != nil {
+		addArg("detected_at >= $N", *p.Since)
+	}
+	if p.Until != nil {
+		addArg("detected_at < $N", *p.Until)
+	}
+	if p.Cursor != nil && *p.Cursor != "" {
+		if t, err := time.Parse(time.RFC3339Nano, *p.Cursor); err == nil {
+			addArg("detected_at < $N", t)
+		}
+	}
+
+	q += " ORDER BY detected_at DESC, id DESC LIMIT $" + itoa(idx)
+	args = append(args, limit)
+
+	rows, err := h.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []api.IntelligenceEvent{}
+	for rows.Next() {
+		var (
+			ev          api.IntelligenceEvent
+			id, hostID  uuid.UUID
+			detailBytes []byte
+		)
+		if err := rows.Scan(
+			&id, &hostID, &ev.EventCode, &ev.Severity, &detailBytes,
+			&ev.OccurredAt, &ev.DetectedAt, &ev.CorrelationId,
+		); err != nil {
+			return nil, err
+		}
+		ev.Id = openapitypes.UUID(id)
+		ev.HostId = openapitypes.UUID(hostID)
+		if len(detailBytes) > 0 {
+			var d map[string]any
+			if json.Unmarshal(detailBytes, &d) == nil {
+				ev.Detail = &d
+			}
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// GetIntelligenceState implements api.ServerInterface.
+// Spec api-os-intelligence AC-06, AC-07, AC-08.
+func (h *handlers) GetIntelligenceState(
+	w http.ResponseWriter,
+	r *http.Request,
+	hostID openapitypes.UUID,
+) {
+	if denied := auth.EnforcePermission(w, r, auth.HostRead); denied {
+		return
+	}
+
+	hid := uuid.UUID(hostID)
+
+	// Spec C-04: probe for the host first. If the host is missing /
+	// soft-deleted, return 404. We deliberately collapse the
+	// "host-missing" and "no-snapshot-yet" cases under the same envelope
+	// so callers cannot probe host existence here.
+	if _, err := h.hosts.GetByID(r.Context(), hid); err != nil {
+		if errors.Is(err, host.ErrHostNotFound) {
+			writeError(w, http.StatusNotFound, "hosts.not_found", "client",
+				"host not found", false)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"host lookup failed", true)
+		return
+	}
+
+	var (
+		snapshotBytes []byte
+		collectedAt   time.Time
+	)
+	err := h.pool.QueryRow(r.Context(),
+		`SELECT snapshot, collected_at FROM host_intelligence_state WHERE host_id = $1`,
+		hid,
+	).Scan(&snapshotBytes, &collectedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Spec C-04: same envelope as "host unknown".
+			writeError(w, http.StatusNotFound, "hosts.not_found", "client",
+				"host not found", false)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"state lookup failed", true)
+		return
+	}
+
+	var snap map[string]any
+	if len(snapshotBytes) > 0 {
+		_ = json.Unmarshal(snapshotBytes, &snap)
+	}
+	writeJSON(w, http.StatusOK, api.IntelligenceState{
+		HostId:      openapitypes.UUID(hid),
+		Snapshot:    snap,
+		CollectedAt: collectedAt,
+	})
+}

--- a/app/specs/api/os-intelligence.spec.yaml
+++ b/app/specs/api/os-intelligence.spec.yaml
@@ -1,0 +1,118 @@
+spec:
+  id: api-os-intelligence
+  title: OS Intelligence read API
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: GET /api/v1/intelligence/{events,state} endpoints
+    description: >
+      Operator-facing read surface over the OS Intelligence data the
+      collector (system-os-intelligence) writes. Two endpoints:
+
+        GET /api/v1/intelligence/events
+            List recent detected changes across the fleet (or a single
+            host with ?host_id=). Filter by event_code, severity,
+            time-range. Cursor pagination on detected_at DESC.
+
+        GET /api/v1/intelligence/state/{host_id}
+            Last full snapshot for one host. Returns the JSONB blob
+            from host_intelligence_state plus the collected_at
+            timestamp. Used by the host detail page to render the
+            "what we know about this server" panel without operators
+            having to scroll the event log.
+
+      RBAC: both endpoints require host:read. A separate
+      intelligence:read permission was considered but the value-add
+      vs. host:read is marginal — anyone allowed to look at hosts is
+      allowed to look at the Intelligence data about them. Defer
+      finer-grained RBAC to a follow-up if customer feedback demands.
+
+    related_specs:
+      - system-os-intelligence
+      - api-hosts
+
+  objective:
+    summary: >
+      Two new handlers in internal/server/intelligence_handlers.go
+      implement the endpoints. Pagination follows the same cursor
+      pattern as GET /api/v1/audit/events (detected_at as the cursor
+      token, opaque-string body). The response shapes mirror the
+      collector's typed structures (Event + Snapshot).
+    scope:
+      includes:
+        - 'OpenAPI: GET /api/v1/intelligence/events + GET /api/v1/intelligence/state/{host_id}'
+        - 'Handler implementation in internal/server/intelligence_handlers.go'
+        - 'RBAC host:read enforcement'
+        - 'Filter params: host_id, event_code, severity, since, until, cursor, limit'
+        - 'Response schemas: IntelligenceEventsPage, IntelligenceState'
+      excludes:
+        - 'Real-time push (SSE / WebSocket) — handled by the existing eventbus + future SSE work'
+        - 'Mutation endpoints — Intelligence is read-only from operator POV; the collector is the only writer'
+        - 'Frontend rendering — depends on frontend stack direction'
+
+  constraints:
+    - id: C-01
+      description: 'Both endpoints MUST enforce host:read. 403 authz.permission_denied for callers without it. No audit event emitted on the deny path (EnforcePermission owns that)'
+      type: security
+      enforcement: error
+    - id: C-02
+      description: 'GET /intelligence/events MUST cap limit at 200 (default 50). limit < 0 or > 200 yields 400 pagination.limit_exceeded'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'GET /intelligence/events MUST support cursor pagination on detected_at DESC. cursor is the RFC3339Nano-formatted detected_at of the boundary row; when limit rows are returned, response.next_cursor is set to enable continuation'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'GET /intelligence/state/{host_id} MUST return 404 hosts.not_found if the host is unknown or soft-deleted, AND 404 if the host exists but has no host_intelligence_state row yet (no collection has run). The two 404 cases share the same envelope so callers cannot probe host existence via the state endpoint'
+      type: security
+      enforcement: error
+    - id: C-05
+      description: 'The events response severity filter accepts the closed set {info, low, medium, high, critical}. Unknown severity values yield 400 validation.field_range'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'GET /api/v1/intelligence/events with viewer role returns 200 with a paginated list. items[] is an array of IntelligenceEvent; pagination has at least the next_cursor field nullable'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: 'GET /api/v1/intelligence/events without an authenticated session returns 403'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-03
+      description: 'GET /api/v1/intelligence/events?limit=300 returns 400 pagination.limit_exceeded — the cap is 200'
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-04
+      description: 'GET /api/v1/intelligence/events?host_id=<id>&event_code=system.package.updated returns only matching rows for that host + code'
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-05
+      description: 'GET /api/v1/intelligence/events?limit=2 against a 5-row dataset returns 2 items + a non-null next_cursor; following the cursor returns the next 2 items'
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-06
+      description: 'GET /api/v1/intelligence/state/{unknown_id} returns 404 hosts.not_found. The envelope is the canonical ErrorEnvelope shape'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-07
+      description: 'GET /api/v1/intelligence/state/{id_with_no_state_yet} returns 404 hosts.not_found (same envelope as AC-06 — operators cannot probe host existence via this endpoint)'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-08
+      description: 'GET /api/v1/intelligence/state/{id_with_state} returns 200 with the snapshot JSON + collected_at timestamp. The snapshot has the typed shape collector.Snapshot exposes'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-09
+      description: 'GET /api/v1/intelligence/events?severity=panic returns 400 validation.field_range — severity is a closed set'
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-10
+      description: 'GET /api/v1/intelligence/events?since=<ts>&until=<ts> filters by detected_at within [since, until). Inclusive on since, exclusive on until — same semantics as /audit/events'
+      priority: high
+      references_constraints: [C-03]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -34,6 +34,7 @@ domains:
             - system-credential-store
             - system-host-discovery
             - system-os-intelligence
+            - api-os-intelligence
             - system-host-inventory
             - system-ssh-connectivity
             - api-auth


### PR DESCRIPTION
## Summary
PR 1.3 in the OS Discovery → OS Intelligence sequence. Stacks on top of #441 (PR 1.2 — collector + taxonomy).

- New spec **api-os-intelligence** v1.0.0 (Tier 2, 5 C / 10 AC)
- OpenAPI: \`GET /api/v1/intelligence/events\` (cursor pagination + filters) + \`GET /api/v1/intelligence/state/{host_id}\` (last snapshot)
- Handler: \`internal/server/intelligence_handlers.go\` — RBAC host:read, dynamic SQL filter builder, single 404 envelope for unknown-host OR no-snapshot-yet (C-04 anti-probing)
- 3 new response schemas: \`IntelligenceEvent\`, \`IntelligenceEventsPage\`, \`IntelligenceState\`
- 10 API integration tests covering AC-01..AC-10

## Spec coverage (api-os-intelligence)
- AC-01 viewer can list (200 + envelope)
- AC-02 anonymous 403
- AC-03 limit=300 → 400 pagination.limit_exceeded
- AC-04 filter by host_id + event_code returns only matching rows
- AC-05 limit=2 + cursor → 2+2 paginated correctly
- AC-06 GET /state/{unknown} → 404 hosts.not_found
- AC-07 GET /state/{host_with_no_snapshot} → 404 same envelope (anti-probing)
- AC-08 GET /state/{host_with_snapshot} → 200 with snapshot + collected_at
- AC-09 severity=panic → 400 validation.field_range
- AC-10 since/until time-range \[inclusive, exclusive) filter

## Stacking
- Base branch: \`feat/os-intelligence-phase-1.2\` (PR #441)
- Merge order: #440 → #441 → this PR

## Test plan
- [ ] CI green on Quality + security gates
- [ ] Manual smoke: hit \`GET /api/v1/intelligence/events?limit=10\` after PR 1.2 has populated some events