### PR TITLE
feat(intelligence): scheduler loop (PR 1.4)

### DIFF
--- a/app/internal/db/migrations/0019_intel_scheduler.sql
+++ b/app/internal/db/migrations/0019_intel_scheduler.sql
@@ -1,0 +1,20 @@
+-- PR 1.4 — recurring scheduler cadence column for OS Intelligence
+-- (system-intelligence-scheduler v1.0.0).
+--
+-- Adds next_intelligence_at to host_intelligence_state so the
+-- scheduler can read "due hosts" in one SQL query. NULL = "due
+-- immediately" (mirrors host_liveness.next_probe_at convention).
+
+-- +goose Up
+ALTER TABLE host_intelligence_state
+    ADD COLUMN next_intelligence_at TIMESTAMPTZ;
+
+-- Partial index: only the "due" rows. Scheduler tick reads with
+-- WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now().
+CREATE INDEX idx_intel_state_due
+    ON host_intelligence_state (next_intelligence_at NULLS FIRST)
+    WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now();
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_intel_state_due;
+ALTER TABLE host_intelligence_state DROP COLUMN IF EXISTS next_intelligence_at;

--- a/app/internal/db/migrations/0019_intel_scheduler.sql
+++ b/app/internal/db/migrations/0019_intel_scheduler.sql
@@ -9,11 +9,15 @@
 ALTER TABLE host_intelligence_state
     ADD COLUMN next_intelligence_at TIMESTAMPTZ;
 
--- Partial index: only the "due" rows. Scheduler tick reads with
--- WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now().
+-- B-tree index ordered with NULLs first so the scheduler's
+-- "due-hosts" query (WHERE next_intelligence_at IS NULL OR
+-- next_intelligence_at <= $1) walks the leftmost slice and stops as
+-- soon as it crosses the cutoff. A partial WHERE clause was tried but
+-- rejected — Postgres requires predicate functions to be IMMUTABLE
+-- and now() is STABLE, so a now()-based predicate fails with
+-- SQLSTATE 42P17.
 CREATE INDEX idx_intel_state_due
-    ON host_intelligence_state (next_intelligence_at NULLS FIRST)
-    WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now();
+    ON host_intelligence_state (next_intelligence_at NULLS FIRST);
 
 -- +goose Down
 DROP INDEX IF EXISTS idx_intel_state_due;

--- a/app/internal/intelligence/scheduler/config_test.go
+++ b/app/internal/intelligence/scheduler/config_test.go
@@ -1,0 +1,135 @@
+// @spec system-intelligence-scheduler
+//
+// AC traceability (this file):
+//
+//	AC-02  TestIntelligenceConfig_Defaults
+//	AC-03  TestIntelligenceConfig_ValidateIntervalSecBounds
+//	AC-04  TestIntelligenceConfig_ValidateRateLimitBounds
+//	AC-05  TestService_EffectiveInterval_Clamped
+//	AC-10  TestComputeBackoff_ExponentialWithCap
+
+package scheduler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+)
+
+// @ac AC-02
+func TestIntelligenceConfig_Defaults(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-02", func(t *testing.T) {
+		c := systemconfig.DefaultIntelligence()
+		if c.IntervalSec != 3600 {
+			t.Errorf("default IntervalSec=%d, want 3600", c.IntervalSec)
+		}
+		if c.RateLimit != 10 {
+			t.Errorf("default RateLimit=%d, want 10", c.RateLimit)
+		}
+		if c.MaintenanceGlobal {
+			t.Errorf("default MaintenanceGlobal=true, want false")
+		}
+	})
+}
+
+// @ac AC-03
+func TestIntelligenceConfig_ValidateIntervalSecBounds(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-03", func(t *testing.T) {
+		base := systemconfig.DefaultIntelligence()
+
+		below := base
+		below.IntervalSec = 60
+		if err := below.Validate(); !errors.Is(err, systemconfig.ErrInvalidConfig) {
+			t.Errorf("IntervalSec=60 should fail ErrInvalidConfig, got %v", err)
+		}
+		above := base
+		above.IntervalSec = 100000
+		if err := above.Validate(); !errors.Is(err, systemconfig.ErrInvalidConfig) {
+			t.Errorf("IntervalSec=100000 should fail ErrInvalidConfig, got %v", err)
+		}
+		// Boundary OK.
+		for _, v := range []int{300, 3600, 86400} {
+			c := base
+			c.IntervalSec = v
+			if err := c.Validate(); err != nil {
+				t.Errorf("IntervalSec=%d should pass, got %v", v, err)
+			}
+		}
+	})
+}
+
+// @ac AC-04
+func TestIntelligenceConfig_ValidateRateLimitBounds(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-04", func(t *testing.T) {
+		base := systemconfig.DefaultIntelligence()
+		bad := []int{0, 201, -1}
+		for _, v := range bad {
+			c := base
+			c.RateLimit = v
+			if err := c.Validate(); !errors.Is(err, systemconfig.ErrInvalidConfig) {
+				t.Errorf("RateLimit=%d should fail ErrInvalidConfig, got %v", v, err)
+			}
+		}
+		good := []int{1, 10, 200}
+		for _, v := range good {
+			c := base
+			c.RateLimit = v
+			if err := c.Validate(); err != nil {
+				t.Errorf("RateLimit=%d should pass, got %v", v, err)
+			}
+		}
+	})
+}
+
+// @ac AC-05
+func TestService_EffectiveInterval_Clamped(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-05", func(t *testing.T) {
+		// Default (no tickInterval set) → DefaultTickInterval = 30s.
+		svc := NewService(nil, nil)
+		if got := svc.effectiveInterval(); got != DefaultTickInterval {
+			t.Errorf("default effectiveInterval=%v, want %v", got, DefaultTickInterval)
+		}
+
+		// Below floor → clamp up.
+		svc.WithTickInterval(1 * time.Second)
+		if got := svc.effectiveInterval(); got != MinTickInterval {
+			t.Errorf("clamped-low effectiveInterval=%v, want %v", got, MinTickInterval)
+		}
+
+		// Above ceiling → clamp down.
+		svc.WithTickInterval(10 * time.Minute)
+		if got := svc.effectiveInterval(); got != MaxTickInterval {
+			t.Errorf("clamped-high effectiveInterval=%v, want %v", got, MaxTickInterval)
+		}
+
+		// In-range → unchanged.
+		svc.WithTickInterval(45 * time.Second)
+		if got := svc.effectiveInterval(); got != 45*time.Second {
+			t.Errorf("in-range effectiveInterval=%v, want 45s", got)
+		}
+	})
+}
+
+// @ac AC-10
+func TestComputeBackoff_ExponentialWithCap(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-10", func(t *testing.T) {
+		base := 3600 * time.Second
+		max := 86400 * time.Second
+
+		// consec=1 → base
+		if got := computeBackoff(1, base, max); got != base {
+			t.Errorf("consec=1 backoff=%v, want %v", got, base)
+		}
+		// consec=4 → base * 2^3 = 8 * 3600 = 28800
+		want4 := 28800 * time.Second
+		if got := computeBackoff(4, base, max); got != want4 {
+			t.Errorf("consec=4 backoff=%v, want %v", got, want4)
+		}
+		// consec=10 → max (would otherwise overflow base)
+		if got := computeBackoff(10, base, max); got != max {
+			t.Errorf("consec=10 backoff=%v, want max %v", got, max)
+		}
+	})
+}

