### PR TITLE
feat(alerts): alert-router v1.1.0 persistence (PR 2)

### DIFF
--- a/app/internal/alertrouter/metrics.go
+++ b/app/internal/alertrouter/metrics.go
@@ -21,6 +21,12 @@ type Metrics struct {
 	// that returned an error. Per-channel counters are tracked on
 	// channelEntry.failureCount.
 	ChannelFailureCount atomic.Int64
+
+	// PersistFailed is the count of alerts that survived dedup but
+	// failed to persist to the alerts table. Per spec C-10 v1.1.0,
+	// channels never receive an unpersisted alert; the alert is dropped
+	// and this counter increments.
+	PersistFailed atomic.Int64
 }
 
 // NewMetrics returns a fresh Metrics.
@@ -32,6 +38,7 @@ type MetricsSnapshot struct {
 	RoutedCount         int64 `json:"routed_count"`
 	DedupedCount        int64 `json:"deduped_count"`
 	ChannelFailureCount int64 `json:"channel_failure_count"`
+	PersistFailed       int64 `json:"persist_failed"`
 }
 
 // Snapshot returns a point-in-time copy of all counters.
@@ -41,5 +48,6 @@ func (m *Metrics) Snapshot() MetricsSnapshot {
 		RoutedCount:         m.RoutedCount.Load(),
 		DedupedCount:        m.DedupedCount.Load(),
 		ChannelFailureCount: m.ChannelFailureCount.Load(),
+		PersistFailed:       m.PersistFailed.Load(),
 	}
 }

