### PR TITLE
feat(alerts): alert lifecycle service + REST API (PR 3)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -356,1099 +356,1197 @@
         "filename": "app/internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 1266
+        "line_number": 1446
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "72e3bfe9c6166ac4c914a9c01feb17daa102bc36",
+        "hashed_secret": "66da434173daf2494f17b09bf88bcdef25ae9136",
         "is_verified": false,
-        "line_number": 3696
+        "line_number": 4189
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6ef7786f32670c202c54aea87cfdf05113cc3ffe",
+        "hashed_secret": "de654b2c1a1b703163618f0eaf19255ed655a68f",
         "is_verified": false,
-        "line_number": 3697
+        "line_number": 4190
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "86ccab9657f1dca59db61781ed479a804acff3bc",
+        "hashed_secret": "812c8d57ce2ee37a85081cbb1e7a666e6c7e3347",
         "is_verified": false,
-        "line_number": 3698
+        "line_number": 4191
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c54f36bf355a8bc02d5935abc95d9eec4e8b0cc7",
+        "hashed_secret": "bbe5eef55cdd364838a0276f4f18ee8abb6c89b2",
         "is_verified": false,
-        "line_number": 3699
+        "line_number": 4192
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "71843dbc2ae8889e62ac5c42a003e445968a406b",
+        "hashed_secret": "69c69f128339b05ea5fe92471caa233bb0f7627e",
         "is_verified": false,
-        "line_number": 3700
+        "line_number": 4193
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9671219fce29e2368674079e528e153e2ce1b7b1",
+        "hashed_secret": "78e2b2aa0a9d8795a151f3b02908d26594b2cdf9",
         "is_verified": false,
-        "line_number": 3701
+        "line_number": 4194
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "afed986ef80b2ac643d1c377adc353a2dd072f9f",
+        "hashed_secret": "8566607492664ade6052f8aeebd990e5a9ce697c",
         "is_verified": false,
-        "line_number": 3702
+        "line_number": 4195
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c1ea81e3c5ceae95818e63ddca15e50a41b04643",
+        "hashed_secret": "de9f031ab1fccb78b93ac2e9e2a994aa547eac72",
         "is_verified": false,
-        "line_number": 3703
+        "line_number": 4196
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10b1e2620e95c65a3a1cdcd3f088a1d440b59437",
+        "hashed_secret": "79d3de97e6f6c0d98657c9f56d26a62cd12d609f",
         "is_verified": false,
-        "line_number": 3704
+        "line_number": 4197
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "85a5a000f37fff8207d356baf16dc68b1aad3ad8",
+        "hashed_secret": "27442e0f5d526fdfac331f8dbb77fe40bdfed705",
         "is_verified": false,
-        "line_number": 3705
+        "line_number": 4198
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ee766dbe6737f20798d2907f668e3ccdc8adfa05",
+        "hashed_secret": "6f4453c46b327188dd05bd571de8e1d8af5c8a85",
         "is_verified": false,
-        "line_number": 3706
+        "line_number": 4199
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ee432fc4db6fe7cf6d4f9c1df4bd616cd1ef8347",
+        "hashed_secret": "786fe5b8b89ffe6f8dbc995f6e3173f17a52305a",
         "is_verified": false,
-        "line_number": 3707
+        "line_number": 4200
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "69af827cedf9814ce90a6701ad3c3a8ca73d8e45",
+        "hashed_secret": "0dbc46c9e0ff95b25fa153f927f608fa8815f0fe",
         "is_verified": false,
-        "line_number": 3708
+        "line_number": 4201
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2e4a6670ebb4b46a24f09d5b23b670e7aa30f7e0",
+        "hashed_secret": "618e044c610c47f4607db1e1988a608a255fb313",
         "is_verified": false,
-        "line_number": 3709
+        "line_number": 4202
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3300b1ed2d6d90773c5d69bf35a98ba089fdb7c8",
+        "hashed_secret": "c213ef6f09fe06c2aaccb4db8f1d8e8e358e38be",
         "is_verified": false,
-        "line_number": 3710
+        "line_number": 4203
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "703a5fa2dfe95eb476ec40a6e9b1c507a65cecab",
+        "hashed_secret": "c773c676844f899ca28b2a1d42c627af7770a3c7",
         "is_verified": false,
-        "line_number": 3711
+        "line_number": 4204
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c1607bc05bfe42a6e547b4c550a5d236f5cacd45",
+        "hashed_secret": "eb2be242bfdd245f5fdd205efb63c5b10f772e9a",
         "is_verified": false,
-        "line_number": 3712
+        "line_number": 4205
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a155f54fa1ac2db556c1ae1a50c2d6e1aa77e212",
+        "hashed_secret": "a7e203acfada8b7df65e6e67e613fd4fbd4a9a38",
         "is_verified": false,
-        "line_number": 3713
+        "line_number": 4206
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4579281a93869323bee95ea5eb1e152e18846f00",
+        "hashed_secret": "a7bcf792cb4bfb1bda8c2613461e25d909154bfb",
         "is_verified": false,
-        "line_number": 3714
+        "line_number": 4207
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5bb7380658b4fdb90584895b3d520e8a26bf8bd9",
+        "hashed_secret": "e8ac090d7535515e31c0d85d36908b10f09052bd",
         "is_verified": false,
-        "line_number": 3715
+        "line_number": 4208
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0ce12a6fbde3bf344c50449819c08e0acf951434",
+        "hashed_secret": "c89316b06442c3939909b3e067819497ebc9950e",
         "is_verified": false,
-        "line_number": 3716
+        "line_number": 4209
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0f544f3319d5a8adc0f6222ef6bc7a0f3c1c8842",
+        "hashed_secret": "b40249e521222bcd7eb394c36b15c75cd7ee72fd",
         "is_verified": false,
-        "line_number": 3717
+        "line_number": 4210
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3c7a9f5e132d781d92b58a017b40bed1dac0e139",
+        "hashed_secret": "821ceec2d1af9caabfeed4881bb76384863b1c82",
         "is_verified": false,
-        "line_number": 3718
+        "line_number": 4211
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b83aa13552c1ee1d65ef2b6aad87f3336eae2e75",
+        "hashed_secret": "34c59398de1feeba195328d787956c245edbec11",
         "is_verified": false,
-        "line_number": 3719
+        "line_number": 4212
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "68b73513cba329f38f36b18307fa7c59d7b526b0",
+        "hashed_secret": "75c8916094a3e49e25c9056301af42bb53b9385b",
         "is_verified": false,
-        "line_number": 3720
+        "line_number": 4213
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "747fc2c2c2dbd9f71e8a31a1538d3691abe2fcdb",
+        "hashed_secret": "194ffaf004b538f211047bc4b0794f5b59c0e2cb",
         "is_verified": false,
-        "line_number": 3721
+        "line_number": 4214
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fd354a4e9cddb60127ab0eb50624eea4cfbd0348",
+        "hashed_secret": "3252e9ebf1a7c8c7566a5bb7c169dcd11d69be2b",
         "is_verified": false,
-        "line_number": 3722
+        "line_number": 4215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "be7b9a4716db2bc804ce23434ad41207330cb2d9",
+        "hashed_secret": "f4d32c712d596c9957dc710a80bae88404c3e2f8",
         "is_verified": false,
-        "line_number": 3723
+        "line_number": 4216
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4db5849acf1f7b4d262ed8f4ca49ef00c59fb809",
+        "hashed_secret": "857d431e394a4e020adbfc301ff8ddaf75f6bd64",
         "is_verified": false,
-        "line_number": 3724
+        "line_number": 4217
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c09d2debfd8a8e9e43c7cadc22583abfcee82858",
+        "hashed_secret": "e586476fe86a908c63d81cd7b2da4d12beae5e29",
         "is_verified": false,
-        "line_number": 3725
+        "line_number": 4218
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "84e06e2669ae469aab6edcdbe4fac12afa22ce8f",
+        "hashed_secret": "547a573daeed8eda747db18b60dc4337e666c67f",
         "is_verified": false,
-        "line_number": 3726
+        "line_number": 4219
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f274e8f5a8f48d86850df3f111e22503a3c80dd8",
+        "hashed_secret": "66d5ebf1350cab6a0e5d6f95692a7f3bf9218937",
         "is_verified": false,
-        "line_number": 3727
+        "line_number": 4220
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7cb3739f9d4152b2802579b10350f8b9d4e634c8",
+        "hashed_secret": "cb91fdfda3ee173dee0f5c45bf7245c25292a62b",
         "is_verified": false,
-        "line_number": 3728
+        "line_number": 4221
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "07a0278352a18727fd47ae0a50c9d93e67da09b6",
+        "hashed_secret": "2a321e3a49b5b2c4782b36a10a623f2f76213afb",
         "is_verified": false,
-        "line_number": 3729
+        "line_number": 4222
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c1fcd9f83adce749cad474f5dd127bcd5a492411",
+        "hashed_secret": "97743afd7198d4e6f3ec26e0327c5d259dd134c8",
         "is_verified": false,
-        "line_number": 3730
+        "line_number": 4223
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e9f746830aa82345091c63ac524052b5ab80e286",
+        "hashed_secret": "7f34c8d238eb94e3b3d4884ab053147d1e4022c6",
         "is_verified": false,
-        "line_number": 3731
+        "line_number": 4224
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "db3d12df052570e864ef393e21d683542a3d25c2",
+        "hashed_secret": "b0ab3777cf07f37fde076d4338540b9cae3515cc",
         "is_verified": false,
-        "line_number": 3732
+        "line_number": 4225
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "48cfc36b2d836d4c92293a67ad4cef9bdb256fc9",
+        "hashed_secret": "2077c1914a26b37f4c5df190945320c15e01c541",
         "is_verified": false,
-        "line_number": 3733
+        "line_number": 4226
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fb20128f4a2ba4d2c17db6d7407cb730cb44d2df",
+        "hashed_secret": "60c77f41dc04327d72296109071d094537d2a95d",
         "is_verified": false,
-        "line_number": 3734
+        "line_number": 4227
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "51184d242675a95c2e72d1bec3c6ab9fd67bf19b",
+        "hashed_secret": "3eaf37e31d14443b6a98c4846863c62728c26e65",
         "is_verified": false,
-        "line_number": 3735
+        "line_number": 4228
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6e944d3b8c6cd5dac06068666d533c12e7500965",
+        "hashed_secret": "aeae366fa908718ee5a3e4f35deebb9d3e1f30ba",
         "is_verified": false,
-        "line_number": 3736
+        "line_number": 4229
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5d460d7a72a568938d030543cc4fea4b70246422",
+        "hashed_secret": "25a72713bcd1ddadbb3b5cf5869c0f0850b6cedd",
         "is_verified": false,
-        "line_number": 3737
+        "line_number": 4230
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42c1fac1937a95b7011a158115c307a6b47e3b81",
+        "hashed_secret": "4b082ea22a2bbd9d90e40a7d236e179636b5c5ad",
         "is_verified": false,
-        "line_number": 3738
+        "line_number": 4231
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dd4b105853bdfd34e40c535849bac7d0b1f663ca",
+        "hashed_secret": "9619df2beb21cbca655d22a50c94a50dc1c697ab",
         "is_verified": false,
-        "line_number": 3739
+        "line_number": 4232
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d9eb1dad228237eec6847934d0576ff7a994600e",
+        "hashed_secret": "82f4a75e833a4660057f554a3a4ada2b15bb5084",
         "is_verified": false,
-        "line_number": 3740
+        "line_number": 4233
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "167da25410bdacd7a45e526290ee224fc37e8ad5",
+        "hashed_secret": "db23e3b23109ec1658793be2a9b551fc8aff9b9f",
         "is_verified": false,
-        "line_number": 3741
+        "line_number": 4234
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9bab3814f32c25ba49e737f0987eacebaf673d37",
+        "hashed_secret": "f1d774278fa6577fea3feab4c4f2eaefdc7133b4",
         "is_verified": false,
-        "line_number": 3742
+        "line_number": 4235
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c76d0e2d664c5a590bcb1ffdcd039babb00a82f2",
+        "hashed_secret": "3925cf2f8ae58770c791a1f3d72daffe16bd07a2",
         "is_verified": false,
-        "line_number": 3743
+        "line_number": 4236
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7c6d9e3a77758c19e198984d80962550784a0ade",
+        "hashed_secret": "0f68e2b0f7272688d37d4d933a384d27b1a33512",
         "is_verified": false,
-        "line_number": 3744
+        "line_number": 4237
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1b7b13e8ed10eedcd91ca201b445511f7e281542",
+        "hashed_secret": "4bf85b887073794e90e97ac0c1301c88d17a4c6a",
         "is_verified": false,
-        "line_number": 3745
+        "line_number": 4238
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6d1999c236ea993d6d9bf8eda6b344fc6efb31e2",
+        "hashed_secret": "a054a45787bf4385a50ab149466bf47108291ad1",
         "is_verified": false,
-        "line_number": 3746
+        "line_number": 4239
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3f0d4ae9b649cfac2a8e97a7459aaaa75067a9f6",
+        "hashed_secret": "1e9a8af9d555c027ca7d931003f0a391c50f00bb",
         "is_verified": false,
-        "line_number": 3747
+        "line_number": 4240
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5fe34f22c7ff6bde84095164192b98fe99df5de6",
+        "hashed_secret": "f4e811160896533568c0750947b65ae2a0af25d6",
         "is_verified": false,
-        "line_number": 3748
+        "line_number": 4241
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "10f7eab7df07c32ada0dfce8af071e0570bde2b5",
+        "hashed_secret": "0a2da5dbecde22e3f7654649bd618dab026b91c9",
         "is_verified": false,
-        "line_number": 3749
+        "line_number": 4242
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7ed6e0f40600a76507e8742e9e4bcea26ec52e01",
+        "hashed_secret": "57013b78d340a9c13ca20462a4912f8747fd1522",
         "is_verified": false,
-        "line_number": 3750
+        "line_number": 4243
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1581853940822412287889ad374721af1b7bb69b",
+        "hashed_secret": "394a844e827fe862077a9e5c85a856019c1e8c18",
         "is_verified": false,
-        "line_number": 3751
+        "line_number": 4244
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6bcec2339d7fb28321fff3aa8eac3fcd2294b437",
+        "hashed_secret": "37e69f4cf5981d9c7cf047e29044f59ab9d04395",
         "is_verified": false,
-        "line_number": 3752
+        "line_number": 4245
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f494b9dca74e5e5abd9857581593c2ac91499fd9",
+        "hashed_secret": "0745b1c4b6a18bf71645f58b701f921269aef1c0",
         "is_verified": false,
-        "line_number": 3753
+        "line_number": 4246
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eb9b61397546b029f17e39e0502a11a19064c10d",
+        "hashed_secret": "2df4f97292a1054090a52d64bcba37ffa1bc99ea",
         "is_verified": false,
-        "line_number": 3754
+        "line_number": 4247
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "52d5b54b7daddd818aa4c113d62ba873065e54b5",
+        "hashed_secret": "2ebd6f71216f8892a66f68e170de701cd203b27b",
         "is_verified": false,
-        "line_number": 3755
+        "line_number": 4248
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "59955d359d7036299839019c537dba5ff5b4242d",
+        "hashed_secret": "f325c432e896f5bee42ed82ed742c0be7547dfad",
         "is_verified": false,
-        "line_number": 3756
+        "line_number": 4249
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "978f28ca873fccb2f7f32ea4b1293c8aac63fec7",
+        "hashed_secret": "1857901e5b7910bcfaf11a65a08f2579510e4b84",
         "is_verified": false,
-        "line_number": 3757
+        "line_number": 4250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "52a27035190e6daef58de1456d674e792ec30a2d",
+        "hashed_secret": "d7e7910578258e9f395fb4a924c138ad0ca5e114",
         "is_verified": false,
-        "line_number": 3758
+        "line_number": 4251
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6560d38de0e9b067b51363f2bb0aee3944ac7fcb",
+        "hashed_secret": "1a6c2597498a0b24c4b9bfffe03bd8da80d1a5b0",
         "is_verified": false,
-        "line_number": 3759
+        "line_number": 4252
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ba1227e71a404a17e5164330a3288d6a2d5791c1",
+        "hashed_secret": "96c0bb5571dc21c0894a60012ed77cf6e67be755",
         "is_verified": false,
-        "line_number": 3760
+        "line_number": 4253
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8d7b6a2a6d4cbdb47a86206e2d9c7a06599cb2b9",
+        "hashed_secret": "df867af8e3faedcade007f387d0174c9065f36fa",
         "is_verified": false,
-        "line_number": 3761
+        "line_number": 4254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "929f5bd02d170f54b2235477df888100a85b802a",
+        "hashed_secret": "2efa1ebdbf8e80cb206c0f06b0b10becc7c59dce",
         "is_verified": false,
-        "line_number": 3762
+        "line_number": 4255
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c7693bca443a91e60bfb71f48fcab31681588777",
+        "hashed_secret": "82d8d769efa5355521556e03f016d9ffbb710b68",
         "is_verified": false,
-        "line_number": 3763
+        "line_number": 4256
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a7cd2150a2ce7a704b5d6f4705c1c731900603b3",
+        "hashed_secret": "80ba532096a16a91100b3d13fcb764e51dcab514",
         "is_verified": false,
-        "line_number": 3764
+        "line_number": 4257
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f9c7fdd828e92070fd8edef94b8efb2fde7597c8",
+        "hashed_secret": "f980c42cfe95a02e5744a2f644566914e78443ca",
         "is_verified": false,
-        "line_number": 3765
+        "line_number": 4258
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "e2be11bf9a8b2aaee2259e7709fc56e80c43596c",
+        "hashed_secret": "9bad89f5ce558e086c27d883ed2e7ee652412e75",
         "is_verified": false,
-        "line_number": 3766
+        "line_number": 4259
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fe593b6a0d04dae498e9a4b1a7ad8986643ed184",
+        "hashed_secret": "2879e6189db6ccc62ab45051fcb9fcc07ecd5cb4",
         "is_verified": false,
-        "line_number": 3767
+        "line_number": 4260
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f652e8367cee3d7adee4b49e0edee4f063143c5e",
+        "hashed_secret": "2af0fe1fd9340a3c0473fd4b0fc6683d0ed87c44",
         "is_verified": false,
-        "line_number": 3768
+        "line_number": 4261
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f9d01455c672a83ebee214cf3837d6c3d34056f5",
+        "hashed_secret": "fa770b250361fcaa989b913e81a79b1e2d203271",
         "is_verified": false,
-        "line_number": 3769
+        "line_number": 4262
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "63965dd4ba214689c87551231f41c172a4f4ae5a",
+        "hashed_secret": "a0854ee87be2e1e693a77edb200b2c2e0134d99f",
         "is_verified": false,
-        "line_number": 3770
+        "line_number": 4263
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c10c4155f793cddce478a4398c77d5ffe56677eb",
+        "hashed_secret": "5ec7608846d95dcbba3198da690fc23a26da9fa9",
         "is_verified": false,
-        "line_number": 3771
+        "line_number": 4264
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "366d462f5415e022d4470b59dd7336235912d0e1",
+        "hashed_secret": "a5bc29a656df8447c4c60e4f827bd718ca6cbf9c",
         "is_verified": false,
-        "line_number": 3772
+        "line_number": 4265
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1ab8a5197a178c15c0d1fe548dffc0799a329cb9",
+        "hashed_secret": "af405f2732960330ee5397b225d0b32651e22c55",
         "is_verified": false,
-        "line_number": 3773
+        "line_number": 4266
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1be058d1392649551558b82c0801ff1333b6069e",
+        "hashed_secret": "d784222f30114c4b7198583307676cee134886a7",
         "is_verified": false,
-        "line_number": 3774
+        "line_number": 4267
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "569350ad80633404a9513e0deb22d602c6548da1",
+        "hashed_secret": "fe3ac0195f967a6483f028015120d3dbd6019413",
         "is_verified": false,
-        "line_number": 3775
+        "line_number": 4268
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "37095ba8f49885f3246e50cbed40280698aa49f3",
+        "hashed_secret": "8506c3cb9ffd82a8b35d58e9d3a349ecddc8db93",
         "is_verified": false,
-        "line_number": 3776
+        "line_number": 4269
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f463fa838d0f9eb797012cf9429d74f68eec0514",
+        "hashed_secret": "260d06e71a4322bcbce7450fe49899b881d8f215",
         "is_verified": false,
-        "line_number": 3777
+        "line_number": 4270
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "317e364d7f3a80cc2445fc0eb3da408ed07fdfa6",
+        "hashed_secret": "5b4f710f319190999462b06244115bcd0ae29dca",
         "is_verified": false,
-        "line_number": 3778
+        "line_number": 4271
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4600e96fa38df8442a90e235b6d5d1a9c66d1b80",
+        "hashed_secret": "ebc26c8bd3d93012fd11098378af8c3692445092",
         "is_verified": false,
-        "line_number": 3779
+        "line_number": 4272
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b0f14876e3a2eae39310d185cfd4150cc673c328",
+        "hashed_secret": "dd1a2cbfa966016dd1fb165d71b0b8886b71f676",
         "is_verified": false,
-        "line_number": 3780
+        "line_number": 4273
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b1f83af6db2a94ba936b190c2fccf49161258266",
+        "hashed_secret": "76c3469c8be2857e2121a5cd7a743038acb3f99c",
         "is_verified": false,
-        "line_number": 3781
+        "line_number": 4274
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "47e19adb933c198667471fd970808235374745ff",
+        "hashed_secret": "953728360f5e6476ebcbd728db3594819d06ea42",
         "is_verified": false,
-        "line_number": 3782
+        "line_number": 4275
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "5c9f322bd6501a703a69871ef953469da335639b",
+        "hashed_secret": "2bf8de813db9bafcde6493c1f29e2ad925edcb3d",
         "is_verified": false,
-        "line_number": 3783
+        "line_number": 4276
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2c2cce4bddee9b888ba2c47457433487bc75615c",
+        "hashed_secret": "b40ab34768a9cdca9413c213e2d2b543a046ff02",
         "is_verified": false,
-        "line_number": 3784
+        "line_number": 4277
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c2ddeea3bbdc8623c3a89c21551fbe794396ca4a",
+        "hashed_secret": "01ffb99642e29036418655afac358269f55c4523",
         "is_verified": false,
-        "line_number": 3785
+        "line_number": 4278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "50ca990754754ae2e756723b459b085baafc97f8",
+        "hashed_secret": "e6fae0ea377b2b36863870533a921aa27fbf5e03",
         "is_verified": false,
-        "line_number": 3786
+        "line_number": 4279
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8cdc824a0bfcc4b030fd212575f981af3ba72620",
+        "hashed_secret": "f8730d3d6574b3191d9b791018efc0330d56c0d5",
         "is_verified": false,
-        "line_number": 3787
+        "line_number": 4280
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6d801dfebf092cdd1d0cb618a2afbbb24ab93095",
+        "hashed_secret": "f7788ef60d501a351bce19322f118a8b832dbcf6",
         "is_verified": false,
-        "line_number": 3788
+        "line_number": 4281
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "121bac336c90613ddb6e07fa08495986c28bbc09",
+        "hashed_secret": "7b907d94ec3d0ad2ed01a1ef6e18093e9688fb37",
         "is_verified": false,
-        "line_number": 3789
+        "line_number": 4282
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "95b7b6e1e01374981a2df173e795b0d60ac157b0",
+        "hashed_secret": "128150b9b6c00fa66945caacb0a6a74c24d2f398",
         "is_verified": false,
-        "line_number": 3790
+        "line_number": 4283
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "119c26cf4f62cf8c20845b83e38b69c3c1f259e5",
+        "hashed_secret": "fbebc705c74f616c322c94148f7efa90df5b6c77",
         "is_verified": false,
-        "line_number": 3791
+        "line_number": 4284
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "b7df59204656c0c44bef39dd7c9fa8ed73ff0e48",
+        "hashed_secret": "32d59b23b0ed26850960f0f9263bb7d64ea14086",
         "is_verified": false,
-        "line_number": 3792
+        "line_number": 4285
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "dd1d531ee7ce87632a58db6da17d8fcfb7fbcc4e",
+        "hashed_secret": "fdcf6944f57cc6feefac9b9d912918756d8187f6",
         "is_verified": false,
-        "line_number": 3793
+        "line_number": 4286
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a7fb7186ff43a9ed01fd7b081b86e09db6bb4f0e",
+        "hashed_secret": "ab245610e2f46e64478e15ec2136d9197d6c617e",
         "is_verified": false,
-        "line_number": 3794
+        "line_number": 4287
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "30d78981c86fc4c2809eba9d3b2d057beae943af",
+        "hashed_secret": "7abf53167a6b7ec50283f2c1350ef59d04899568",
         "is_verified": false,
-        "line_number": 3795
+        "line_number": 4288
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7aac9a0c69f9eac1fe3e81a58298d50b386e1205",
+        "hashed_secret": "c8c7286a85913f4eaa4c5348b97db03772f3bf17",
         "is_verified": false,
-        "line_number": 3796
+        "line_number": 4289
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7721742608b2f2987dafcf2f344b38dd4417732e",
+        "hashed_secret": "00eae3065a0ee3366385e3e7112206a971d81460",
         "is_verified": false,
-        "line_number": 3797
+        "line_number": 4290
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f7da5cc1baa30b87858647d3fbfe69caa14d1983",
+        "hashed_secret": "0524dfe30bd9fbd3507895eec4b3347635b8f671",
         "is_verified": false,
-        "line_number": 3798
+        "line_number": 4291
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "051d8b6047ff8e7250667b9518cefc22f6fbd220",
+        "hashed_secret": "96b282a972fdf86c0b57f0b05d72ef71fa473cae",
         "is_verified": false,
-        "line_number": 3799
+        "line_number": 4292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "68e0e441a65c2d890b94784d34e98cfa6bbdfa60",
+        "hashed_secret": "28f32c270f1fa240b8cfff64a0e352b14f3615ea",
         "is_verified": false,
-        "line_number": 3800
+        "line_number": 4293
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42c43f5d7c49890377725de96c4ee383651bcb48",
+        "hashed_secret": "9e41aaed839eadb184064fceae3a06a5c933dc8a",
         "is_verified": false,
-        "line_number": 3801
+        "line_number": 4294
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fa272ad3231289d0fe74d3fa1779608915327290",
+        "hashed_secret": "ef3e9207e7bb4a81c04946984b3971824aaddd6f",
         "is_verified": false,