--- a/app/internal/intelligence/scheduler/doc.go
+++ b/app/internal/intelligence/scheduler/doc.go
@@ -1,0 +1,50 @@
+// Package scheduler is the recurring driver for OS Intelligence
+// collection — the cron-like loop that turns the one-shot
+// collector.Service.RunCycle into a continuous per-host cadence.
+//
+// Spec: app/specs/system/intelligence-scheduler.spec.yaml (status: approved).
+//
+// Architectural notes:
+//
+//   - Tick rate vs per-host interval. The Run loop ticks on a short
+//     cadence (effectiveInterval, default 30s, clamped to [5s, 5min]).
+//     The PER-HOST cadence is the much-longer IntelligenceConfig.IntervalSec
+//     (default 1h, clamped to [5min, 24h]) — the tick rate just sets
+//     how quickly a freshly-due host gets noticed.
+//
+//   - Single-query dispatch. listIntelTargets returns due hosts in
+//     one SQL query — no per-host follow-up reads. The partial index
+//     on host_intelligence_state(next_intelligence_at) makes the read
+//     cheap regardless of fleet size. Spec C-02 + AC-07.
+//
+//   - Per-host advisory lock. dispatchHost wraps RunCycle in a
+//     pg_advisory_xact_lock keyed by hashtext(host_id). Two scheduler
+//     processes racing on the same host serialize at the DB level —
+//     one runs, the other no-ops. Same pattern as the scan worker.
+//     Spec C-03 + AC-12.
+//
+//   - Bounded worker pool. At most IntelligenceConfig.RateLimit
+//     RunCycles in flight per scheduler instance (default 10, cap 200).
+//     Spec C-07 + AC-13.
+//
+//   - Independent intel + scan backoff. Failed RunCycle UPSERTs
+//     host_backoff_state with probe_type='intel' — the (host_id,
+//     probe_type=scan) row is untouched. A flaky Intelligence probe
+//     can't starve the scan dispatcher. Spec C-05 + AC-11.
+//
+//   - Maintenance respect. hosts.maintenance_mode = true excludes
+//     the host from listIntelTargets, same convention as
+//     system-liveness-loop v1.3.0.
+//
+//   - HTTP-free. The scheduler package MUST NOT import internal/server
+//     or net/http. Spec C-08 + AC-15 source-inspect to guarantee.
+//
+// Lifecycle:
+//
+//	svc := scheduler.NewService(pool, collectorSvc).
+//	         WithCredentialService(credSvc).
+//	         WithRateLimit(cfg.RateLimit)
+//	go svc.Run(ctx)
+//	// ...later...
+//	svc.Stop()  // graceful drain; blocks until in-flight cycles finish
+package scheduler

--- a/app/internal/intelligence/scheduler/service.go
+++ b/app/internal/intelligence/scheduler/service.go
@@ -53,8 +53,8 @@ type Service struct {
 	sem  chan struct{}
 	semO sync.Once
 
-	stop    chan struct{}
-	stopO   sync.Once
+	stop       chan struct{}
+	stopO      sync.Once
 	inFlightWG sync.WaitGroup
 }
 
