### PR TITLE
feat(frontend): wire host.discovered + intelligence.event SSE topics (PR 5b)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -185,7 +185,13 @@ jobs:
 
       - name: specter sync (AC coverage thresholds)
         if: steps.paths.outputs.go == 'true'
-        run: specter sync
+        # --tests '**/*' broadens default discovery to include .test.tsx
+        # files. Specter's `sync` coverage phase does not honor
+        # settings.tests_glob in specter.yaml (the `coverage` subcommand
+        # does — known specter quirk). The annotation walker still
+        # filters on @spec / @ac, so non-test files in the broad glob
+        # are skipped at parse time.
+        run: specter sync --tests '**/*'
 
       - name: upload specter artifacts
         if: always() && steps.paths.outputs.go == 'true'

--- a/app/frontend/src/api/schema.d.ts
+++ b/app/frontend/src/api/schema.d.ts
@@ -788,6 +788,229 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/intelligence/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List OS Intelligence change events
+         * @description Returns the change events the OS Intelligence collector
+         *     recorded — newly opened ports, package updates, service
+         *     failures, etc. Cursor pagination on detected_at DESC. Filter
+         *     by host_id, event_code, severity, since/until. Spec
+         *     api-os-intelligence.
+         */
+        get: operations["getIntelligenceEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/intelligence/state/{host_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Last full Intelligence snapshot for one host
+         * @description Returns the most recent host_intelligence_state row for the
+         *     given host. 404 hosts.not_found if the host is unknown OR if
+         *     no Intelligence cycle has populated the row yet (operators
+         *     cannot probe host existence via this endpoint). Spec
+         *     api-os-intelligence.
+         */
+        get: operations["getIntelligenceState"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/alerts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List persisted alerts (paginated, filterable)
+         * @description Returns alerts in the alerts table — written by the
+         *     system-alert-router persistence amendment (v1.1.0). Cursor
+         *     pagination on occurred_at DESC. RBAC: alert:read. Spec
+         *     api-alerts.
+         */
+        get: operations["getAlerts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/alerts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Single alert by id
+         * @description Returns the alert row (including terminal states — resolved /
+         *     dismissed are still queryable). RBAC: alert:read. Spec api-alerts.
+         */
+        get: operations["getAlertByID"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/alerts/{id}:acknowledge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Acknowledge an active alert
+         * @description active -> acknowledged. RBAC: alert:write. Spec api-alerts.
+         */
+        post: operations["postAlertAcknowledge"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/alerts/{id}:silence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Silence an alert until a timestamp (or indefinitely)
+         * @description active|acknowledged -> silenced. Optional body.until specifies
+         *     when the silence elapses; missing means indefinite. Past until
+         *     returns 400. RBAC: alert:write. Spec api-alerts.
+         */
+        post: operations["postAlertSilence"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/alerts/{id}:resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resolve an alert
+         * @description active|acknowledged|silenced -> resolved. RBAC: alert:write. Spec api-alerts.
+         */
+        post: operations["postAlertResolve"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/alerts/{id}:dismiss": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dismiss an alert (terminal)
+         * @description Any non-dismissed state -> dismissed. RBAC: alert:write. Spec api-alerts.
+         */
+        post: operations["postAlertDismiss"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Unified Activity feed (UNION over alerts + transactions + intelligence + audit)
+         * @description Returns the per-source RBAC-filtered union of recent events.
+         *     Caller's permissions decide which sources contribute; hidden_count
+         *     reports how many rows the caller's RBAC suppressed so the UI
+         *     can render "N visible / M hidden". Spec api-activity.
+         */
+        get: operations["getActivity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/hosts/{id}/discovery:run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Synchronous on-demand OS fingerprint discovery for a single host
+         * @description Opens one SSH session against the host using its resolved
+         *     credential, runs the closed-set probe batch (os-release, uname,
+         *     meminfo, df, hostname, getenforce, aa-status, firewall), parses
+         *     the outputs, upserts host_system_info + denormalized hosts.os_*
+         *     columns in a single transaction, publishes
+         *     eventbus.HostDiscovered, and emits the host.discovery.completed
+         *     audit event. Spec system-host-discovery.
+         */
+        post: operations["postHostDiscoveryRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -905,6 +1128,15 @@ export interface components {
             updated_at?: string;
             maintenance_mode?: boolean;
             check_priority?: number;
+            /** @description rhel | debian | suse | alpine | arch | gentoo | other; null pre-Discovery */
+            os_family?: string | null;
+            os_version?: string | null;
+            /** @description e.g. x86_64, aarch64 */
+            architecture?: string | null;
+            /** @description e.g. platform:el9 */
+            platform_identifier?: string | null;
+            /** Format: date-time */
+            os_discovered_at?: string | null;
         };
         HostLiveness: {
             /** @enum {string} */
@@ -997,6 +1229,12 @@ export interface components {
             last_scan_at?: string | null;
             /** @description Null when no liveness probe has ever run against this host. */
             liveness?: components["schemas"]["HostLiveness"] | null;
+            os_family?: string | null;
+            os_version?: string | null;
+            architecture?: string | null;
+            platform_identifier?: string | null;
+            /** Format: date-time */
+            os_discovered_at?: string | null;
         };
         HostListResponse: {
             hosts: components["schemas"]["HostListItem"][];
@@ -1218,6 +1456,144 @@ export interface components {
              * @enum {string}
              */
             new_reachability_status: "reachable" | "unreachable" | "unknown";
+        };
+        IntelligenceEvent: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            host_id: string;
+            /** @description Closed taxonomy: e.g. system.package.updated */
+            event_code: string;
+            /** @enum {string} */
+            severity: "info" | "low" | "medium" | "high" | "critical";
+            detail?: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            occurred_at: string;
+            /** Format: date-time */
+            detected_at: string;
+            correlation_id?: string;
+        };
+        IntelligenceEventsPage: {
+            items: components["schemas"]["IntelligenceEvent"][];
+            next_cursor?: string | null;
+        };
+        IntelligenceState: {
+            /** Format: uuid */
+            host_id: string;
+            /** @description Free-form host_intelligence_state.snapshot — mirrors collector.Snapshot */
+            snapshot: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            collected_at: string;
+        };
+        Alert: {
+            /** Format: uuid */
+            id: string;
+            dedup_key: string;
+            alert_type: string;
+            /** @enum {string} */
+            severity: "info" | "low" | "medium" | "high" | "critical";
+            /** Format: uuid */
+            host_id?: string | null;
+            rule_id?: string;
+            title: string;
+            body?: string;
+            tags?: {
+                [key: string]: string;
+            };
+            /** @enum {string} */
+            state: "active" | "acknowledged" | "silenced" | "resolved" | "dismissed";
+            /** Format: date-time */
+            occurred_at: string;
+            /** Format: uuid */
+            acknowledged_by?: string | null;
+            /** Format: date-time */
+            acknowledged_at?: string | null;
+            /** Format: uuid */
+            silenced_by?: string | null;
+            /** Format: date-time */
+            silenced_until?: string | null;
+            /** Format: uuid */
+            resolved_by?: string | null;
+            /** Format: date-time */
+            resolved_at?: string | null;
+            /** Format: uuid */
+            dismissed_by?: string | null;
+            /** Format: date-time */
+            dismissed_at?: string | null;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
+        };
+        AlertsPage: {
+            items: components["schemas"]["Alert"][];
+            next_cursor?: string | null;
+        };
+        Activity: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            source: "alert" | "transaction" | "intelligence" | "audit";
+            /** @enum {string} */
+            severity: "info" | "low" | "medium" | "high" | "critical";
+            /** Format: uuid */
+            host_id?: string | null;
+            title: string;
+            summary?: string;
+            /** Format: date-time */
+            occurred_at: string;
+        };
+        ActivityPage: {
+            items: components["schemas"]["Activity"][];
+            hidden_count: number;
+            next_cursor?: string | null;
+        };
+        /** @description Optional body for POST lifecycle endpoints. silence accepts an optional until; all accept a reason for the audit detail. */
+        AlertLifecycleRequest: {
+            reason?: string;
+            /** Format: date-time */
+            until?: string | null;
+        };
+        /**
+         * @description Result of a Discovery run. Mirrors the host_system_info table
+         *     column-for-column. Spec system-host-discovery.
+         */
+        HostSystemInfo: {
+            /** Format: uuid */
+            host_id: string;
+            os_name?: string | null;
+            os_version?: string | null;
+            os_version_full?: string | null;
+            os_id?: string | null;
+            os_id_like?: string | null;
+            os_pretty_name?: string | null;
+            platform_identifier?: string | null;
+            /** @description Rollup family — rhel, debian, suse, alpine, arch, gentoo, other */
+            os_family?: string | null;
+            kernel_name?: string | null;
+            kernel_release?: string | null;
+            kernel_version?: string | null;
+            architecture?: string | null;
+            mem_total_mb?: number | null;
+            mem_available_mb?: number | null;
+            swap_total_mb?: number | null;
+            disk_total_gb?: number | null;
+            disk_used_gb?: number | null;
+            disk_free_gb?: number | null;
+            hostname?: string | null;
+            fqdn?: string | null;
+            /** @description Enforcing | Permissive | Disabled | empty if not present */
+            selinux_status?: string | null;
+            apparmor_enabled?: boolean | null;
+            /** @description firewalld | ufw | nftables | iptables | empty */
+            firewall_service?: string | null;
+            firewall_status?: string | null;
+            /** Format: date-time */
+            collected_at: string;
         };
         FleetRuleFailure: {
             rule_id: string;
@@ -3053,6 +3429,474 @@ export interface operations {
             };
             /** @description A probe for this host is already in flight */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getIntelligenceEvents: {
+        parameters: {
+            query?: {
+                host_id?: string;
+                event_code?: string;
+                severity?: "info" | "low" | "medium" | "high" | "critical";
+                since?: string;
+                until?: string;
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Events page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelligenceEventsPage"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks host:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getIntelligenceState: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Last snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelligenceState"];
+                };
+            };
+            /** @description Caller lacks host:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Host unknown OR no snapshot yet */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getAlerts: {
+        parameters: {
+            query?: {
+                state?: "active" | "acknowledged" | "silenced" | "resolved" | "dismissed";
+                host_id?: string;
+                severity?: "info" | "low" | "medium" | "high" | "critical";
+                since?: string;
+                until?: string;
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Alerts page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertsPage"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks alert:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getAlertByID: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Alert */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Alert"];
+                };
+            };
+            /** @description Caller lacks alert:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Alert not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postAlertAcknowledge: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AlertLifecycleRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated alert */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Alert"];
+                };
+            };
+            /** @description Caller lacks alert:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Alert not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Invalid transition for current state */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postAlertSilence: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AlertLifecycleRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated alert */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Alert"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks alert:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Alert not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Invalid transition for current state */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postAlertResolve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AlertLifecycleRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated alert */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Alert"];
+                };
+            };
+            /** @description Caller lacks alert:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Alert not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Invalid transition for current state */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postAlertDismiss: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["AlertLifecycleRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated alert */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Alert"];
+                };
+            };
+            /** @description Caller lacks alert:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Alert not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Invalid transition for current state */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getActivity: {
+        parameters: {
+            query?: {
+                source?: "alert" | "transaction" | "intelligence" | "audit";
+                severity?: "info" | "low" | "medium" | "high" | "critical";
+                host_id?: string;
+                since?: string;
+                until?: string;
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Activity page */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActivityPage"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Anonymous caller */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postHostDiscoveryRun: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Discovery result — the captured SystemFacts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HostSystemInfo"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks host:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Host not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Host unreachable — SSH dial or credential resolve failed */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Discovery service not wired on the server */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/app/frontend/src/hooks/useLiveEvents.ts
+++ b/app/frontend/src/hooks/useLiveEvents.ts
@@ -22,9 +22,14 @@ import { useAuthStore } from '@/store/useAuthStore';
 // 3-5s backoff. If we ever need explicit backoff control we'll switch
 // to a manual fetch + ReadableStream loop.
 
+// Closed v1.0 set of topics this hook subscribes to. Each MUST exist
+// in backend eventbus.AllEventKinds (Go-side closed enum). Spec
+// frontend-live-events C-01 + AC-01 enforce.
 export const ALL_TOPICS = [
   'host.changed',
   'monitoring.band.changed',
+  'host.discovered',
+  'intelligence.event',
 ] as const;
 
 type Topic = (typeof ALL_TOPICS)[number];
@@ -89,6 +94,38 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}) {
         queryClient.invalidateQueries({ queryKey: ['hosts'] });
         if (hostId) {
           queryClient.invalidateQueries({ queryKey: ['host', hostId] });
+        }
+      },
+      // Spec frontend-live-events C-03 + AC-04 — Discovery completion
+      // updates the denormalized hosts.os_family / os_version columns
+      // that BOTH the list and the detail page render. Same
+      // invalidation shape as host.changed.
+      'host.discovered': (e) => {
+        const env = parseEnvelope(e);
+        if (!env) return;
+        const hostId = (env.payload?.HostID ?? env.payload?.host_id) as
+          | string
+          | undefined;
+        queryClient.invalidateQueries({ queryKey: ['hosts'] });
+        if (hostId) {
+          queryClient.invalidateQueries({ queryKey: ['host', hostId] });
+        }
+      },
+      // Spec frontend-live-events C-04 + AC-05 — intel events fire on
+      // package/service/user/network changes. The detail page's
+      // Intelligence feed re-renders; the list view does NOT (intel
+      // events don't affect any list column). Skipping ['hosts']
+      // here avoids a fleet-wide refetch on every intel event.
+      'intelligence.event': (e) => {
+        const env = parseEnvelope(e);
+        if (!env) return;
+        const hostId = (env.payload?.HostID ?? env.payload?.host_id) as
+          | string
+          | undefined;
+        if (hostId) {
+          queryClient.invalidateQueries({
+            queryKey: ['host_intelligence_events', hostId],
+          });
         }
       },
     };

--- a/app/frontend/tests/hooks/useLiveEvents.test.tsx
+++ b/app/frontend/tests/hooks/useLiveEvents.test.tsx
@@ -1,0 +1,173 @@
+// @spec frontend-live-events
+//
+// AC traceability (this file):
+//
+//   AC-01  test('frontend-live-events/AC-01 — ALL_TOPICS is the closed v1.0 set')
+//   AC-02  test('frontend-live-events/AC-02 — host.changed invalidates [hosts] + [host, id]')
+//   AC-03  test('frontend-live-events/AC-03 — monitoring.band.changed invalidates [hosts] + [host, id]')
+//   AC-04  test('frontend-live-events/AC-04 — host.discovered invalidates [hosts] + [host, id]')
+//   AC-05  test('frontend-live-events/AC-05 — intelligence.event invalidates [host_intelligence_events, id] only, NOT [hosts]')
+//   AC-06  test('frontend-live-events/AC-06 — missing host_id falls back to list-only')
+//   AC-07  test('frontend-live-events/AC-07 — source-inspect: exactly one new EventSource(...) call')
+
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ReactNode } from 'react';
+import { ALL_TOPICS, useLiveEvents } from '@/hooks/useLiveEvents';
+import { useAuthStore } from '@/store/useAuthStore';
+
+// ---------- EventSource stub --------------------------------------------
+
+interface StubListener {
+  topic: string;
+  fn: (e: MessageEvent) => void;
+}
+
+class StubEventSource {
+  static instances: StubEventSource[] = [];
+  url: string;
+  listeners: StubListener[] = [];
+  onerror: ((e: Event) => void) | null = null;
+  closed = false;
+
+  constructor(url: string, _init?: EventSourceInit) {
+    this.url = url;
+    StubEventSource.instances.push(this);
+  }
+
+  addEventListener(topic: string, fn: (e: MessageEvent) => void) {
+    this.listeners.push({ topic, fn });
+  }
+
+  removeEventListener(_topic: string, _fn: (e: MessageEvent) => void) {
+    // no-op for the stub
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  // Test helper — fire a topic at all matching listeners.
+  fire(topic: string, payload: Record<string, unknown>) {
+    const envelope = JSON.stringify({
+      kind: topic,
+      timestamp: new Date().toISOString(),
+      payload,
+    });
+    const ev = new MessageEvent(topic, { data: envelope });
+    for (const l of this.listeners) {
+      if (l.topic === topic) l.fn(ev);
+    }
+  }
+}
+
+beforeEach(() => {
+  StubEventSource.instances = [];
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+    StubEventSource as unknown as typeof EventSource;
+  // Auth store: stub an identity so useLiveEvents opens a connection.
+  useAuthStore.setState({
+    identity: { id: 'test-user', is_anonymous: false, role: 'admin' },
+  });
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+// @ac AC-01
+// AC-01: ALL_TOPICS exported as closed v1.0 set of 4 topics.
+test('frontend-live-events/AC-01 — ALL_TOPICS is the closed v1.0 set', () => {
+  const want = [
+    'host.changed',
+    'monitoring.band.changed',
+    'host.discovered',
+    'intelligence.event',
+  ];
+  expect([...ALL_TOPICS]).toEqual(want);
+  expect(ALL_TOPICS.length).toBe(4);
+});
+
+// Helper to mount the hook and return the stub + spies.
+function mountHook() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const spy = vi.spyOn(qc, 'invalidateQueries');
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  renderHook(() => useLiveEvents(), { wrapper: Wrapper });
+  const es = StubEventSource.instances[StubEventSource.instances.length - 1];
+  if (!es) throw new Error('useLiveEvents did not open an EventSource');
+  return { es, spy };
+}
+
+// @ac AC-02
+test('frontend-live-events/AC-02 — host.changed invalidates [hosts] + [host, id]', () => {
+  const { es, spy } = mountHook();
+  es.fire('host.changed', { host_id: 'h-aaa' });
+  const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
+  expect(calls).toContainEqual(['hosts']);
+  expect(calls).toContainEqual(['host', 'h-aaa']);
+});
+
+// @ac AC-03
+test('frontend-live-events/AC-03 — monitoring.band.changed invalidates [hosts] + [host, id]', () => {
+  const { es, spy } = mountHook();
+  es.fire('monitoring.band.changed', { host_id: 'h-bbb' });
+  const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
+  expect(calls).toContainEqual(['hosts']);
+  expect(calls).toContainEqual(['host', 'h-bbb']);
+});
+
+// @ac AC-04
+test('frontend-live-events/AC-04 — host.discovered invalidates [hosts] + [host, id]', () => {
+  const { es, spy } = mountHook();
+  es.fire('host.discovered', { host_id: 'h-ccc' });
+  const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
+  expect(calls).toContainEqual(['hosts']);
+  expect(calls).toContainEqual(['host', 'h-ccc']);
+});
+
+// @ac AC-05
+test('frontend-live-events/AC-05 — intelligence.event invalidates [host_intelligence_events, id] only', () => {
+  const { es, spy } = mountHook();
+  es.fire('intelligence.event', { host_id: 'h-ddd' });
+  const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
+  expect(calls).toContainEqual(['host_intelligence_events', 'h-ddd']);
+  expect(calls).not.toContainEqual(['hosts']);
+});
+
+// @ac AC-06
+test('frontend-live-events/AC-06 — missing host_id falls back to list-only', () => {
+  const { es, spy } = mountHook();
+  es.fire('host.discovered', {});
+  const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
+  expect(calls).toContainEqual(['hosts']);
+  // Must NOT invalidate ["host", undefined] — defensive.
+  const hostKeyed = calls.filter((k) => Array.isArray(k) && k[0] === 'host');
+  expect(hostKeyed).toEqual([]);
+});
+
+// @ac AC-07
+test('frontend-live-events/AC-07 — source-inspect: exactly one new EventSource(...) call', () => {
+  const src = readFileSync(
+    resolve(process.cwd(), 'src/hooks/useLiveEvents.ts'),
+    'utf8',
+  );
+  const matches = src.match(/new\s+EventSource\s*\(/g) ?? [];
+  expect(matches.length).toBe(1);
+});

--- a/app/specs/frontend/live-events.spec.yaml
+++ b/app/specs/frontend/live-events.spec.yaml
@@ -1,0 +1,116 @@
+spec:
+  id: frontend-live-events
+  title: useLiveEvents SSE hook — topic ↔ query-key invalidation contract
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Client-side SSE subscriber that auto-invalidates TanStack Query keys on bus events
+    description: >
+      The frontend opens ONE SSE connection to /api/v1/events (spec
+      api-events-stream) at app mount time and converts each incoming
+      bus event into a TanStack Query invalidation. This spec locks
+      the topic-to-query-key map so the backend's published
+      EventKinds stay aligned with the frontend's invalidation
+      vocabulary.
+
+      v1.0.0 closed set of subscribed topics (each MUST appear in
+      eventbus.AllEventKinds — verified by the backend's
+      system-event-bus AC-07 + matched at this spec's AC-01):
+
+        - host.changed                — list + detail invalidation
+        - monitoring.band.changed     — list + detail invalidation
+        - host.discovered             — list + detail invalidation
+                                        (denormalized OS fields landed)
+        - intelligence.event          — detail intelligence_events query
+                                        invalidation; list page is NOT
+                                        invalidated (intel events don't
+                                        affect the list view)
+
+      Spec system-event-bus AC-07 enumerates the backend closed enum;
+      this spec mirrors the frontend's subset. The two MUST stay in
+      lock-step: every kind we subscribe to here MUST exist on the
+      backend; new backend kinds without a frontend handler are
+      acceptable (no invalidation needed yet) but new frontend topics
+      without a matching backend kind cause silent no-ops.
+
+    related_specs:
+      - api-events-stream
+      - system-event-bus
+      - system-host-discovery
+      - system-os-intelligence
+
+  objective:
+    summary: >
+      Source of truth for the ALL_TOPICS array exported from
+      app/frontend/src/hooks/useLiveEvents.ts and the handlers
+      mapping each topic to a TanStack Query invalidation. Tests
+      mount the hook with a stubbed EventSource, fire each topic,
+      and assert the right query keys are invalidated.
+    scope:
+      includes:
+        - ALL_TOPICS exported as a closed const tuple
+        - Per-topic handler invalidating the right query keys
+        - Single EventSource connection per mounted hook (no per-topic sockets)
+      excludes:
+        - Reconnect / backoff policy — owned by the EventSource browser implementation
+        - Auth flow — cookie session; spec api-events-stream owns
+        - Per-tab dedup — out of scope; the hook is mounted once at app root
+
+  constraints:
+    - id: C-01
+      description: 'ALL_TOPICS MUST be a closed const-tuple containing exactly the four kinds: host.changed, monitoring.band.changed, host.discovered, intelligence.event. Adding a fifth requires bumping this spec''s version and updating the test'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'host.changed and monitoring.band.changed handlers MUST invalidate [hosts] AND when the envelope carries a host_id also [host, id]'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'host.discovered handler MUST invalidate [hosts] AND [host, id]. Rationale: HostListItem and HostResponse both carry os_family/os_version (denormalized columns); Discovery completion changes both views'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'intelligence.event handler MUST invalidate [host_intelligence_events, host_id]. It MUST NOT invalidate [hosts] — intel events fire on packages/services/users changes, none of which appear on the list page. Avoiding the list invalidation prevents a fleet-wide re-fetch on every intel event'
+      type: performance
+      enforcement: error
+    - id: C-05
+      description: 'The hook MUST open EXACTLY ONE EventSource per mount cycle. Multiple useEffect re-runs from React Strict Mode dev re-mounts close the previous socket before opening the new one (cleanup function in the useEffect return)'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'Each topic handler MUST tolerate a missing host_id in the envelope (defensive — the eventbus contract carries one, but a malformed event must not throw). Missing host_id falls back to the list-only invalidation path'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'ALL_TOPICS as exported from useLiveEvents.ts equals exactly the closed set ["host.changed", "monitoring.band.changed", "host.discovered", "intelligence.event"]. Verified by importing the const and asserting the array contents + length'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: 'Mounting useLiveEvents with stub EventSource and firing a host.changed event carrying host_id=H invokes queryClient.invalidateQueries with queryKey=["hosts"] AND ["host", H]'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: 'Same as AC-02 but with monitoring.band.changed: invalidates ["hosts"] and ["host", H]'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: 'Firing host.discovered with host_id=H invalidates ["hosts"] AND ["host", H] — both views render denormalized OS fields'
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-05
+      description: 'Firing intelligence.event with host_id=H invalidates ["host_intelligence_events", H]. Spies on queryClient.invalidateQueries observe ZERO calls with queryKey=["hosts"]'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: 'Firing host.discovered with an envelope missing host_id falls back to invalidating ["hosts"] only — no throw, no error log, no spurious ["host", undefined] invalidation'
+      priority: high
+      references_constraints: [C-06]
+    - id: AC-07
+      description: 'Source inspection: useLiveEvents.ts opens exactly ONE `new EventSource(...)` call. Multiple sockets per mount cycle are forbidden'
+      priority: critical
+      references_constraints: [C-05]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -54,11 +54,11 @@ domains:
             - system-worker-subcommand
 settings:
     specs_dir: specs
-    # Default discovery is limited to .test.ts / _test.go. The frontend
-    # mixes .test.ts (source-inspection) with .test.tsx (component tests
-    # that need JSX), so explicitly include both. Without this, .tsx
-    # tests are silently invisible and frontend specs covered only by
-    # .tsx tests report 0% coverage.
+    # Honored by `specter coverage` (not by `specter sync` — CI passes
+    # --tests '**/*' as a workaround). Default discovery walks only
+    # .test.ts / _test.go; .test.tsx is silently invisible, which
+    # broke frontend-live-events coverage in PR 5b. List form documents
+    # the three extensions we use; the CI flag covers the sync gap.
     tests_glob:
         - '**/*_test.go'
         - '**/*.test.ts'

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -46,6 +46,7 @@ domains:
             - api-users
             - api-credentials
             - api-events-stream
+            - frontend-live-events
             - api-hosts
             - frontend-host-detail
             - api-openapi-docs

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -54,6 +54,15 @@ domains:
             - system-worker-subcommand
 settings:
     specs_dir: specs
+    # Default discovery is limited to .test.ts / _test.go. The frontend
+    # mixes .test.ts (source-inspection) with .test.tsx (component tests
+    # that need JSX), so explicitly include both. Without this, .tsx
+    # tests are silently invisible and frontend specs covered only by
+    # .tsx tests report 0% coverage.
+    tests_glob:
+        - '**/*_test.go'
+        - '**/*.test.ts'
+        - '**/*.test.tsx'
     coverage:
         tier1: 100
         tier2: 80


### PR DESCRIPTION
## Summary

PR 5b in the OS Discovery + Intelligence frontend wiring sequence. Extends the `useLiveEvents` hook to subscribe to two new event-bus topics that the backend already emits, so list/detail pages refresh automatically when Discovery completes or Intelligence diffs land — no manual refetch, no polling.

New spec **`frontend-live-events` v1.0.0** (Tier 2, 6 constraints / 7 ACs) locks the `ALL_TOPICS` closed set and the per-topic invalidation contract so backend (`eventbus.AllEventKinds`) and frontend stay in lock-step.

### Changes

- `ALL_TOPICS` extended from 2 → 4 topics: adds `host.discovered` and `intelligence.event`
- `host.discovered` handler mirrors `host.changed`: invalidates `['hosts']` + `['host', id]` (both views render the denormalized `os_family`/`os_version` columns Discovery populates — landed in PR 5a)
- `intelligence.event` handler invalidates only `['host_intelligence_events', id]`. Skipping `['hosts']` is intentional — intel events fire on package/service/user changes that don't appear on the list page; a fleet-wide refetch on every intel event would defeat the closed-set design (spec C-04)
- `schema.d.ts` regenerated from `openapi.yaml` (now contains the merged intelligence, hosts, and discovery endpoint types)
- 7 vitest tests cover AC-01..AC-07 with a `StubEventSource` pattern, including the defensive "envelope missing `host_id`" fallback path and source-inspection for exactly one `new EventSource(...)` call per mount

### Unblocks

- **PR 5c** — host list OS column from real `os_family` (replaces `detectOS()` heuristic)
- **PR 6** — host detail OS panel + Re-run Discovery button
- **PR 7** — host detail Intelligence events feed + activated Packages/Services/Users/Network tabs

## Test plan

- [x] 7 new tests pass — `frontend/tests/hooks/useLiveEvents.test.tsx`
- [x] Full frontend suite green (58 tests across 8 files)
- [x] Spec validates — `frontend-live-events.spec.yaml` is well-formed
- [ ] CI: spec-checks, frontend-tests, lint