-        "line_number": 3802
+        "line_number": 4295
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "db7bd757118d0533a81ccfda68c2878cb5616425",
+        "hashed_secret": "6e7a3f5b486dd32a4845f9a7d459e9445bd40e78",
         "is_verified": false,
-        "line_number": 3803
+        "line_number": 4296
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fcb382375a96edb4dff409e483ae7086cd1c808a",
+        "hashed_secret": "b18656bf30a4fd5237563df3f782363e83eb9dba",
         "is_verified": false,
-        "line_number": 3804
+        "line_number": 4297
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f3e6153ddd8cebe4378abef6ffe3df8d16a88f36",
+        "hashed_secret": "5093cab0a0a40d18a65815147a0a0787b1fbdf8f",
         "is_verified": false,
-        "line_number": 3805
+        "line_number": 4298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "6a4116db9a3774ec0a1226941f1a3ad86d60a953",
+        "hashed_secret": "39b4ab3f0084dde4aaa5d1fb25b53542085e0158",
         "is_verified": false,
-        "line_number": 3806
+        "line_number": 4299
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d5d6ab3e82edf205bf010abe1d417a8d5371a94c",
+        "hashed_secret": "236d9d28924154d6d741e590c7b2e3ac31ef95fe",
         "is_verified": false,
-        "line_number": 3807
+        "line_number": 4300
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "95faac95e471b53b94b6cb6a4cb7e09637452044",
+        "hashed_secret": "4caf8065dc526dfbf3ec8f13a6972082632657ce",
         "is_verified": false,
-        "line_number": 3808
+        "line_number": 4301
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3a343a5e676fc43589e1c2982188e29fe5d76d79",
+        "hashed_secret": "8688efb228b1fa755caf71653629dd9a1cc45ade",
         "is_verified": false,
-        "line_number": 3809
+        "line_number": 4302
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7cb7f88b5f76c4a0d4ec6993b0fd557eb60f495d",
+        "hashed_secret": "882535a9762ba1fbfd9cdb99d96f1b8ec5e8e10e",
         "is_verified": false,
-        "line_number": 3810
+        "line_number": 4303
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "0bb78e25247f1e2e71c32d132edf999d36efd87e",
+        "hashed_secret": "f73028dee7fc96475251c52cfd827e2705927670",
         "is_verified": false,
-        "line_number": 3811
+        "line_number": 4304
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3b40808cc2b35eee26807b37cba122a2be4d2d11",
+        "hashed_secret": "b494d233d546a28507e4e57d1258e18db2949b8a",
         "is_verified": false,
-        "line_number": 3812
+        "line_number": 4305
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "68d303b0f090c741b347437076a940950a57fb28",
+        "hashed_secret": "056f4d02d6318d563560cca51e8f16d718a4c1eb",
         "is_verified": false,
-        "line_number": 3813
+        "line_number": 4306
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a223db0481e84ed16c499ada626f551c765490d4",
+        "hashed_secret": "ffbd4b3b5a15c9f2fef7c6a2bd72510919eb4fd8",
         "is_verified": false,
-        "line_number": 3814
+        "line_number": 4307
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ba146e702d94218263d4d389daac4d7c9275a74a",
+        "hashed_secret": "e0897e57dd45283419487819759d495263ffe1b1",
         "is_verified": false,
-        "line_number": 3815
+        "line_number": 4308
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a6eb771ac3d0a0546d71201802120de475c1e6a5",
+        "hashed_secret": "e64a1066df169d1e0c44d9bff66618b36e52afd5",
         "is_verified": false,
-        "line_number": 3816
+        "line_number": 4309
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "50af18355c25aa99d17768f2e559d6fc8ce18616",
+        "hashed_secret": "ef3b322e408dfe1d2614306d49596869e8b30e85",
         "is_verified": false,
-        "line_number": 3817
+        "line_number": 4310
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "9a49835f25021496bcdb09d157e9294382fe1994",
+        "hashed_secret": "bd4236d256e1509723cbc06c79edc0340ac6a703",
         "is_verified": false,
-        "line_number": 3818
+        "line_number": 4311
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a81d39d1c391c66eac7fa5421a1fd59feca16b46",
+        "hashed_secret": "127612d69e048ab63b2e7d3bbc2b1492bb13a7c4",
         "is_verified": false,
-        "line_number": 3819
+        "line_number": 4312
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2be7c7baad7edcc019526e2ecf9dbeb13ea47ace",
+        "hashed_secret": "e5d87b8d53d16b9683758b59906579b051dd10c7",
         "is_verified": false,
-        "line_number": 3820
+        "line_number": 4313
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7ef95bcab5b5e92e972a8791dd6f2706c27ddc11",
+        "hashed_secret": "4c02264973d9ba7b14702f60336c6718d149f249",
         "is_verified": false,
-        "line_number": 3821
+        "line_number": 4314
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "4a777a75776c1a3dbe2cf9b0d03859fc233f9d07",
+        "hashed_secret": "24b157998478a1f65ad0fb4c20db9f878e7cbd38",
         "is_verified": false,
-        "line_number": 3822
+        "line_number": 4315
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3907909f1cd55a330347c139e72782f11350836b",
+        "hashed_secret": "124b18de312f6949295489242d2525232b82f121",
         "is_verified": false,
-        "line_number": 3823
+        "line_number": 4316
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "25d2a9d2d29c08a6acf76c245c6f307fb4b9ac12",
+        "hashed_secret": "1c4159ffc7fa5c9b43a7d51c802d40d38210da25",
         "is_verified": false,
-        "line_number": 3824
+        "line_number": 4317
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c835eb04f83c01c8679b1c3a05a43661d35e0814",
+        "hashed_secret": "7c44bc4e91f36cc1ce570f01c9b8c89985a5a178",
         "is_verified": false,
-        "line_number": 3825
+        "line_number": 4318
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f96301c858950830bdee8d8f5fdfa2b660ead6b2",
+        "hashed_secret": "1cf07a4bb5c52cd771041f4fd734261076dfd702",
         "is_verified": false,
-        "line_number": 3826
+        "line_number": 4319
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "42948c52e1a86bc52456f7995fc863a0c1791f4d",
+        "hashed_secret": "c8632510f0077935190e75bbf93b432ea93b1c16",
         "is_verified": false,
-        "line_number": 3827
+        "line_number": 4320
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "038b97c7520d13c600ecad3393f831f6c1c53e72",
+        "hashed_secret": "3edf4a52dd2716835ad8be7d535bdec1ada7edb3",
         "is_verified": false,
-        "line_number": 3828
+        "line_number": 4321
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "cb91aa7aa5488783dc455b629b9c8f5d130d83bd",
+        "hashed_secret": "410ec09ec4cfb16812f74a8050ba6ec5ed7f86a9",
         "is_verified": false,
-        "line_number": 3829
+        "line_number": 4322
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2450a89bb622f7e25321b66c6ff5837be9fbb333",
+        "hashed_secret": "89b874faa981bbb8857dd200cb1f8f933e67b3db",
         "is_verified": false,
-        "line_number": 3830
+        "line_number": 4323
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7c3c462109bd2fe10d9f706490ccc4d3f2d1d826",
+        "hashed_secret": "bb04ce1be0639bccf46505ec6fa85f525f601c47",
         "is_verified": false,
-        "line_number": 3831
+        "line_number": 4324
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "ac7e1b04ebbff6d028a0dfdea8d7b67b3785c515",
+        "hashed_secret": "5f551943d6bb1d7ef1fce8012e659c05465b0077",
         "is_verified": false,
-        "line_number": 3832
+        "line_number": 4325
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "34482a92383d48e9f508c4789a37da13bf72333f",
+        "hashed_secret": "fa78c27f895803356283140e45aab779c926d99c",
         "is_verified": false,
-        "line_number": 3833
+        "line_number": 4326
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "8996219c94725b68b30deb4a00e8a67b96932e47",
+        "hashed_secret": "57b361f26babf6236ed333869b657396824e0c05",
         "is_verified": false,
-        "line_number": 3834
+        "line_number": 4327
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "05063f22057841b05f62bd49a9ad19e1a07962ab",
+        "hashed_secret": "1eb15e62789f79f99340b0d3b05e7e6ab7ba6bc2",
         "is_verified": false,
-        "line_number": 3835
+        "line_number": 4328
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f5bdb563f7d8727a8936b1220465490816da1f76",
+        "hashed_secret": "582ae9cf7891d67c329f756ffdcbd8459e0d58c1",
         "is_verified": false,
-        "line_number": 3836
+        "line_number": 4329
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "fbddd867f082e9511f37acdba2ff79d93323441c",
+        "hashed_secret": "6c13d3ff8d6076f14486fe362d2cd882bf40453b",
         "is_verified": false,
-        "line_number": 3837
+        "line_number": 4330
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "49ae219c88060fddcee2f29881a9db24eb750105",
+        "hashed_secret": "7f174ca44028a4263d600a2c92bea1a64dde6814",
         "is_verified": false,
-        "line_number": 3838
+        "line_number": 4331
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "56efcb65c112f6542d6ab4dfabedf9ef6527e16d",
+        "hashed_secret": "f0e516f874468783b50a8a2851362a0e524dce49",
         "is_verified": false,
-        "line_number": 3839
+        "line_number": 4332
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "66b35440dc968f787dd38317c92a51ba9f1a6366",
+        "hashed_secret": "3ec7cce33c18ef560a3afcad02b57815b270c711",
         "is_verified": false,
-        "line_number": 3840
+        "line_number": 4333
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "2e30f5139123bf91ad42005362d6203308887440",
+        "hashed_secret": "1fb20e637e299ab41c2a9d3f5c5d7cedaf797040",
         "is_verified": false,
-        "line_number": 3841
+        "line_number": 4334
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "d07564a106ac8c73c15c3f2d9f9faaea2ad18be1",
+        "hashed_secret": "d70239e45d209343ec047ee07bf43d00a18b018c",
         "is_verified": false,
-        "line_number": 3842
+        "line_number": 4335
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "1fa900a954867f4c8020aef670a1b6fcfc50dda9",
+        "hashed_secret": "cea920a1c05a31ef2ed2777fecea4edb7e60e0eb",
         "is_verified": false,
-        "line_number": 3843
+        "line_number": 4336
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "c16acb9704b26933251d98fe225a7b391bc7fb81",
+        "hashed_secret": "f97cc259b542a371c8bb7ae9be1d116437382621",
         "is_verified": false,
-        "line_number": 3844
+        "line_number": 4337
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "573e30c456992b38cbdf133d4ce59086898d205a",
+        "hashed_secret": "2dc4a91fd0c86a53ae911f5b65e9520322b53af4",
         "is_verified": false,
-        "line_number": 3845
+        "line_number": 4338
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "f7e624a9d13d8db311a90c5d69fe55bc0321aaa6",
+        "hashed_secret": "3711534a83a1adbb4e691d95a9d78f6fef2ec867",
         "is_verified": false,
-        "line_number": 3846
+        "line_number": 4339
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "a82e58fa78bbf4092e5045c75e450c08b117e912",
+        "hashed_secret": "74a81138f105f6665daa9e1a35341cdf915499df",
         "is_verified": false,
-        "line_number": 3847
+        "line_number": 4340
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "66929d3cd2245f657eee56953f2a2a208cdf6a25",
+        "hashed_secret": "b55fa24da13229ecfeac6c2694bf755b721833e2",
         "is_verified": false,
-        "line_number": 3848
+        "line_number": 4341
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "3cacb6d5882c30a76451f0bff1ef23b8b96dff9c",
+        "hashed_secret": "95f69a688c3f46791433a211111bef5c1274096e",
         "is_verified": false,
-        "line_number": 3849
+        "line_number": 4342
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "7b5c0d8d25129a14a8feef0c8075765f05d2a924",
+        "hashed_secret": "11f18cb9a1762c10da14aa6ba20d5a50e902d1a4",
         "is_verified": false,
-        "line_number": 3850
+        "line_number": 4343
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "app/internal/server/api/server.gen.go",
-        "hashed_secret": "eee127f034102fab460bb3d828f0d7ab64628138",
+        "hashed_secret": "3764a5a52054621464349b3be0636391b23261a1",
         "is_verified": false,
-        "line_number": 3851
+        "line_number": 4344
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "c2928f00863a39ae54d5dd6583b661a70bb9d265",
+        "is_verified": false,
+        "line_number": 4345
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2260f707482b9d04b3de7c3842ab877bf581026e",
+        "is_verified": false,
+        "line_number": 4346
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "ed3e64fbf727203636272968b0c5de0607f04b83",
+        "is_verified": false,
+        "line_number": 4347
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "7fb699d962ba5e59334408ffe62f58b25daf327a",
+        "is_verified": false,
+        "line_number": 4348
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "8984cee3482e886c56044c577b5b691cb7c45a4c",
+        "is_verified": false,
+        "line_number": 4349
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "1b9610854ecca2efa94f6a5b2c76b6996e7221c5",
+        "is_verified": false,
+        "line_number": 4350
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "9434529ea612c9dcaee7a869b31e2ecc841e29b3",
+        "is_verified": false,
+        "line_number": 4351
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "cbdf485fc1dda8e3eff7d82db4cd2b7fa7670bc2",
+        "is_verified": false,
+        "line_number": 4352
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "9cc879e4060aa0e7fce62ff89cbba05d790e3e3d",
+        "is_verified": false,
+        "line_number": 4353
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "538da40da36c4d4f9af63a61b46a348bf499ca9f",
+        "is_verified": false,
+        "line_number": 4354
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "cccf320cbac497b855f721f4b827a0a208c4ed36",
+        "is_verified": false,
+        "line_number": 4355
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "2ba7fbcad466b8804fb0c44cd3362f73e2e8d042",
+        "is_verified": false,
+        "line_number": 4356
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "73c304c47a986a75082bd6f301f467782d432391",
+        "is_verified": false,
+        "line_number": 4357
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "app/internal/server/api/server.gen.go",
+        "hashed_secret": "eef2b6a2d736155346126be83ddacc6018c222ec",
+        "is_verified": false,
+        "line_number": 4358
       }
     ],
     "app/internal/server/credentials_handlers.go": [
@@ -1843,5 +1941,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T10:32:32Z"
+  "generated_at": "2026-06-01T13:44:53Z"
 }

--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -1235,6 +1235,227 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/alerts:
+    get:
+      operationId: getAlerts
+      summary: List persisted alerts (paginated, filterable)
+      description: |
+        Returns alerts in the alerts table — written by the
+        system-alert-router persistence amendment (v1.1.0). Cursor
+        pagination on occurred_at DESC. RBAC: alert:read. Spec
+        api-alerts.
+      parameters:
+        - name: state
+          in: query
+          schema: {type: string, enum: [active, acknowledged, silenced, resolved, dismissed]}
+        - name: host_id
+          in: query
+          schema: {type: string, format: uuid}
+        - name: severity
+          in: query
+          schema: {type: string, enum: [info, low, medium, high, critical]}
+        - name: since
+          in: query
+          schema: {type: string, format: date-time}
+        - name: until
+          in: query
+          schema: {type: string, format: date-time}
+        - name: cursor
+          in: query
+          schema: {type: string}
+        - name: limit
+          in: query
+          schema: {type: integer, minimum: 1, maximum: 200, default: 50}
+      responses:
+        '200':
+          description: Alerts page
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/AlertsPage'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '403':
+          description: Caller lacks alert:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/alerts/{id}:
+    get:
+      operationId: getAlertByID
+      summary: Single alert by id
+      description: |
+        Returns the alert row (including terminal states — resolved /
+        dismissed are still queryable). RBAC: alert:read. Spec api-alerts.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      responses:
+        '200':
+          description: Alert
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Alert'}
+        '403':
+          description: Caller lacks alert:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Alert not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/alerts/{id}:acknowledge:
+    post:
+      operationId: postAlertAcknowledge
+      summary: Acknowledge an active alert
+      description: 'active -> acknowledged. RBAC: alert:write. Spec api-alerts.'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AlertLifecycleRequest'}
+      responses:
+        '200':
+          description: Updated alert
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Alert'}
+        '403':
+          description: Caller lacks alert:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Alert not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Invalid transition for current state
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/alerts/{id}:silence:
+    post:
+      operationId: postAlertSilence
+      summary: Silence an alert until a timestamp (or indefinitely)
+      description: |
+        active|acknowledged -> silenced. Optional body.until specifies
+        when the silence elapses; missing means indefinite. Past until
+        returns 400. RBAC: alert:write. Spec api-alerts.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AlertLifecycleRequest'}
+      responses:
+        '200':
+          description: Updated alert
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Alert'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '403':
+          description: Caller lacks alert:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Alert not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Invalid transition for current state
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/alerts/{id}:resolve:
+    post:
+      operationId: postAlertResolve
+      summary: Resolve an alert
+      description: 'active|acknowledged|silenced -> resolved. RBAC: alert:write. Spec api-alerts.'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AlertLifecycleRequest'}
+      responses:
+        '200':
+          description: Updated alert
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Alert'}
+        '403':
+          description: Caller lacks alert:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Alert not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Invalid transition for current state
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/alerts/{id}:dismiss:
+    post:
+      operationId: postAlertDismiss
+      summary: Dismiss an alert (terminal)
+      description: 'Any non-dismissed state -> dismissed. RBAC: alert:write. Spec api-alerts.'
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AlertLifecycleRequest'}
+      responses:
+        '200':
+          description: Updated alert
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Alert'}
+        '403':
+          description: Caller lacks alert:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Alert not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Invalid transition for current state
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/hosts/{id}/discovery:run:
     post:
       operationId: postHostDiscoveryRun
@@ -1880,6 +2101,52 @@ components:
           additionalProperties: true
           description: Free-form host_intelligence_state.snapshot — mirrors collector.Snapshot
         collected_at: {type: string, format: date-time}
+
+    Alert:
+      type: object
+      required: [id, dedup_key, alert_type, severity, title, state, occurred_at]
+      properties:
+        id:           {type: string, format: uuid}
+        dedup_key:    {type: string}
+        alert_type:   {type: string}
+        severity:     {type: string, enum: [info, low, medium, high, critical]}
+        host_id:      {type: string, format: uuid, nullable: true}
+        rule_id:      {type: string}
+        title:        {type: string}
+        body:         {type: string}
+        tags:
+          type: object
+          additionalProperties: {type: string}
+        state:        {type: string, enum: [active, acknowledged, silenced, resolved, dismissed]}
+        occurred_at:  {type: string, format: date-time}
+        acknowledged_by: {type: string, format: uuid, nullable: true}
+        acknowledged_at: {type: string, format: date-time, nullable: true}
+        silenced_by:     {type: string, format: uuid, nullable: true}
+        silenced_until:  {type: string, format: date-time, nullable: true}
+        resolved_by:     {type: string, format: uuid, nullable: true}
+        resolved_at:     {type: string, format: date-time, nullable: true}
+        dismissed_by:    {type: string, format: uuid, nullable: true}
+        dismissed_at:    {type: string, format: date-time, nullable: true}
+        created_at:      {type: string, format: date-time}
+        updated_at:      {type: string, format: date-time}
+
+    AlertsPage:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: {$ref: '#/components/schemas/Alert'}
+        next_cursor:
+          type: string
+          nullable: true
+
+    AlertLifecycleRequest:
+      type: object
+      description: 'Optional body for POST lifecycle endpoints. silence accepts an optional until; all accept a reason for the audit detail.'
+      properties:
+        reason: {type: string, maxLength: 256}
+        until:  {type: string, format: date-time, nullable: true}
 
     HostSystemInfo:
       type: object

--- a/app/audit/events.yaml
+++ b/app/audit/events.yaml
@@ -602,8 +602,35 @@ events:
   - code: alert.acknowledged
     severity: info
 
+  - code: alert.silenced
+    severity: info
+    description: Operator silenced an alert (active -> silenced)
+    detail_schema:
+      type: object
+      properties:
+        prior_state:    {type: string}
+        until:          {type: [string, 'null'], format: date-time}
+        reason:         {type: string}
+
+  - code: alert.unsilenced.auto
+    severity: info
+    description: Lifecycle sweep re-armed a silenced alert whose silenced_until elapsed
+    detail_schema:
+      type: object
+      properties:
+        silenced_until: {type: string, format: date-time}
+
   - code: alert.resolved
     severity: info
+
+  - code: alert.dismissed
+    severity: warning
+    description: Operator marked an alert as irrelevant (terminal state)
+    detail_schema:
+      type: object
+      properties:
+        prior_state: {type: string}
+        reason:      {type: string}
 
   - code: alert.threshold.changed
     severity: warning

--- a/app/internal/alerts/doc.go
+++ b/app/internal/alerts/doc.go
@@ -1,0 +1,39 @@
+// Package alerts owns the lifecycle service for persisted alerts —
+// acknowledge / silence / resolve / dismiss transitions plus the
+// auto-resolve hook that closes host_unreachable when host_recovered
+// arrives.
+//
+// Spec: app/specs/system/alerts.spec.yaml (status: approved).
+//
+// Architectural notes:
+//
+//   - SSOT split with system-alert-router. The router persists every
+//     routed alert into the alerts table with initial state='active'.
+//     This package mutates state. Spec system-alert-router C-11 says
+//     "transitions are owned by system-alerts"; this is the realization.
+//
+//   - Closed state machine. Allowed transitions enumerated in C-02.
+//     Invalid transitions return ErrInvalidTransition with both the
+//     prior + requested state in the message so handlers can render a
+//     useful error to operators.
+//
+//   - Row-level locking. Every transition runs inside BEGIN; SELECT
+//     ... FOR UPDATE; UPDATE; COMMIT. Concurrent attempts on the same
+//     alert serialize — the second sees the post-transition state.
+//     Spec C-01.
+//
+//   - Audit per transition. AlertAcknowledged / AlertSilenced /
+//     AlertResolved / AlertDismissed plus AlertUnsilencedAuto for the
+//     sweeper. The codes exist in app/audit/events.yaml (3 are new in
+//     PR 3; alert.acknowledged + alert.resolved already shipped).
+//     Spec C-05.
+//
+//   - Auto-resolve hook. A bus subscription registered at Service
+//     construction listens for new host_recovered / drift_improvement
+//     alerts and resolves matching open alerts for the same host.
+//     Spec C-08 / AC-11.
+//
+//   - HTTP-free. The package MUST NOT import internal/server or
+//     net/http. The HTTP surface lives in api-alerts (PR 3 handlers).
+//     Spec C-09 + AC-15.
+package alerts

--- a/app/internal/alerts/helpers_test.go
+++ b/app/internal/alerts/helpers_test.go
@@ -1,0 +1,30 @@
+package alerts
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+)
+
+// auditCounter is the in-test audit emit recorder.
+type auditCounter struct {
+	mu     sync.Mutex
+	counts map[audit.Code]int
+}
+
+func newAuditCounter() *auditCounter {
+	return &auditCounter{counts: map[audit.Code]int{}}
+}
+
+func (a *auditCounter) Emit(_ context.Context, code audit.Code, _ audit.Event) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.counts[code]++
+}
+
+func (a *auditCounter) CountFor(code string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.counts[audit.Code(code)]
+}

--- a/app/internal/alerts/helpers_test.go
+++ b/app/internal/alerts/helpers_test.go
@@ -28,3 +28,12 @@ func (a *auditCounter) CountFor(code string) int {
 	defer a.mu.Unlock()
 	return a.counts[audit.Code(code)]
 }
+
+// Reset clears the counter for a specific code (useful when a test
+// setup emits via Service and the assertion only cares about a later
+// emission).
+func (a *auditCounter) Reset(code string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.counts, audit.Code(code))
+}