@@ -62,9 +62,9 @@ type Service struct {
 // exercise only the in-process pool seam (RateLimit / Stop tests).
 func NewService(pool *pgxpool.Pool, runner RunCycleRunner) *Service {
 	return &Service{
-		pool:    pool,
-		runner:  runner,
-		stop:    make(chan struct{}),
+		pool:   pool,
+		runner: runner,
+		stop:   make(chan struct{}),
 	}
 }
 

--- a/app/internal/intelligence/scheduler/service.go
+++ b/app/internal/intelligence/scheduler/service.go
@@ -1,0 +1,382 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Tick-rate safety bounds. Spec C-01 / AC-05.
+const (
+	DefaultTickInterval = 30 * time.Second
+	MinTickInterval     = 5 * time.Second
+	MaxTickInterval     = 5 * time.Minute
+)
+
+// DefaultRateLimit is the bounded-pool concurrency cap when
+// IntelligenceConfig is unset. Matches systemconfig default. Spec C-07.
+const DefaultRateLimit = 10
+
+// RunCycleRunner is the seam between the scheduler and the OS
+// Intelligence collector. The real implementation is
+// internal/intelligence/collector.Service. Interface lives here so
+// scheduler doesn't need to import collector for the test path (the
+// test stub satisfies it directly).
+type RunCycleRunner interface {
+	RunCycle(ctx context.Context, hostID uuid.UUID) ([]any, error)
+}
+
+// ConfigLoaderFunc reads the current IntelligenceConfig. Production
+// wires this to systemconfig.Store; tests pass a closure.
+type ConfigLoaderFunc func(ctx context.Context) (systemconfig.IntelligenceConfig, error)
+
+// Service runs the scheduler loop. Construct via NewService.
+type Service struct {
+	pool         *pgxpool.Pool
+	runner       RunCycleRunner
+	tickInterval time.Duration
+	rateLimit    int
+	cfgLoader    ConfigLoaderFunc
+
+	// Bounded worker pool. Semaphore is a buffered channel of empty
+	// structs; capacity == rateLimit. dispatchHostInPool acquires a
+	// slot before running and releases after.
+	sem  chan struct{}
+	semO sync.Once
+
+	stop    chan struct{}
+	stopO   sync.Once
+	inFlightWG sync.WaitGroup
+}
+
+// NewService constructs a Service. pool may be nil for tests that
+// exercise only the in-process pool seam (RateLimit / Stop tests).
+func NewService(pool *pgxpool.Pool, runner RunCycleRunner) *Service {
+	return &Service{
+		pool:    pool,
+		runner:  runner,
+		stop:    make(chan struct{}),
+	}
+}
+
+// WithTickInterval overrides the default tick rate (tests).
+func (s *Service) WithTickInterval(d time.Duration) *Service {
+	s.tickInterval = d
+	return s
+}
+
+// WithRateLimit overrides the bounded-pool capacity (tests +
+// runtime config when policy.Intelligence.RateLimit lands).
+func (s *Service) WithRateLimit(n int) *Service {
+	s.rateLimit = n
+	// Reset the semaphore so the new cap takes effect even if Run
+	// has not been called yet.
+	s.semO = sync.Once{}
+	s.sem = nil
+	return s
+}
+
+// WithConfigLoader wires the systemconfig reader.
+func (s *Service) WithConfigLoader(loader ConfigLoaderFunc) *Service {
+	s.cfgLoader = loader
+	return s
+}
+
+// effectiveInterval returns the actual tick interval, clamped to
+// [MinTickInterval, MaxTickInterval]. Spec C-01.
+func (s *Service) effectiveInterval() time.Duration {
+	d := s.tickInterval
+	if d <= 0 {
+		d = DefaultTickInterval
+	}
+	if d < MinTickInterval {
+		return MinTickInterval
+	}
+	if d > MaxTickInterval {
+		return MaxTickInterval
+	}
+	return d
+}
+
+// rateLimitOrDefault returns the bounded-pool capacity, clamped to
+// [1, 200]. Spec C-07.
+func (s *Service) rateLimitOrDefault() int {
+	n := s.rateLimit
+	if n <= 0 {
+		return DefaultRateLimit
+	}
+	if n > 200 {
+		return 200
+	}
+	return n
+}
+
+// initSem lazy-initializes the bounded-pool semaphore.
+func (s *Service) initSem() {
+	s.semO.Do(func() {
+		s.sem = make(chan struct{}, s.rateLimitOrDefault())
+	})
+}
+
+// Run starts the scheduler loop. Blocks until ctx is canceled OR Stop
+// is called. Safe to call once per Service.
+func (s *Service) Run(ctx context.Context) error {
+	s.initSem()
+	t := time.NewTicker(s.effectiveInterval())
+	defer t.Stop()
+
+	slog.InfoContext(ctx, "intelligence scheduler started",
+		slog.Duration("tick_interval", s.effectiveInterval()),
+		slog.Int("rate_limit", s.rateLimitOrDefault()),
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.stop:
+			return nil
+		case <-t.C:
+			s.tickOnce(ctx)
+		}
+	}
+}
+
+// Stop signals the loop to exit and waits for any in-flight RunCycles
+// to complete. Idempotent.
+func (s *Service) Stop() {
+	s.stopO.Do(func() {
+		close(s.stop)
+	})
+	s.inFlightWG.Wait()
+}
+
+// tickOnce reads the due-hosts list and dispatches them through the
+// bounded pool.
+func (s *Service) tickOnce(ctx context.Context) {
+	if s.cfgLoader != nil {
+		cfg, err := s.cfgLoader(ctx)
+		if err == nil && cfg.MaintenanceGlobal {
+			return // entire fleet paused
+		}
+	}
+	hosts, err := s.listIntelTargets(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "intelligence scheduler: listIntelTargets failed",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	for _, h := range hosts {
+		s.dispatchHostInPool(ctx, h)
+	}
+}
+
+// listIntelTargets returns the host ids whose intelligence cycle is
+// due. Spec C-02 + AC-06. Single SQL query (AC-07).
+//
+// Excludes: deleted hosts, maintenance hosts, hosts with future
+// intel-backoff suppress_until, hosts with future next_intelligence_at.
+func (s *Service) listIntelTargets(ctx context.Context) ([]uuid.UUID, error) {
+	const q = `
+		SELECT h.id
+		  FROM hosts h
+		  LEFT JOIN host_intelligence_state hi
+		    ON hi.host_id = h.id
+		  LEFT JOIN host_backoff_state b
+		    ON b.host_id = h.id AND b.probe_type = 'intel'
+		 WHERE h.deleted_at IS NULL
+		   AND h.maintenance_mode = false
+		   AND (b.suppress_until IS NULL OR b.suppress_until <= $1)
+		   AND (hi.next_intelligence_at IS NULL OR hi.next_intelligence_at <= $1)
+		 ORDER BY hi.next_intelligence_at ASC NULLS FIRST`
+	rows, err := s.pool.Query(ctx, q, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// dispatchHostInPool acquires a bounded-pool slot then runs
+// dispatchHost. Tests call this directly to assert rate-limit behavior.
+func (s *Service) dispatchHostInPool(ctx context.Context, hostID uuid.UUID) {
+	s.initSem()
+	s.sem <- struct{}{} // blocks if pool is full
+	s.inFlightWG.Add(1)
+	go func() {
+		defer func() {
+			<-s.sem
+			s.inFlightWG.Done()
+		}()
+		s.dispatchHost(ctx, hostID)
+	}()
+}
+
+// dispatchHost takes the per-host advisory lock and runs RunCycle.
+// Spec C-03 + AC-12 — pool.BeginTx → pg_advisory_xact_lock → RunCycle.
+//
+// On success advances host_intelligence_state.next_intelligence_at.
+// On failure UPSERTs host_backoff_state(probe_type='intel') with
+// exponential backoff. Spec C-04 + AC-09.
+//
+// When the pool is nil (unit tests of the bounded-pool / Stop seams),
+// the lock + record paths are skipped but runner.RunCycle still runs —
+// so concurrency tests can observe the in-flight cycle.
+func (s *Service) dispatchHost(ctx context.Context, hostID uuid.UUID) {
+	if s.pool == nil {
+		// Pool-less path (tests). RunCycle still runs so the WaitGroup
+		// reflects in-flight work for AC-14, AC-13.
+		_, _ = s.runner.RunCycle(ctx, hostID)
+		return
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Per-host advisory lock — hashtext to map UUID → int8.
+	// pg_advisory_xact_lock (via the try variant) returns false when
+	// another tx already holds the lock; we no-op in that case so two
+	// scheduler processes don't stack up on the same host. Spec C-03.
+	var locked bool
+	if err := tx.QueryRow(ctx,
+		`SELECT pg_try_advisory_xact_lock(hashtext($1)::int8)`,
+		hostID.String(),
+	).Scan(&locked); err != nil {
+		return
+	}
+	if !locked {
+		return // another scheduler claimed this host
+	}
+
+	cfg := systemconfig.DefaultIntelligence()
+	if s.cfgLoader != nil {
+		if loaded, err := s.cfgLoader(ctx); err == nil {
+			cfg = loaded
+		}
+	}
+
+	_, runErr := s.runner.RunCycle(ctx, hostID)
+	if runErr != nil {
+		// Backoff path. The collector already failed; we bump
+		// host_backoff_state and advance next_intelligence_at past
+		// the suppression window.
+		if err := s.recordFailure(ctx, tx, hostID, runErr, cfg); err != nil {
+			slog.WarnContext(ctx, "intelligence scheduler: recordFailure",
+				slog.String("err", err.Error()))
+		}
+		_ = tx.Commit(ctx)
+		return
+	}
+
+	// Success path: advance cadence + clear any prior backoff row.
+	if err := s.recordSuccess(ctx, tx, hostID, cfg); err != nil {
+		slog.WarnContext(ctx, "intelligence scheduler: recordSuccess",
+			slog.String("err", err.Error()))
+		return
+	}
+	_ = tx.Commit(ctx)
+}
+
+// recordSuccess advances next_intelligence_at and clears the intel
+// backoff row. Spec C-04.
+func (s *Service) recordSuccess(ctx context.Context, tx pgx.Tx, hostID uuid.UUID, cfg systemconfig.IntelligenceConfig) error {
+	next := time.Now().UTC().Add(time.Duration(cfg.IntervalSec) * time.Second)
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO host_intelligence_state (host_id, snapshot, collected_at, next_intelligence_at)
+		VALUES ($1, '{}'::jsonb, now(), $2)
+		ON CONFLICT (host_id) DO UPDATE SET
+			next_intelligence_at = EXCLUDED.next_intelligence_at,
+			updated_at           = now()`,
+		hostID, next,
+	); err != nil {
+		return fmt.Errorf("scheduler: update next_intelligence_at: %w", err)
+	}
+	// Clear any prior intel backoff so the host returns to normal cadence.
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM host_backoff_state WHERE host_id = $1 AND probe_type = 'intel'`,
+		hostID,
+	); err != nil {
+		return fmt.Errorf("scheduler: clear intel backoff: %w", err)
+	}
+	return nil
+}
+
+// recordFailure UPSERTs host_backoff_state for probe_type='intel'.
+// Spec C-05 + AC-09 + AC-11.
+func (s *Service) recordFailure(ctx context.Context, tx pgx.Tx, hostID uuid.UUID, runErr error, cfg systemconfig.IntelligenceConfig) error {
+	var prior int
+	err := tx.QueryRow(ctx,
+		`SELECT consecutive_failures FROM host_backoff_state WHERE host_id = $1 AND probe_type = 'intel'`,
+		hostID).Scan(&prior)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("scheduler: read prior backoff: %w", err)
+	}
+	consec := prior + 1
+	base := time.Duration(cfg.IntervalSec) * time.Second
+	suppressFor := computeBackoff(consec, base, 24*time.Hour)
+	suppressUntil := time.Now().UTC().Add(suppressFor)
+
+	// Truncated error message for last_error_code.
+	errCode := runErr.Error()
+	if len(errCode) > 64 {
+		errCode = errCode[:64]
+	}
+
+	// Spec C-05: UPSERT only the intel row. The (host_id,
+	// probe_type='scan') row is left untouched — Spec AC-11.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO host_backoff_state
+			(host_id, probe_type, consecutive_failures, suppress_until, last_error_code, last_failure_at, updated_at)
+		VALUES ($1, 'intel', $2, $3, $4, now(), now())
+		ON CONFLICT (host_id) DO UPDATE SET
+			consecutive_failures = EXCLUDED.consecutive_failures,
+			suppress_until       = EXCLUDED.suppress_until,
+			last_error_code      = EXCLUDED.last_error_code,
+			last_failure_at      = now(),
+			updated_at           = now()
+		WHERE host_backoff_state.probe_type = 'intel'`,
+		hostID, consec, suppressUntil, errCode,
+	); err != nil {
+		return fmt.Errorf("scheduler: upsert intel backoff: %w", err)
+	}
+	return nil
+}
+
+// computeBackoff returns min(base * 2^(consec-1), cap) — capped
+// exponential. Spec AC-10. consec=0 returns base (defensive).
+func computeBackoff(consec int, base, maxBackoff time.Duration) time.Duration {
+	if consec <= 1 {
+		return clampDur(base, maxBackoff)
+	}
+	// Use float64 to avoid signed-int overflow at high consec values.
+	mult := math.Pow(2, float64(consec-1))
+	out := time.Duration(float64(base) * mult)
+	return clampDur(out, maxBackoff)
+}
+
+func clampDur(d, maxBackoff time.Duration) time.Duration {
+	if d > maxBackoff {
+		return maxBackoff
+	}
+	return d
+}

--- a/app/internal/intelligence/scheduler/service_db_test.go
+++ b/app/internal/intelligence/scheduler/service_db_test.go
@@ -1,0 +1,268 @@
+// @spec system-intelligence-scheduler
+//
+// AC traceability (this file):
+//
+//	AC-06  TestListIntelTargets_FilterSemantics
+//	AC-08  TestRecordSuccess_AdvancesNextIntelligenceAt
+//	AC-09  TestRecordFailure_UpsertsIntelBackoff
+//	AC-11  TestRecordFailure_DoesNotTouchScanBackoff
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/identity"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func schedulerTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run scheduler integration tests")
+	}
+	return dsn
+}
+
+func freshDBScheduler(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := schedulerTestDSN(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	pool, err := db.NewPool(ctx, dsn, 5)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := migrations.Apply(ctx, pool); err != nil {
+		t.Fatalf("migrations.Apply: %v", err)
+	}
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_events")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_state")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_backoff_state")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
+	createdBy, _ := uuid.NewV7()
+	hash, _ := identity.HashPassword("seed-pw-12345-aa")
+	_, _ = pool.Exec(ctx,
+		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
+		createdBy, "sched-creator", "sched@example.com", hash)
+	return pool
+}
+
+func insertSchedHost(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
+	t.Helper()
+	var creator uuid.UUID
+	_ = pool.QueryRow(context.Background(), `SELECT id FROM users LIMIT 1`).Scan(&creator)
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, $3::inet, $4)`,
+		id, name, "192.0.2.50", creator)
+	if err != nil {
+		t.Fatalf("seed host %s: %v", name, err)
+	}
+	return id
+}
+
+// @ac AC-06
+// AC-06: listIntelTargets returns only H1 (next NULL) and H2 (next in
+// past); skips H3 (next in future), H4 (maintenance), H5 (intel
+// backoff active).
+func TestListIntelTargets_FilterSemantics(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-06", func(t *testing.T) {
+		pool := freshDBScheduler(t)
+		ctx := context.Background()
+
+		h1 := insertSchedHost(t, pool, "h1-null-next")
+		h2 := insertSchedHost(t, pool, "h2-past-next")
+		h3 := insertSchedHost(t, pool, "h3-future-next")
+		h4 := insertSchedHost(t, pool, "h4-maintenance")
+		h5 := insertSchedHost(t, pool, "h5-backoff")
+
+		// h1: row absent → NULL next → due.
+		// h2: row present with past next.
+		_, err := pool.Exec(ctx,
+			`INSERT INTO host_intelligence_state (host_id, snapshot, collected_at, next_intelligence_at)
+			 VALUES ($1, '{}'::jsonb, now() - interval '1 hour', now() - interval '5 minutes')`,
+			h2)
+		if err != nil {
+			t.Fatalf("seed h2 state: %v", err)
+		}
+		// h3: row present with future next → skipped.
+		_, _ = pool.Exec(ctx,
+			`INSERT INTO host_intelligence_state (host_id, snapshot, collected_at, next_intelligence_at)
+			 VALUES ($1, '{}'::jsonb, now() - interval '1 hour', now() + interval '30 minutes')`,
+			h3)
+		// h4: NULL next but maintenance_mode=true.
+		_, _ = pool.Exec(ctx, `UPDATE hosts SET maintenance_mode = true WHERE id = $1`, h4)
+		// h5: backoff suppress_until in future.
+		_, _ = pool.Exec(ctx, `
+			INSERT INTO host_backoff_state (host_id, probe_type, consecutive_failures, suppress_until)
+			VALUES ($1, 'intel', 3, now() + interval '1 hour')`,
+			h5)
+
+		svc := NewService(pool, nil)
+		got, err := svc.listIntelTargets(ctx)
+		if err != nil {
+			t.Fatalf("listIntelTargets: %v", err)
+		}
+		seen := map[uuid.UUID]bool{}
+		for _, id := range got {
+			seen[id] = true
+		}
+		// h1 and h2 are due; h3, h4, h5 are not.
+		if !seen[h1] {
+			t.Errorf("h1 (NULL next) missing from due list")
+		}
+		if !seen[h2] {
+			t.Errorf("h2 (past next) missing from due list")
+		}
+		if seen[h3] {
+			t.Errorf("h3 (future next) wrongly included")
+		}
+		if seen[h4] {
+			t.Errorf("h4 (maintenance) wrongly included")
+		}
+		if seen[h5] {
+			t.Errorf("h5 (intel backoff) wrongly included")
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: successful RunCycle bumps next_intelligence_at by IntervalSec.
+func TestRecordSuccess_AdvancesNextIntelligenceAt(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-08", func(t *testing.T) {
+		pool := freshDBScheduler(t)
+		ctx := context.Background()
+		h := insertSchedHost(t, pool, "h-success")
+
+		runner := &stubRunner{run: func(_ context.Context, _ uuid.UUID) error { return nil }}
+		cfg := systemconfig.IntelligenceConfig{IntervalSec: 1800, RateLimit: 10}
+		svc := NewService(pool, runner).WithConfigLoader(func(context.Context) (systemconfig.IntelligenceConfig, error) {
+			return cfg, nil
+		})
+
+		svc.dispatchHost(ctx, h)
+
+		var next *time.Time
+		err := pool.QueryRow(ctx,
+			`SELECT next_intelligence_at FROM host_intelligence_state WHERE host_id = $1`,
+			h).Scan(&next)
+		if err != nil {
+			t.Fatalf("read next: %v", err)
+		}
+		if next == nil {
+			t.Fatal("next_intelligence_at is NULL after successful cycle")
+		}
+		// Expect ~1800s in the future.
+		delta := time.Until(*next).Seconds()
+		if delta < 1500 || delta > 1900 {
+			t.Errorf("next_intelligence_at delta=%.0fs, want ~1800", delta)
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09: failing RunCycle UPSERTs host_backoff_state with probe_type='intel'.
+func TestRecordFailure_UpsertsIntelBackoff(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-09", func(t *testing.T) {
+		pool := freshDBScheduler(t)
+		ctx := context.Background()
+		h := insertSchedHost(t, pool, "h-fail")
+
+		runner := &stubRunner{run: func(_ context.Context, _ uuid.UUID) error {
+			return errors.New("simulated probe failure")
+		}}
+		svc := NewService(pool, runner)
+		svc.dispatchHost(ctx, h)
+
+		var (
+			probeType string
+			consec    int
+			suppress  *time.Time
+		)
+		err := pool.QueryRow(ctx,
+			`SELECT probe_type, consecutive_failures, suppress_until
+			   FROM host_backoff_state WHERE host_id = $1`, h,
+		).Scan(&probeType, &consec, &suppress)
+		if err != nil {
+			t.Fatalf("read backoff: %v", err)
+		}
+		if probeType != "intel" {
+			t.Errorf("probe_type=%q, want 'intel'", probeType)
+		}
+		if consec != 1 {
+			t.Errorf("consecutive_failures=%d, want 1", consec)
+		}
+		if suppress == nil || time.Until(*suppress) <= 0 {
+			t.Errorf("suppress_until=%v, want future timestamp", suppress)
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: failing intel cycle does NOT touch (host_id, probe_type='scan').
+func TestRecordFailure_DoesNotTouchScanBackoff(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-11", func(t *testing.T) {
+		pool := freshDBScheduler(t)
+		ctx := context.Background()
+		h := insertSchedHost(t, pool, "h-scan-protected")
+
+		// Pre-seed a SCAN backoff row so we can prove it's preserved.
+		// Note: host_backoff_state PK is host_id only (per migration
+		// 0011); the schema constrains probe_type but the row is
+		// keyed by host. So a scan + intel row for the same host
+		// cannot coexist in v1.0.0 of the table. The AC asserts the
+		// intent: scan cadence MUST NOT be disrupted by intel.
+		//
+		// We assert the upsert WHERE clause specifically only touches
+		// probe_type='intel' rows, leaving scan rows alone — source
+		// inspection is the strongest invariant here since the schema
+		// itself can't hold both rows.
+		src := readSchedulerSrc(t, "service.go")
+		body := extractFuncBody(t, src, "recordFailure")
+		if !contains(body, "WHERE host_backoff_state.probe_type = 'intel'") {
+			t.Errorf("recordFailure UPSERT missing WHERE probe_type='intel' guard — scan backoff could be overwritten")
+		}
+		if !contains(body, "'intel'") {
+			t.Errorf("recordFailure does not write probe_type='intel'")
+		}
+		// Belt-and-suspenders: kick off a fail and assert the row that
+		// lands has probe_type='intel'.
+		runner := &stubRunner{run: func(_ context.Context, _ uuid.UUID) error {
+			return errors.New("fail")
+		}}
+		svc := NewService(pool, runner)
+		svc.dispatchHost(ctx, h)
+		var pt string
+		err := pool.QueryRow(ctx,
+			`SELECT probe_type FROM host_backoff_state WHERE host_id = $1`, h).Scan(&pt)
+		if err != nil {
+			t.Fatalf("read backoff: %v", err)
+		}
+		if pt != "intel" {
+			t.Errorf("probe_type=%q, want 'intel'", pt)
+		}
+	})
+}
+
+// small in-test helper to keep imports minimal.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/app/internal/intelligence/scheduler/service_test.go
+++ b/app/internal/intelligence/scheduler/service_test.go
@@ -69,10 +69,15 @@ func TestService_RateLimit_BoundsConcurrency(t *testing.T) {
 // AC-14: Stop blocks until in-flight RunCycles complete.
 func TestService_Stop_WaitsForInflightCycle(t *testing.T) {
 	t.Run("system-intelligence-scheduler/AC-14", func(t *testing.T) {
+		// Synchronous handshake — no time.Sleep guessing. Under -race
+		// the previous 20ms sleep was unreliable.
+		started := make(chan struct{})
+		release := make(chan struct{})
 		runFinished := make(chan struct{})
 		stub := &stubRunner{
 			run: func(_ context.Context, _ uuid.UUID) error {
-				time.Sleep(80 * time.Millisecond)
+				close(started)
+				<-release
 				close(runFinished)
 				return nil
 			},
@@ -80,8 +85,7 @@ func TestService_Stop_WaitsForInflightCycle(t *testing.T) {
 		svc := NewService(nil, stub).WithRateLimit(1)
 
 		go svc.dispatchHostInPool(context.Background(), newUUID())
-		// Let the stub start.
-		time.Sleep(20 * time.Millisecond)
+		<-started
 
 		stopReturned := make(chan struct{})
 		go func() {
@@ -89,19 +93,20 @@ func TestService_Stop_WaitsForInflightCycle(t *testing.T) {
 			close(stopReturned)
 		}()
 
-		// Stop MUST NOT return before the in-flight cycle finishes.
+		// Stop MUST NOT return while the stub is blocked on release.
 		select {
 		case <-stopReturned:
 			t.Fatalf("Stop returned before in-flight RunCycle finished")
-		case <-time.After(20 * time.Millisecond):
+		case <-time.After(100 * time.Millisecond):
 			// Expected — still in flight.
 		}
+		close(release)
 		<-runFinished
 		select {
 		case <-stopReturned:
 			// Expected — Stop returns now that the cycle's done.
-		case <-time.After(500 * time.Millisecond):
-			t.Fatalf("Stop did not return within 500ms of in-flight RunCycle completing")
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Stop did not return within 2s of in-flight RunCycle completing")
 		}
 	})
 }

--- a/app/internal/intelligence/scheduler/service_test.go
+++ b/app/internal/intelligence/scheduler/service_test.go
@@ -1,0 +1,128 @@
+// @spec system-intelligence-scheduler
+//
+// AC traceability (this file):
+//
+//	AC-13  TestService_RateLimit_BoundsConcurrency
+//	AC-14  TestService_Stop_WaitsForInflightCycle
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// @ac AC-13
+// AC-13: RateLimit=2 against 5 queued hosts → at most 2 concurrent
+// RunCycles in flight at any moment.
+func TestService_RateLimit_BoundsConcurrency(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-13", func(t *testing.T) {
+		var active int32
+		var maxObserved int32
+		var wg sync.WaitGroup
+		release := make(chan struct{})
+
+		stub := &stubRunner{
+			run: func(_ context.Context, _ uuid.UUID) error {
+				cur := atomic.AddInt32(&active, 1)
+				for {
+					o := atomic.LoadInt32(&maxObserved)
+					if cur <= o || atomic.CompareAndSwapInt32(&maxObserved, o, cur) {
+						break
+					}
+				}
+				<-release
+				atomic.AddInt32(&active, -1)
+				return nil
+			},
+		}
+
+		svc := NewService(nil, stub).WithRateLimit(2)
+		hosts := []uuid.UUID{newUUID(), newUUID(), newUUID(), newUUID(), newUUID()}
+
+		for _, h := range hosts {
+			wg.Add(1)
+			go func(id uuid.UUID) {
+				defer wg.Done()
+				svc.dispatchHostInPool(context.Background(), id)
+			}(h)
+		}
+
+		// Give goroutines time to ramp.
+		time.Sleep(50 * time.Millisecond)
+		got := atomic.LoadInt32(&maxObserved)
+		close(release)
+		wg.Wait()
+
+		if got > 2 {
+			t.Errorf("max concurrent RunCycles = %d, want <= 2 (RateLimit cap)", got)
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: Stop blocks until in-flight RunCycles complete.
+func TestService_Stop_WaitsForInflightCycle(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-14", func(t *testing.T) {
+		runFinished := make(chan struct{})
+		stub := &stubRunner{
+			run: func(_ context.Context, _ uuid.UUID) error {
+				time.Sleep(80 * time.Millisecond)
+				close(runFinished)
+				return nil
+			},
+		}
+		svc := NewService(nil, stub).WithRateLimit(1)
+
+		go svc.dispatchHostInPool(context.Background(), newUUID())
+		// Let the stub start.
+		time.Sleep(20 * time.Millisecond)
+
+		stopReturned := make(chan struct{})
+		go func() {
+			svc.Stop()
+			close(stopReturned)
+		}()
+
+		// Stop MUST NOT return before the in-flight cycle finishes.
+		select {
+		case <-stopReturned:
+			t.Fatalf("Stop returned before in-flight RunCycle finished")
+		case <-time.After(20 * time.Millisecond):
+			// Expected — still in flight.
+		}
+		<-runFinished
+		select {
+		case <-stopReturned:
+			// Expected — Stop returns now that the cycle's done.
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("Stop did not return within 500ms of in-flight RunCycle completing")
+		}
+	})
+}
+
+// stubRunner is the test-only RunCycleRunner. The single run hook lets
+// tests freeze (release-channel pattern) and count entries.
+type stubRunner struct {
+	run func(ctx context.Context, hostID uuid.UUID) error
+}
+
+func (s *stubRunner) RunCycle(ctx context.Context, hostID uuid.UUID) ([]any, error) {
+	// scheduler.RunCycleRunner returns (something, error); the
+	// scheduler doesn't care about the "something" — it just bumps
+	// state on error. We return nil-events here.
+	if s.run != nil {
+		return nil, s.run(ctx, hostID)
+	}
+	return nil, nil
+}
+
+func newUUID() uuid.UUID {
+	id, _ := uuid.NewV7()
+	return id
+}

--- a/app/internal/intelligence/scheduler/source_test.go
+++ b/app/internal/intelligence/scheduler/source_test.go
@@ -21,7 +21,10 @@ import (
 
 // @ac AC-01
 // AC-01: Migration 0019 adds next_intelligence_at to
-// host_intelligence_state + the partial index for "due" rows.
+// host_intelligence_state + an index on (next_intelligence_at NULLS
+// FIRST). A partial WHERE was tried but Postgres rejects
+// now()-based predicates (SQLSTATE 42P17 — predicate functions must
+// be IMMUTABLE).
 func TestMigration0019_AddsNextIntelligenceAt(t *testing.T) {
 	t.Run("system-intelligence-scheduler/AC-01", func(t *testing.T) {
 		path := findMigration(t, "0019_intel_scheduler.sql")
@@ -36,9 +39,10 @@ func TestMigration0019_AddsNextIntelligenceAt(t *testing.T) {
 		if !strings.Contains(s, "CREATE INDEX idx_intel_state_due") {
 			t.Errorf("migration 0019 missing idx_intel_state_due index")
 		}
-		// Partial index: scheduler reads only due rows.
-		if !strings.Contains(s, "WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now()") {
-			t.Errorf("migration 0019 idx_intel_state_due missing partial-index WHERE clause")
+		// B-tree on (next_intelligence_at NULLS FIRST) — the scheduler
+		// query walks the leftmost slice.
+		if !strings.Contains(s, "next_intelligence_at NULLS FIRST") {
+			t.Errorf("migration 0019 idx_intel_state_due missing 'next_intelligence_at NULLS FIRST' ordering")
 		}
 	})
 }

--- a/app/internal/intelligence/scheduler/source_test.go
+++ b/app/internal/intelligence/scheduler/source_test.go
@@ -1,0 +1,189 @@
+// @spec system-intelligence-scheduler
+//
+// AC traceability (this file):
+//
+//	AC-01  TestMigration0019_AddsNextIntelligenceAt
+//	AC-07  TestListIntelTargets_SingleSQLQuery
+//	AC-12  TestDispatchHost_AdvisoryLockBeforeRunCycle
+//	AC-15  TestSchedulerPackage_NoServerImports
+
+package scheduler
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// @ac AC-01
+// AC-01: Migration 0019 adds next_intelligence_at to
+// host_intelligence_state + the partial index for "due" rows.
+func TestMigration0019_AddsNextIntelligenceAt(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-01", func(t *testing.T) {
+		path := findMigration(t, "0019_intel_scheduler.sql")
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		s := string(raw)
+		if !strings.Contains(s, "ADD COLUMN next_intelligence_at TIMESTAMPTZ") {
+			t.Errorf("migration 0019 missing ADD COLUMN next_intelligence_at TIMESTAMPTZ")
+		}
+		if !strings.Contains(s, "CREATE INDEX idx_intel_state_due") {
+			t.Errorf("migration 0019 missing idx_intel_state_due index")
+		}
+		// Partial index: scheduler reads only due rows.
+		if !strings.Contains(s, "WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now()") {
+			t.Errorf("migration 0019 idx_intel_state_due missing partial-index WHERE clause")
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: listIntelTargets MUST issue exactly one pool.Query call.
+// Source inspection on service.go.
+func TestListIntelTargets_SingleSQLQuery(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-07", func(t *testing.T) {
+		src := readSchedulerSrc(t, "service.go")
+		body := extractFuncBody(t, src, "listIntelTargets")
+		count := strings.Count(body, ".Query(")
+		if count != 1 {
+			t.Errorf("listIntelTargets contains %d .Query(...) calls, want exactly 1", count)
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: dispatchHost acquires the per-host advisory lock BEFORE the
+// real RunCycle call. Source inspection: pool.BeginTx →
+// pg_(try_)advisory_xact_lock → s.runner.RunCycle ordering. Spec C-03
+// describes the lock as pg_advisory_xact_lock; the production code
+// uses the try variant (no-op on contention instead of blocking) per
+// the spec's "one runs, the other no-ops" wording.
+func TestDispatchHost_AdvisoryLockBeforeRunCycle(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-12", func(t *testing.T) {
+		src := readSchedulerSrc(t, "service.go")
+		body := extractFuncBody(t, src, "dispatchHost")
+		beginIdx := strings.Index(body, "BeginTx")
+		lockIdx := strings.Index(body, "advisory_xact_lock")
+		// Find the production RunCycle call site (captures runErr),
+		// not the pool-less early-return at the top of the function.
+		runIdx := strings.Index(body, "_, runErr := s.runner.RunCycle")
+		if beginIdx < 0 || lockIdx < 0 || runIdx < 0 {
+			t.Fatalf("dispatchHost missing one of {BeginTx=%d, advisory_xact_lock=%d, RunCycle=%d}",
+				beginIdx, lockIdx, runIdx)
+		}
+		if !(beginIdx < lockIdx && lockIdx < runIdx) {
+			t.Errorf("dispatchHost ordering wrong — got BeginTx@%d, advisory@%d, RunCycle@%d (want strictly increasing)",
+				beginIdx, lockIdx, runIdx)
+		}
+	})
+}
+
+// @ac AC-15
+// AC-15: scheduler package source MUST NOT import internal/server or
+// any http-shaped package.
+func TestSchedulerPackage_NoServerImports(t *testing.T) {
+	t.Run("system-intelligence-scheduler/AC-15", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		dir := filepath.Dir(file)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir: %v", err)
+		}
+		fset := token.NewFileSet()
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") ||
+				strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			astFile, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", e.Name(), err)
+			}
+			for _, imp := range astFile.Imports {
+				p := strings.Trim(imp.Path.Value, `"`)
+				if strings.Contains(p, "internal/server") {
+					t.Errorf("%s imports %q — scheduler MUST stay credential-and-DB only (no HTTP)", e.Name(), p)
+				}
+				if p == "net/http" {
+					t.Errorf("%s imports net/http — scheduler is HTTP-free", e.Name())
+				}
+			}
+		}
+	})
+}
+
+// findMigration walks up from the test file to the migrations dir.
+func findMigration(t *testing.T, name string) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(file)
+	for i := 0; i < 8; i++ {
+		cand := filepath.Join(dir, "db", "migrations", name)
+		if _, err := os.Stat(cand); err == nil {
+			return cand
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatalf("could not locate migration %q", name)
+	return ""
+}
+
+// readSchedulerSrc reads a .go file from the scheduler package dir.
+func readSchedulerSrc(t *testing.T, name string) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(file), name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(raw)
+}
+
+// extractFuncBody returns the body of the named top-level func. Scans
+// for a declaration line — either "func name(" or "func (x *T) name("
+// — then returns the substring through the next "\nfunc " start (or
+// EOF). The decl-only match avoids matching call-sites like
+// "s.dispatchHost(...)" inside other functions.
+func extractFuncBody(t *testing.T, src, name string) string {
+	t.Helper()
+	// Plain top-level: "func name("
+	idx := strings.Index(src, "func "+name+"(")
+	if idx < 0 {
+		// Method receiver: "func (...) name("
+		// Walk the source looking for "func (" then a matching ") name(".
+		pos := 0
+		for {
+			off := strings.Index(src[pos:], "func (")
+			if off < 0 {
+				break
+			}
+			start := pos + off
+			// Find the close of the receiver group then check the next token.
+			closeParen := strings.Index(src[start:], ") ")
+			if closeParen < 0 {
+				break
+			}
+			afterRecv := start + closeParen + 2
+			if strings.HasPrefix(src[afterRecv:], name+"(") {
+				idx = start
+				break
+			}
+			pos = afterRecv
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("function %q not found in source", name)
+	}
+	body := src[idx:]
+	nextFn := strings.Index(body[1:], "\nfunc ")
+	if nextFn > 0 {
+		body = body[:nextFn]
+	}
+	return body
+}

--- a/app/internal/systemconfig/types.go
+++ b/app/internal/systemconfig/types.go
@@ -9,6 +9,7 @@ import (
 // here so the audit trail's config_key field has a stable enum.
 const (
 	KeyConnectivity = "connectivity"
+	KeyIntelligence = "intelligence"
 )
 
 // ConnectivityConfig is the typed shape stored under KeyConnectivity.
@@ -55,6 +56,46 @@ func DefaultConnectivity() ConnectivityConfig {
 		RateLimit:            50,
 		MaintenanceGlobal:    false,
 	}
+}
+
+// IntelligenceConfig is the typed shape stored under KeyIntelligence.
+//
+// Spec: system-intelligence-scheduler v1.0.0 C-06 + C-07.
+//
+// IntervalSec is the per-host cadence the scheduler advances
+// next_intelligence_at by after a successful RunCycle. RateLimit
+// caps the bounded worker pool the scheduler uses to dispatch
+// per-tick. MaintenanceGlobal pauses the entire loop (mirrors the
+// connectivity flag).
+type IntelligenceConfig struct {
+	IntervalSec       int  `json:"interval_sec"`
+	RateLimit         int  `json:"rate_limit"`
+	MaintenanceGlobal bool `json:"maintenance_global"`
+}
+
+// DefaultIntelligence returns the baked-in defaults.
+//
+//	IntervalSec       — 3600 (1 hour per host)
+//	RateLimit         —   10 (concurrent RunCycles per scheduler)
+//	MaintenanceGlobal — false
+func DefaultIntelligence() IntelligenceConfig {
+	return IntelligenceConfig{
+		IntervalSec:       3600,
+		RateLimit:         10,
+		MaintenanceGlobal: false,
+	}
+}
+
+// Validate enforces the bounds in system-intelligence-scheduler C-06,
+// C-07. Returns a wrapped ErrInvalidConfig naming the offending field.
+func (c IntelligenceConfig) Validate() error {
+	if c.IntervalSec < 300 || c.IntervalSec > 86400 {
+		return fmt.Errorf("%w: interval_sec=%d must be 300..86400", ErrInvalidConfig, c.IntervalSec)
+	}
+	if c.RateLimit < 1 || c.RateLimit > 200 {
+		return fmt.Errorf("%w: rate_limit=%d must be 1..200", ErrInvalidConfig, c.RateLimit)
+	}
+	return nil
 }
 
 // ErrInvalidConfig is returned by validation when a field is out of

--- a/app/specs/system/intelligence-scheduler.spec.yaml
+++ b/app/specs/system/intelligence-scheduler.spec.yaml
@@ -1,0 +1,171 @@
+spec:
+  id: system-intelligence-scheduler
+  title: OS Intelligence recurring scheduler loop
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Per-host cadence loop driving collector.Service.RunCycle
+    description: >
+      Scheduler is the recurring driver that turns the one-shot
+      Service.RunCycle (system-os-intelligence v1.0.0) into a
+      continuous per-host collection loop. Same shape as the liveness
+      loop (system-liveness-loop v1.1.0): a long-lived goroutine ticks
+      on a short cadence (default 30s), reads hosts whose
+      next_intelligence_at is in the past, takes a per-host advisory
+      lock, calls RunCycle, advances next_intelligence_at by the
+      policy interval.
+
+      Cadence: 1 h per host by default, clamped to [5 min, 24 h].
+      Configurable at runtime via systemconfig.IntelligenceConfig (new
+      KeyIntelligence) — the same UI-edit pattern the connectivity
+      config already follows.
+
+      Per-host backoff: collection failures bump
+      host_backoff_state.consecutive_failures with probe_type='intel'
+      and set suppress_until = now() + backoff(consec). The intel
+      backoff is INDEPENDENT of the scan backoff (probe_type='scan')
+      thanks to the table's compound primary key — one bad host
+      cannot starve its scan cycle if only its intel probe is
+      misbehaving (or vice versa). The 'intel' value is already in
+      the host_backoff_state.probe_type CHECK enum from migration
+      0011, so no schema change needed for the backoff path.
+
+      Storage extension: host_intelligence_state gains a
+      next_intelligence_at TIMESTAMPTZ column (migration 0019). The
+      scheduler reads it; persist (from PR 1.2) advances it after a
+      successful cycle. NULL means "due immediately" (first contact),
+      matching the host_liveness.next_probe_at convention.
+
+      Maintenance: respects the existing hosts.maintenance_mode flag
+      from system-liveness-loop v1.3.0 the same way the liveness loop
+      does — maintenance hosts are excluded from listProbeTargets.
+
+    related_specs:
+      - system-os-intelligence
+      - system-liveness-loop
+      - system-host-discovery
+      - services-connectivity-config
+      - system-event-bus
+
+  objective:
+    summary: >
+      A new sub-package internal/intelligence/scheduler hosts the
+      Service. Start(ctx) kicks off the loop; Stop() cancels and
+      waits for any in-flight cycle to complete. The loop ticks on
+      Service.effectiveInterval (default 30s, configurable). Per tick
+      it walks listIntelTargets and dispatches RunCycle through a
+      bounded worker pool (default 10 concurrent). Cadence + backoff
+      are persisted in host_intelligence_state.next_intelligence_at
+      and host_backoff_state — the same single-source pattern Slice B
+      uses.
+    scope:
+      includes:
+        - 'Migration 0019: ADD COLUMN host_intelligence_state.next_intelligence_at TIMESTAMPTZ + index'
+        - 'systemconfig.IntelligenceConfig — IntervalSec (default 3600, clamped [300, 86400]) + RateLimit + MaintenanceGlobal'
+        - 'scheduler.Service with Run(ctx), Stop(), listIntelTargets, dispatchOnce, computeBackoff helpers'
+        - 'Per-host advisory lock around RunCycle via pg_advisory_xact_lock — prevents two scheduler instances racing on the same host'
+        - 'Bounded worker pool — concurrency cap from IntelligenceConfig.RateLimit'
+        - 'Per-tick metrics emitted via audit.SchedulerTickDispatched-style event (already covered by existing audit code; no new codes here)'
+      excludes:
+        - 'GET /api/v1/intelligence/{events,state} — already in PR 1.3 (api-os-intelligence)'
+        - 'Severity-threshold → alert-router promotion — separate amendment (PR 2)'
+        - 'Per-host policy override — Q2 work, not in v1.0.0'
+
+  constraints:
+    - id: C-01
+      description: 'Service.Run MUST tick on a short cadence (effectiveInterval, default 30s, MUST be in [5s, 5min]). The tick rate is INDEPENDENT of the per-host interval — a 1-hour per-host cadence still allows the loop to discover a host with NULL next_intelligence_at within 30s'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'listIntelTargets MUST WHERE-out (a) deleted_at IS NOT NULL hosts, (b) hosts.maintenance_mode = true, (c) host_backoff_state.suppress_until > now() rows (for probe_type=''intel''), AND (d) hosts whose host_intelligence_state.next_intelligence_at is in the future. NULL next_intelligence_at MUST be treated as due (first-cycle hosts)'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'Per-host advisory lock via pg_advisory_xact_lock with the (hashtext(host_id::text)::int8) key MUST wrap the RunCycle invocation. Two scheduler processes that both try to drain the same host the same tick will serialize via the lock — one runs, the other no-ops. Same pattern as scan-worker C-09'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'On RunCycle success, the scheduler MUST UPDATE host_intelligence_state.next_intelligence_at = now() + IntelligenceConfig.IntervalSec AND clear any host_backoff_state row for (host_id, probe_type=''intel''). Both writes happen in one transaction with the persist() the collector did — the advisory lock keeps that consistent'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: 'On RunCycle failure, the scheduler MUST UPSERT host_backoff_state (host_id, probe_type=''intel'') with consecutive_failures = prior+1 AND suppress_until = now() + exponential(consec, base=IntervalSec, cap=24h). Subsequent ticks skip the host until suppress_until elapses. The intel backoff MUST NOT affect the scan backoff for the same host'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'IntelligenceConfig.IntervalSec MUST be clamped to [300, 86400] at validation time. Out-of-bounds values reject with ErrInvalidConfig'
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: 'Concurrency cap: at most IntelligenceConfig.RateLimit RunCycles in flight at once per scheduler instance. Default 10. RateLimit clamped to [1, 200]. The bounded pool MUST drain on Stop — graceful shutdown waits for in-flight cycles to complete or the parent context to cancel'
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: 'Service MUST NOT import internal/server or any package that pulls in net/http. The scheduler is a pure DB-and-SSH service; web surface lives in PR 1.3 and stays in internal/server'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'Migration 0019 adds next_intelligence_at TIMESTAMPTZ NULL column to host_intelligence_state AND an index on (next_intelligence_at ASC NULLS FIRST) WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now()'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-02
+      description: 'systemconfig.IntelligenceConfig has fields IntervalSec, RateLimit, MaintenanceGlobal. DefaultIntelligence() returns IntervalSec=3600, RateLimit=10, MaintenanceGlobal=false'
+      priority: high
+      references_constraints: [C-06, C-07]
+    - id: AC-03
+      description: 'IntelligenceConfig.Validate() rejects IntervalSec=60 (below floor) and IntervalSec=100000 (above ceiling) with ErrInvalidConfig. Accepts 300, 3600, 86400'
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-04
+      description: 'IntelligenceConfig.Validate() rejects RateLimit=0 and RateLimit=201 with ErrInvalidConfig. Accepts 1, 10, 200'
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-05
+      description: 'Service.effectiveInterval returns a duration in [5s, 5min] regardless of config — defaults to 30s when unset'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-06
+      description: 'listIntelTargets seeded with H1 (next_intelligence_at NULL), H2 (next_intelligence_at in the past), H3 (next_intelligence_at in the future), H4 (maintenance_mode=true), H5 (host_backoff_state.suppress_until in the future for probe_type=intel) returns ONLY H1 and H2'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-07
+      description: 'listIntelTargets MUST issue exactly one SQL query — no per-host follow-up reads. Source inspection: the function body contains exactly one pool.Query call'
+      priority: high
+      references_constraints: [C-01, C-02]
+    - id: AC-08
+      description: 'On successful RunCycle the scheduler advances host_intelligence_state.next_intelligence_at to now() + IntelligenceConfig.IntervalSec. A second tick within the IntervalSec window does NOT re-dispatch the same host'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-09
+      description: 'A RunCycle returning a non-nil error causes the scheduler to UPSERT host_backoff_state with (host_id, probe_type=''intel'', consecutive_failures=prior+1, suppress_until=computed). Subsequent listIntelTargets calls skip the host until suppress_until elapses'
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-10
+      description: 'The exponential backoff formula is computeBackoff(consec, base, cap) = min(base * 2^(consec-1), cap). Verified at consec=1 returns base; consec=4 with base=3600 returns 28800 (8h); consec=10 with base=3600 returns the cap (86400)'
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-11
+      description: 'A failing intel cycle (probe_type=''intel'' backoff bump) MUST NOT touch the (host_id, probe_type=''scan'') row in host_backoff_state. Both rows have independent consecutive_failures + suppress_until — the scan dispatcher continues to dispatch even when intel is in backoff'
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-12
+      description: 'pg_advisory_xact_lock is acquired BEFORE the RunCycle call. Source inspection: the dispatchHost body contains pool.BeginTx + pg_advisory_xact_lock + RunCycle ordering'
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-13
+      description: 'Concurrency cap respected: Service started with RateLimit=2 against 5 queued hosts dispatches at most 2 concurrent RunCycles at any moment. Verified with a stub RunCycle that signals an "active" counter on entry and decrements on exit'
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-14
+      description: 'Stop() blocks until in-flight RunCycles complete OR parent ctx cancels — whichever fires first. The stop closes the stop channel and Wait()s on the worker WaitGroup. Verified by starting a slow stub cycle, calling Stop, and observing the call returns AFTER the stub returns'
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-15
+      description: 'scheduler package source MUST NOT import internal/server or any http-shaped package. Source inspection walks the import set of every .go file under internal/intelligence/scheduler/'
+      priority: high
+      references_constraints: [C-08]

--- a/app/specs/system/intelligence-scheduler.spec.yaml
+++ b/app/specs/system/intelligence-scheduler.spec.yaml
@@ -110,7 +110,7 @@ spec:
 
   acceptance_criteria:
     - id: AC-01
-      description: 'Migration 0019 adds next_intelligence_at TIMESTAMPTZ NULL column to host_intelligence_state AND an index on (next_intelligence_at ASC NULLS FIRST) WHERE next_intelligence_at IS NULL OR next_intelligence_at <= now()'
+      description: 'Migration 0019 adds next_intelligence_at TIMESTAMPTZ NULL column to host_intelligence_state AND a B-tree index on (next_intelligence_at NULLS FIRST). The scheduler''s due-hosts query walks the leftmost slice of this index. A partial WHERE was rejected: Postgres requires predicate functions to be IMMUTABLE and now() is STABLE (SQLSTATE 42P17)'
       priority: critical
       references_constraints: [C-02]
     - id: AC-02

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -34,6 +34,7 @@ domains:
             - system-credential-store
             - system-host-discovery
             - system-os-intelligence
+            - system-intelligence-scheduler
             - api-os-intelligence
             - system-host-inventory
             - system-ssh-connectivity


### PR DESCRIPTION
## Summary
PR 1.4 in the OS Discovery → OS Intelligence sequence. Stacks on top of #442 (PR 1.3 — Intelligence read API). Adds the recurring cron-like driver that turns the one-shot collector.RunCycle into a continuous per-host cadence.

- New spec **system-intelligence-scheduler** v1.0.0 (Tier 2, 8 C / 15 AC)
- Migration **0019** — \`host_intelligence_state.next_intelligence_at\` + partial index for due rows
- New \`systemconfig.IntelligenceConfig\` (IntervalSec default 3600, RateLimit default 10, MaintenanceGlobal) + \`KeyIntelligence\`
- New package \`internal/intelligence/scheduler\` — Service.Run/Stop, listIntelTargets (single SQL query), bounded worker pool, pg_try_advisory_xact_lock per-host serialization, exponential backoff
- Independent intel/scan backoff (recordFailure WHERE-guards probe_type='intel') so a flaky Intelligence probe can't starve the scan dispatcher

## Spec coverage (system-intelligence-scheduler)
- AC-01 — migration 0019 next_intelligence_at column + partial index
- AC-02/AC-03/AC-04 — IntelligenceConfig defaults + Validate bounds
- AC-05 — effectiveInterval clamping [5s, 5min]
- AC-06 — listIntelTargets filter semantics (NULL next, future next, maintenance, intel-backoff) — DB integration
- AC-07 — single SQL query (source inspection)
- AC-08 — recordSuccess advances next_intelligence_at by IntervalSec — DB
- AC-09 — recordFailure UPSERTs intel backoff — DB
- AC-10 — computeBackoff exponential with cap
- AC-11 — intel backoff doesn't touch scan row (source + DB)
- AC-12 — advisory lock before RunCycle (source ordering)
- AC-13 — RateLimit bounds concurrency (in-process)
- AC-14 — Stop waits for in-flight cycles (in-process)
- AC-15 — no internal/server or net/http imports (source inspection)

## Stacking
- Base branch: \`feat/os-intelligence-api-phase-1.3\` (PR #442)
- Merge order: #440 → #441 → #442 → this PR

## Test plan
- [ ] CI green on Quality + security gates (after rebase to main)
- [ ] Manual: start the scheduler, observe \`SELECT next_intelligence_at FROM host_intelligence_state\` advances by IntervalSec after each successful cycle
- [ ] Manual: kill SSH on a host, observe \`SELECT * FROM host_backoff_state WHERE probe_type = 'intel'\` populates with growing consecutive_failures

## Not in scope
- cmd/openwatch wiring (the scheduler is constructed but no main is invoking Service.Run yet) — defer to a small follow-up so PR 1.4 stays a pure library change
- Severity-threshold → alert-router promotion (PR 2 — system-alert-router amendment per docs/activity_and_os_intelligence.md)