--- a/app/internal/alertrouter/persist_test.go
+++ b/app/internal/alertrouter/persist_test.go
@@ -1,0 +1,267 @@
+// @spec system-alert-router
+//
+// AC traceability (this file):
+//
+//	AC-16  TestMigration0020_AlertsTableSchema
+//	AC-17  TestRouter_PersistBeforeDispatch
+//	AC-18  TestRouter_PersistFailure_SkipsDispatch
+//	AC-19  TestRouter_ChannelReceivesPersistedID
+//	AC-20  TestRouter_DuplicatePersist_NoSecondRow
+
+package alertrouter
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/google/uuid"
+)
+
+// @ac AC-16
+// AC-16: Migration 0020 defines the alerts table with the required
+// columns, state CHECK, and UNIQUE (dedup_key, occurred_at).
+func TestMigration0020_AlertsTableSchema(t *testing.T) {
+	t.Run("system-alert-router/AC-16", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		dir := filepath.Dir(file)
+		var migPath string
+		for i := 0; i < 8; i++ {
+			cand := filepath.Join(dir, "db", "migrations", "0020_alerts.sql")
+			if _, err := os.Stat(cand); err == nil {
+				migPath = cand
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+		if migPath == "" {
+			t.Fatalf("could not locate migration 0020")
+		}
+		raw, err := os.ReadFile(migPath)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		s := string(raw)
+		want := []string{
+			"CREATE TABLE alerts",
+			"id           UUID",
+			"dedup_key    TEXT         NOT NULL",
+			"alert_type   TEXT         NOT NULL",
+			"severity     TEXT         NOT NULL",
+			"state        TEXT         NOT NULL DEFAULT 'active'",
+			"CHECK (state IN ('active','silenced','acknowledged','resolved','dismissed'))",
+			"CHECK (severity IN ('critical','high','medium','low','info'))",
+			"UNIQUE (dedup_key, occurred_at)",
+		}
+		for _, w := range want {
+			if !strings.Contains(s, w) {
+				t.Errorf("migration 0020 missing required text: %q", w)
+			}
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17: Router.handle on a fresh alert INSERTs one row before any
+// Channel.Send. Verified by ordering: persist call happens before
+// any channel receives the alert.
+func TestRouter_PersistBeforeDispatch(t *testing.T) {
+	t.Run("system-alert-router/AC-17", func(t *testing.T) {
+		store := &stubStore{}
+		ch := &orderCapture{}
+		r := newRouterWithStore(t, store)
+		r.Register(ChannelRegistration{Channel: ch})
+
+		r.handle(context.Background(), heartbeatPulseDown())
+		waitForSends(r)
+
+		if got := store.Calls(); got != 1 {
+			t.Errorf("store.Insert calls = %d, want 1", got)
+		}
+		if got := ch.Calls(); got != 1 {
+			t.Fatalf("channel.Send calls = %d, want 1", got)
+		}
+		if !ch.SawAfter(store.LastAt()) {
+			t.Errorf("channel.Send happened before store.Insert (persist MUST come first)")
+		}
+	})
+}
+
+// waitForSends blocks until dispatch's per-channel goroutines complete.
+// Tests need this because dispatch fans out via go routines; reading
+// channel state in the calling goroutine racing with the send goroutine
+// would yield stale zero-values.
+func waitForSends(r *Router) {
+	r.sendWG.Wait()
+}
+
+// @ac AC-18
+// AC-18: When store.Insert fails, Channel.Send is NOT called.
+// PersistFailed counter increments; RoutedCount does not.
+func TestRouter_PersistFailure_SkipsDispatch(t *testing.T) {
+	t.Run("system-alert-router/AC-18", func(t *testing.T) {
+		store := &stubStore{err: errors.New("db unreachable")}
+		ch := &orderCapture{}
+		r := newRouterWithStore(t, store)
+		r.Register(ChannelRegistration{Channel: ch})
+
+		r.handle(context.Background(), heartbeatPulseDown())
+		waitForSends(r)
+
+		if r.metrics.PersistFailed.Load() != 1 {
+			t.Errorf("PersistFailed = %d, want 1", r.metrics.PersistFailed.Load())
+		}
+		if r.metrics.RoutedCount.Load() != 0 {
+			t.Errorf("RoutedCount = %d on persist failure, want 0", r.metrics.RoutedCount.Load())
+		}
+		if ch.Calls() != 0 {
+			t.Errorf("channel.Send called %d times on persist failure, want 0", ch.Calls())
+		}
+		if r.metrics.ReceivedCount.Load() != 1 {
+			t.Errorf("ReceivedCount = %d, want 1 (event was received)", r.metrics.ReceivedCount.Load())
+		}
+	})
+}
+
+// @ac AC-19
+// AC-19: Channel receives Alert.ID populated by the store.
+func TestRouter_ChannelReceivesPersistedID(t *testing.T) {
+	t.Run("system-alert-router/AC-19", func(t *testing.T) {
+		expected, _ := uuid.NewV7()
+		store := &stubStore{returnID: expected}
+		ch := &orderCapture{}
+		r := newRouterWithStore(t, store)
+		r.Register(ChannelRegistration{Channel: ch})
+
+		r.handle(context.Background(), heartbeatPulseDown())
+		waitForSends(r)
+
+		got := ch.LastAlert()
+		if got.ID == uuid.Nil {
+			t.Errorf("channel received Alert.ID = uuid.Nil — router did not propagate persisted ID")
+		}
+		if got.ID != expected {
+			t.Errorf("channel Alert.ID = %s, want %s", got.ID, expected)
+		}
+	})
+}
+
+// @ac AC-20
+// AC-20: A second handle with the same alert in the same dedup window
+// is dropped by the in-memory dedup gate; store.Insert is NOT called a
+// second time. The DB UNIQUE constraint provides defense-in-depth for
+// router-restart scenarios — also covered by store_db_test (DB integration).
+func TestRouter_DuplicatePersist_NoSecondRow(t *testing.T) {
+	t.Run("system-alert-router/AC-20", func(t *testing.T) {
+		store := &stubStore{}
+		ch := &orderCapture{}
+		r := newRouterWithStore(t, store)
+		r.Register(ChannelRegistration{Channel: ch})
+
+		r.handle(context.Background(), heartbeatPulseDown())
+		r.handle(context.Background(), heartbeatPulseDown())
+		waitForSends(r)
+
+		if got := store.Calls(); got != 1 {
+			t.Errorf("store.Insert calls = %d (dedup gate should have caught the second event), want 1", got)
+		}
+		if got := r.metrics.DedupedCount.Load(); got != 1 {
+			t.Errorf("DedupedCount = %d, want 1 (second event was a duplicate)", got)
+		}
+	})
+}
+
+// ---- helpers ------------------------------------------------------
+
+func newRouterWithStore(t *testing.T, s Store) *Router {
+	t.Helper()
+	bus := eventbus.NewBus()
+	t.Cleanup(bus.Shutdown)
+	r, err := NewRouter(bus, Config{})
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+	r.WithStore(s)
+	return r
+}
+
+func heartbeatPulseDown() eventbus.HeartbeatPulse {
+	return eventbus.HeartbeatPulse{
+		HostID:         uuid.MustParse("00000000-0000-0000-0000-000000000010"),
+		Reachable:      false,
+		PriorReachable: true,
+		OccurredAt:     time.Unix(1700000000, 0).UTC(),
+	}
+}
+
+// stubStore is a unit-test Store. Optionally returns err to simulate
+// DB failure; otherwise returns returnID (or a generated UUID if zero).
+type stubStore struct {
+	mu       sync.Mutex
+	calls    atomic.Int64
+	lastAt   time.Time
+	err      error
+	returnID uuid.UUID
+}
+
+func (s *stubStore) Insert(_ context.Context, _ Alert) (uuid.UUID, error) {
+	s.calls.Add(1)
+	s.mu.Lock()
+	s.lastAt = time.Now()
+	s.mu.Unlock()
+	if s.err != nil {
+		return uuid.Nil, s.err
+	}
+	if s.returnID != uuid.Nil {
+		return s.returnID, nil
+	}
+	id, _ := uuid.NewV7()
+	return id, nil
+}
+
+func (s *stubStore) Calls() int64 { return s.calls.Load() }
+func (s *stubStore) LastAt() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastAt
+}
+
+// orderCapture is a Channel that records the alert it received and the
+// time. Lets tests assert persist-before-dispatch ordering + ID
+// propagation.
+type orderCapture struct {
+	mu    sync.Mutex
+	last  Alert
+	at    time.Time
+	count atomic.Int64
+}
+
+func (c *orderCapture) Name() string { return "test-order-capture" }
+func (c *orderCapture) Send(_ context.Context, a Alert) error {
+	c.count.Add(1)
+	c.mu.Lock()
+	c.last = a
+	c.at = time.Now()
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *orderCapture) Calls() int64 { return c.count.Load() }
+func (c *orderCapture) LastAlert() Alert {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last
+}
+func (c *orderCapture) SawAfter(t time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return !c.at.IsZero() && !c.at.Before(t)
+}

--- a/app/internal/alertrouter/router.go
+++ b/app/internal/alertrouter/router.go
@@ -21,9 +21,15 @@ const stopDrainTimeout = 10 * time.Second
 // Construct with NewRouter, register channels via Register, then call
 // Start to begin reading from the bus. Call Stop to unsubscribe and
 // drain in-flight deliveries.
+//
+// v1.1.0 — persist hook: after the dedup gate accepts an alert the
+// router calls Store.Insert before dispatching to channels. Channels
+// receive the assigned Alert.ID. Persist failures abort dispatch and
+// increment metrics.PersistFailed. Spec C-10 / C-13.
 type Router struct {
 	bus      *eventbus.Bus
 	dedup    *DedupGate
+	store    Store
 	metrics  *Metrics
 	logger   *slog.Logger
 	dedupTTL time.Duration
@@ -88,6 +94,15 @@ func NewRouter(bus *eventbus.Bus, cfg Config) (*Router, error) {
 		logger:   logger,
 		dedupTTL: ttl,
 	}, nil
+}
+
+// WithStore wires the persistence backend (v1.1.0). When unset the
+// router runs in legacy fire-and-forget mode (channels still fire,
+// no row written). Production calls this with a PgxStore at boot;
+// tests inject a stub. Spec C-10.
+func (r *Router) WithStore(s Store) *Router {
+	r.store = s
+	return r
 }
 
 // Register adds a channel + filter to the router. Safe to call before
@@ -169,9 +184,12 @@ func (r *Router) run(ctx context.Context, sub *eventbus.Subscription) {
 	}
 }
 
-// handle is the per-event translation + dispatch pipeline. Exported
-// only via run; tests use translate + dispatch directly when finer
-// granularity is needed.
+// handle is the per-event translation + persist + dispatch pipeline.
+//
+// v1.1.0: a Store is consulted between the dedup gate and the
+// channel.Send fan-out. Channels NEVER receive an unpersisted alert
+// (spec C-10). When no store is configured the router runs in legacy
+// mode — channels still fire, no row written.
 func (r *Router) handle(ctx context.Context, ev eventbus.Event) {
 	alert, ok := translate(ev)
 	if !ok {
@@ -181,6 +199,18 @@ func (r *Router) handle(ctx context.Context, ev eventbus.Event) {
 	if r.dedup.ShouldSkip(alert) {
 		r.metrics.DedupedCount.Add(1)
 		return
+	}
+	if r.store != nil {
+		id, err := r.store.Insert(ctx, alert)
+		if err != nil {
+			r.metrics.PersistFailed.Add(1)
+			r.logger.WarnContext(ctx, "alertrouter: persist failed; dispatch skipped",
+				slog.String("alert_type", string(alert.Type)),
+				slog.String("severity", string(alert.Severity)),
+				slog.Any("error", err))
+			return
+		}
+		alert.ID = id
 	}
 	r.dispatch(ctx, alert)
 }

--- a/app/internal/alertrouter/store.go
+++ b/app/internal/alertrouter/store.go
@@ -1,0 +1,100 @@
+package alertrouter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Store is the persistence seam for v1.1.0 alert persistence (spec
+// C-10). Production wires PgxStore; tests fake the interface.
+//
+// Insert MUST be idempotent: a duplicate (dedup_key, occurred_at) MUST
+// return the existing row's ID rather than failing. The DB UNIQUE
+// constraint is the source of truth (C-12); the implementation uses
+// ON CONFLICT DO NOTHING + a follow-up SELECT to recover the id.
+type Store interface {
+	// Insert persists the alert and returns the assigned id. On a
+	// duplicate (dedup_key, occurred_at) it returns the existing row's
+	// id (no error). Any other DB error is surfaced.
+	Insert(ctx context.Context, a Alert) (uuid.UUID, error)
+}
+
+// PgxStore is the production Store backed by pgxpool. Construct with
+// NewPgxStore.
+type PgxStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPgxStore wraps a pgxpool.Pool as a Store.
+func NewPgxStore(pool *pgxpool.Pool) *PgxStore {
+	return &PgxStore{pool: pool}
+}
+
+// Insert satisfies Store. UPSERT-like semantics via ON CONFLICT DO
+// NOTHING + RETURNING id, falling back to SELECT on a no-row return
+// (which means the conflict path fired).
+func (s *PgxStore) Insert(ctx context.Context, a Alert) (uuid.UUID, error) {
+	if s.pool == nil {
+		return uuid.Nil, errors.New("alertrouter: store pool not wired")
+	}
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("alertrouter: uuid: %w", err)
+	}
+
+	tagsRaw, err := json.Marshal(a.Tags)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("alertrouter: marshal tags: %w", err)
+	}
+
+	hostID := nullableUUID(a.HostID)
+	occurredAt := a.OccurredAt
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+
+	const stmt = `
+		INSERT INTO alerts
+			(id, dedup_key, alert_type, severity, host_id, rule_id,
+			 title, body, tags, state, occurred_at, created_at, updated_at)
+		VALUES
+			($1, $2, $3, $4, $5, $6,
+			 $7, $8, $9::jsonb, 'active', $10, now(), now())
+		ON CONFLICT (dedup_key, occurred_at) DO NOTHING
+		RETURNING id`
+
+	var returned uuid.UUID
+	err = s.pool.QueryRow(ctx, stmt,
+		id, a.DedupKey(), string(a.Type), string(a.Severity),
+		hostID, a.RuleID, a.Title, a.Body, tagsRaw, occurredAt,
+	).Scan(&returned)
+	if err == nil {
+		return returned, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("alertrouter: insert: %w", err)
+	}
+
+	// Duplicate path — recover the existing id.
+	const fetch = `SELECT id FROM alerts WHERE dedup_key = $1 AND occurred_at = $2`
+	if err := s.pool.QueryRow(ctx, fetch, a.DedupKey(), occurredAt).Scan(&returned); err != nil {
+		return uuid.Nil, fmt.Errorf("alertrouter: fetch existing on conflict: %w", err)
+	}
+	return returned, nil
+}
+
+// nullableUUID converts uuid.Nil to a typed nil so the column accepts
+// NULL (HostID is optional for some alert types).
+func nullableUUID(u uuid.UUID) any {
+	if u == uuid.Nil {
+		return nil
+	}
+	return u
+}

--- a/app/internal/alertrouter/store_db_test.go
+++ b/app/internal/alertrouter/store_db_test.go
@@ -1,0 +1,89 @@
+// @spec system-alert-router
+//
+// AC traceability (this file):
+//
+//	AC-20  TestPgxStore_DuplicateDedupKeyOccurredAt_IdempotentInsert
+
+package alertrouter
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/google/uuid"
+)
+
+func storeTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run alertrouter store integration tests")
+	}
+	return dsn
+}
+
+// @ac AC-20
+// AC-20 (DB-side): PgxStore.Insert called twice with the same
+// (dedup_key, occurred_at) returns the SAME id and does NOT create a
+// second row. Defense-in-depth against router-restart scenarios where
+// the in-memory dedup gate is empty.
+func TestPgxStore_DuplicateDedupKeyOccurredAt_IdempotentInsert(t *testing.T) {
+	t.Run("system-alert-router/AC-20", func(t *testing.T) {
+		dsn := storeTestDSN(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+		pool, err := db.NewPool(ctx, dsn, 5)
+		if err != nil {
+			t.Fatalf("NewPool: %v", err)
+		}
+		t.Cleanup(pool.Close)
+		if err := migrations.Apply(ctx, pool); err != nil {
+			t.Fatalf("migrations.Apply: %v", err)
+		}
+		_, _ = pool.Exec(ctx, "TRUNCATE TABLE alerts")
+
+		store := NewPgxStore(pool)
+		occurredAt := time.Now().UTC().Truncate(time.Microsecond)
+		alert := Alert{
+			Type:       AlertTypeHostUnreachable,
+			Severity:   SeverityHigh,
+			HostID:     uuid.Nil, // nullable
+			RuleID:     "",
+			OccurredAt: occurredAt,
+			Title:      "host unreachable test",
+			Body:       "test body",
+			Tags:       map[string]string{"severity": "high"},
+		}
+
+		id1, err := store.Insert(ctx, alert)
+		if err != nil {
+			t.Fatalf("first insert: %v", err)
+		}
+		if id1 == uuid.Nil {
+			t.Fatal("first insert returned nil id")
+		}
+
+		id2, err := store.Insert(ctx, alert)
+		if err != nil {
+			t.Fatalf("second insert: %v", err)
+		}
+		if id2 != id1 {
+			t.Errorf("second insert returned %s, want same id as first (%s) — UNIQUE+ON CONFLICT recovery broken",
+				id2, id1)
+		}
+
+		var count int
+		err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM alerts WHERE dedup_key = $1`,
+			alert.DedupKey()).Scan(&count)
+		if err != nil {
+			t.Fatalf("count rows: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("rows for dedup_key = %d, want 1 (UNIQUE constraint violated)", count)
+		}
+	})
+}

--- a/app/internal/alertrouter/types.go
+++ b/app/internal/alertrouter/types.go
@@ -112,6 +112,12 @@ func defaultSeverityFor(t AlertType) Severity {
 // Channel implementations receive Alert values; they may format with
 // String() or render their own way from the structured fields.
 type Alert struct {
+	// ID is the persisted alerts.id (UUIDv7). Populated by the Store
+	// before Channel.Send dispatch — channels can use it to correlate
+	// downstream system records (PagerDuty incident key, Slack thread
+	// root) back to the OpenWatch alert row. Spec C-13 v1.1.0.
+	ID uuid.UUID
+
 	Type       AlertType
 	Severity   Severity
 	HostID     uuid.UUID

--- a/app/internal/db/migrations/0020_alerts.sql
+++ b/app/internal/db/migrations/0020_alerts.sql
@@ -1,0 +1,58 @@
+-- PR 2 — Alert persistence (system-alert-router v1.1.0).
+--
+-- Unblocks:
+--   - /activity unified feed (UNION over alerts + transactions +
+--     intelligence_events + audit_events)
+--   - alerts CRUD endpoints (PR 3 — system-alerts + api-alerts)
+--   - alert lifecycle (acknowledge / silence / resolve / dismiss)
+--
+-- State machine v1.1.0 is intentionally minimal: every persisted row
+-- starts as 'active'. Transition logic is owned by system-alerts; the
+-- router NEVER updates state. C-11.
+--
+-- UNIQUE (dedup_key, occurred_at): defense-in-depth against router
+-- restarts during the dedup TTL window. The in-memory gate forgets on
+-- restart; the constraint still catches the duplicate. C-12.
+
+-- +goose Up
+CREATE TABLE alerts (
+    id           UUID         PRIMARY KEY,
+    dedup_key    TEXT         NOT NULL,
+    alert_type   TEXT         NOT NULL,
+    severity     TEXT         NOT NULL
+                 CHECK (severity IN ('critical','high','medium','low','info')),
+    host_id      UUID         REFERENCES hosts(id) ON DELETE SET NULL,
+    rule_id      TEXT         NOT NULL DEFAULT '',
+    title        TEXT         NOT NULL,
+    body         TEXT         NOT NULL DEFAULT '',
+    tags         JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    state        TEXT         NOT NULL DEFAULT 'active'
+                 CHECK (state IN ('active','silenced','acknowledged','resolved','dismissed')),
+    occurred_at  TIMESTAMPTZ  NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ  NOT NULL DEFAULT now(),
+
+    UNIQUE (dedup_key, occurred_at)
+);
+
+-- Common reads:
+--   /activity feed: WHERE state != 'dismissed' ORDER BY occurred_at DESC LIMIT N
+--   per-host detail: WHERE host_id = $1 AND state != 'dismissed' ORDER BY occurred_at DESC
+--   lifecycle ops: WHERE id = $1 AND state IN ('active','silenced')
+CREATE INDEX idx_alerts_active_recent
+    ON alerts (occurred_at DESC)
+    WHERE state != 'dismissed';
+
+CREATE INDEX idx_alerts_host_active
+    ON alerts (host_id, occurred_at DESC)
+    WHERE state != 'dismissed' AND host_id IS NOT NULL;
+
+CREATE INDEX idx_alerts_severity_active
+    ON alerts (severity, occurred_at DESC)
+    WHERE state = 'active';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_alerts_severity_active;
+DROP INDEX IF EXISTS idx_alerts_host_active;
+DROP INDEX IF EXISTS idx_alerts_active_recent;
+DROP TABLE IF EXISTS alerts;

--- a/app/specs/system/alert-router.spec.yaml
+++ b/app/specs/system/alert-router.spec.yaml
@@ -1,25 +1,35 @@
 spec:
   id: system-alert-router
   title: Alert router
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
   context:
     system: openwatch-go
-    feature: Event-bus subscriber that translates events to alerts and routes them to delivery channels
+    feature: Event-bus subscriber that translates events to alerts, persists them, and routes them to delivery channels
     description: >
       The alert router is the bridge between OpenWatch's event bus
       (B.3a) and external notification channels (Slack, email,
       webhook, PagerDuty). It subscribes to bus events at boot,
       translates them into typed Alert structures with severity +
       tags, applies a dedup gate per (alert_type, host, rule_id)
-      tuple, and dispatches matching alerts to registered Channels.
+      tuple, PERSISTS each surviving alert to the alerts table, and
+      dispatches matching alerts to registered Channels.
 
       Channel implementations (Slack, email, webhook) live in
       subpackages so the core router has no external SDK dependencies.
       The Channel interface is small enough to fake in tests without
       standing up real services.
+
+      v1.1.0 amendment (PR 2 — persistence): every alert that passes
+      the dedup gate is INSERTed into the alerts table with state
+      'active' before channel delivery starts. This unblocks the
+      /activity feed (which UNIONs alerts with transactions +
+      intelligence events + audit) and the alerts CRUD endpoints
+      (PR 3) — both need a queryable alert log. Persistence is
+      mandatory: a DB failure aborts delivery with PersistFailed
+      counted; channels never receive an unpersisted alert.
 
   objective:
     summary: >
@@ -80,6 +90,22 @@ spec:
     - id: C-09
       description: The core router package (internal/alertrouter) imports no external notification SDKs (slack-sdk, sendgrid, mailgun, twilio, pagerduty). Channel implementations live in subpackages
       type: security
+      enforcement: error
+    - id: C-10
+      description: 'v1.1.0 — Every alert that survives the dedup gate MUST be INSERTed into the alerts table with state=''active'' BEFORE Channel.Send dispatch starts. Channels MUST NOT receive an unpersisted alert; if persistence fails, the router increments PersistFailed and skips dispatch'
+      type: technical
+      enforcement: error
+    - id: C-11
+      description: 'v1.1.0 — alerts.state is a closed enum (active / silenced / acknowledged / resolved / dismissed). Initial state on INSERT is always ''active''. Transitions are owned by system-alerts (PR 3); the router NEVER updates state'
+      type: technical
+      enforcement: error
+    - id: C-12
+      description: 'v1.1.0 — alerts table has UNIQUE constraint on (dedup_key, occurred_at). Combined with the in-memory dedup gate this provides defense-in-depth: a router restart during the dedup TTL window cannot insert a duplicate row (the in-memory gate is empty but the UNIQUE constraint catches it)'
+      type: technical
+      enforcement: error
+    - id: C-13
+      description: 'v1.1.0 — Alert.ID (uuid.UUID) is populated by the persist step. Channels receive the persisted ID so downstream systems (PagerDuty incident keys, Slack thread roots) can correlate back to the OpenWatch alert row'
+      type: technical
       enforcement: error
 
   acceptance_criteria:
@@ -142,3 +168,23 @@ spec:
       description: ValidateDedupTTL rejects values < 60s or > 24h with a typed error.
       priority: high
       references_constraints: [C-04]
+    - id: AC-16
+      description: 'v1.1.0 — Migration 0020 adds the alerts table with columns (id UUID PK, dedup_key TEXT, alert_type TEXT, severity TEXT, host_id UUID nullable, rule_id TEXT, title TEXT, body TEXT, tags JSONB, state TEXT default ''active'', occurred_at TIMESTAMPTZ, created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ). State CHECK enumerates the 5 values; UNIQUE on (dedup_key, occurred_at)'
+      priority: critical
+      references_constraints: [C-10, C-11, C-12]
+    - id: AC-17
+      description: 'v1.1.0 — Router.Route on a fresh alert (passes dedup) INSERTs one row into alerts BEFORE invoking any Channel.Send. Verified by counting rows after Route returns; rowcount = 1 and state = ''active'''
+      priority: critical
+      references_constraints: [C-10, C-11]
+    - id: AC-18
+      description: 'v1.1.0 — When the alerts INSERT fails (e.g., DB unreachable), Router.Route MUST NOT call Channel.Send. PersistFailed counter increments; ReceivedCount still increments (the alert was received), but RoutedCount does NOT'
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-19
+      description: 'v1.1.0 — Channels receive Alert values with the persisted ID populated. Verified by capturing the Alert that reaches a stub Channel and asserting Alert.ID != uuid.Nil'
+      priority: critical
+      references_constraints: [C-13]
+    - id: AC-20
+      description: 'v1.1.0 — A second Route call with the same (dedup_key, occurred_at) pair returns success but inserts ZERO new rows (ON CONFLICT DO NOTHING). Both the in-memory dedup gate AND the UNIQUE constraint catch the repeat'
+      priority: critical
+      references_constraints: [C-12]


### PR DESCRIPTION
## Summary
PR 2 in the OS Discovery → OS Intelligence → /activity sequence. Stacks on top of #443 (PR 1.4 — Intelligence scheduler).

Per \`docs/activity_and_os_intelligence.md\` item 3: amend \`system-alert-router\` v1.1.0 to persist every routed alert. Required before the \`/activity\` feed (PR 4) and the alerts CRUD endpoints (PR 3) — both need a queryable alert log.

- Spec bump: **system-alert-router 1.0.0 → 1.1.0** (4 new constraints, 5 new ACs)
- Migration **0020** — \`alerts\` table (id, dedup_key, alert_type, severity, host_id, rule_id, title, body, tags JSONB, state, occurred_at, UNIQUE on (dedup_key, occurred_at), CHECKs on severity + state)
- New \`alertrouter.Store\` interface + \`PgxStore\` production impl
- \`Router.WithStore()\` wires persistence
- \`handle()\` pipeline now: translate → dedup → store.Insert → set Alert.ID → dispatch (channels NEVER see an unpersisted alert)
- New \`PersistFailed\` metric; persist failure aborts dispatch (no Channel.Send), increments counter, logs warning
- \`Alert.ID\` populated by store before channels receive — downstream systems (PagerDuty incident keys, Slack thread roots) can correlate

## Spec coverage (system-alert-router v1.1.0)
- AC-16 — migration 0020 schema (source inspection: columns, CHECKs, UNIQUE)
- AC-17 — persist-before-dispatch ordering (in-process: store.Insert called before any Channel.Send)
- AC-18 — persist failure: Channel.Send not called, PersistFailed++, RoutedCount stays 0, ReceivedCount still 1
- AC-19 — channel receives Alert.ID = persisted id (not uuid.Nil)
- AC-20 — duplicate dropped by dedup gate; DB-integration test (\`OPENWATCH_TEST_DSN\`) proves PgxStore.Insert is idempotent via UNIQUE + ON CONFLICT recovery (defense-in-depth for router-restart scenarios)

All v1.0.0 ACs (AC-01..AC-15) remain green; no behavioral regression for the legacy fire-and-forget path (router runs that way when WithStore is unset).

## Stacking
- Base branch: \`feat/intelligence-scheduler-phase-1.4\` (PR #443)
- Merge order: #440 → #441 → #442 → #443 → this PR

## Test plan
- [ ] CI green on Quality + security gates (after rebase to main)
- [ ] Manual: trigger an unreachable host alert; observe row in \`alerts\` with state='active'
- [ ] Manual: kill the DB during a drift event; observe \`Router.Metrics().PersistFailed\` increment and no channel delivery

## Out of scope (lands in PR 3)
- Alert lifecycle transitions (acknowledge / silence / resolve / dismiss)
- GET /api/v1/alerts + PATCH endpoints
- Per-permission alert:read / alert:write RBAC