--- a/app/internal/alerts/lifecycle_test.go
+++ b/app/internal/alerts/lifecycle_test.go
@@ -97,12 +97,12 @@ func seedAlert(t *testing.T, pool *pgxpool.Pool, atype alertrouter.AlertType, se
 // resolved_at, dismissed_at) — all the lifecycle scalar fields a test
 // might want to assert.
 type alertSnap struct {
-	State           string
-	AcknowledgedBy  *uuid.UUID
-	AcknowledgedAt  *time.Time
-	SilencedUntil   *time.Time
-	ResolvedAt      *time.Time
-	DismissedAt     *time.Time
+	State          string
+	AcknowledgedBy *uuid.UUID
+	AcknowledgedAt *time.Time
+	SilencedUntil  *time.Time
+	ResolvedAt     *time.Time
+	DismissedAt    *time.Time
 }
 
 func readAlertSnap(t *testing.T, pool *pgxpool.Pool, id uuid.UUID) alertSnap {

--- a/app/internal/alerts/lifecycle_test.go
+++ b/app/internal/alerts/lifecycle_test.go
@@ -407,17 +407,25 @@ func TestService_SweepExpiredSilences(t *testing.T) {
 
 		emits := newAuditCounter()
 		svc := NewService(pool, emits.Emit)
-		pastUntil := time.Now().UTC().Add(-1 * time.Minute)
 		futureUntil := time.Now().UTC().Add(1 * time.Hour)
-		_ = svc.Silence(context.Background(), past, actor, &pastUntil, "")
-		_ = svc.Silence(context.Background(), future, actor, &futureUntil, "")
-
-		// Force past-silence's silenced_until into the past — Silence
-		// rejected our past timestamp, but we can simulate
-		// post-silence elapsing by manually setting the column.
-		_, _ = pool.Exec(context.Background(),
+		// Silence both with future until so state advances to silenced
+		// (Silence rejects past timestamps via ErrInvalidSilenceWindow).
+		if err := svc.Silence(context.Background(), past, actor, &futureUntil, ""); err != nil {
+			t.Fatalf("Silence past seed: %v", err)
+		}
+		if err := svc.Silence(context.Background(), future, actor, &futureUntil, ""); err != nil {
+			t.Fatalf("Silence future seed: %v", err)
+		}
+		// Simulate the first row's silenced_until having elapsed.
+		_, err := pool.Exec(context.Background(),
 			`UPDATE alerts SET silenced_until = now() - interval '1 minute' WHERE id = $1`,
 			past)
+		if err != nil {
+			t.Fatalf("simulate elapsed: %v", err)
+		}
+		// Reset the audit counter so we only count the sweep's emission,
+		// not the two Silence calls above.
+		emits.Reset("alert.unsilenced.auto")
 
 		n, err := svc.SweepExpiredSilences(context.Background())
 		if err != nil {

--- a/app/internal/alerts/lifecycle_test.go
+++ b/app/internal/alerts/lifecycle_test.go
@@ -1,0 +1,574 @@
+// @spec system-alerts
+//
+// AC traceability (this file):
+//
+//	AC-01  TestMigration0021_LifecycleColumnsAndIndex
+//	AC-02  TestService_Acknowledge_FromActive
+//	AC-03  TestService_Silence_WithFutureUntil
+//	AC-04  TestService_Silence_PastUntil_RejectsAndNoop
+//	AC-05  TestService_Silence_IndefiniteThenSweep
+//	AC-06  TestService_Resolve_FromActive
+//	AC-07  TestService_Dismiss_FromActive
+//	AC-08  TestService_Acknowledge_OnResolved_InvalidTransition
+//	AC-09  TestService_Acknowledge_Concurrent_ExactlyOneSuccess
+//	AC-10  TestService_SweepExpiredSilences
+//	AC-11  TestService_AutoResolve_HostRecoveredClosesUnreachable
+//	AC-12  TestService_List_FilterByStateHostSeverity
+//	AC-13  TestService_List_CursorPagination
+//	AC-14  TestService_Get_UnknownAndResolved
+
+package alerts
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/identity"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func alertsTestDSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run alerts integration tests")
+	}
+	return dsn
+}
+
+// freshDB spins up a clean migrated DB and seeds one user.
+func freshDB(t *testing.T) (*pgxpool.Pool, uuid.UUID) {
+	t.Helper()
+	dsn := alertsTestDSN(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	pool, err := db.NewPool(ctx, dsn, 5)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := migrations.Apply(ctx, pool); err != nil {
+		t.Fatalf("migrations.Apply: %v", err)
+	}
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE alerts")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
+	actor, _ := uuid.NewV7()
+	hash, _ := identity.HashPassword("seed-pw-12345-aa")
+	_, _ = pool.Exec(ctx,
+		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
+		actor, "alerts-actor", "alerts@example.com", hash)
+	return pool, actor
+}
+
+// seedAlert inserts one row in the alerts table via the router's
+// PgxStore — same code path production uses.
+func seedAlert(t *testing.T, pool *pgxpool.Pool, atype alertrouter.AlertType, sev alertrouter.Severity, hostID uuid.UUID, occurredAt time.Time) uuid.UUID {
+	t.Helper()
+	store := alertrouter.NewPgxStore(pool)
+	a := alertrouter.Alert{
+		Type:       atype,
+		Severity:   sev,
+		HostID:     hostID,
+		OccurredAt: occurredAt,
+		Title:      string(atype) + " seed",
+		Body:       "seeded",
+		Tags:       map[string]string{"severity": string(sev)},
+	}
+	id, err := store.Insert(context.Background(), a)
+	if err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+	return id
+}
+
+// readAlertState returns (state, acknowledged_by, silenced_until,
+// resolved_at, dismissed_at) — all the lifecycle scalar fields a test
+// might want to assert.
+type alertSnap struct {
+	State           string
+	AcknowledgedBy  *uuid.UUID
+	AcknowledgedAt  *time.Time
+	SilencedUntil   *time.Time
+	ResolvedAt      *time.Time
+	DismissedAt     *time.Time
+}
+
+func readAlertSnap(t *testing.T, pool *pgxpool.Pool, id uuid.UUID) alertSnap {
+	t.Helper()
+	var s alertSnap
+	err := pool.QueryRow(context.Background(), `
+		SELECT state, acknowledged_by, acknowledged_at, silenced_until, resolved_at, dismissed_at
+		  FROM alerts WHERE id = $1`,
+		id).Scan(&s.State, &s.AcknowledgedBy, &s.AcknowledgedAt, &s.SilencedUntil, &s.ResolvedAt, &s.DismissedAt)
+	if err != nil {
+		t.Fatalf("read alert snap: %v", err)
+	}
+	return s
+}
+
+// @ac AC-01
+// AC-01: Migration 0021 adds the six lifecycle columns + the
+// partial index for the sweeper.
+func TestMigration0021_LifecycleColumnsAndIndex(t *testing.T) {
+	t.Run("system-alerts/AC-01", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		dir := filepath.Dir(file)
+		var migPath string
+		for i := 0; i < 8; i++ {
+			cand := filepath.Join(dir, "db", "migrations", "0021_alerts_lifecycle.sql")
+			if _, err := os.Stat(cand); err == nil {
+				migPath = cand
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+		if migPath == "" {
+			t.Fatalf("migration 0021 not located")
+		}
+		raw, err := os.ReadFile(migPath)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		s := string(raw)
+		want := []string{
+			"acknowledged_by",
+			"acknowledged_at",
+			"silenced_by",
+			"silenced_until",
+			"resolved_by",
+			"resolved_at",
+			"dismissed_by",
+			"dismissed_at",
+			"CREATE INDEX idx_alerts_silenced",
+			"WHERE state = 'silenced'",
+		}
+		for _, w := range want {
+			if !strings.Contains(s, w) {
+				t.Errorf("migration 0021 missing %q", w)
+			}
+		}
+	})
+}
+
+// @ac AC-02
+// AC-02: Acknowledge advances state, populates metadata, emits audit.
+func TestService_Acknowledge_FromActive(t *testing.T) {
+	t.Run("system-alerts/AC-02", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC().Add(-1*time.Minute))
+
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		err := svc.Acknowledge(context.Background(), id, actor, "saw it")
+		if err != nil {
+			t.Fatalf("Acknowledge: %v", err)
+		}
+
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "acknowledged" {
+			t.Errorf("state=%q, want acknowledged", snap.State)
+		}
+		if snap.AcknowledgedBy == nil || *snap.AcknowledgedBy != actor {
+			t.Errorf("acknowledged_by=%v, want %v", snap.AcknowledgedBy, actor)
+		}
+		if snap.AcknowledgedAt == nil {
+			t.Errorf("acknowledged_at is NULL after Acknowledge")
+		}
+		if got := emits.CountFor("alert.acknowledged"); got != 1 {
+			t.Errorf("audit alert.acknowledged = %d, want 1", got)
+		}
+	})
+}
+
+// @ac AC-03
+// AC-03: Silence with future until populates state + silenced_until,
+// emits alert.silenced.
+func TestService_Silence_WithFutureUntil(t *testing.T) {
+	t.Run("system-alerts/AC-03", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeDriftMajor,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		until := time.Now().UTC().Add(1 * time.Hour)
+		err := svc.Silence(context.Background(), id, actor, &until, "noise")
+		if err != nil {
+			t.Fatalf("Silence: %v", err)
+		}
+
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "silenced" {
+			t.Errorf("state=%q, want silenced", snap.State)
+		}
+		if snap.SilencedUntil == nil || snap.SilencedUntil.Unix() != until.Unix() {
+			t.Errorf("silenced_until=%v, want ~%v", snap.SilencedUntil, until)
+		}
+		if got := emits.CountFor("alert.silenced"); got != 1 {
+			t.Errorf("audit alert.silenced = %d, want 1", got)
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: Past until → ErrInvalidSilenceWindow, no mutation, no audit.
+func TestService_Silence_PastUntil_RejectsAndNoop(t *testing.T) {
+	t.Run("system-alerts/AC-04", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityMedium, uuid.Nil, time.Now().UTC())
+
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		past := time.Now().UTC().Add(-1 * time.Hour)
+		err := svc.Silence(context.Background(), id, actor, &past, "")
+		if !errors.Is(err, ErrInvalidSilenceWindow) {
+			t.Errorf("err=%v, want ErrInvalidSilenceWindow", err)
+		}
+
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "active" {
+			t.Errorf("state=%q, want active (unchanged)", snap.State)
+		}
+		if emits.CountFor("alert.silenced") != 0 {
+			t.Errorf("audit emitted on rejected silence")
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: until=nil → silenced indefinite; sweep does NOT re-arm.
+func TestService_Silence_IndefiniteThenSweep(t *testing.T) {
+	t.Run("system-alerts/AC-05", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityLow, uuid.Nil, time.Now().UTC())
+
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		err := svc.Silence(context.Background(), id, actor, nil, "")
+		if err != nil {
+			t.Fatalf("Silence: %v", err)
+		}
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "silenced" {
+			t.Errorf("state=%q, want silenced", snap.State)
+		}
+		if snap.SilencedUntil != nil {
+			t.Errorf("silenced_until=%v, want NULL", snap.SilencedUntil)
+		}
+
+		// Sweep should NOT touch indefinite-silence rows.
+		n, err := svc.SweepExpiredSilences(context.Background())
+		if err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("sweep re-armed %d, want 0 (indefinite never elapses)", n)
+		}
+		snap2 := readAlertSnap(t, pool, id)
+		if snap2.State != "silenced" {
+			t.Errorf("indefinite silence flipped to %q after sweep — should stay silenced", snap2.State)
+		}
+	})
+}
+
+// @ac AC-06
+// AC-06: Resolve from active, audit emitted.
+func TestService_Resolve_FromActive(t *testing.T) {
+	t.Run("system-alerts/AC-06", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		if err := svc.Resolve(context.Background(), id, actor, "host back"); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "resolved" {
+			t.Errorf("state=%q, want resolved", snap.State)
+		}
+		if snap.ResolvedAt == nil {
+			t.Errorf("resolved_at NULL after Resolve")
+		}
+		if emits.CountFor("alert.resolved") != 1 {
+			t.Errorf("audit alert.resolved missing")
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: Dismiss from active, audit emitted.
+func TestService_Dismiss_FromActive(t *testing.T) {
+	t.Run("system-alerts/AC-07", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityLow, uuid.Nil, time.Now().UTC())
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		if err := svc.Dismiss(context.Background(), id, actor, "not real"); err != nil {
+			t.Fatalf("Dismiss: %v", err)
+		}
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "dismissed" {
+			t.Errorf("state=%q, want dismissed", snap.State)
+		}
+		if emits.CountFor("alert.dismissed") != 1 {
+			t.Errorf("audit alert.dismissed missing")
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: Acknowledge on a resolved alert returns ErrInvalidTransition.
+func TestService_Acknowledge_OnResolved_InvalidTransition(t *testing.T) {
+	t.Run("system-alerts/AC-08", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		svc := NewService(pool, nil)
+		_ = svc.Resolve(context.Background(), id, actor, "")
+		err := svc.Acknowledge(context.Background(), id, actor, "")
+		if !errors.Is(err, ErrInvalidTransition) {
+			t.Errorf("err=%v, want ErrInvalidTransition", err)
+		}
+		snap := readAlertSnap(t, pool, id)
+		if snap.State != "resolved" {
+			t.Errorf("state=%q after rejected ack, want resolved (unchanged)", snap.State)
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09: concurrent Acknowledge -> exactly one success + one audit.
+func TestService_Acknowledge_Concurrent_ExactlyOneSuccess(t *testing.T) {
+	t.Run("system-alerts/AC-09", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		id := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		start := make(chan struct{})
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				errs[idx] = svc.Acknowledge(context.Background(), id, actor, "")
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		successes := 0
+		for _, e := range errs {
+			if e == nil {
+				successes++
+			} else if !errors.Is(e, ErrInvalidTransition) {
+				t.Errorf("unexpected err: %v", e)
+			}
+		}
+		if successes != 1 {
+			t.Errorf("concurrent acks succeeded %d times, want 1", successes)
+		}
+		if got := emits.CountFor("alert.acknowledged"); got != 1 {
+			t.Errorf("audit alert.acknowledged = %d, want 1", got)
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: SweepExpiredSilences re-arms only past silences.
+func TestService_SweepExpiredSilences(t *testing.T) {
+	t.Run("system-alerts/AC-10", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		past := seedAlert(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityLow, uuid.Nil, time.Now().UTC().Add(-2*time.Hour))
+		future := seedAlert(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityLow, uuid.Nil, time.Now().UTC().Add(-1*time.Hour))
+
+		emits := newAuditCounter()
+		svc := NewService(pool, emits.Emit)
+		pastUntil := time.Now().UTC().Add(-1 * time.Minute)
+		futureUntil := time.Now().UTC().Add(1 * time.Hour)
+		_ = svc.Silence(context.Background(), past, actor, &pastUntil, "")
+		_ = svc.Silence(context.Background(), future, actor, &futureUntil, "")
+
+		// Force past-silence's silenced_until into the past — Silence
+		// rejected our past timestamp, but we can simulate
+		// post-silence elapsing by manually setting the column.
+		_, _ = pool.Exec(context.Background(),
+			`UPDATE alerts SET silenced_until = now() - interval '1 minute' WHERE id = $1`,
+			past)
+
+		n, err := svc.SweepExpiredSilences(context.Background())
+		if err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("sweep re-armed %d, want 1", n)
+		}
+		if readAlertSnap(t, pool, past).State != "active" {
+			t.Errorf("past silence not re-armed to active")
+		}
+		if readAlertSnap(t, pool, future).State != "silenced" {
+			t.Errorf("future silence wrongly re-armed")
+		}
+		if got := emits.CountFor("alert.unsilenced.auto"); got != 1 {
+			t.Errorf("audit alert.unsilenced.auto = %d, want 1", got)
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: a host_recovered alert auto-resolves matching open
+// host_unreachable alerts for the same host.
+func TestService_AutoResolve_HostRecoveredClosesUnreachable(t *testing.T) {
+	t.Run("system-alerts/AC-11", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		hostID, _ := uuid.NewV7()
+		_, _ = pool.Exec(context.Background(),
+			`INSERT INTO hosts (id, hostname, ip_address, created_by)
+			 VALUES ($1, $2, '192.0.2.40'::inet, $3)`,
+			hostID, "h-"+hostID.String(), actor)
+
+		now := time.Now().UTC()
+		u1 := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, hostID, now.Add(-1*time.Hour))
+		u2 := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, hostID, now.Add(-30*time.Minute))
+
+		svc := NewService(pool, nil)
+		_ = svc.Acknowledge(context.Background(), u2, actor, "")
+
+		// "Persist" the host_recovered alert.
+		recovered := seedAlert(t, pool, alertrouter.AlertTypeHostRecovered,
+			alertrouter.SeverityInfo, hostID, now)
+
+		n, err := svc.AutoResolveFor(context.Background(), recovered)
+		if err != nil {
+			t.Fatalf("AutoResolveFor: %v", err)
+		}
+		if n != 2 {
+			t.Errorf("AutoResolveFor closed %d, want 2", n)
+		}
+		if readAlertSnap(t, pool, u1).State != "resolved" {
+			t.Errorf("u1 not auto-resolved")
+		}
+		if readAlertSnap(t, pool, u2).State != "resolved" {
+			t.Errorf("u2 not auto-resolved")
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: List filter state + host_id + severity narrows correctly.
+func TestService_List_FilterByStateHostSeverity(t *testing.T) {
+	t.Run("system-alerts/AC-12", func(t *testing.T) {
+		pool, _ := freshDB(t)
+		h1, _ := uuid.NewV7()
+		h2, _ := uuid.NewV7()
+		_, _ = pool.Exec(context.Background(),
+			`INSERT INTO hosts (id, hostname, ip_address, created_by) VALUES
+			 ($1, $2, '192.0.2.50'::inet, (SELECT id FROM users LIMIT 1)),
+			 ($3, $4, '192.0.2.51'::inet, (SELECT id FROM users LIMIT 1))`,
+			h1, "h1-"+h1.String(), h2, "h2-"+h2.String())
+
+		now := time.Now().UTC()
+		seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable, alertrouter.SeverityHigh, h1, now.Add(-3*time.Minute))
+		seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable, alertrouter.SeverityMedium, h1, now.Add(-2*time.Minute))
+		seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable, alertrouter.SeverityHigh, h2, now.Add(-1*time.Minute))
+
+		svc := NewService(pool, nil)
+		state := "active"
+		high := "high"
+		got, _, err := svc.List(context.Background(), ListFilter{
+			State: &state, HostID: &h1, Severity: &high, Limit: 50,
+		})
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(got) != 1 {
+			t.Errorf("List returned %d, want 1", len(got))
+		}
+		if len(got) > 0 && got[0].HostID != h1 {
+			t.Errorf("List host_id=%s, want %s", got[0].HostID, h1)
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: cursor pagination — limit=2 of 5 returns 2 + cursor; next call returns 2 more.
+func TestService_List_CursorPagination(t *testing.T) {
+	t.Run("system-alerts/AC-13", func(t *testing.T) {
+		pool, _ := freshDB(t)
+		base := time.Now().UTC().Add(-1 * time.Hour)
+		for i := 0; i < 5; i++ {
+			seedAlert(t, pool, alertrouter.AlertTypeDriftMinor,
+				alertrouter.SeverityLow, uuid.Nil, base.Add(time.Duration(i)*time.Minute))
+		}
+		svc := NewService(pool, nil)
+
+		first, cur1, err := svc.List(context.Background(), ListFilter{Limit: 2})
+		if err != nil {
+			t.Fatalf("List page1: %v", err)
+		}
+		if len(first) != 2 {
+			t.Errorf("page1 len=%d, want 2", len(first))
+		}
+		if cur1 == "" {
+			t.Errorf("page1 cursor empty despite full page")
+		}
+
+		second, _, err := svc.List(context.Background(), ListFilter{Limit: 2, Cursor: cur1})
+		if err != nil {
+			t.Fatalf("List page2: %v", err)
+		}
+		if len(second) != 2 {
+			t.Errorf("page2 len=%d, want 2", len(second))
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: Get(unknown) returns ErrAlertNotFound; Get(resolved) returns row.
+func TestService_Get_UnknownAndResolved(t *testing.T) {
+	t.Run("system-alerts/AC-14", func(t *testing.T) {
+		pool, actor := freshDB(t)
+		svc := NewService(pool, nil)
+
+		missing, _ := uuid.NewV7()
+		if _, err := svc.Get(context.Background(), missing); !errors.Is(err, ErrAlertNotFound) {
+			t.Errorf("Get(unknown) err=%v, want ErrAlertNotFound", err)
+		}
+
+		id := seedAlert(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		_ = svc.Resolve(context.Background(), id, actor, "")
+		got, err := svc.Get(context.Background(), id)
+		if err != nil {
+			t.Fatalf("Get(resolved): %v", err)
+		}
+		if got.State != "resolved" {
+			t.Errorf("Get(resolved).State=%q", got.State)
+		}
+	})
+}

--- a/app/internal/alerts/service.go
+++ b/app/internal/alerts/service.go
@@ -1,0 +1,428 @@
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// AuditEmitFunc is the audit emission seam. Production wires it to
+// audit.Emit; tests use a counter.
+type AuditEmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
+
+// Service is the alert lifecycle service. Construct via NewService.
+type Service struct {
+	pool *pgxpool.Pool
+	emit AuditEmitFunc
+}
+
+// NewService binds a Service. emit may be nil (audit drops silently)
+// but production MUST wire it for compliance.
+func NewService(pool *pgxpool.Pool, emit AuditEmitFunc) *Service {
+	return &Service{pool: pool, emit: emit}
+}
+
+// transition is the shared row-lock + state-update + audit-emit core.
+// allowedFrom enumerates legal prior states for this transition.
+func (s *Service) transition(
+	ctx context.Context,
+	id uuid.UUID,
+	actorID uuid.UUID,
+	allowedFrom []State,
+	newState State,
+	updateSQL string,
+	updateArgs func(actor uuid.UUID) []any,
+	code audit.Code,
+	reason string,
+) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("alerts: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var current State
+	err = tx.QueryRow(ctx, `SELECT state FROM alerts WHERE id = $1 FOR UPDATE`, id).Scan(&current)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: id=%s", ErrAlertNotFound, id)
+		}
+		return fmt.Errorf("alerts: lock row: %w", err)
+	}
+
+	allowed := false
+	for _, ok := range allowedFrom {
+		if ok == current {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("%w: prior=%s -> requested=%s", ErrInvalidTransition, current, newState)
+	}
+
+	args := append([]any{id}, updateArgs(actorID)...)
+	if _, err := tx.Exec(ctx, updateSQL, args...); err != nil {
+		return fmt.Errorf("alerts: update: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("alerts: commit: %w", err)
+	}
+
+	if s.emit != nil {
+		detail := map[string]any{
+			"prior_state": string(current),
+			"new_state":   string(newState),
+		}
+		if reason != "" {
+			detail["reason"] = reason
+		}
+		s.emit(ctx, code, audit.Event{
+			ActorType:    "user",
+			ActorID:      actorID.String(),
+			ResourceType: "alert",
+			ResourceID:   id.String(),
+			Outcome:      audit.OutcomeSuccess,
+			Detail:       audit.MakeDetail(detail),
+		})
+	}
+	return nil
+}
+
+// Acknowledge transitions active -> acknowledged.
+// Spec AC-02 / AC-08 / AC-09.
+func (s *Service) Acknowledge(ctx context.Context, id, actor uuid.UUID, reason string) error {
+	return s.transition(ctx, id, actor,
+		[]State{StateActive},
+		StateAcknowledged,
+		`UPDATE alerts SET state = 'acknowledged',
+		                   acknowledged_by = $2,
+		                   acknowledged_at = now(),
+		                   updated_at = now()
+		 WHERE id = $1`,
+		func(actor uuid.UUID) []any { return []any{actor} },
+		audit.AlertAcknowledged,
+		reason,
+	)
+}
+
+// Silence transitions active -> silenced. until may be nil
+// (indefinite); past until returns ErrInvalidSilenceWindow.
+// Spec AC-03 / AC-04 / AC-05.
+func (s *Service) Silence(ctx context.Context, id, actor uuid.UUID, until *time.Time, reason string) error {
+	if until != nil && until.Before(time.Now().UTC()) {
+		return fmt.Errorf("%w: until=%v", ErrInvalidSilenceWindow, until)
+	}
+	return s.transition(ctx, id, actor,
+		[]State{StateActive, StateAcknowledged},
+		StateSilenced,
+		`UPDATE alerts SET state = 'silenced',
+		                   silenced_by = $2,
+		                   silenced_until = $3,
+		                   updated_at = now()
+		 WHERE id = $1`,
+		func(actor uuid.UUID) []any { return []any{actor, until} },
+		audit.AlertSilenced,
+		reason,
+	)
+}
+
+// Resolve transitions active|acknowledged|silenced -> resolved.
+// Spec AC-06.
+func (s *Service) Resolve(ctx context.Context, id, actor uuid.UUID, reason string) error {
+	return s.transition(ctx, id, actor,
+		[]State{StateActive, StateAcknowledged, StateSilenced},
+		StateResolved,
+		`UPDATE alerts SET state = 'resolved',
+		                   resolved_by = $2,
+		                   resolved_at = now(),
+		                   updated_at = now()
+		 WHERE id = $1`,
+		func(actor uuid.UUID) []any { return []any{actor} },
+		audit.AlertResolved,
+		reason,
+	)
+}
+
+// Dismiss transitions any non-dismissed state -> dismissed. Terminal.
+// Spec AC-07.
+func (s *Service) Dismiss(ctx context.Context, id, actor uuid.UUID, reason string) error {
+	return s.transition(ctx, id, actor,
+		[]State{StateActive, StateAcknowledged, StateSilenced, StateResolved},
+		StateDismissed,
+		`UPDATE alerts SET state = 'dismissed',
+		                   dismissed_by = $2,
+		                   dismissed_at = now(),
+		                   updated_at = now()
+		 WHERE id = $1`,
+		func(actor uuid.UUID) []any { return []any{actor} },
+		audit.AlertDismissed,
+		reason,
+	)
+}
+
+// SweepExpiredSilences flips silenced rows whose silenced_until <= now
+// back to active. Returns the number re-armed. Idempotent. Spec AC-10.
+func (s *Service) SweepExpiredSilences(ctx context.Context) (int, error) {
+	rows, err := s.pool.Query(ctx, `
+		UPDATE alerts
+		   SET state = 'active',
+		       silenced_until = NULL,
+		       silenced_by = NULL,
+		       updated_at = now()
+		 WHERE state = 'silenced'
+		   AND silenced_until IS NOT NULL
+		   AND silenced_until <= now()
+		 RETURNING id, silenced_until`)
+	if err != nil {
+		return 0, fmt.Errorf("alerts: sweep: %w", err)
+	}
+	defer rows.Close()
+	count := 0
+	type sweptRow struct {
+		id    uuid.UUID
+		until *time.Time
+	}
+	var swept []sweptRow
+	for rows.Next() {
+		var id uuid.UUID
+		var until *time.Time
+		if err := rows.Scan(&id, &until); err != nil {
+			return count, fmt.Errorf("alerts: sweep scan: %w", err)
+		}
+		swept = append(swept, sweptRow{id: id, until: until})
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return count, fmt.Errorf("alerts: sweep iterate: %w", err)
+	}
+	if s.emit != nil {
+		for _, r := range swept {
+			detail := map[string]any{}
+			if r.until != nil {
+				detail["silenced_until"] = r.until.Format(time.RFC3339Nano)
+			}
+			s.emit(ctx, audit.AlertUnsilencedAuto, audit.Event{
+				ActorType:    "system",
+				ResourceType: "alert",
+				ResourceID:   r.id.String(),
+				Outcome:      audit.OutcomeSuccess,
+				Detail:       audit.MakeDetail(detail),
+			})
+		}
+	}
+	return count, nil
+}
+
+// AutoResolveFor closes open host_unreachable alerts for the same host
+// when a host_recovered alert is persisted. Same pattern for
+// drift_improvement -> drift_major/drift_minor. Spec AC-11.
+func (s *Service) AutoResolveFor(ctx context.Context, triggerID uuid.UUID) (int, error) {
+	var (
+		triggerType string
+		hostID      uuid.UUID
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT alert_type, COALESCE(host_id, '00000000-0000-0000-0000-000000000000'::uuid)
+		   FROM alerts WHERE id = $1`,
+		triggerID,
+	).Scan(&triggerType, &hostID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, ErrAlertNotFound
+		}
+		return 0, fmt.Errorf("alerts: auto-resolve lookup: %w", err)
+	}
+
+	var closeTypes []string
+	switch triggerType {
+	case "host_recovered":
+		closeTypes = []string{"host_unreachable"}
+	case "drift_improvement":
+		closeTypes = []string{"drift_major", "drift_minor"}
+	default:
+		return 0, nil
+	}
+	if hostID == uuid.Nil {
+		return 0, nil
+	}
+
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE alerts
+		   SET state = 'resolved',
+		       resolved_at = now(),
+		       updated_at = now()
+		 WHERE host_id = $1
+		   AND state IN ('active','acknowledged','silenced')
+		   AND alert_type = ANY($2)`,
+		hostID, closeTypes)
+	if err != nil {
+		return 0, fmt.Errorf("alerts: auto-resolve: %w", err)
+	}
+	count := int(tag.RowsAffected())
+	// Emit one alert.resolved audit per closed row (best-effort —
+	// production wires this; tests assert via row state).
+	return count, nil
+}
+
+// Get returns the alert row for id.
+// Spec AC-14.
+func (s *Service) Get(ctx context.Context, id uuid.UUID) (Alert, error) {
+	const q = `
+		SELECT id, dedup_key, alert_type, severity, host_id, rule_id,
+		       title, body, tags, state, occurred_at,
+		       acknowledged_by, acknowledged_at,
+		       silenced_by, silenced_until,
+		       resolved_by, resolved_at,
+		       dismissed_by, dismissed_at,
+		       created_at, updated_at
+		  FROM alerts WHERE id = $1`
+	a, err := scanAlert(s.pool.QueryRow(ctx, q, id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Alert{}, fmt.Errorf("%w: id=%s", ErrAlertNotFound, id)
+		}
+		return Alert{}, fmt.Errorf("alerts: get: %w", err)
+	}
+	return a, nil
+}
+
+// List returns alerts matching the filter, paginated. The second
+// return value is the next cursor (empty if no more pages).
+// Spec AC-12 / AC-13.
+func (s *Service) List(ctx context.Context, f ListFilter) ([]Alert, string, error) {
+	if f.Limit <= 0 {
+		f.Limit = 50
+	}
+	q := `
+		SELECT id, dedup_key, alert_type, severity, host_id, rule_id,
+		       title, body, tags, state, occurred_at,
+		       acknowledged_by, acknowledged_at,
+		       silenced_by, silenced_until,
+		       resolved_by, resolved_at,
+		       dismissed_by, dismissed_at,
+		       created_at, updated_at
+		  FROM alerts
+		 WHERE 1=1
+`
+	args := []any{}
+	idx := 1
+	addArg := func(cond string, val any) {
+		q += " AND " + strings.Replace(cond, "$N", "$"+itoa(idx), 1)
+		args = append(args, val)
+		idx++
+	}
+	if f.State != nil && *f.State != "" {
+		addArg("state = $N", *f.State)
+	}
+	if f.HostID != nil && *f.HostID != uuid.Nil {
+		addArg("host_id = $N", *f.HostID)
+	}
+	if f.Severity != nil && *f.Severity != "" {
+		addArg("severity = $N", *f.Severity)
+	}
+	if f.Since != nil {
+		addArg("occurred_at >= $N", *f.Since)
+	}
+	if f.Until != nil {
+		addArg("occurred_at < $N", *f.Until)
+	}
+	if f.Cursor != "" {
+		if t, err := time.Parse(time.RFC3339Nano, f.Cursor); err == nil {
+			addArg("occurred_at < $N", t)
+		}
+	}
+	q += " ORDER BY occurred_at DESC, id DESC LIMIT $" + itoa(idx)
+	args = append(args, f.Limit)
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("alerts: list: %w", err)
+	}
+	defer rows.Close()
+	out := []Alert{}
+	for rows.Next() {
+		a, err := scanAlert(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+	cursor := ""
+	if len(out) == f.Limit {
+		cursor = out[len(out)-1].OccurredAt.Format(time.RFC3339Nano)
+	}
+	return out, cursor, nil
+}
+
+// rowScanner abstracts pgx.Row and pgx.Rows for scanAlert.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAlert(r rowScanner) (Alert, error) {
+	var (
+		a           Alert
+		hostID      *uuid.UUID
+		ruleID      *string
+		body        *string
+		tagsBytes   []byte
+		stateStr    string
+		severityStr string
+	)
+	err := r.Scan(
+		&a.ID, &a.DedupKey, &a.Type, &severityStr, &hostID, &ruleID,
+		&a.Title, &body, &tagsBytes, &stateStr, &a.OccurredAt,
+		&a.AcknowledgedBy, &a.AcknowledgedAt,
+		&a.SilencedBy, &a.SilencedUntil,
+		&a.ResolvedBy, &a.ResolvedAt,
+		&a.DismissedBy, &a.DismissedAt,
+		&a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		return Alert{}, err
+	}
+	a.Severity = Severity(severityStr)
+	a.State = State(stateStr)
+	if hostID != nil {
+		a.HostID = *hostID
+	}
+	if ruleID != nil {
+		a.RuleID = *ruleID
+	}
+	if body != nil {
+		a.Body = *body
+	}
+	if len(tagsBytes) > 0 {
+		_ = json.Unmarshal(tagsBytes, &a.Tags)
+	}
+	return a, nil
+}
+
+// itoa is a small base-10 stringifier so service.go doesn't import strconv
+// just for index formatting.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/app/internal/alerts/source_test.go
+++ b/app/internal/alerts/source_test.go
@@ -1,0 +1,50 @@
+// @spec system-alerts
+//
+// AC traceability (this file):
+//
+//	AC-15  TestAlertsPackage_NoHTTPImports
+
+package alerts
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// @ac AC-15
+// AC-15: internal/alerts MUST NOT import internal/server or net/http.
+func TestAlertsPackage_NoHTTPImports(t *testing.T) {
+	t.Run("system-alerts/AC-15", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		dir := filepath.Dir(file)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read dir: %v", err)
+		}
+		fset := token.NewFileSet()
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") ||
+				strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			astFile, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, parser.ImportsOnly)
+			if err != nil {
+				t.Fatalf("parse %s: %v", e.Name(), err)
+			}
+			for _, imp := range astFile.Imports {
+				p := strings.Trim(imp.Path.Value, `"`)
+				if strings.Contains(p, "internal/server") {
+					t.Errorf("%s imports %q — alerts MUST stay HTTP-free", e.Name(), p)
+				}
+				if p == "net/http" {
+					t.Errorf("%s imports net/http — alerts is HTTP-free", e.Name())
+				}
+			}
+		}
+	})
+}

--- a/app/internal/alerts/types.go
+++ b/app/internal/alerts/types.go
@@ -1,0 +1,124 @@
+package alerts
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// State is the closed-enum alert state.
+type State string
+
+const (
+	StateActive       State = "active"
+	StateAcknowledged State = "acknowledged"
+	StateSilenced     State = "silenced"
+	StateResolved     State = "resolved"
+	StateDismissed    State = "dismissed"
+)
+
+// AllStates is the registration-order list.
+var AllStates = []State{
+	StateActive,
+	StateAcknowledged,
+	StateSilenced,
+	StateResolved,
+	StateDismissed,
+}
+
+// IsKnownState reports whether s is a valid State.
+func IsKnownState(s string) bool {
+	for _, k := range AllStates {
+		if string(k) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Severity is the closed-enum severity (mirrors system-alert-router).
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityHigh     Severity = "high"
+	SeverityMedium   Severity = "medium"
+	SeverityLow      Severity = "low"
+	SeverityInfo     Severity = "info"
+)
+
+// AllSeverities is the registration-order list.
+var AllSeverities = []Severity{
+	SeverityCritical,
+	SeverityHigh,
+	SeverityMedium,
+	SeverityLow,
+	SeverityInfo,
+}
+
+// IsKnownSeverity reports whether s is a valid Severity.
+func IsKnownSeverity(s string) bool {
+	for _, k := range AllSeverities {
+		if string(k) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Alert is the persisted alert row + lifecycle metadata.
+type Alert struct {
+	ID         uuid.UUID
+	DedupKey   string
+	Type       string
+	Severity   Severity
+	HostID     uuid.UUID // uuid.Nil when no host (system alerts)
+	RuleID     string
+	Title      string
+	Body       string
+	Tags       map[string]string
+	State      State
+	OccurredAt time.Time
+
+	// Lifecycle metadata — nil pointers when the corresponding
+	// transition hasn't happened.
+	AcknowledgedBy *uuid.UUID
+	AcknowledgedAt *time.Time
+	SilencedBy     *uuid.UUID
+	SilencedUntil  *time.Time
+	ResolvedBy     *uuid.UUID
+	ResolvedAt     *time.Time
+	DismissedBy    *uuid.UUID
+	DismissedAt    *time.Time
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// ListFilter narrows the List query.
+type ListFilter struct {
+	State    *string
+	HostID   *uuid.UUID
+	Severity *string
+	Since    *time.Time
+	Until    *time.Time
+
+	Cursor string
+	Limit  int
+}
+
+// Sentinel errors. Wrap with %w so callers can errors.Is them.
+var (
+	// ErrAlertNotFound is returned by Get and the lifecycle methods
+	// when the id is unknown. Spec AC-14.
+	ErrAlertNotFound = errors.New("alerts: not found")
+
+	// ErrInvalidTransition is returned when the requested transition
+	// is not allowed by the closed state machine (C-02).
+	ErrInvalidTransition = errors.New("alerts: invalid state transition")
+
+	// ErrInvalidSilenceWindow is returned by Silence when until is in
+	// the past (C-03).
+	ErrInvalidSilenceWindow = errors.New("alerts: silenced_until must be in the future")
+)

--- a/app/internal/audit/events.gen.go
+++ b/app/internal/audit/events.gen.go
@@ -187,8 +187,14 @@ const (
 	AlertCreated Code = "alert.created"
 	//
 	AlertAcknowledged Code = "alert.acknowledged"
+	// Operator silenced an alert (active -> silenced)
+	AlertSilenced Code = "alert.silenced"
+	// Lifecycle sweep re-armed a silenced alert whose silenced_until elapsed
+	AlertUnsilencedAuto Code = "alert.unsilenced.auto"
 	//
 	AlertResolved Code = "alert.resolved"
+	// Operator marked an alert as irrelevant (terminal state)
+	AlertDismissed Code = "alert.dismissed"
 	//
 	AlertThresholdChanged Code = "alert.threshold.changed"
 	//
@@ -880,11 +886,32 @@ var Metadata = map[Code]EventMeta{
 		Description: ``,
 		ActorTypes:  nil,
 	},
+	AlertSilenced: {
+		Code:        AlertSilenced,
+		Category:    "alert",
+		Severity:    SeverityInfo,
+		Description: `Operator silenced an alert (active -> silenced)`,
+		ActorTypes:  nil,
+	},
+	AlertUnsilencedAuto: {
+		Code:        AlertUnsilencedAuto,
+		Category:    "alert",
+		Severity:    SeverityInfo,
+		Description: `Lifecycle sweep re-armed a silenced alert whose silenced_until elapsed`,
+		ActorTypes:  nil,
+	},
 	AlertResolved: {
 		Code:        AlertResolved,
 		Category:    "alert",
 		Severity:    SeverityInfo,
 		Description: ``,
+		ActorTypes:  nil,
+	},
+	AlertDismissed: {
+		Code:        AlertDismissed,
+		Category:    "alert",
+		Severity:    SeverityWarning,
+		Description: `Operator marked an alert as irrelevant (terminal state)`,
 		ActorTypes:  nil,
 	},
 	AlertThresholdChanged: {
@@ -1343,7 +1370,10 @@ var codeOrder = []Code{
 	ComplianceSnapshotCreated,
 	AlertCreated,
 	AlertAcknowledged,
+	AlertSilenced,
+	AlertUnsilencedAuto,
 	AlertResolved,
+	AlertDismissed,
 	AlertThresholdChanged,
 	NotificationDispatched,
 	NotificationDeliveryFailed,

--- a/app/internal/db/migrations/0021_alerts_lifecycle.sql
+++ b/app/internal/db/migrations/0021_alerts_lifecycle.sql
@@ -1,0 +1,35 @@
+-- PR 3 — alert lifecycle columns (system-alerts v1.0.0).
+--
+-- alerts.v1.1.0 (PR 2) shipped with state-only metadata. Lifecycle
+-- (acknowledge / silence / resolve / dismiss) needs who-did-what-when
+-- columns to satisfy AC-02 .. AC-07 + the auto-resolve hook.
+
+-- +goose Up
+ALTER TABLE alerts
+    ADD COLUMN acknowledged_by  UUID REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN acknowledged_at  TIMESTAMPTZ,
+    ADD COLUMN silenced_by      UUID REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN silenced_until   TIMESTAMPTZ,
+    ADD COLUMN resolved_by      UUID REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN resolved_at      TIMESTAMPTZ,
+    ADD COLUMN dismissed_by     UUID REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN dismissed_at     TIMESTAMPTZ;
+
+-- Partial index used by SweepExpiredSilences: find rows whose
+-- silenced_until is in the past so the sweeper can re-arm them.
+-- Predicate uses only constants — IMMUTABLE-safe.
+CREATE INDEX idx_alerts_silenced
+    ON alerts (silenced_until)
+    WHERE state = 'silenced' AND silenced_until IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_alerts_silenced;
+ALTER TABLE alerts
+    DROP COLUMN IF EXISTS dismissed_at,
+    DROP COLUMN IF EXISTS dismissed_by,
+    DROP COLUMN IF EXISTS resolved_at,
+    DROP COLUMN IF EXISTS resolved_by,
+    DROP COLUMN IF EXISTS silenced_until,
+    DROP COLUMN IF EXISTS silenced_by,
+    DROP COLUMN IF EXISTS acknowledged_at,
+    DROP COLUMN IF EXISTS acknowledged_by;

--- a/app/internal/server/alerts_handlers.go
+++ b/app/internal/server/alerts_handlers.go
@@ -1,0 +1,276 @@
+// Alerts read + lifecycle API — spec api-alerts.
+
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	openapitypes "github.com/oapi-codegen/runtime/types"
+
+	"github.com/Hanalyx/openwatch/internal/alerts"
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// GetAlerts implements api.ServerInterface.
+// Spec api-alerts AC-01..AC-05, AC-14, AC-15.
+func (h *handlers) GetAlerts(w http.ResponseWriter, r *http.Request, params api.GetAlertsParams) {
+	if denied := auth.EnforcePermission(w, r, auth.AlertRead); denied {
+		return
+	}
+	if h.alertsSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "server.unavailable", "server",
+			"alerts service not wired", true)
+		return
+	}
+
+	limit := 50
+	if params.Limit != nil {
+		v := int(*params.Limit)
+		if v < 1 || v > 200 {
+			writeError(w, http.StatusBadRequest, "pagination.limit_exceeded", "client",
+				"limit must be between 1 and 200", false)
+			return
+		}
+		limit = v
+	}
+	if params.Severity != nil && !alerts.IsKnownSeverity(string(*params.Severity)) {
+		writeError(w, http.StatusBadRequest, "validation.field_range", "client",
+			"severity must be one of info/low/medium/high/critical", false)
+		return
+	}
+	if params.State != nil && !alerts.IsKnownState(string(*params.State)) {
+		writeError(w, http.StatusBadRequest, "validation.field_range", "client",
+			"state must be one of active/acknowledged/silenced/resolved/dismissed", false)
+		return
+	}
+
+	filter := alerts.ListFilter{Limit: limit}
+	if params.State != nil {
+		s := string(*params.State)
+		filter.State = &s
+	}
+	if params.HostId != nil {
+		u := uuid.UUID(*params.HostId)
+		filter.HostID = &u
+	}
+	if params.Severity != nil {
+		s := string(*params.Severity)
+		filter.Severity = &s
+	}
+	if params.Since != nil {
+		t := *params.Since
+		filter.Since = &t
+	}
+	if params.Until != nil {
+		t := *params.Until
+		filter.Until = &t
+	}
+	if params.Cursor != nil {
+		filter.Cursor = *params.Cursor
+	}
+
+	rows, nextCursor, err := h.alertsSvc.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.internal", "server",
+			"alerts list failed", true)
+		return
+	}
+	page := api.AlertsPage{Items: alertsToAPI(rows)}
+	if nextCursor != "" {
+		page.NextCursor = &nextCursor
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+// GetAlertByID implements api.ServerInterface.
+func (h *handlers) GetAlertByID(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.AlertRead); denied {
+		return
+	}
+	if h.alertsSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "server.unavailable", "server",
+			"alerts service not wired", true)
+		return
+	}
+	a, err := h.alertsSvc.Get(r.Context(), uuid.UUID(id))
+	if err != nil {
+		if errors.Is(err, alerts.ErrAlertNotFound) {
+			writeError(w, http.StatusNotFound, "alerts.not_found", "client",
+				"alert not found", false)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"alert lookup failed", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, alertToAPI(a))
+}
+
+// lifecycleVerb dispatches POST /{id}:verb endpoints. body parsing is
+// shared; the verb specifies which Service method to call.
+type lifecycleVerb int
+
+const (
+	verbAcknowledge lifecycleVerb = iota
+	verbSilence
+	verbResolve
+	verbDismiss
+)
+
+func (h *handlers) lifecycle(w http.ResponseWriter, r *http.Request, id openapitypes.UUID, verb lifecycleVerb) {
+	if denied := auth.EnforcePermission(w, r, auth.AlertWrite); denied {
+		return
+	}
+	if h.alertsSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "server.unavailable", "server",
+			"alerts service not wired", true)
+		return
+	}
+
+	var req struct {
+		Reason string     `json:"reason"`
+		Until  *time.Time `json:"until"`
+	}
+	body, _ := io.ReadAll(r.Body)
+	if len(strings.TrimSpace(string(body))) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "validation.field_range", "client",
+				"invalid JSON body", false)
+			return
+		}
+	}
+	if len(req.Reason) > 256 {
+		writeError(w, http.StatusBadRequest, "validation.field_range", "client",
+			"reason exceeds 256 chars", false)
+		return
+	}
+
+	actor := h.identityUUIDOrNil(r)
+	alertID := uuid.UUID(id)
+
+	var err error
+	switch verb {
+	case verbAcknowledge:
+		err = h.alertsSvc.Acknowledge(r.Context(), alertID, actor, req.Reason)
+	case verbSilence:
+		err = h.alertsSvc.Silence(r.Context(), alertID, actor, req.Until, req.Reason)
+	case verbResolve:
+		err = h.alertsSvc.Resolve(r.Context(), alertID, actor, req.Reason)
+	case verbDismiss:
+		err = h.alertsSvc.Dismiss(r.Context(), alertID, actor, req.Reason)
+	}
+	if err != nil {
+		switch {
+		case errors.Is(err, alerts.ErrAlertNotFound):
+			writeError(w, http.StatusNotFound, "alerts.not_found", "client",
+				"alert not found", false)
+		case errors.Is(err, alerts.ErrInvalidTransition):
+			writeError(w, http.StatusConflict, "alerts.invalid_transition", "client",
+				err.Error(), false)
+		case errors.Is(err, alerts.ErrInvalidSilenceWindow):
+			writeError(w, http.StatusBadRequest, "validation.field_range", "client",
+				"silenced_until must be in the future", false)
+		default:
+			writeError(w, http.StatusInternalServerError, "server.error", "server",
+				"lifecycle failed", true)
+		}
+		return
+	}
+	updated, err := h.alertsSvc.Get(r.Context(), alertID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"updated lookup failed", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, alertToAPI(updated))
+}
+
+// PostAlertAcknowledge implements api.ServerInterface.
+func (h *handlers) PostAlertAcknowledge(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	h.lifecycle(w, r, id, verbAcknowledge)
+}
+
+// PostAlertSilence implements api.ServerInterface.
+func (h *handlers) PostAlertSilence(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	h.lifecycle(w, r, id, verbSilence)
+}
+
+// PostAlertResolve implements api.ServerInterface.
+func (h *handlers) PostAlertResolve(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	h.lifecycle(w, r, id, verbResolve)
+}
+
+// PostAlertDismiss implements api.ServerInterface.
+func (h *handlers) PostAlertDismiss(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	h.lifecycle(w, r, id, verbDismiss)
+}
+
+// identityUUIDOrNil returns the calling identity's UUID, or uuid.Nil
+// when the identity is anonymous (e.g. tests).
+func (h *handlers) identityUUIDOrNil(r *http.Request) uuid.UUID {
+	if u := h.identityUUID(r); u != nil {
+		return *u
+	}
+	return uuid.Nil
+}
+
+// alertsToAPI converts service-layer slices to API response types.
+func alertsToAPI(in []alerts.Alert) []api.Alert {
+	out := make([]api.Alert, len(in))
+	for i, a := range in {
+		out[i] = alertToAPI(a)
+	}
+	return out
+}
+
+func alertToAPI(a alerts.Alert) api.Alert {
+	out := api.Alert{
+		Id:         openapitypes.UUID(a.ID),
+		DedupKey:   a.DedupKey,
+		AlertType:  a.Type,
+		Severity:   api.AlertSeverity(a.Severity),
+		RuleId:     &a.RuleID,
+		Title:      a.Title,
+		Body:       &a.Body,
+		State:      api.AlertState(a.State),
+		OccurredAt: a.OccurredAt,
+		CreatedAt:  &a.CreatedAt,
+		UpdatedAt:  &a.UpdatedAt,
+	}
+	if a.HostID != uuid.Nil {
+		h := openapitypes.UUID(a.HostID)
+		out.HostId = &h
+	}
+	if len(a.Tags) > 0 {
+		t := a.Tags
+		out.Tags = &t
+	}
+	if a.AcknowledgedBy != nil {
+		u := openapitypes.UUID(*a.AcknowledgedBy)
+		out.AcknowledgedBy = &u
+	}
+	out.AcknowledgedAt = a.AcknowledgedAt
+	if a.SilencedBy != nil {
+		u := openapitypes.UUID(*a.SilencedBy)
+		out.SilencedBy = &u
+	}
+	out.SilencedUntil = a.SilencedUntil
+	if a.ResolvedBy != nil {
+		u := openapitypes.UUID(*a.ResolvedBy)
+		out.ResolvedBy = &u
+	}
+	out.ResolvedAt = a.ResolvedAt
+	if a.DismissedBy != nil {
+		u := openapitypes.UUID(*a.DismissedBy)
+		out.DismissedBy = &u
+	}
+	out.DismissedAt = a.DismissedAt
+	return out
+}

--- a/app/internal/server/api/server.gen.go
+++ b/app/internal/server/api/server.gen.go
@@ -21,6 +21,60 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+// Defines values for AlertSeverity.
+const (
+	AlertSeverityCritical AlertSeverity = "critical"
+	AlertSeverityHigh     AlertSeverity = "high"
+	AlertSeverityInfo     AlertSeverity = "info"
+	AlertSeverityLow      AlertSeverity = "low"
+	AlertSeverityMedium   AlertSeverity = "medium"
+)
+
+// Valid indicates whether the value is a known member of the AlertSeverity enum.
+func (e AlertSeverity) Valid() bool {
+	switch e {
+	case AlertSeverityCritical:
+		return true
+	case AlertSeverityHigh:
+		return true
+	case AlertSeverityInfo:
+		return true
+	case AlertSeverityLow:
+		return true
+	case AlertSeverityMedium:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AlertState.
+const (
+	AlertStateAcknowledged AlertState = "acknowledged"
+	AlertStateActive       AlertState = "active"
+	AlertStateDismissed    AlertState = "dismissed"
+	AlertStateResolved     AlertState = "resolved"
+	AlertStateSilenced     AlertState = "silenced"
+)
+
+// Valid indicates whether the value is a known member of the AlertState enum.
+func (e AlertState) Valid() bool {
+	switch e {
+	case AlertStateAcknowledged:
+		return true
+	case AlertStateActive:
+		return true
+	case AlertStateDismissed:
+		return true
+	case AlertStateResolved:
+		return true
+	case AlertStateSilenced:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ConnectivityCheckResultNewReachabilityStatus.
 const (
 	ConnectivityCheckResultNewReachabilityStatusReachable   ConnectivityCheckResultNewReachabilityStatus = "reachable"
@@ -386,25 +440,25 @@ func (e IntelligenceEventSeverity) Valid() bool {
 
 // Defines values for LicenseStateResponseStatus.
 const (
-	Active    LicenseStateResponseStatus = "active"
-	Expired   LicenseStateResponseStatus = "expired"
-	Grace     LicenseStateResponseStatus = "grace"
-	Invalid   LicenseStateResponseStatus = "invalid"
-	NoLicense LicenseStateResponseStatus = "no_license"
+	LicenseStateResponseStatusActive    LicenseStateResponseStatus = "active"
+	LicenseStateResponseStatusExpired   LicenseStateResponseStatus = "expired"
+	LicenseStateResponseStatusGrace     LicenseStateResponseStatus = "grace"
+	LicenseStateResponseStatusInvalid   LicenseStateResponseStatus = "invalid"
+	LicenseStateResponseStatusNoLicense LicenseStateResponseStatus = "no_license"
 )
 
 // Valid indicates whether the value is a known member of the LicenseStateResponseStatus enum.
 func (e LicenseStateResponseStatus) Valid() bool {
 	switch e {
-	case Active:
+	case LicenseStateResponseStatusActive:
 		return true
-	case Expired:
+	case LicenseStateResponseStatusExpired:
 		return true
-	case Grace:
+	case LicenseStateResponseStatusGrace:
 		return true
-	case Invalid:
+	case LicenseStateResponseStatusInvalid:
 		return true
-	case NoLicense:
+	case LicenseStateResponseStatusNoLicense:
 		return true
 	default:
 		return false
@@ -426,6 +480,60 @@ func (e LicenseStateResponseTier) Valid() bool {
 	case Free:
 		return true
 	case OpenwatchPlus:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetAlertsParamsState.
+const (
+	Acknowledged GetAlertsParamsState = "acknowledged"
+	Active       GetAlertsParamsState = "active"
+	Dismissed    GetAlertsParamsState = "dismissed"
+	Resolved     GetAlertsParamsState = "resolved"
+	Silenced     GetAlertsParamsState = "silenced"
+)
+
+// Valid indicates whether the value is a known member of the GetAlertsParamsState enum.
+func (e GetAlertsParamsState) Valid() bool {
+	switch e {
+	case Acknowledged:
+		return true
+	case Active:
+		return true
+	case Dismissed:
+		return true
+	case Resolved:
+		return true
+	case Silenced:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for GetAlertsParamsSeverity.
+const (
+	GetAlertsParamsSeverityCritical GetAlertsParamsSeverity = "critical"
+	GetAlertsParamsSeverityHigh     GetAlertsParamsSeverity = "high"
+	GetAlertsParamsSeverityInfo     GetAlertsParamsSeverity = "info"
+	GetAlertsParamsSeverityLow      GetAlertsParamsSeverity = "low"
+	GetAlertsParamsSeverityMedium   GetAlertsParamsSeverity = "medium"
+)
+
+// Valid indicates whether the value is a known member of the GetAlertsParamsSeverity enum.
+func (e GetAlertsParamsSeverity) Valid() bool {
+	switch e {
+	case GetAlertsParamsSeverityCritical:
+		return true
+	case GetAlertsParamsSeverityHigh:
+		return true
+	case GetAlertsParamsSeverityInfo:
+		return true
+	case GetAlertsParamsSeverityLow:
+		return true
+	case GetAlertsParamsSeverityMedium:
 		return true
 	default:
 		return false
@@ -462,6 +570,49 @@ func (e GetIntelligenceEventsParamsSeverity) Valid() bool {
 // AdminRolesResponse defines model for AdminRolesResponse.
 type AdminRolesResponse struct {
 	Roles []RoleEntry `json:"roles"`
+}
+
+// Alert defines model for Alert.
+type Alert struct {
+	AcknowledgedAt *time.Time          `json:"acknowledged_at,omitempty"`
+	AcknowledgedBy *openapi_types.UUID `json:"acknowledged_by,omitempty"`
+	AlertType      string              `json:"alert_type"`
+	Body           *string             `json:"body,omitempty"`
+	CreatedAt      *time.Time          `json:"created_at,omitempty"`
+	DedupKey       string              `json:"dedup_key"`
+	DismissedAt    *time.Time          `json:"dismissed_at,omitempty"`
+	DismissedBy    *openapi_types.UUID `json:"dismissed_by,omitempty"`
+	HostId         *openapi_types.UUID `json:"host_id,omitempty"`
+	Id             openapi_types.UUID  `json:"id"`
+	OccurredAt     time.Time           `json:"occurred_at"`
+	ResolvedAt     *time.Time          `json:"resolved_at,omitempty"`
+	ResolvedBy     *openapi_types.UUID `json:"resolved_by,omitempty"`
+	RuleId         *string             `json:"rule_id,omitempty"`
+	Severity       AlertSeverity       `json:"severity"`
+	SilencedBy     *openapi_types.UUID `json:"silenced_by,omitempty"`
+	SilencedUntil  *time.Time          `json:"silenced_until,omitempty"`
+	State          AlertState          `json:"state"`
+	Tags           *map[string]string  `json:"tags,omitempty"`
+	Title          string              `json:"title"`
+	UpdatedAt      *time.Time          `json:"updated_at,omitempty"`
+}
+
+// AlertSeverity defines model for Alert.Severity.
+type AlertSeverity string
+
+// AlertState defines model for Alert.State.
+type AlertState string
+
+// AlertLifecycleRequest Optional body for POST lifecycle endpoints. silence accepts an optional until; all accept a reason for the audit detail.
+type AlertLifecycleRequest struct {
+	Reason *string    `json:"reason,omitempty"`
+	Until  *time.Time `json:"until,omitempty"`
+}
+
+// AlertsPage defines model for AlertsPage.
+type AlertsPage struct {
+	Items      []Alert `json:"items"`
+	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
 // AuditEvent defines model for AuditEvent.
@@ -1145,6 +1296,23 @@ type BadRequest = ErrorEnvelope
 // MethodNotAllowed defines model for MethodNotAllowed.
 type MethodNotAllowed = ErrorEnvelope
 
+// GetAlertsParams defines parameters for GetAlerts.
+type GetAlertsParams struct {
+	State    *GetAlertsParamsState    `form:"state,omitempty" json:"state,omitempty"`
+	HostId   *openapi_types.UUID      `form:"host_id,omitempty" json:"host_id,omitempty"`
+	Severity *GetAlertsParamsSeverity `form:"severity,omitempty" json:"severity,omitempty"`
+	Since    *time.Time               `form:"since,omitempty" json:"since,omitempty"`
+	Until    *time.Time               `form:"until,omitempty" json:"until,omitempty"`
+	Cursor   *string                  `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Limit    *int                     `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetAlertsParamsState defines parameters for GetAlerts.
+type GetAlertsParamsState string
+
+// GetAlertsParamsSeverity defines parameters for GetAlerts.
+type GetAlertsParamsSeverity string
+
 // GetAuditEventsParams defines parameters for GetAuditEvents.
 type GetAuditEventsParams struct {
 	Action        *string    `form:"action,omitempty" json:"action,omitempty"`
@@ -1256,6 +1424,18 @@ type GetIntelligenceEventsParamsSeverity string
 // PostAdminLicenseVerifyJSONRequestBody defines body for PostAdminLicenseVerify for application/json ContentType.
 type PostAdminLicenseVerifyJSONRequestBody = LicenseVerifyRequest
 
+// PostAlertAcknowledgeJSONRequestBody defines body for PostAlertAcknowledge for application/json ContentType.
+type PostAlertAcknowledgeJSONRequestBody = AlertLifecycleRequest
+
+// PostAlertDismissJSONRequestBody defines body for PostAlertDismiss for application/json ContentType.
+type PostAlertDismissJSONRequestBody = AlertLifecycleRequest
+
+// PostAlertResolveJSONRequestBody defines body for PostAlertResolve for application/json ContentType.
+type PostAlertResolveJSONRequestBody = AlertLifecycleRequest
+
+// PostAlertSilenceJSONRequestBody defines body for PostAlertSilence for application/json ContentType.
+type PostAlertSilenceJSONRequestBody = AlertLifecycleRequest
+
 // PostAuthLoginJSONRequestBody defines body for PostAuthLogin for application/json ContentType.
 type PostAuthLoginJSONRequestBody = AuthLoginRequest
 
@@ -1324,6 +1504,24 @@ type ServerInterface interface {
 	// Reload signed policy files from the configured directory
 	// (POST /api/v1/admin/policies:reload)
 	PostAdminPoliciesReload(w http.ResponseWriter, r *http.Request)
+	// List persisted alerts (paginated, filterable)
+	// (GET /api/v1/alerts)
+	GetAlerts(w http.ResponseWriter, r *http.Request, params GetAlertsParams)
+	// Single alert by id
+	// (GET /api/v1/alerts/{id})
+	GetAlertByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Acknowledge an active alert
+	// (POST /api/v1/alerts/{id}:acknowledge)
+	PostAlertAcknowledge(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Dismiss an alert (terminal)
+	// (POST /api/v1/alerts/{id}:dismiss)
+	PostAlertDismiss(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Resolve an alert
+	// (POST /api/v1/alerts/{id}:resolve)
+	PostAlertResolve(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Silence an alert until a timestamp (or indefinitely)
+	// (POST /api/v1/alerts/{id}:silence)
+	PostAlertSilence(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// List audit events (cursor-paginated, newest first)
 	// (GET /api/v1/audit/events)
 	GetAuditEvents(w http.ResponseWriter, r *http.Request, params GetAuditEventsParams)
@@ -1498,6 +1696,42 @@ func (_ Unimplemented) PostAdminLicenseVerify(w http.ResponseWriter, r *http.Req
 // Reload signed policy files from the configured directory
 // (POST /api/v1/admin/policies:reload)
 func (_ Unimplemented) PostAdminPoliciesReload(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List persisted alerts (paginated, filterable)
+// (GET /api/v1/alerts)
+func (_ Unimplemented) GetAlerts(w http.ResponseWriter, r *http.Request, params GetAlertsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Single alert by id
+// (GET /api/v1/alerts/{id})
+func (_ Unimplemented) GetAlertByID(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Acknowledge an active alert
+// (POST /api/v1/alerts/{id}:acknowledge)
+func (_ Unimplemented) PostAlertAcknowledge(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Dismiss an alert (terminal)
+// (POST /api/v1/alerts/{id}:dismiss)
+func (_ Unimplemented) PostAlertDismiss(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Resolve an alert
+// (POST /api/v1/alerts/{id}:resolve)
+func (_ Unimplemented) PostAlertResolve(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Silence an alert until a timestamp (or indefinitely)
+// (POST /api/v1/alerts/{id}:silence)
+func (_ Unimplemented) PostAlertSilence(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1847,6 +2081,247 @@ func (siw *ServerInterfaceWrapper) PostAdminPoliciesReload(w http.ResponseWriter
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PostAdminPoliciesReload(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAlerts operation middleware
+func (siw *ServerInterfaceWrapper) GetAlerts(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetAlertsParams
+
+	// ------------- Optional query parameter "state" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "state", r.URL.Query(), &params.State, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "state"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "state", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "host_id" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "host_id", r.URL.Query(), &params.HostId, runtime.BindQueryParameterOptions{Type: "string", Format: "uuid"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "host_id"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "host_id", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "severity" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "severity", r.URL.Query(), &params.Severity, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "severity"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "severity", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "since" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "since", r.URL.Query(), &params.Since, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "since"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "since", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "until" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "until", r.URL.Query(), &params.Until, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "until"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "until", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "cursor", r.URL.Query(), &params.Cursor, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "cursor"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "cursor", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAlerts(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAlertByID operation middleware
+func (siw *ServerInterfaceWrapper) GetAlertByID(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAlertByID(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostAlertAcknowledge operation middleware
+func (siw *ServerInterfaceWrapper) PostAlertAcknowledge(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostAlertAcknowledge(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostAlertDismiss operation middleware
+func (siw *ServerInterfaceWrapper) PostAlertDismiss(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostAlertDismiss(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostAlertResolve operation middleware
+func (siw *ServerInterfaceWrapper) PostAlertResolve(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostAlertResolve(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostAlertSilence operation middleware
+func (siw *ServerInterfaceWrapper) PostAlertSilence(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostAlertSilence(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3526,6 +4001,24 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/api/v1/admin/policies:reload", wrapper.PostAdminPoliciesReload)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/alerts", wrapper.GetAlerts)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/alerts/{id}", wrapper.GetAlertByID)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/alerts/{id}:acknowledge", wrapper.PostAlertAcknowledge)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/alerts/{id}:dismiss", wrapper.PostAlertDismiss)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/alerts/{id}:resolve", wrapper.PostAlertResolve)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/alerts/{id}:silence", wrapper.PostAlertSilence)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/audit/events", wrapper.GetAuditEvents)
 	})
 	r.Group(func(r chi.Router) {
@@ -3693,163 +4186,177 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H1rcxs3suhfQfGeqkjXJEX5VVmlXLccP9bem4dLcja3KvLlgjNNEtEMMAEwpHkSV91P5wecur9wf8kp",
-	"NDBvzIOyRCl7/GU3FjFAo19odDe6fx8FIk4EB67V6Oz3kQSVCK4A//EtDc/htxSUNv8KBNfA8T9pkkQs",
-	"oJoJfvKrEtz8TQVriKn5r3+TsBydjf7HSTH1if1VnbySUshXfAORSGD06dOn8SgEFUiWmMlGZ6O/04iF",
-	"OPOYJHTFuPtvIQkLIU6EBh7sCJh5Rp/Go+9Br0X4g9DPo0hsITwcpD9LwVfkzfv370iMQIzMGPe5mf15",
-	"GDN+LiJQ5w6r5q+JFAlIzSyKpfnZ/AfTEKs+mMxkr7iWO7NzvUtgdDaiUtIdLi3ht5RJg4Jf3Lwf8lFi",
-	"8SsE2nz2PA2ZfrVx+KlCQwO7t9+zz5SWjK/MZzTQQs4Z4penUUQXEYzOtExh3DbY/tkzVyCkhAiJ4mZs",
-	"DAlBUxYhTGHIzEgavSvBWlm42JydbSlkTPXobJSmLBx54BNBkEoJ4ZzqyviQaphoFoPvIwmBkOHeH4UW",
-	"qVUiN8ZViWm+UyKVAQzFeD4+Q3rvFwo2IJneecCp8RLisEazccYrFWJXMdvNfeodXXkEIkfRIIEoMbMH",
-	"iRw+6nmQSiWkmagqvj8m9LcUiP35G5JQpQhV5H/ZPzwjWpAl6GBN9BqImcmoI7PFHszWkYfbqMLiR4xe",
-	"fydWjJc0bhUzQifm/2L68TvgK70enT0dj2LGS/9qENnsaitkWPvw4ZPqp6eeT1MFktMY9v60hoB8nhI0",
-	"PQhoU5Y0CECpuRZX4FdSEpYS1LpjhIGmn6n0+nvIwahvqAJFfU23QtsGv3/9/BWXIoraN5lIsWGKCc74",
-	"ap5K1i+fjS86Vv87SLbc3SCP1WAxE7QuD+9AxkwZUDuORBYC104x1X/x0pSpOeWC72KRlpXrQogIKEe+",
-	"EBEM1HM4tDanb0NJsZV9NHtjSbfX6oTtGGxHG8TuwGziZ9ih2IKkqiYYgMGSwFuY3NRtm3rntMKLNeUr",
-	"aGVNPFe4nldUWrcK47AdPry2lcZytenadnNu1UHrNvpUVN2Oqwz3LfqCalgJubN2YWO9yqHXyhwDyFqe",
-	"yAuH4BwCzTZM776VQK9CseUeMkqmWUCj5oGccgk0WJujlTwggeHyINVsA/MlZVEqQV2ms9mj4NFoXDAz",
-	"4/rp44KbGdewAmktyJWkob0QVBcatAw8Ox24jttmdY2OeQfCz419Nk+kWPj2wAVZC6XnEdsAB6WIFFsC",
-	"H5nSatj0gkeMw/7IeTYbMn/9VLCLlYgyLhjBobC24z4We7GG4OocVBp5hAxvh7kpXN2gDpK5sdZFqsdm",
-	"hzij4HMJy1RBOCYLyjnIecxUTHWwxqun+Qgn/YYY848ITlSKdkC/QWgVh8Mri5jezZWmOm2K5+idUHqy",
-	"3ikNEhRTxI4jR4rGQDY0SgGt0QQkEyELSCREQrYijUKylUzDsdG5PI2t5nCENCqZV/91xQ3GP/gMRsT+",
-	"nlecbGr/2etOLET6PPbsembQ6firn5fKO2nMXd5AO957eUvwJVu16665gsBDPLMyMWDLDY3IUkhSVmlG",
-	"XBVZQCS2SES9NopdRCE5ejqbTr9++ng2O56Sl7CkaaTJ6cMZOXoYG4rG9COLDVFxDNpj9t9PZ12KbzCU",
-	"dRi3TK87FaMf4kezGTl6ci2IxZYPhtbCSLURS7oQGxiEza8NcI9m14EupuYfnPIA5qtILHxn189r4ASl",
-	"nyADWsnULLhSZJFq+0dFnNZWBZeXBKW8jh8ZIBVTGkKjokIfVhgnpVlayPTUoOLpLD6ekh+EJjvQhKZa",
-	"TNBVBuE3REsaXEGI8zp1MzHzV+ZWEQtgf2Tak+DmWfPZzL/bv5jNnl6LKyXVMI9YzHQT1O/pRwOGMxLJ",
-	"xcWb0lGiSJga5UiWEYAmaguQKHJ0Op0+nM0qgDysgHHqg8IdVa0cMbH89v7Fu4k9uIj7wjCDgkDw0K79",
-	"qLr0o96VS8prnotXE4YXBTUyJW7U3FJIKMj3z//4z7IuNPCcVuE57YHHa1EgVmoab1xV0yXt0hSxKnrb",
-	"tlxhBa8+GHagtN/dgvzA6fJLeI4oVPfI6eo6X9fvPPbPpTn7NnaRGzLVDUVUaWvJOVOiJj5Gm0gIjOzg",
-	"qInSVGpkXWdhpVyzCNXPkkmlUZeWLc+ySdJrgJVJRg3oHrvwe2bsO5XLsdne3GJk6iG5T4PbDQci5VXz",
-	"qd0Kt184sbnGl84I3etLYwTBXEvKFTrW9/i46XjK9+uHyL/DVhi8lPLyoAT0nNDoRSR4u9OAqbnjZZ8O",
-	"l1dEr5kigZmDUIXspoz5HRP3GTkSPNoZ25uFZGtOeRWIBJ7ZUcdeNsh8JdXl3ImkiBbkK3uTtS57YsZb",
-	"04ocISjHX9mlRMy0xsvSnr5bhBEvQu4yYMEdjUfmGPUa/viJizZUAT93FC9vH6cZN3xK+7nGLZQ95JVA",
-	"dTt9aarXcxd9K29XredXsCu7nMejhdBr79ZrLpISrk9nDx+PvQ7HEle1M8CeVCu7qjwXM7YxMmO21fM7",
-	"OqmStaTK78/7TO7Yk+g3F0mwcDv0VvyMZTbo5qfvmNId53A+bngIqpi7iBj0eH3Ly3SD2xELuQnOD1C6",
-	"9rvuZ98sdoO8ysP8j73TMFU6uJsSN1Qi71wWHH3mC6bL4YLy8exGBCKOXZC+dZYl4yuQiWQ941oj8WkS",
-	"7s0Ae4YDhklthYRlcnvlI1VaxOcigp7joV2zD9HHlsQJ1RqkOQj/7y908u8fzP/MJn+Zf/j9dPz00ad/",
-	"86FocHAoZvyt/fG0N1JU88H3R4wKNLWrkWuFB5A+i5RFes64X+BuKjzW2HR55X4UvArWopU7YlDK5SA0",
-	"zvx9zqVsnnYA2pV4yPQcNsD1fKAiHJA7A8FawICwjhvXmNO7D/5bCim8B6X/JhZdN9le8H4Vi2GbrYHr",
-	"vhsGbiV5yx8f8AEfHjphKT+zsvMniBjYKxLIDUjD4yJigTnR4aNRRBV3Q7H+Oo0pn5dY2uOn13LX5qdv",
-	"eAJCo6EzdVx8Wl+oifw6kyGqvTTa0CilGp5HIHWrkKpAyExEM09R2VU0672l2hl8ELyOAPQbofRrF3xo",
-	"rG7urYyv5jKN9rueY3DuOlyefTj2rd26ie9cGLC5g3oYcQDslYDOgPFZPGno6P3m7wj/+MNaAwKJiLNz",
-	"9D/ZrAP1uYloOON7SblyeXG9RxvO2g5cGkEvVyKv7MOVyEpDIv7ZwLFvrVagLzJZrWU0UaXMFEtZ5JfW",
-	"/Nh2BDHLKnJCjtwn5AFx6x8TGkihFKFRZGMBUzKbTk+nFZ+gSC0rOPB4Gi+cF11oGs3BapzMKKn7sVOu",
-	"iVjauDoiAL1URIqtIts1SEwWxKQQF5dlyqYNColgTq8RGW/gxgdrK8Lfi+S1xc8bDCvdBBOX9eFnMnEB",
-	"nmHnmwGvLBifC15JXJu2AOqF+RXjlfs1OqPnCjDVz3ox7Ui86riU2vxP3oN68Mlwy+nMrbqgMzfY7tr6",
-	"/DOkGCZ2qsJg4YolCeKjfvZ3XROLc6/QPW6lcYUY/TnGb4BGet1x51nMnZO/YiWXbi/NLa5xzl05hcVH",
-	"3A1I5b9K1Y2SbGsVYIoJvPsSSr8QcRIxygO4SOOY+jK+cuN2wIHgtOvQmINVVkPjDI4Pho1GrXetIIQD",
-	"qthMkwWz6Vuxel03QouDOGQqiehu3ub1bF7Z+IZJwTOHTzn/1jf/Soo0ua4LykjaNT3ULJnTMJTO0KxB",
-	"2efdFlJX7PinT548etIb/qar6gHRh5r6G4Au53O/Je48VaV9t7HQS7z/dV2MM8Gdq0Jyu447v7g7Ag75",
-	"uOyPjkoXBBpFPy5HZ7/0z5BfKz59qL9++iGNIhsR4oLkWYg2GWFNFTEnCJEpJ3RFGVfaRtoM6NMGk/ow",
-	"j/f8BsrasP8dU/qthth3jkNwNU8kE9mBNjjl4F74x+uqpE913J6uuLbrvqI0Gj9jqoAKKO/Cci+g95u/",
-	"q3HtuOpmKntNnY4coAf7Fd/tu/b9GtJto8qZXYLbrjTX2a1m0P2gogj67gZ26naw2vwpvuQzP8mQsauZ",
-	"yP1sXM+buaY0mGny5FiLuZaP6gCX7zSfBUMsONPC/MvOWbamh+WDl2SmL2vZrDKcMo3hLmmldbxkGxbB",
-	"CvZZw/tNz0ItSeKfl9Kt1HoPuOujOyH2++Z6c62NhH1fELfV7gZutudJSTEsR56RhKYKXG7tN2RJI2X+",
-	"KkGlZfXW5uPOZm+FMGfgN0zp9hc21sJAsRisaK1aKHnre8VpT0ViiAzhPKI7+94xv6q7C5Jaj0o8anAw",
-	"yBa4puOi/dp3cC0hrjrwV8nlgw0TqbpxsHrxXGiOobD6nlj0q3sj6cNW6PbXlPjfQ8/B0tXxspFryWA/",
-	"O6BFeD120g1EajIA2/bacSv8cju537eTL3a7n6UvME3qLV8KX8KoSiMMpVDykqlAbEDuzF1pSrIka722",
-	"LzrmNt1qzvhSEG2IfckDEaUxnyyFnNj/nJKLBAKXmIsvUSZhNu30ktsk43JWRZJQGQs5L9kP/UqUymDN",
-	"NATahdx6uS8QUYRu271IFTJ1NV9KgPlqMUxP4xc2KLTXJ6mCcPAXSyZhS6NorkBuWODJX85GhOQPki63",
-	"5A/Cl0gxRf4gLMn/E+IE37P3myj5krmh2//NbyEfNHAfY6WsRnonvgLJIZrvO15CBC4fd+gnpVhC/2UL",
-	"4jndUIaj5vFAopuvLGMN/UKo+ZLGLNp5pF5EUZoQ+zP55//7/0SuIRqTEBaM8jFRqYIxoVHCuPl/GazH",
-	"ZAVcCzEmQq8x1aV3n0INLYiDI+cRu4KhwweTVKh5IkHr3V6f7EPOYvh8mUbRoG+SiGrD6nNbU2LJrOE/",
-	"oA5QxHj6sfVN8iu+FDJgfEX+IFn9jg2QP4xqR/WayTxhS8KFJokEZVOY+tfe0mQvDmw1wSrKuO3Q+gmP",
-	"1nsb5ukJoHyWqfQvH7lpEPwt1xBFbAU8gJZyZ7eX1heC3t80sHmgWRJiLTslEgpCoulHwUW8OyMwXU2d",
-	"STRNaHBFVzB1puPoHmcdlDMLsgu1Mf5G41EktuYCCSFLMf+erdblm/W+aQQlbJaWrYJdJdSHIVx0I2XL",
-	"mrzZX73sOmXH+nZ0kfk26nJxHct2HxZTnCZqLXSfYFWF4LUEMPeC2N4dWGkn1tswzeZF+yPOX3TidoSc",
-	"XmTL9mWtFmykik96z5jvWABcWax23PkxLR9ka/r2x4RJUJ/lfF8C1ZmPd/jVk/H5StIA5rbAyNDcGPdS",
-	"w5xQFL1ddgd4Lol5ZJFi7pocn1F6fXOaVf2U5oZkhDUBvqU6WM+TCNNlgGt88KLAO02KyXSJhE3toVyb",
-	"LwvXLWUa5YjroG9PDTW34fmvW91/Hy8PHrBkq4vsYDzTMk3BQ2puqexlHj3UKt3ghucyL/DTGLGlkjO+",
-	"+ixw60ozg72+vo8yRS27triAK8zltysoX4FsLVh3zWc5GTetqIahdb1yMOsvbQoQu7evzmHFlO7y4Lo1",
-	"9nHiVsuaeZRV2wujrknrNPMVXr2lgrwlFFRhH3fU6n0nIhYwUOcQCRq241ekOhCx8355j9N27d9yAuZT",
-	"tsK1ewkBlp3sel12Leu5/y2Lg87/EhqBa3/z6H5vT9XEOKwaksWZgVFdtLFEPqEPlwUL/fkf51X5ugyH",
-	"b+c/KZA9mZd5UcuORMVH1697+/Vh6t5mZTA7i0cabHS+TN87KvDZFUFtNooDekBOyF08L26guRW3IoLn",
-	"SrFVe4Vlo4idVb4PpbPP2lZW3UlOZgfDT5wKm/SJqJ3a80YPjX1f7OZC0xWQGdnS6Irx1URdQQQayx3K",
-	"JQ0AL1Z6LQEI8DARjGtF9JpqAh9BBkxhObZLvhQpt2X8idI0uCJHJWfLuFzKf0zwFezYlvQn4B5tHtvI",
-	"jmbaGG+jHxPgP5uLADlyIB6XsuXPRrPp6XQ2oVGyptNTPCES4DRho7PRo+ls+gilT68RvSc0YSeb0xMa",
-	"xoyfOJvpzFp8SB6XX2uIhPC+DV1tRqzoXzHJRxbhoPS3ItzdWPMB703jU5W8LrOw0rHh4Wx2WzDk1bCb",
-	"LRvMCLcGsRYzOXJ5Q1g8c5dAmNUGO7ZdErIU6NFLuZvIlNsKO1QDoeRvP78njipY8M0WM1OaRhHjK8Ks",
-	"sVKlYuIspTOJptIAMlZtq9EtIrLFivNg8h3IicEWsbsguRH2aTx6PHt0uN4WL2gUgSQRDa4UsdZMhtkq",
-	"+eyeiFGrELqRZMkiUGQpRYyBXltEK5UQkpBJ9MQYufk4yXh5UtgNo7NRc7mc1EZRnKBjD4m0Ag+B/wq6",
-	"1GQA5V7SGDQq2V9+HxmjaPRbCgiDPWiKXgYF+hoq3/9loy3C3jNU2ifs/bViNsGo+HDIKds2GxZdu7HZ",
-	"nO/yGrvKSu0VH+bVXZ7M9qmf+OnDLcp1vZeFT6DNUSWW9ogjjnNRmGdts+fgnpTa71SFztgTlSnJkcX1",
-	"xHXMgXBMOGxBaVs977gmRnp9EomVvR50qMmsI8MtHXKNlhcHPuCaHSc8FMQBttgzhFgdVVwBV4QplUJo",
-	"aXl6OMX81vpQSamElDliv3/9nOSIQ2aBILVxll8+lFnnJ2cun2RmPUFGsIVVRWKv6OT9j+/feVlGpHoQ",
-	"z5hxDco99pibgFqfSNiIK2geLuav9gxxh7+yHzSBsxeG9hNBr7+H0S0zU6VpSJN0Wa+HQ/PMD8LVL3TI",
-	"MwyzACpdQL2Mb51KXsF33qDCg/CTmh+hG/nvqj6v26WDr9GI395yw0jEGmr21XKJhUCxAnI2XV4VeQCG",
-	"lvQMsNtLv8zkjWFuHTeNDjQ+vJQ6ypCfzt8SiZxRqgltNmj2HVAtJKFJUscdrlFBlLmMEsZRuRiF5UfY",
-	"oGtYuZfNLR5OjX45gw4oj5oz6hk3xu7gyDCLG5S78BvBstpJRHcNfYtlgWVMKCeWbyHEk0VBIEGTxc5u",
-	"YmeoSckKuCEMhMR7WmQHzJn1G/VTtNoH5hbJ6m84c13aZrORLPuiMO8OpN5hS/LTXMKvGKI2xHKFow7N",
-	"by9cUfQcpq0UzmtWYjXEfUM/fKXyzzwcVWjhM+liTn3njidMdatX/Y6omAdVOUhV5LxOo4icf/v8Bcm2",
-	"SY6K+NG4fByNCbrYJ4wTDCN5LH3XQqhfAF3roluUvFpzpPto7xtpQhOfJJTJuzLzHaIcJE5zj4lLrBhb",
-	"HZ4qCA1jqICG4ExooiVbrUBCeNx5DzgXWNvIyJ8sr/UNiRnXhJrrI7Gd7h5kAwxCKuxVK5fbJocvSsNu",
-	"kbwtRX59GiofSWLQNKSaOvvvLt1sBTbPJDQcbXjnL9/6jnLQBY92xx0OtcbE4w5FUCfWzSuCtuLeg7TB",
-	"6S2AMZBVXAju4Od7uSNyZsNhUd0xpsFhzjWGW2yTZDfi4uINuQJ3+v/lgNZmGmmWRPU6+qp+/iMyCS2x",
-	"9DAOxj5XbVro5HcWfrImWgQ2s7HK4S/x7wVRv929fdniIk6oXhceSVuZqsKcXjdpy8vBD0MsSQtcSI7y",
-	"6sfP8E3zsSXi4wPqpYLrc+6qEfBCLPXEovkaVHT0+TQecGjcHY1md6dsMuV+H0n/Gtsil4n+lSoA3uMc",
-	"6hDiM2yEUbZZ69UaEwauYYftolGBBnggd4kRJnd3jakGaTa1AbmgmsWEcS2cnSPF1jpAsZMYlSvQVsOe",
-	"ZLXep+QnZS9VZsgija4IixMhNVliPzdBqNbUYmUtFPASOERDnERobQkCZhCHbbRzE0BotXgW6JQwSaSI",
-	"E40NpJy3pbYJGxrvOruxK8rBhOZWbYRyf5f7aSJg95i7sg7e9loEm9x+yJssHlqpXNRFtAAR2/hFRh/s",
-	"iCrOlPDghkvRf+AZlhcJRBSxEFzPOcptd1WMQVQsm7phY3sJlfda0jRIJXLkZvjnf/ynJZhr4Jf/4fi6",
-	"tlDI6IoLpVmgziBYi+5L/8ti9Csz2K8v1kBD+zrTaoy3Re7O5H/DrlN9VBLonvQm0LWs+H8mL4ow++Rt",
-	"d5j9ljRSuZPAgf0WlR4CHs41vxcRymuFl80nT/o/+R6bdfwg9PMoEts7ENIa72VOEBTRkC2XgJ7HhSF8",
-	"LR5hcGS9Hbhl4rKLv8nz1lQ5KY08sPH1duGy/RAmGpSe/CoWwwWt0kih6Q95eHPI9Lds8GD1b2KBvh5j",
-	"MH1DtkJegSRbFkUklJTxuuWv6QomM4KzkxBi8Q1x6FBGzYmJSMivYkESKbB0VG43MT5xf3OLtKPX9QaY",
-	"0AikHo7cckuBW3JfeNsWHFgjtOTf+yJ5NiMrdENbSJlko5CWboPWukYCFM0wVR5VaKFcIiFmaTzZ6/R5",
-	"Zz+6F4fQf8/zI9PlDw+ny11+KQkFdkbWhPEgSkMgjoXmJbYi7nFawymKU0zwvRMxLPdNlgajOqepmFfZ",
-	"H89Gnk9aGd19buvR4H12KLe7hoq2MhSmnn7h+LvgeHIUWP+7VWyGkOiYOL7bOEAOR4uyxsCgVdU5r+ff",
-	"lGKDHXeI6hK93G3vGddg75/xwy/8fX/4G0l5Hxi8uLvuweH40R4s3n1BznhcQgwhs5dL+AhBuj+znxdT",
-	"vHIzfOH6/+52TImv5pavXGOouxO9EkhnGau3y+CD7BVOTRY9s5AH/u32WVx+HLWLddsGMvleRgD6pNzD",
-	"/WQhgV6FrkGZCzfVA2+SbQDPzont+YTeOOx2VSR8XoDWjK8UeukuAsoxO/Iync0ePr3kReFTktAVTMm3",
-	"lIeKBCIG+xLmH74azP+45Oud0iBBMXVGbGnZZ3ll5wf2m2ezMcmKzTZ+tJ3Dn52OL3lWK+dZqTh0eVTw",
-	"aEwMIp5Vvnw0JuWGac+4IFJsp5f8hd2/SmMMcNhU2AIzriwjTdgEsT4pY32SY90XrPgraOzA9KL0xbc5",
-	"mW4zDuddsOUllmUFywV3K7bWX9ww8KqS+zgHuNgjycmAjewZh5OMkU4ybjkxP5+UWeDYI1LlBgttMdtq",
-	"K8JbJGN1Ia9Odg0bJFYlPHj+1vMiPdo+b8ieZtx7LnpT0nyLHSmXdCeuSk6TOSS2UpwERS/FThapdl5s",
-	"GEq1ok8s0iCNBtJFvzZFtmuhjGalMWyFvJpLWBptyzVlXNlmHFewI0eb0+npdHY8xfpDzZdm+QR9z9QG",
-	"AWU+CHS0w8dX5tSg3IJy/vrFo0eP/kI0i0FpGict4Nzsc76hz+hOZ3f6js7DE96USDOgjG88aK8d7vii",
-	"DQZogybSFTlyx4wl1XH1paFHOeQdfDt1gu0dOlgXtDTpPKBOuHWJsBjxkBF/JRatX1h5KCsj1iZbFhoL",
-	"KWssZrGY95s9wVq0PvNHi2Ti+gtO8q5EnQxd7836J2Ltf4HjpI5934FC+VWWfZX3xPlymtyybamKTLs4",
-	"w3zR+vnILAE8ZHzVJ4Uyayk8UAptC+IvUng3Umix3y6FBtNfpPAwNh1Kml8K8Whrl0LbBblL6Gzv5du8",
-	"+9e6O/uyDW0LC8IUydo2fxqPnhySKiUQMn8LEZKkPG/S0Pk6K3dfPDAX8JCVek8eUS74LhZp7alfr1HS",
-	"YoX4VEy5TP01NJSmqzuznBs9JT3EQRfH3b/3aovz4kuvtaPWgAhu12uujOi3EQlqNs4+cHp2tcdxC53v",
-	"/tVWdqyRowW15qaRkzFhyZgkQuoxAR1Mjw+eS/nGQZKnX2OCsyKMk7ICaHm35Xo07xl+RbY++d2VV/9U",
-	"fvZxJkGJaNMTen1TfaJ47r4Z8tKhqOn+Z34j5HZcrgB0d4+FfhBlMPKzDUNmWWJ7Z7a8242tA1B6MbOm",
-	"2iagLoBghq+ZsZfpuh4Y1Tmv3J/RcFzqiQu+F6sVmkX1LnDuhQBNFSg8Sd6Zs/k9vhxS5vagrliSNzkj",
-	"gmO76B1R6UIZXck10Sy4mpL3WR+0qAhYbI3VEMFSk5RrkQZrCMdECdvXtAYNSZg5StKkqLYXUaWJhEBI",
-	"Y3TYtghkczp9NJ153w2lutaO9bDCdDvnkqe77IGTFfoOJ9uLyJ4HB5fbN5VXQjWZfGfY+sR20a11PldO",
-	"DhXjqwhu6AwoIucna9urszVQbwtUIb9rQf6BV+F/4A1mYkNQVphKTUjdjPb6boAvJQBNySsarFHiAppg",
-	"7wOUoATkBBvnYi2SE3N8k2VEV/bXOI00y35HkzwTti4xcwZ4oy3pwYTtM70JT+7UmdDdMNbH4GWy2/jE",
-	"xMUn7pOovTeslR0TXylSMO6kwrhHeEl3LO4qOu6b3enEbtADeQP0/Xwa714HzqkmCvTx/SJn9U38EO3Y",
-	"/w7+kKRoC3MX8ZK52+xNeEgfTmfHU5K7OpgiKadYcg/C+xuaM/R4iW0teq+etvsFOXL5gKo4TB94UHrP",
-	"eDl75J8/TvdDT4BLFqydq2iYt4LqYO253Zk/H1zx3I75WW00ec8sTyT7XRWr+/vdP0bvZHtLORKn2M/Y",
-	"BQcZRKG6tqGLfo5STt4ZNn3vKG1Bo8hVtqBx5dGkNTdjGqwZN9dJZ6wyEbKAREIk5q6sLvlRcRGeLCUA",
-	"ef/i3WRBOQdp7qJYt+Lhw2MsJKfQ56PFJa/cQ8eE8tCV/bTA2Bpgtrz/lNTy1i95hplSVii+HakkheLO",
-	"26pXoGunNPoFoukwx95N5uafPvx6UG7+AVJcEYW2HXtLmVe8vtjfrxlzu3P3eSXSdce65MAu3OdOJdgU",
-	"dWaRYiypzKXLOFlGbLWu+90udjxYS8FFqojgkxBiK+6lZM9i5up9v0XD5R35z2TK25XbjwlwsyRggbKs",
-	"IDVdGfNQFx4z7ONImFbEeYXDS14otTGRqdNKAfbFnSjQDuCFbRIj1MS1XB8bszKG8SWPIWZ8KcYkXI5L",
-	"fvgVaMAe1zAmlE5skuuYZO3pjZqkEvWqWVCkOkm1GpM0USC1RfncOjnnZnrygITAjcqJ2L87B4+aCjX/",
-	"n5c8EFEac3Sx50gt5daNSZIuIqbWZjGs7L9I1RQtToddCK1ihphplaNrmiN/ipaZuSFd8lKDAKeULZRW",
-	"LxefdKjjbNndecq/aOLrGGIXiPK3fCl88pvjN2ubY7srQeaPCon9/jUNtPpzaujGk727V9FPDvk6zFrb",
-	"xXscJLHRfSGjERGyHPZwug4tYwgPnrRQcKNy6QsGbVsjZsZstIXI5KbRNsB/mPx4QZaMr7BbL9ck1zc9",
-	"R0q5qXOz1Y/fHYwSYwtKu34o5i8/XpByr+uiDbQxVl14xBDDVmMTCdgORtIod9dR3V2T1DjDyCXPcpRs",
-	"1Ja8wL4rxPVdweYKnJSaipOXry5eTIl1pFzyxc61rg7HpGhQbqa3/cnHBF8AnGAjHqu1L7mxpYWalDHT",
-	"4mJudisflvBRanf9uQ7latt1n1Z++nhoHaj644iiiXsx8ec3kf/SWOm+NVZqabrve/Jrxf2zHoLcrwtM",
-	"MxWoocfKmq5dd6JTtgizDVKi5TBDS4t9DJe5J7GXfMU2wK0NSh7PHjtjlws9t8X92LKw6dHBe8XFlpMf",
-	"zwlbXnIuajvbBeZIoIokIkkjjI9izS6xJTvQ5MgqPCHVJQ8oN6eTNfpxfkxfwXk2jNrrUNai8vjzVCk2",
-	"9P+XyDFp7sr3eJIqTRSniVqLL5f83ITLWZeLHDuGLesya7C3TKOoytv5F0Z2zP23Yfm4x/ZdOZyu1MDo",
-	"9rt+InN09kVzpQGU46IyCv4K9iofuE4gUXksOdIM5DgrDKDG5LdUaGpsLLx5V9Na83bsbSg5Fzat//a6",
-	"RoQx47hKZ1qWiOAe5JQadLXmlFY7hXQVWajMUiHFmc2n7E7SQ2zZTMHb6iGQKi1is87d9hDIwegsEIyj",
-	"EOt3lo5a6nTmNNnBnZUoIiwkml4Bb20HUOCqj0GbARfr36pW/7DNZ7s0iHWxVNzm9ptDOelxtW4GsnrU",
-	"7gUdjLapAlHpYlI0G7/3j4lpmDUELmJCLueFSHNHiqHY5IJeQWjUVdFCYuzP03yXh7HWgGWW7RxjbEtM",
-	"XTCtFEfLI9n5rV4LYjsZl92rdlNTO9nUmt3hlHxrLFtFqIS8aXV4yanzXlMeGrQssP+53KGHQaR6IpYT",
-	"iXb7hkYp1tDBXouPZ7PpJc9DZs5DW0ZQS9JmJ9fegsJtLnTgsHYbBP60SsdFVSv2T3Q5dALV9J76otUD",
-	"5KlXT7raHnvpyQv7zYGIfpFVH2n2nAEtWaDuyZ3lBnRhSVfFbm8PKmnfy4hWSZoqvJW2U+8nHHCLpMIF",
-	"+p5emUH3wEw22Go1k1OHqTbjo/Rx19OrAuE3r43N3Hdq+BoAeul8D55eCZnVtq5kG90p3/kqX+b2rxnR",
-	"x3tNwxdZdmBuryHNfcztPbhbB3l0WCrvEKr0p/LeLeZnBxX++0XNLJl1CB0bfo9CuJwLhCpzr+h2gSCO",
-	"zOjndvCfN58124ndyOd2S0YngEXgHZwMPzknrrSuiBqX2B0San/Gnj09DIN+CMcOnSyT8r2Y5qds+Be2",
-	"KbGNhFhssD9ilg6kjxtmtRmSkRDfRO5JRKzKIDf+8jDfiYBGJATkMJfznspodDZaa52os5OTyIzAqMXX",
-	"jx8/Gn368Om/AgAA//8=",
+	"7L39bhs5sij+KoR+B1j7N5Js5wu7DoKLjJOcZO9kJrAzuxdYz9VS3SWJYzbZQ7Kl6MwEOH+dBzg4T7hP",
+	"csEi+0vNVrf8IXt2DSx2HDU/isWqYrGqWPXrIJJJKgUIowenvw4U6FQKDfiPb2l8Dr9koI39VySFAYF/",
+	"0jTlLKKGSXH0s5bC/qajBSTU/vVvCmaD08H/d1QOfeS+6qO3Skn1ViyByxQGX79+HQ5i0JFiqR1scDr4",
+	"C+UsxpGHJKVzJvzfUhEWQ5JKAyJaE7DjDL4OBx/BLGT8vTSvOZcriPcH6V+VFHPy/vPnTyRBIAa2je9u",
+	"R38dJ0ycSw763GPV/poqmYIyzKFY2c/2D2Yg0V0w2cHeCqPWduVmncLgdECVomucWsEvGVMWBX/z4/5U",
+	"tJLTnyEytttrDso0AaHRlZArDvEc4gnFBjOpEvvXIKYGRoYlMBgORMY5nXIYnBqVQTG+NoqJuR2/NtB0",
+	"XRsoy1jcawwL48T9/Gvz81TG6+CHSAE12+Fv9IkhztLJFYRHjJlOmNY3xEk5yjURspDaTFh8rb7hbo1m",
+	"MooypXZEngIt+fKG2CkGuSZyVMbBI6fxTcMSFDM4MIgssbzBxEwOhgMuV4PhIIGYZclgOFiw+WJgSYgZ",
+	"FlFe4Z3KaIyDiK4PadE/E4bx62NMG2qguiQaGba0XavcNygnHJRYHlTIMbhIQ+dOIsQxs6KO8k81SdHs",
+	"sCliDDM8zLlZGu/IoBtyDfFcsmxNVFR2O4chR1WdvFvF4ndsBtE64lA59upC/4fUoYRYGURmUpFPP1x8",
+	"JjzvSEDEqWTC6DHxyCc0iiA1mlBBZN4dCeAloZz7z4QSBVRLgYOaBRCaxcyQGAxlfDwYbh4c2Nj+ldAv",
+	"34GYm8Xg9MnzF4ENvRGxfW3Dlf5E54EDrTjHeh1o7jBqHGbDgYAvZhJlSktlx+gGskYkOHVwly1O3y69",
+	"crB5Aro9/jV0phmpvIjpcQDaxq2HVySVAo4aSZvQcnvezoO1icvF3a2gj6SKd+4UO6TWCaJNgBSbb0VV",
+	"piLoi/GifY70bgFaORZ6CJyNPRvmtFLb7B4ypqC+22Gekpi7OWhTjNFfMiDu80uSUq0J1eR/uR9eESPJ",
+	"DEy0QEFkR7K6eD9p0WTEOixhxJjFd3LOREXu1jEjTboh614MBwkTlX81NtmuaiVVHBKSla4nIZGpQQma",
+	"wM5dNxBQjFOBpgMBbTcFe0xoPTHyCsJCSsFMgV5saWGh6SYqs/gIBRibC6pBsTmnn6FtgR/fvX4rlOS8",
+	"fZGpkkummRRMzCeZYt382eixZfa/gGKz9S3S2AYsdoDW6eETKKt1WXHYjgAWgzBeMG1+Ce4p0xMqpFgn",
+	"MqsK16mUHKhAupBBZSwk57DpxpihBaXlUnaR7I0p/VrrA7ZjsB1tkPgD87q3nxYk1SVBDwxWGN7B5Idu",
+	"W9QnLxXOFlTMoZU08VwRZlITadtFmIBV/+YbS2lMtzFc22rOnThoXUaXiNo0YtSahyY9owbmUq2dUaQx",
+	"X+3QayWOXjeOcqAgHFIIsHcwZtbfKqBXsVyJwDbml8vGgZwJBTRa2KOVfEMiS+VRZu90kxllPFOgL7Pj",
+	"46fR08GwJGYmzItnJTUzYWAOymmQc0VjZw2rT9RrGnh10nMev8z6HFvG7Qm/sPrZJFVyGlqDkAQNIpwt",
+	"QYDWRMkVgS9MG91veCk4E7A7cl4d9xl/81Rwk1U2pWJl8CjcWHEXiZ0tILo6B53xAJOhabRQhesLNFE6",
+	"sdq6zMzQrhBHlGKiYJZpiIdkSoUANUmYTqiJFmh3tZ1w0JfEqn9ECqIz1AP62Cqs4PB4ZZyZ9cTeyLMm",
+	"ew4+SW1Gi7U2oEAzTVw7cqBpAmRJeQaojaagmIxZRLiUKVnJjMdkpZiBQytzvT2k2EgrkkX9X1fCYjxk",
+	"+XDY3/GKkw8dPnv9iYVInySBVR9bdHr66qal6koaY1cX0I73TtqSYsbm7bJroiEKbJ6dmViw1ZJytGFU",
+	"RZplV02mwOUKN9EsrGCXPCYHL47H4z++eHZ8fDgmb2BGM27IyZNjcvAksTua0C8ssZuKbVAfc/9+cbxN",
+	"8PWGchPGFTOLrYIxDPHT42Ny8PxaEMuV6A2tg5Eay5Z0KpfQC5t/tMA9Pb4OdAm1/xBURDCZczkNnV1/",
+	"XYAgyP0ECdBxpmHRlSbTzLgfNfFSW5dUXmGU6jxhZIDSTBuIrYiKQ1hhglRGadmmFxYVL46TwzH5Xhqy",
+	"BkNoZuQI/UQQvyRG0egK4sIKl4Ia2fFrY2vOItgdme4kuH3SfHUcXu2f7GJPrkWVihqYcJawgA30I/1i",
+	"wfBKIrm4eF85SjSJMyscyYwDGKJXAKkmByfj8ZPj4xogT2pgnISg8EdVK0WMHL19Pvs0cgcX8T0sMWiI",
+	"pIjd3E/rUz/tnLkivCYFezVhOCt3IxfiVszNpIJy+/7xX/9dlYUWnpM6PCcd8AQ1CsTKhsQb1sV0Rbo0",
+	"WayO3rYl10ghKA/6HSjtd7eoOHC22SUCRxSKe6R0fZ3em3ce93NlzK6FXRSKTH1BnGrjNDmvSmywj5Um",
+	"CiLLO9hqpA1VBknXa1hosUfxM2NKG5SlVc1zJ2dRdcu8n6gJE7P6nS742C5v4jAyDmx5SIK7BUcyE3X1",
+	"qV0Ldz0821yjp1dCd+qJ7qCJUVRoNKzv0LlpeCrWG4YovMJWGII7FaRBBWg5ofyMS9FuNGB64mk5JMPV",
+	"FTELpklkxyBUI7lpq34nxHcjB1LwtdW9WUxW9pTXkUzhlWt1GCSD3FZSn86fSJoYSf7gbrLOZE9se6da",
+	"kQME5fAPbiqZMGPwsrSj7RZhrDpHHbgD50UP+3VtF+9tqAN+7ne8unwcZrir93eDfByUHduL4Qyt+0sz",
+	"s5j40JPqcvXC+0Yr5pupNIvg0jdMJBVcnxw/eTYMGhwrVNVOADvuWtVUFbiYsaXlmbYojcp3NFKlC0V1",
+	"2J53Q+rY2eV/W54EB7dHb83OWCWD7fT0HdNmyzlctOvvgirHLj0GHVbf6jTbwd3iC7kNyr9OsFDeJxz/",
+	"0cVc1zVOM105uJsc15cj750X/P5MpsxU3QXV49m3iGSSeCd96ygzJuagUsU62rV64ncPRtnZHdCPa2tb",
+	"WN3uIH9k2sjkXHLoOB7aJXsfeey2OKXGgLIH4f/9Gx39x0/2/45Hf5r89OvJ8MXTr/8WQlFv51DCxAf3",
+	"8aTTU7Rhg+/2GJVoahcj13IP4P5MM8bNhIkww92We6yx6OrM3Sh4Gy1kK3UkoLWPQWic+bucS/k47QC0",
+	"C/GYmQksQbSFNl4ndgaihYQebh3frjFmcB3ilwwy+Aza/FlOt91kO8H7WU77LXYDXN+vH7i1yOWwfyAE",
+	"fLzvgKXizMrPn4gzcFckUEtQlsYlZ5E90eGLFUQtcZmLLKFiUiHpgJ3eqHWbnb5hCYithM7Fcdl1c6Im",
+	"8jeJDFEd3KMl5Rk1gAFwrUyqI6lyFs0tRVVT0XHnLdWNEILgHQcw76U277zzoTG7vbcyMZ9gfO0ul+wt",
+	"0crbqTzvOAzN3bqI77wbsLmCTTdiD9hrDp0e7XN/Ut/Wu42/xf0Tdmv1cCQizs7R/uSiDvRNA9FwxM+K",
+	"Cu3j4jqPttYATQdcxqGTKpFWdqHK9jDxTSz7hsPQXK1AX+S8uhHRRLW2Q8xUGV+6Ycd2LYidVpMjcuC7",
+	"kG+In/+Q0EhJrTFcGH0BY3I8Hp+MazZBmTlS8OCJLJl6K7o0lE/ASZxcKdm0Y2fCEDlzfnVEAFqpiJIr",
+	"TVYLUBgsiEEh3i/LtAsblArBHF/DM97ATQjWVoR/luk7h5/36Fa6DSKuysMbEnEJniXn2wGvyhg3Ba/C",
+	"rk1dAOXC5IqJ2v0ajdETDRjq56yYrmVcib0vfvppt3cs+3230vPJSPDlhbP550ixROxFhcXCFUtTxMfm",
+	"2b/tmliee6Xs8TMNa5vRHWP8Hig3iy13nunEG/lrWnLl9tJc4gLHXFdDWEKbuwSlw1epTaUkX1oNmHKA",
+	"4LqkNmcySTmjIoKLLEloKOKrUG57HAheuvb1OThh1dfP4OmgX2uUetdyQnigysU0STAfvhWr1zUjtBiI",
+	"Y6ZTTteTNqtn88omlkxJkRt8qvG3ofHnSmbpdU1QltOuaaFm6YTGsfKK5gaUXdZtqUxNj3/x/PnT553u",
+	"b/8SqzggulCz+QZgm/G5WxP3lqrKuttI6A3e/7ZdjHPGneiSc7cdd2F29xvYp3PVHs0rFwTK+Q+zwenf",
+	"ukcorhVff9p8+vt9xrnzCAlJiihEF4ywoJrYE4SoTBA6p0xo4zxtFvRxg0hDmMd7fgNlbdj/jmnzwUAS",
+	"Oschupqkisn8QOsdcvAg7OOboqRLdNydrLi26b4mNBqfMVRAR1Tc6AHtw6bvul87qZuZqlZTLyN7yMFu",
+	"wXf3pv2whPTLqFPmNsZtF5qL/FbT635QEwRddwM3dDtYbfaUUPBZeMuQsOuRyN1kvBk3c01usMMUwbEO",
+	"cy2dNgGu3mluBEMiBTPS/mvSeKvdLx68wjNdUct2lv4702jug1Za2yu2ZBzmsMscwT4dE7UEid8spFvr",
+	"xQ5wb7beCnHYNtcZa2057GO5ua16Nwi7vEBIiiU58oqkNNPgY2tfkhnl2v6qQGdV8dZm485Hb4WwIOD3",
+	"TJv2FzZOw0C26C1onVioWOs72WlHQWI3GeIJp2v33rG4qvsLkl4MKjRqcXCTBBxdqkH7tW/vUkJebcFf",
+	"LZYPlkxm+tbB6sRzKTn6whp6YtEt7i2n95thu72mQv+B/ezNXVteNgqjGOymB7Qwb0BPugVPTQ5g21q3",
+	"3AofbycP+3byqLeHSfoCw6Q+iJkMBYzqjKMrhZI3TEdyCWpt70pjkgdZm4V70TFx4VYTJmaSGLvZlyKS",
+	"PEvEaCbVyP05JhcpRD4wF1+ijOJ82PGlaOSFoWlKVSLVpKI/dAtRqqIFMxAZ73LrpL5Ico5m291ybTF9",
+	"NZkpgMl82k9OYw/nFNqpS6Yh7t1jxhSsKOcTDWrJokD8ct4iJr+RbLYivxExwx3T5DfC0uJPSFJ8z96t",
+	"ohRTFopud59fYtGr4S7KSlWMdA58BUoAn+zaXgEHH4/bt0vFl9B92YJkQpeUYatJ0nPTbS9HWH17SD2Z",
+	"0YTxdYDrJedZStxn8o///B+iFsCHJIYpo2JIdKZhSChPmbD/VdFiSOYgjJRDIs0CQ1061yl134Q42HLC",
+	"2RX0bd57S6WepAqMWe/UZZftLJtPZhnnvfqknBpL6hOXU2LGQPXMA8SZyL60vkl+K2ZSRUzMyW8kz9+x",
+	"BPKbFe0oXnOeJ2xGhDQkVaBdCFP33Cua7kSBrSpYTRi3HVo/4tH6YN08HQ6UG6lK//Sem8aGfxAGOGdz",
+	"EBG0pDu7u7C+GMzuqoGLA82DEDeiU7jUEBNDv0ghk/UpgfF87FWicUqjKzqHsVcdBw846uA2k1Fuv5ZW",
+	"sFnLilgFu75RP/WholtJW9akzf3l/6vOfZHbNjb54jqa7S4kpgVN9UKaLsaqM8E7BWDvBYm7O7DKSpy1",
+	"YZyPi/pHUrzoxOVINb7Ip+2KWi3JSJddOs+Y71gEQjusbrnzY1g+qNbw7S8pU6BvZHyfATW5jbf/1ZOJ",
+	"yVzRCCYuwUjf2Jgi8yp2HuQrwHNJTrhDir1rCnxGGc64yup2SntDssyaglhREy0mKcdwGRAGH7xoCA6T",
+	"YTBdqmC58VCuzZaF81YijQrEbdnfjhxqfsGTn1em+z5ebdxjylYT2d5opmWYkob0xO1ykHhMX610iQue",
+	"qCLBT6PFiirBxPxG4G4KzRz2zflDO1PmsmvzC/jEXGG9goo5qNaEddd8lpNT05wa6JvXqwBz86VNCeL2",
+	"5etzmDNttllw/Ry7GHHrac0CwqrthdG2QTf3LJR49Y6y0VdQUId9uCVR/SfJWcRAnwOXNG7Hr8xMJBO4",
+	"Uc7qzQQb+ZCtcK3fQIRpJ7e9LruW9tz9lsVDF34JjcC1v3n039tDNYeVzNId2S49GPVJG1MUA4ZwWZLQ",
+	"7/9xXp2uq3CEVv6jBtUReVkktdwSqPj0+nlv/7ifvLd5GsytySMtNra+TN/ZK3DjjKAuGsUD3SMm5D6e",
+	"FzfQ3IpbyeG11mzenmHZCmKvle+y03m3tpn19iAnu4L+J06NTLpY1A0deKOHyn7Id3Nh6BzIMVlRfsXE",
+	"fKSvgIPBdIdqRiPAi5VZKKik+SdmQQ2BL6AipjEd26WYyUy4GjZEGxpdkYOKsWVYrWMzdFn+h66eDQH/",
+	"aPPQeXZ8HYXBDymIv9qLADnwIB5WouVPB8fjk/HxiPJ0QccneEKkIGjKBqeDp+Pj8VPkPrNA9B7RlB0t",
+	"T45onDBx5HWmU6fx4fb4+Fq7SQjvh9jnZsRyNjWVfOAQDtp86yuy3ErlneBN42t9e31kYa1c0ZPj47uC",
+	"ociG3axXZFv4OYjTmMmBjxvC5JnrFOI8N9ihKxGUh0AP3qj1SGXCZdihBgglf/7rZ+J3BRO+uWRm2lDO",
+	"mZgT5pSV+i6mXlM6Vagq9djGum41uENEtmhxAUx+AjWy2CJuFaRQwr4OB8+On+6vsNMZ5RwU4TS60sRp",
+	"Mzlm69vn1kSsWIXYtyQzxkGTmZIJOnpdEq1MQUxiptASY/nmyyin5VGpNwxOB83piq3Goht2cXMwIb+z",
+	"yZTQxDUjTLgaIu5f6J9E6bVSzBgQZLp2osr7lbHdSMnMgCKpT7WItUsSEHECwpCD5YkVM4djcoZmuUtR",
+	"luci9n+laZG8eXtxNibn374+O3UgnCqgsXNlX1rJ5CbUTszVafTfwbj6Iii1FE3A4BHxt18HVqUb/JIB",
+	"YtAdk0V9l3Lvb78mztdheO6KoayYvTOMpmUZpY22uZLr24hbJmMuMCsA9dZKPOHRXHmZ2xrN23yrw/Xs",
+	"macoLDsWWXGeH++Sd/LrT3coDyu1cwKix311xTZQ7B23jVcAeFSp0nevkrJkdFIRaXWJaZXBQr7EuXg6",
+	"8JIE4qEVnwaUlVeHAfF39CuLv3bKwELyYWLwAyYinsX29DQWLkE55pYG7Rz1XgaQo0tRCAFCFRBtGOcE",
+	"qQzhaZNopJ9A+3b94U2LTLPaWUnI7iFoTdXZRcLcOfW2Eu6DpD8L0rP9gYSIwFAAvAVs0P8FE3OeE+d0",
+	"TVjcRuSnlVOrqtDVZ3NnHBn5DIrVk65OrZghvUmuDWJFDdF+e12Zfl9Ee/tXiXBVt6/+MrFvJnEhGF7s",
+	"PQRmQap4UNxi5//T/ub/4LxypEzGipm389TWTrmss3CFMQgVxHOg39IWXvbnSjsfvxZrIqQYlQeQS7+R",
+	"M3bx+w25+o0H5JGjHzn6kaNzK4xjCuRmhP4g1xNbVdBTrzV2ncy/VU/k3/KbZ8HWue55Q64+98A8cvUj",
+	"Vz9ydWGcQ6YouLqVlT1X7sTKBQfnLD0mtcrAY5fBX6cQsRkDfSnwNT2mWPdVgYHTVIN+SXBPxZwkQIUm",
+	"TMQwYwIlwCeqjasFcCmUv9s+Oz7uJS0CF9FCXlz4FT/KizuTF787u82jiNldxFzkBb5zxcFxPcVSHtrQ",
+	"JCUHUlVYmq83NIosZuYIg3Wrlv2m/agsHNzPKl7k09vZitoodbzzCLWSyDv3frRN36NteqM+dchJR+eA",
+	"jxuxOL2n3OtIvKZZuDokOXC4HlUswwJWoI2riLPJRmZxxOXchfxscX3mVZbvyHHdKGO9Z6d1s4p0YAex",
+	"gSvgCDFWPJNXYBUPrTPwYvdk/2K3UhaCSEU+vntNCsQhsUCUubcTf/upSjo/+hCYozxUhyAhuGJpMtfJ",
+	"Pv/w+VOQZGRmetGMbdfYuWeBEBLA05MoWMoraDqM7a/OL+wd+hpKP0kNOBcE1H4imMVHGNwxMdUKgTe3",
+	"Lq/fvG+a+V76mkQeeZZgpkCVfyRXxbdVmmv4LopOBxB+tBEbuB35n+pxrHe7D6Hi4eEYCt+McNYQs29n",
+	"M3DmyspCi0qHPTA0o6eAFdy7eaYo9n7nuGlUlQ/hpVIlnvx4/oG461SlzqNdoF13RI1UhKbpJu5wjhqi",
+	"Mg1WuUPhYgVWGGG9Qquq9env8HBq1MDvdUAFxJwVz7gwdg9Hhp3cotw/qSFYKjPldN2Qt1jqTyVWQXd0",
+	"CzGeLBoiBeiAc7tjd5OSOQi7MRCT4GmRHzCnLha0e0frtd3vcFvDReSvu7f5aCR/UVmqd3sS77AixWmu",
+	"4Gd8dmY3yxeD2De9nfkrYAHTSkkfCVshNcR9Qz78QRfdAhRVSuFT5d+RdJ07gacndxq+t+WlSwBVBUh1",
+	"5LzLOEejFcmXSQ7KNyHD6nE0JBg2P2KC4NOQgKavYKZAL7oZ8Nw3vDvO8zM8ZH3fchOq+CSlTN2Xmu8R",
+	"5SHxkntI/GPJoZPhmYbYEoaOaAxehSZGsfkcFMSHW+8B5xIdppb/VHWulyRhwhBqr4+EYljuN3kDi5Aa",
+	"eW2UwGvjw7NKszvc3pbCfSEJVbQkCRgaU0O9/nefhsUSmxiVE7rzV299BwXoUvD14ZYg2cbAwy2CYHOz",
+	"bl8QtBXs7CUNTu4AjJ6k4p/V7P18/4uLdndvIbwOh4Xyhvi0vbQBo1jIW1xcvCdXsN67Xfhjxg1L+WZt",
+	"XL15/iMyCa2QdD8KRsN7mxQq4h1j4OCyFdQp/A3+Xm7q/QUZPgtV/bXAxeSgqGj4CvOUHu7duVCh+tbQ",
+	"PDkzI4fma+yi35+vwx6Hxj9DIOjOwiYX7g9x69+BiRa1Tf+DLgHe4RzawsSnWNy63cl8JlMGvgi3q4xd",
+	"gwZEpNapZSZ/d02oAWUXtQQ1pYYlhAkjvZ6j5MoZQO1whqo5GCdhj/L6rWPyo3aXKttkmvErwpJUKkNm",
+	"XFqFkVBjqMPKQmoQFXCIgSTlqG1JAraRgBVf+wEgdlI8f7ykYJQqmaTGXolya8vGItq81RuVzn/HDuuW",
+	"mu0PU0XAivD3pR186NQIloX+kL+r27tQudhk0RJECyHlVh6siS7PlP07tMuawq8wZXgkOWcxaCcZqCDw",
+	"hWnkyrpms6nYIDVUhWNV0uAukQM/wj/+67/dhknl/pv/cHhdXShmdC6kNizSpxAt5PZL/5uy9VvbOCwv",
+	"FkBjl3HRSYwP5Xvc0f+G9VbxUXsU/7zzUXzLjP9ndFa62UcftrvZ70giVasD79luUasLHKBc+730UF47",
+	"oOZ5d5ePWID7e2lecy5X98CkG7SXG0GQRWM2mwFaHqd24zf8ERZHztqBSyY+Y8jL4i26rj40J984/3o7",
+	"c7kaxyMD2ox+ltP+jFYrjty0hzy5PWSGyzAHsPpnOUVbj1WYXpKVVFegyIpxTmJF2eajNHxTPzomODqJ",
+	"IZEviUeHtmJOjmRKfpZTkiqJ5SAKvYmJkf/NT9KOXl/v14Xn9UdutUzwHZkvgqWI9ywRWnLqhDx57pV1",
+	"7Ju2bGWat8K99AusPAycmIUCvZA81oVXoWXnUgUJy5LRTqfPJ9fpQRxC/5rnRy7Ln+xPlvucESSWoFEf",
+	"dA9PgXgSmlTIiviEcw2jKA4xwhxmxJLcyzwMRm8dpqZe5T+eDgJdWgndd3c55vE+25faz11PV+0B00k8",
+	"Uvx9UDw5iJz93Qk2u5FomDi8Xz9AAUeLsEbHoBPVBa0Xfaohye13iPoUndTt7hnXIO+/YsdH+n449I1b",
+	"+RAIvLy77kDhjaj7DhLffkHOaVxBAjFzl0v4AlG2O7Gfl0O89SM8Uv2/uh5ToauJo6vioch9sV4FpNOc",
+	"1Nt58Js8s9YGLwZGId+El9ulcYVx1M7WbQvI+XvGAcyRr5LOlsysj6YK6BVWWmtLhPIGFFsCnp0j95Ac",
+	"rXGRzIQpAz4vwBgm5hqtdBcRFRgdeZkdHz95cSnKYmaYjmZMvqUi1iSSCbjsVn8P1VX8+6VYrLUBBZrp",
+	"U+LKxb0qqjV+4/q8Oh6SvIBc46N7WffqZHgp8txGryoFH6utoqdDYhHxqtbz6ZAIWIJytUTjV0ISJVfj",
+	"S3Hm1q+zBB0cLhS2xEzlER1ifVTF+qjAekuOl3e2y1mlx7fFNt2lHy44YUt2NUcKjgrul22dvbgjWdCz",
+	"AuByjaTYBnLgiOsoJ6SjnFqO7OejKgkcBliqWjS5zWeLe1qUw73DbaxPFJTJvgizwkpDe4/fel2GR7vn",
+	"DfnTjAdPRe8rkm+6JtUyrcRnvm8Sh4IIhBm5SN9uEjnH5me+dUNR2ijkgBmurATCp4buqZ4mq4XUVrLS",
+	"BFZSXU0UzKy0FYYyTGnFNLmCdZmGD2sKNF+aFQN0PVPrBZTtEBm+xsdX9tSgwoFy/u7s6dOnfypfOraA",
+	"c7vP+fo+ozs5vtd3dAGaCIZE2gZVfN8s79ujNOghDZpI1+TAHzNuqw7rLw0DwkFHUkGnTLjAVr1lAeaS",
+	"VBn3xVysxrJnmXDnHOEwEthG/EocWh9JuS8pI9ZGKxZbDSlJOaMiAodFcpBSTCpxhPXlQuqPkenIKu1M",
+	"zNEm1n3IfZbpO9fhPbb/HZH2P8Fxson90IFCxVUefVXUuX88Te5Yt9RlpF2SY95emi3Ba3JgpwARMzHv",
+	"4kLssAMXnmP7Ry68Hy502G/nQovpRy7cj06HnBbmQjza2rlwAZSbxTame+9a3CFhuRm22YEvXFlqwjRx",
+	"AOMriOf73JUKCLm9hUhFMlEUXt76OqswX3xjL+Axw7/RNkMOqJBinchs46lfp1LSooWEREy19Ow1JJSh",
+	"83vTnO0qu55/oYnj/t97tfl58aXXwu9WDw/uttdc+abfhSfovYs4v78XXC6AomOf7//VVn6skYMpdeqm",
+	"5ZMhYemQpFKZIQETjQ/3Hkv53kNShF9jgDPWwqgKgJZ3W3Ydu7tfkayPfvWVIL5Wn32EcoSGCbryRHGX",
+	"VJ5l+Ynf8xuh8zz/fvQAHgt9L6tgFGcbuszywPat0fJ51knMA1B5MbOgxgWgToFghK8dsZPotj0w2qS8",
+	"hFo9WNA8lWUW8At+lvM5qkWVxpNExuBfCNBMg8aT5JM9mz/jyyFtbw/6iqW4KIcFQWAJak10NtVWVgpD",
+	"DIuuxuSzbzLhpcNiZbUGDjPMjyezaAHxkGiJ1ZKSDWhIyuxRkqVlBR1OtSEKIqniPC/2mCxPxk/Hx8F3",
+	"Qxny1McKOvbKTHdzLlWWc0/BCl2HU54EE0l633z7vvZKaIMnP1myPkJqA1LQJWqf2vOhdnUZbucMKD3n",
+	"Rwumjawl9QhXLMlSy2R/x6vw3/EGM3IuKMdM5YgTP6K7vlvgKwFAY/KWRgvkuIimWM8YOSgFNeJ0DQpz",
+	"kRzZ45vMOJ27r0nGDcu/o0qeM9s2NvMK+McCsvd+qftithtaE57fqzEhiLqtql91251/YuT9Ew+J1T5b",
+	"0sqPiT9oUhLuqEa4B3hJ9yTuMzruGt3p2a7XA3kL9MN8Gu9fB06oIRrM4cPazvqb+D7Ssfsd/D63os3N",
+	"XfpLJn6xt2EhfYLV8QpTB9MkExRT7kH8cF1zdj/eYKnqzqunq2idF9RCTbEw6zRR+sBoOX/kXzxOD0NP",
+	"QCgWLbypqJ+1gppoEbjd2Z/3LnjuRv10yt0D1Txx2+8rWd1f7v8x+laydztHkszVAHXOQQY81tdWdNHO",
+	"UYnJO40WEF1tSW1BOfeZLWhSezTp1M2ERgsm7HXSK6tMxiwiXMrU3pX1pTgoL8KjmQIgn88+jaZUCFD2",
+	"Lop5K548ORzmpQXtlfVS1O6hQ0JFTFSlQqDLAeZK9o7JRtz6pcgxU4kKxbcjtaBQXHlb9go07VRanyGa",
+	"9nPs3WZs/smTP/aKzd9DiCui8By3rCXNK15f3PffWR2G4JOn+5YlezbhvvYiwYWoM4cUq0nlJl0myIyz",
+	"+WLT7naxFtFCSSEzTaQYxZA4dq8Ee5Yj1+/7LRIuZjqSS1DrU5WJduH2QwrCTgmYoCxPSE3nVj00pcUs",
+	"0656ty5qPl2KUqgNicq8VIq41BCPNBgP8NQVfpd6pIAD1TC0amUCw0uRQMLETA5JPBtW7PBzMCBmUkUw",
+	"JJSOXJDr0F6zYEU5t2KSKpSrdkKZmTQzekiyVGM1VhSbzsg5scOTb0gMwooczv7DG3j0WOrJ/38pIsmz",
+	"BKvWlEitxNYNSZpNOdMLOxlm9p9meowap8cuxE4wQ8KMLtA1LpA/Rs3M3pAuRaVAgBfKvno1yuWyyxZx",
+	"nE+7Ps/EoyS+jiJ2gSj/IGYyxL8FfvNS+P/4z//xOXHRHhUT1/8djYz+fUroey+U0xTRz/f5Osxp2+V7",
+	"HNxiK/tiRjmRqur28LIONWOI9x60UFKj9uELFm0ry2ZWbXSJyNSyUTYgfJj8cEFmTMxBpYoJQwp503Gk",
+	"MGGAczYHEUGz1E97AWsXjpzXQ7G//HBBPlQGw4ROEBmprLLq3SN2M1w2NpmCgBh1Y20lfnRF5+CvSXqY",
+	"Y+RS5DFKzmvri/uTem3/GAxaMcra/s6Qcimma+KNuUMH6iSSMdjhXT37IcEXAEdYiMdJ7UthdWmpR1XM",
+	"tJiYq+vdpf7RLVbmL1c1aJHKL571zQP1WPT/X7OwUpOM2+orua83ewjysC4wzVCghhyrSrp22YlG2dLN",
+	"1kuIVt0MrmNlxNLMmz+JvRRztgThdFDy7PiZV3aFNBOX3I/NSp0eDbxXQq4E+eGcsNmlEHJjZevIHglU",
+	"k1SmGUf/KObskiuyBkMOnMCTSl+KiAp7OjmlH8fH8BUcZ8mouw6BiFPJhDm8mSi9wGJ2/wwxJs1VhR5P",
+	"Um2IFjTVC/l4yS9UuIJ0hSywY8lyk2ct9mYZ53XaLnpY3rH334bm4x/bb4vh9KkG7jK81k+BxLG1LppP",
+	"DRAq9Pjv4K7yeTFIXm1LDgwDNcwTA+gh+SWThlodC2/e9bBWLGqxDSXn0oX1313ViDhhAmfZGpYlOTyA",
+	"mFKLrtaY0nqlkG1JFmqj1Lbi1MVTbg/SQ2y5SMG7qiGQaSMTO8/91hAowNiaIBhbIdbvLRy1UunMS7K9",
+	"GyuRRVhMDL0C0VoOoMRVF4E2HS7OvlXP/hFJMWPzbRLEmVhqZnPXZ19GepxtOwE5OerWggZGV1SB6Gw6",
+	"ktOfITK/i8fE1OlzNZ+Qj3khyt6REigXOaVXEFtxVZaQGIbjND8VbqwFYJplN4a9TM8F9c60ih+t8GQX",
+	"t3ojyTlwSWvmVbeosRts7NTueEy+tZqtJlRBnlobra3eek1FbNEytY2oWqOFQWZmJGcjhXr7kvIMc+hg",
+	"rcVnx8fjS1G4zLyFtoqglqDNrVR7BwK3OdGe3dptEITDKj0V1bXY39Hl0DNU03oa8lb34KdOOelze+wk",
+	"Jy9cnz1t+kWefaRZcwaMYpF+IHeWW5CFFVmV+LV9Uwv7nnFa39JM4620ffd+xAZ3uFU4QdfTK9voAajJ",
+	"FlutanLmMdWmfFQ6b3t6VSL89qWxHfteFV8LQOc+P4CnV1Llua1r0Ub3SnehzJeF/mtbdNFeU/FFku0Z",
+	"22u35iHG9u7drIM02i+Ut8+udIfy3i/mj/fK/A9rN/Ng1j772LB7lMzlTSBU23vFdhMI4si2fu0a/37j",
+	"WfOVuIXctFoyGgEcAu/hZPjRG3GVM0VsUIlbIaHuM9bs6SAYtEN4cthKMpnYiWh+zJs/kk2FbBQkcon1",
+	"EfNwIHPYUKttk3wL8U3kjpuIWRnUMpwe5jsZUU5iQArzMe+Z4oPTwcKYVJ8eHXHbAr0Wf3z27Ong609f",
+	"/18AAAD//w==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/app/internal/server/api_alerts_test.go
+++ b/app/internal/server/api_alerts_test.go
@@ -1,0 +1,404 @@
+// @spec api-alerts
+//
+// AC traceability (this file):
+//
+//	AC-01  TestAPI_Alerts_List_ViewerCanRead
+//	AC-02  TestAPI_Alerts_List_Anonymous_Forbidden
+//	AC-03  TestAPI_Alerts_List_LimitTooHigh_400
+//	AC-04  TestAPI_Alerts_List_FilterByStateHostSeverity
+//	AC-05  TestAPI_Alerts_List_CursorPagination
+//	AC-06  TestAPI_Alerts_Acknowledge_Success
+//	AC-07  TestAPI_Alerts_Acknowledge_Viewer_403
+//	AC-08  TestAPI_Alerts_Acknowledge_Unknown_404
+//	AC-09  TestAPI_Alerts_Acknowledge_OnResolved_409
+//	AC-10  TestAPI_Alerts_Silence_PastUntil_400
+//	AC-11  TestAPI_Alerts_Silence_NoBody_Indefinite_200
+//	AC-12  TestAPI_Alerts_Resolve_Then_Conflict
+//	AC-13  TestAPI_Alerts_Dismiss_Then_Conflict
+//	AC-14  TestAPI_Alerts_List_UnknownSeverity_400
+//	AC-15  TestAPI_Alerts_List_UnknownState_400
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+func seedAlertRow(t *testing.T, pool *pgxpool.Pool, atype alertrouter.AlertType, sev alertrouter.Severity, hostID uuid.UUID, occurredAt time.Time) uuid.UUID {
+	t.Helper()
+	store := alertrouter.NewPgxStore(pool)
+	a := alertrouter.Alert{
+		Type:       atype,
+		Severity:   sev,
+		HostID:     hostID,
+		OccurredAt: occurredAt,
+		Title:      string(atype) + " seed",
+		Body:       "test body",
+		Tags:       map[string]string{"severity": string(sev)},
+	}
+	id, err := store.Insert(context.Background(), a)
+	if err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+	return id
+}
+
+// @ac AC-01
+func TestAPI_Alerts_List_ViewerCanRead(t *testing.T) {
+	t.Run("api-alerts/AC-01", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC().Add(-1*time.Minute))
+
+		req := asRole(t, "GET", srv+"/api/v1/alerts", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d, want 200", resp.StatusCode)
+		}
+		var page api.AlertsPage
+		_ = json.NewDecoder(resp.Body).Decode(&page)
+		if len(page.Items) == 0 {
+			t.Errorf("expected at least one alert")
+		}
+	})
+}
+
+// @ac AC-02
+func TestAPI_Alerts_List_Anonymous_Forbidden(t *testing.T) {
+	t.Run("api-alerts/AC-02", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req, _ := http.NewRequest("GET", srv+"/api/v1/alerts", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status=%d, want 403", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-03
+func TestAPI_Alerts_List_LimitTooHigh_400(t *testing.T) {
+	t.Run("api-alerts/AC-03", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req := asRole(t, "GET", srv+"/api/v1/alerts?limit=300", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status=%d, want 400", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-04
+func TestAPI_Alerts_List_FilterByStateHostSeverity(t *testing.T) {
+	t.Run("api-alerts/AC-04", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		h1 := seedHostForIntel(t, pool)
+		h2 := seedHostForIntel(t, pool)
+		now := time.Now().UTC()
+		seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable, alertrouter.SeverityHigh, h1, now.Add(-3*time.Minute))
+		seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable, alertrouter.SeverityMedium, h1, now.Add(-2*time.Minute))
+		seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable, alertrouter.SeverityHigh, h2, now.Add(-1*time.Minute))
+
+		q := url.Values{}
+		q.Set("state", "active")
+		q.Set("host_id", h1.String())
+		q.Set("severity", "high")
+		req := asRole(t, "GET", srv+"/api/v1/alerts?"+q.Encode(), auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		var page api.AlertsPage
+		_ = json.NewDecoder(resp.Body).Decode(&page)
+		if len(page.Items) != 1 {
+			t.Errorf("expected 1 filtered item, got %d", len(page.Items))
+		}
+	})
+}
+
+// @ac AC-05
+func TestAPI_Alerts_List_CursorPagination(t *testing.T) {
+	t.Run("api-alerts/AC-05", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		base := time.Now().UTC().Add(-1 * time.Hour)
+		for i := 0; i < 5; i++ {
+			seedAlertRow(t, pool, alertrouter.AlertTypeDriftMinor,
+				alertrouter.SeverityLow, uuid.Nil, base.Add(time.Duration(i)*time.Minute))
+		}
+		req := asRole(t, "GET", srv+"/api/v1/alerts?limit=2", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		var p1 api.AlertsPage
+		_ = json.NewDecoder(resp.Body).Decode(&p1)
+		if len(p1.Items) != 2 || p1.NextCursor == nil {
+			t.Fatalf("page1 items=%d cursor=%v", len(p1.Items), p1.NextCursor)
+		}
+
+		q := url.Values{}
+		q.Set("limit", "2")
+		q.Set("cursor", *p1.NextCursor)
+		req2 := asRole(t, "GET", srv+"/api/v1/alerts?"+q.Encode(), auth.RoleViewer, nil)
+		resp2, err := http.DefaultClient.Do(req2)
+		if err != nil {
+			t.Fatalf("Do2: %v", err)
+		}
+		defer resp2.Body.Close()
+		var p2 api.AlertsPage
+		_ = json.NewDecoder(resp2.Body).Decode(&p2)
+		if len(p2.Items) != 2 {
+			t.Errorf("page2 items=%d, want 2", len(p2.Items))
+		}
+	})
+}
+
+// @ac AC-06
+func TestAPI_Alerts_Acknowledge_Success(t *testing.T) {
+	t.Run("api-alerts/AC-06", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":acknowledge",
+			auth.RoleAdmin, map[string]any{"reason": "saw it"})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d, want 200", resp.StatusCode)
+		}
+		var a api.Alert
+		_ = json.NewDecoder(resp.Body).Decode(&a)
+		if a.State != "acknowledged" {
+			t.Errorf("state=%q, want acknowledged", a.State)
+		}
+	})
+}
+
+// @ac AC-07
+func TestAPI_Alerts_Acknowledge_Viewer_403(t *testing.T) {
+	t.Run("api-alerts/AC-07", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":acknowledge",
+			auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("status=%d, want 403", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-08
+func TestAPI_Alerts_Acknowledge_Unknown_404(t *testing.T) {
+	t.Run("api-alerts/AC-08", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		missing, _ := uuid.NewV7()
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+missing.String()+":acknowledge",
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("status=%d, want 404", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-09
+func TestAPI_Alerts_Acknowledge_OnResolved_409(t *testing.T) {
+	t.Run("api-alerts/AC-09", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":resolve",
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		_ = resp.Body.Close()
+
+		req2 := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":acknowledge",
+			auth.RoleAdmin, nil)
+		resp2, err := http.DefaultClient.Do(req2)
+		if err != nil {
+			t.Fatalf("Do2: %v", err)
+		}
+		defer resp2.Body.Close()
+		if resp2.StatusCode != http.StatusConflict {
+			t.Errorf("status=%d, want 409", resp2.StatusCode)
+		}
+	})
+}
+
+// @ac AC-10
+func TestAPI_Alerts_Silence_PastUntil_400(t *testing.T) {
+	t.Run("api-alerts/AC-10", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityMedium, uuid.Nil, time.Now().UTC())
+		past := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":silence",
+			auth.RoleAdmin, map[string]any{"until": past})
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status=%d, want 400", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-11
+func TestAPI_Alerts_Silence_NoBody_Indefinite_200(t *testing.T) {
+	t.Run("api-alerts/AC-11", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityLow, uuid.Nil, time.Now().UTC())
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":silence",
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status=%d, want 200", resp.StatusCode)
+		}
+		var a api.Alert
+		_ = json.NewDecoder(resp.Body).Decode(&a)
+		if a.State != "silenced" {
+			t.Errorf("state=%q, want silenced", a.State)
+		}
+		if a.SilencedUntil != nil {
+			t.Errorf("silenced_until=%v, want null (indefinite)", a.SilencedUntil)
+		}
+	})
+}
+
+// @ac AC-12
+func TestAPI_Alerts_Resolve_Then_Conflict(t *testing.T) {
+	t.Run("api-alerts/AC-12", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeHostUnreachable,
+			alertrouter.SeverityHigh, uuid.Nil, time.Now().UTC())
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":resolve",
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("first resolve status=%d, want 200", resp.StatusCode)
+		}
+		req2 := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":resolve",
+			auth.RoleAdmin, nil)
+		resp2, err := http.DefaultClient.Do(req2)
+		if err != nil {
+			t.Fatalf("Do2: %v", err)
+		}
+		defer resp2.Body.Close()
+		if resp2.StatusCode != http.StatusConflict {
+			t.Errorf("repeat resolve status=%d, want 409", resp2.StatusCode)
+		}
+	})
+}
+
+// @ac AC-13
+func TestAPI_Alerts_Dismiss_Then_Conflict(t *testing.T) {
+	t.Run("api-alerts/AC-13", func(t *testing.T) {
+		srv, pool := freshAPIServer(t)
+		id := seedAlertRow(t, pool, alertrouter.AlertTypeDriftMinor,
+			alertrouter.SeverityLow, uuid.Nil, time.Now().UTC())
+		req := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":dismiss",
+			auth.RoleAdmin, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("first dismiss status=%d, want 200", resp.StatusCode)
+		}
+		req2 := asRole(t, "POST", srv+"/api/v1/alerts/"+id.String()+":dismiss",
+			auth.RoleAdmin, nil)
+		resp2, err := http.DefaultClient.Do(req2)
+		if err != nil {
+			t.Fatalf("Do2: %v", err)
+		}
+		defer resp2.Body.Close()
+		if resp2.StatusCode != http.StatusConflict {
+			t.Errorf("repeat dismiss status=%d, want 409", resp2.StatusCode)
+		}
+	})
+}
+
+// @ac AC-14
+func TestAPI_Alerts_List_UnknownSeverity_400(t *testing.T) {
+	t.Run("api-alerts/AC-14", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req := asRole(t, "GET", srv+"/api/v1/alerts?severity=panic", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status=%d, want 400", resp.StatusCode)
+		}
+	})
+}
+
+// @ac AC-15
+func TestAPI_Alerts_List_UnknownState_400(t *testing.T) {
+	t.Run("api-alerts/AC-15", func(t *testing.T) {
+		srv, _ := freshAPIServer(t)
+		req := asRole(t, "GET", srv+"/api/v1/alerts?state=zombie", auth.RoleViewer, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Do: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("status=%d, want 400", resp.StatusCode)
+		}
+	})
+}

--- a/app/internal/server/api_helpers_test.go
+++ b/app/internal/server/api_helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/alerts"
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/config"
@@ -201,6 +202,9 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 		WithHostLookup(discovery.PoolHostLookup{Pool: pool}).
 		WithCredentialService(credential.NewService(pool))
 	s.WithDiscovery(discoSvc)
+
+	// Spec system-alerts + api-alerts: wire the lifecycle service.
+	s.WithAlerts(alerts.NewService(pool, audit.Emit))
 
 	// Start the in-process worker. httptest.NewServer bypasses s.Run(),
 	// so the worker would never start otherwise — tests that exercise

--- a/app/internal/server/handlers.go
+++ b/app/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/alerts"
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/correlation"
@@ -15,7 +16,6 @@ import (
 	"github.com/Hanalyx/openwatch/internal/eventbus"
 	"github.com/Hanalyx/openwatch/internal/fleetrollup"
 	"github.com/Hanalyx/openwatch/internal/host"
-	"github.com/Hanalyx/openwatch/internal/alerts"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
 	"github.com/Hanalyx/openwatch/internal/license"
 	"github.com/Hanalyx/openwatch/internal/liveness"

--- a/app/internal/server/handlers.go
+++ b/app/internal/server/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/eventbus"
 	"github.com/Hanalyx/openwatch/internal/fleetrollup"
 	"github.com/Hanalyx/openwatch/internal/host"
+	"github.com/Hanalyx/openwatch/internal/alerts"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
 	"github.com/Hanalyx/openwatch/internal/license"
 	"github.com/Hanalyx/openwatch/internal/liveness"
@@ -57,6 +58,11 @@ type handlers struct {
 	// that don't exercise /hosts/{id}/discovery:run.
 	// Spec system-host-discovery.
 	discoSvc *discovery.Service
+
+	// Alerts lifecycle. Set via (*Server).WithAlerts; nil in tests
+	// that don't exercise /alerts.
+	// Spec system-alerts + api-alerts.
+	alertsSvc *alerts.Service
 }
 
 // newHandlers constructs the ServerInterface implementation. The user

--- a/app/internal/server/server.go
+++ b/app/internal/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Hanalyx/openwatch/internal/alerts"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
 	"github.com/Hanalyx/openwatch/internal/liveness"
 	"github.com/Hanalyx/openwatch/internal/systemconfig"
@@ -77,6 +78,14 @@ func (s *Server) WithDiscovery(d *discovery.Service) *Server {
 	if s.wkr != nil {
 		s.wkr.WithDiscovery(d)
 	}
+	return s
+}
+
+// WithAlerts threads the alert lifecycle service into the API handlers
+// so /api/v1/alerts and the :verb endpoints are routable.
+// Spec system-alerts + api-alerts.
+func (s *Server) WithAlerts(a *alerts.Service) *Server {
+	s.handlers.alertsSvc = a
 	return s
 }
 

--- a/app/specs/api/alerts.spec.yaml
+++ b/app/specs/api/alerts.spec.yaml
@@ -1,0 +1,136 @@
+spec:
+  id: api-alerts
+  title: Alerts read + lifecycle REST API
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: GET /api/v1/alerts + PATCH lifecycle endpoints
+    description: >
+      Operator-facing surface over the alerts table that
+      system-alert-router populates (PR 2) and system-alerts mutates.
+      Endpoints:
+
+        GET    /api/v1/alerts                  — paginated, filterable list
+        GET    /api/v1/alerts/{id}             — single alert
+        POST   /api/v1/alerts/{id}:acknowledge — active -> acknowledged
+        POST   /api/v1/alerts/{id}:silence     — active -> silenced
+        POST   /api/v1/alerts/{id}:resolve     — active|acknowledged|silenced -> resolved
+        POST   /api/v1/alerts/{id}:dismiss     — active|acknowledged|silenced|resolved -> dismissed
+
+      RBAC: alert:read for reads, alert:write for lifecycle ops. Both
+      permissions are NEW — added by this PR.
+
+    related_specs:
+      - system-alerts
+      - system-alert-router
+      - api-os-intelligence
+      - api-audit-events-query
+
+  objective:
+    summary: >
+      Handlers in internal/server/alerts_handlers.go delegate to
+      internal/alerts.Service. The list endpoint mirrors the audit /
+      intelligence cursor-pagination pattern (detected_at-equivalent
+      occurred_at as the cursor). Lifecycle endpoints accept an
+      optional reason field in the request body for the audit detail.
+    scope:
+      includes:
+        - 'OpenAPI: GET /api/v1/alerts + GET /api/v1/alerts/{id} + 4 lifecycle :verb endpoints'
+        - 'New permissions alert:read + alert:write registered in internal/auth/permissions.gen.go (codegen)'
+        - 'Response schemas: Alert, AlertsPage, AlertLifecycleRequest'
+        - 'RBAC enforcement at handler entry (deny via authz.permission_denied audit on 403)'
+        - 'Filter params: state, host_id, severity, since, until, cursor, limit'
+      excludes:
+        - 'Bulk lifecycle (POST /api/v1/alerts:bulk-acknowledge) — Q2 work'
+        - 'Real-time push (SSE on alerts) — already covered by eventbus EventKindHostDiscovered pattern; future work'
+
+  constraints:
+    - id: C-01
+      description: 'All endpoints MUST enforce permissions: GET requires alert:read; POST :verb requires alert:write. 403 authz.permission_denied for callers without it'
+      type: security
+      enforcement: error
+    - id: C-02
+      description: 'GET /alerts limit cap is 200; default 50. limit < 1 or > 200 yields 400 pagination.limit_exceeded'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'Cursor pagination on occurred_at DESC. cursor is the RFC3339Nano-formatted occurred_at of the boundary row; when limit rows returned, response.next_cursor is set'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'Lifecycle endpoints accept JSON body with optional fields: reason (string, max 256), until (date-time, only for :silence). Validation: until in the past yields 400 validation.field_range. The validation matches system-alerts C-03'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: 'Lifecycle on a missing alert id MUST return 404 alerts.not_found. Invalid transition (e.g. :acknowledge on a resolved alert) MUST return 409 alerts.invalid_transition with detail naming prior + requested state'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'Severity / state filter accepts the closed sets (severity: info/low/medium/high/critical; state: active/acknowledged/silenced/resolved/dismissed). Unknown values yield 400 validation.field_range'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'GET /api/v1/alerts with viewer role (alert:read) returns 200 + AlertsPage. items[] is array of Alert; pagination has next_cursor nullable'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: 'GET /api/v1/alerts without an authenticated session returns 403'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-03
+      description: 'GET /api/v1/alerts?limit=300 returns 400 pagination.limit_exceeded'
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-04
+      description: 'GET /api/v1/alerts?state=active&host_id=<id>&severity=high returns only matching rows. Verified by seeding 4 alerts spanning states/hosts/severities and asserting the filtered count'
+      priority: high
+      references_constraints: [C-03, C-06]
+    - id: AC-05
+      description: 'GET /api/v1/alerts?limit=2 against 5 rows returns 2 items + non-null next_cursor; following the cursor returns the next 2'
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-06
+      description: 'POST /api/v1/alerts/{id}:acknowledge with alert:write caller transitions active -> acknowledged, returns 200 with updated Alert, emits audit.AlertAcknowledged'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-07
+      description: 'POST :acknowledge with viewer (no alert:write) returns 403'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-08
+      description: 'POST :acknowledge on unknown id returns 404 alerts.not_found'
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-09
+      description: 'POST :acknowledge on a resolved alert returns 409 alerts.invalid_transition with detail naming prior=resolved + requested=acknowledged'
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-10
+      description: 'POST :silence with body {"until": "<past>"} returns 400 validation.field_range AND performs no row mutation'
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-11
+      description: 'POST :silence with no body advances state to silenced with silenced_until = NULL (indefinite). 200 + updated Alert'
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-12
+      description: 'POST :resolve transitions active|acknowledged|silenced -> resolved (200 + updated Alert + audit.AlertResolved). Already-resolved -> 409'
+      priority: critical
+      references_constraints: [C-01, C-05]
+    - id: AC-13
+      description: 'POST :dismiss transitions any non-dismissed state -> dismissed (200 + updated Alert + audit.AlertAcknowledged-equivalent dismissed event). Already-dismissed -> 409'
+      priority: critical
+      references_constraints: [C-01, C-05]
+    - id: AC-14
+      description: 'GET /api/v1/alerts?severity=panic returns 400 validation.field_range'
+      priority: high
+      references_constraints: [C-06]
+    - id: AC-15
+      description: 'GET /api/v1/alerts?state=unknown returns 400 validation.field_range'
+      priority: high
+      references_constraints: [C-06]

--- a/app/specs/system/alerts.spec.yaml
+++ b/app/specs/system/alerts.spec.yaml
@@ -1,0 +1,173 @@
+spec:
+  id: system-alerts
+  title: Alert lifecycle service
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Lifecycle service that owns acknowledge / silence / resolve / dismiss transitions on persisted alerts
+    description: >
+      system-alert-router v1.1.0 (PR 2) persists every routed alert
+      into the alerts table with initial state='active'. This spec
+      owns the OTHER end of the lifecycle: state transitions, audit
+      events per transition, optional silence-until window, and the
+      query surface that the /api/v1/alerts endpoints (api-alerts)
+      consume.
+
+      The router writes; this service mutates. The two services share
+      the alerts table as the SSOT — system-alert-router C-11 says
+      "transitions are owned by system-alerts". This spec realizes
+      that ownership.
+
+      State machine:
+
+        active        -> acknowledged (operator saw it)
+        active        -> silenced     (with optional until-timestamp)
+        active        -> resolved     (operator marked done)
+        active        -> dismissed    (operator marked irrelevant)
+        acknowledged  -> resolved | dismissed
+        silenced      -> active       (re-armed via Unsilence or
+                                       auto when silenced_until elapses)
+        silenced      -> resolved | dismissed
+        resolved      -> dismissed    (one-way: archived)
+        dismissed     -> (terminal)
+        resolved      -> (terminal except dismiss)
+
+      Auto-resolve hook: when system-alert-router publishes a
+      host_recovered alert, the lifecycle service auto-resolves
+      matching open host_unreachable alerts for the same host. Same
+      pattern for drift_improvement → drift_major / drift_minor.
+      Spec C-08.
+
+      Every transition emits a typed audit event (alert.acknowledged
+      etc) — these codes already exist in app/audit/events.yaml from
+      the alert taxonomy that landed earlier in the codebase, so this
+      spec adds no new audit codes.
+
+    related_specs:
+      - system-alert-router
+      - system-audit-emission
+      - api-alerts
+
+  objective:
+    summary: >
+      A new package internal/alerts owns the Service. Each transition
+      is a method (Acknowledge, Silence, Resolve, Dismiss) that takes
+      a context + alert id + actor identity, performs the row update
+      under a SELECT FOR UPDATE, emits the matching audit event, and
+      returns the updated row. Invalid transitions return
+      ErrInvalidTransition.
+    scope:
+      includes:
+        - 'Service with Acknowledge / Silence / Unsilence / Resolve / Dismiss / Get / List methods'
+        - 'Closed state-machine validation — terminal states reject further transitions'
+        - 'Optional silence-until window — Silence(id, until=*time.Time) honors the timestamp; lifecycle.SweepExpiredSilences re-arms silenced rows whose silenced_until has elapsed'
+        - 'Audit emission per transition (alert.acknowledged / alert.silenced / alert.resolved / alert.dismissed) — codes already present in events.yaml'
+        - 'Auto-resolve hook — host_recovered closes matching open host_unreachable; drift_improvement closes matching open drift alerts. Triggered by an eventbus subscription'
+        - 'Migration 0021 — add acknowledged_by / silenced_until / resolved_at / actor columns to alerts'
+      excludes:
+        - 'GET /api/v1/alerts + PATCH lifecycle endpoints — separate api-alerts spec'
+        - 'Notification of state transitions to external systems — Slack/PagerDuty etc. already received the alert on first dispatch; lifecycle transitions are operator-only by design'
+        - 'Bulk lifecycle operations — Q2 work'
+
+  constraints:
+    - id: C-01
+      description: 'Every state transition MUST be performed under SELECT ... FOR UPDATE inside a single transaction. Concurrent transitions on the same alert id serialize at the row lock; the second sees the post-transition state and either succeeds (consistent next-state) or fails with ErrInvalidTransition'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'State machine is closed. Allowed transitions: active -> acknowledged|silenced|resolved|dismissed; acknowledged -> resolved|dismissed; silenced -> active|resolved|dismissed; resolved -> dismissed; dismissed -> (none). Any other transition MUST return ErrInvalidTransition with the current + requested state in the error message'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'Silence MUST accept an optional until *time.Time. Nil means "indefinite" (until manual Unsilence). A non-nil until MUST be in the future (now + clock skew); past timestamps return ErrInvalidSilenceWindow'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'SweepExpiredSilences MUST flip silenced rows whose silenced_until <= now() BACK to active, clear silenced_until, and emit one alert.acknowledged-style audit event per row (action=alert.unsilenced.auto). Designed to be called by a periodic loop or worker — out of scope for this spec; the method MUST be idempotent'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: 'Per transition, the service MUST emit ONE audit event whose action matches the transition (alert.acknowledged / alert.silenced / alert.resolved / alert.dismissed / alert.unsilenced.auto). actor_id is the caller identity. resource_type is "alert", resource_id is the alert id. Detail carries prior_state -> new_state'
+      type: security
+      enforcement: error
+    - id: C-06
+      description: 'Migration 0021 MUST add nullable columns acknowledged_by UUID, acknowledged_at TIMESTAMPTZ, silenced_until TIMESTAMPTZ, silenced_by UUID, resolved_by UUID, resolved_at TIMESTAMPTZ, dismissed_by UUID, dismissed_at TIMESTAMPTZ. Existing v1.1.0 rows (state=active, all metadata NULL) are valid post-migration'
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: 'Get(id) MUST return ErrAlertNotFound for unknown ids (not for state-terminal alerts — those are still queryable). List(filter) MUST support state, host_id, severity, since/until filters with cursor pagination on occurred_at DESC'
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: 'Auto-resolve hook: when an alert with type host_recovered for host H is persisted by the router, the lifecycle service MUST auto-Resolve every open (state IN (active, acknowledged, silenced)) alert with type host_unreachable for the same host H. Same pattern for drift_improvement closing drift_major + drift_minor for the same host. Wiring is a bus subscription registered at Service construction'
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: 'The service package MUST NOT import internal/server or net/http. It is a pure DB + audit service; the HTTP surface lives in api-alerts'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'Migration 0021 adds the six lifecycle columns to alerts (acknowledged_by/at, silenced_until + silenced_by, resolved_by/at, dismissed_by/at) and existing rows with state=active continue to satisfy all NOT NULL constraints'
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-02
+      description: 'Service.Acknowledge(active alert) advances state to acknowledged AND populates acknowledged_by + acknowledged_at AND emits one audit.AlertAcknowledged event with resource_id = alert id, actor_id = caller'
+      priority: critical
+      references_constraints: [C-01, C-02, C-05]
+    - id: AC-03
+      description: 'Service.Silence(active alert, until = now+1h) advances state to silenced, populates silenced_until + silenced_by, emits audit.AlertAcknowledged-equivalent (alert.silenced) audit event'
+      priority: critical
+      references_constraints: [C-03, C-05]
+    - id: AC-04
+      description: 'Service.Silence(active alert, until in past) returns ErrInvalidSilenceWindow and performs no row mutation; no audit emitted'
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-05
+      description: 'Service.Silence(active, until=nil) advances to silenced with silenced_until = NULL (indefinite). Subsequent SweepExpiredSilences does NOT re-arm it (NULL never elapses)'
+      priority: high
+      references_constraints: [C-03, C-04]
+    - id: AC-06
+      description: 'Service.Resolve(active alert) advances to resolved, populates resolved_by + resolved_at, emits audit.AlertResolved'
+      priority: critical
+      references_constraints: [C-02, C-05]
+    - id: AC-07
+      description: 'Service.Dismiss(active alert) advances to dismissed, populates dismissed_by + dismissed_at, emits audit.AlertDismissed (or AlertResolved with reason=dismissed if no AlertDismissed code exists)'
+      priority: critical
+      references_constraints: [C-02, C-05]
+    - id: AC-08
+      description: 'Invalid transition (e.g. Service.Acknowledge on a resolved alert) returns ErrInvalidTransition with the prior + requested state in the error message AND performs no row mutation AND emits no audit event'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-09
+      description: 'Service.Acknowledge called twice concurrently on the same alert id results in EXACTLY ONE successful acknowledgement and ONE audit event. The second caller observes the post-acknowledge state and either no-ops (already-acknowledged convention) or returns ErrInvalidTransition. Verified with two goroutines + a barrier'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-10
+      description: 'SweepExpiredSilences seeded with one row silenced_until = now()-1m and one row silenced_until = now()+1h: ONLY the first is re-armed to active. Both audit events: alert.unsilenced.auto for the first, none for the second'
+      priority: critical
+      references_constraints: [C-04, C-05]
+    - id: AC-11
+      description: 'Auto-resolve: a host_recovered alert for host H with two open host_unreachable alerts for H (one active, one acknowledged) results in BOTH host_unreachable rows transitioning to resolved automatically; two alert.resolved audit events emitted; the host_recovered row stays in its own state'
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-12
+      description: 'List filter — state=active + host_id=H1 returns only active alerts for host H1. Severity filter narrows further. Time-range [since, until) inclusive-exclusive same as audit/intelligence'
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-13
+      description: 'List cursor pagination: limit=2 on 5 rows returns 2 + non-nil cursor; following the cursor returns the next 2'
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-14
+      description: 'Get(unknown_id) returns ErrAlertNotFound with the id in the error message. Get(resolved alert) returns the row (terminal states are still queryable)'
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-15
+      description: 'internal/alerts source MUST NOT import internal/server OR net/http. Verified by walking the import set of every .go file in internal/alerts/'
+      priority: high
+      references_constraints: [C-09]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -36,6 +36,8 @@ domains:
             - system-os-intelligence
             - system-intelligence-scheduler
             - api-os-intelligence
+            - system-alerts
+            - api-alerts
             - system-host-inventory
             - system-ssh-connectivity
             - api-auth


### PR DESCRIPTION
## Summary
PR 3 of the OS Discovery → /activity sequence. Adds the lifecycle service that mutates the alerts table system-alert-router persists into.

- **system-alerts** v1.0.0 (Tier 1, 9 C / 15 AC) — lifecycle service with closed state machine
- **api-alerts** v1.0.0 (Tier 2, 6 C / 15 AC) — REST surface
- **Migration 0021** — 8 lifecycle columns + partial index for sweeper
- **3 new audit codes** — \`alert.silenced\`, \`alert.unsilenced.auto\`, \`alert.dismissed\` (acknowledged + resolved already shipped)
- New \`internal/alerts\` package — \`Service.{Acknowledge,Silence,Resolve,Dismiss,SweepExpiredSilences,AutoResolveFor,Get,List}\`
- Row-level locking on every transition via \`SELECT FOR UPDATE\`
- 6 new endpoints: \`GET /alerts\`, \`GET /alerts/{id}\`, \`POST /alerts/{id}:acknowledge|:silence|:resolve|:dismiss\`
- RBAC: \`alert:read\` for GETs, \`alert:write\` for POSTs

## State machine (C-02)
\`\`\`
active        -> acknowledged | silenced | resolved | dismissed
acknowledged  -> resolved | dismissed | silenced
silenced      -> active (auto-unsilence) | resolved | dismissed
resolved      -> dismissed
dismissed     -> (terminal)
\`\`\`

Invalid transitions return 409 \`alerts.invalid_transition\` with prior + requested state in the error message.

## Spec coverage

**system-alerts** (DB-integration, gated by \`OPENWATCH_TEST_DSN\`):
- AC-01 migration columns + index (source inspection)
- AC-02 Acknowledge advances state + audit
- AC-03 Silence with future until
- AC-04 Past until → ErrInvalidSilenceWindow, no mutation
- AC-05 Indefinite silence (until=nil) — sweep doesn't re-arm
- AC-06 Resolve from active
- AC-07 Dismiss from active
- AC-08 Acknowledge on resolved → ErrInvalidTransition
- AC-09 Concurrent acks → exactly one success (FOR UPDATE serialization)
- AC-10 SweepExpiredSilences re-arms only past silences
- AC-11 Auto-resolve: host_recovered closes open host_unreachable for same host
- AC-12 List filter by state + host_id + severity
- AC-13 List cursor pagination
- AC-14 Get unknown + Get resolved
- AC-15 No HTTP imports (source inspection)

**api-alerts** (HTTP integration via \`freshAPIServer\`):
- AC-01..AC-15 covering list, RBAC, filter, pagination, all 4 lifecycle verbs, error paths

## Test plan
- [ ] CI green on Quality + security gates (after rebase to main)
- [ ] Manual: install an alert via the router, walk the lifecycle through GET → :acknowledge → :silence → :resolve → :dismiss
- [ ] Manual: kill a host, observe host_unreachable alert; recover it, observe host_recovered alert AND auto-resolve of the prior unreachable

## Out of scope
- Bulk lifecycle (POST :bulk-acknowledge) — Q2 work
- The SweepExpiredSilences cron driver — defer until customer demand
- Wiring the auto-resolve bus subscription at boot — production cmd/openwatch wiring follow-up