### PR TITLE
feat(frontend): swap host-list OS column to real os_family (PR 5c)

### DIFF
--- a/app/frontend/src/api/dev-fixtures.ts
+++ b/app/frontend/src/api/dev-fixtures.ts
@@ -23,7 +23,16 @@ export interface DevHost {
   id: string;
   hostname: string;       // "—" if no hostname registered (display falls back to IP)
   ip_address: string;
-  os: 'Ubuntu' | 'RHEL' | 'Debian' | 'SUSE';
+  /**
+   * v1.4.0 (api-hosts) — display label produced by osDisplayLabel()
+   * from the real hosts.os_family column (populated by Discovery).
+   * "Unknown" for pre-Discovery hosts. The legacy closed union
+   * (Ubuntu | RHEL | Debian | SUSE) was widened to string so the
+   * OSChip can render unmapped families with the neutral color
+   * instead of crashing the OS_COLOR lookup.
+   * Spec: frontend-host-list-os.
+   */
+  os: string;
   status: 'down' | 'online';
   /** v1.3.0 — 5-band classification, populated from host_liveness.monitoring_state */
   monitoring: MonitoringBand;

--- a/app/frontend/src/pages/HostsListPage.tsx
+++ b/app/frontend/src/pages/HostsListPage.tsx
@@ -20,6 +20,7 @@ import {
 import api from '@/api/client';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
+import { osDisplayLabel } from '@/utils/osLabel';
 import {
   devHosts,
   devKpis,
@@ -66,7 +67,7 @@ interface ApiHostLiveness {
   privilege_consecutive_failures?: number;
 }
 
-interface ApiHost {
+export interface ApiHost {
   id: string;
   hostname: string;
   ip_address: string;
@@ -82,14 +83,30 @@ interface ApiHost {
   /** v1.5.0 — MAX(host_rule_state.last_checked_at); null when never scanned. */
   last_scan_at?: string | null;
   liveness?: ApiHostLiveness | null;
+  /**
+   * v1.4.0 (api-hosts) — denormalized OS columns populated by
+   * system-host-discovery via Kensa. NULL on hosts that have not yet
+   * been discovered. Drives the OS column display per
+   * frontend-host-list-os v1.0.0.
+   */
+  os_family?: string | null;
+  os_version?: string | null;
+  architecture?: string | null;
+  platform_identifier?: string | null;
+  os_discovered_at?: string | null;
 }
 
-const OS_COLOR: Record<DevHost['os'], string> = {
+// Per-vendor accent for the OS chip. Widened to a string-keyed map so
+// that unmapped families (Unknown — pre-Discovery hosts) get the
+// neutral var(--ow-fg-dim) fallback rather than crashing the lookup.
+// Spec: frontend-host-list-os C-03.
+const OS_COLOR: Record<string, string> = {
   Ubuntu: '#e95420',
   RHEL: '#ee0000',
   Debian: '#a80030',
   SUSE: '#30ba78',
 };
+const OS_COLOR_FALLBACK = 'var(--ow-fg-dim)';
 
 function complianceTier(v: number | null): 'crit' | 'warn' | 'ok' {
   if (v == null || v < 40) return 'crit';
@@ -1293,7 +1310,7 @@ function StatusPill({ band }: { band: MonitoringBand }) {
 }
 
 function OSChip({ os }: { os: DevHost['os'] }) {
-  const color = OS_COLOR[os];
+  const color = OS_COLOR[os] ?? OS_COLOR_FALLBACK;
   return (
     <span
       style={{
@@ -1409,14 +1426,6 @@ function EmptyRegion({
 // API → DevHost mapping (when backend has real data)
 // ─────────────────────────────────────────────────────────────────────────
 
-function detectOS(hostname: string): DevHost['os'] {
-  const h = hostname.toLowerCase();
-  if (h.includes('rhn') || h.includes('rhel') || h.includes('rh')) return 'RHEL';
-  if (h.includes('deb')) return 'Debian';
-  if (h.includes('suse')) return 'SUSE';
-  return 'Ubuntu';
-}
-
 // formatMinutesAgo turns a minute count into a humane "Xm ago" / "Xh ago"
 // / "Xd ago" string. Under 1m reads as "just now" since that's the
 // 30-second tick range from the adaptive health checks loop.
@@ -1428,7 +1437,7 @@ function formatMinutesAgo(minutes: number): string {
   return `${Math.round(hours / 24)}d ago`;
 }
 
-function apiHostToDev(h: ApiHost): DevHost {
+export function apiHostToDev(h: ApiHost): DevHost {
   // v1.3.0: derive both the legacy 'status' (online/down) for components
   // that still consume the binary view, AND the new 'monitoring' band so
   // the StatusPill can render degraded vs critical vs down distinctly.
@@ -1458,7 +1467,7 @@ function apiHostToDev(h: ApiHost): DevHost {
     id: h.id,
     hostname: h.hostname,
     ip_address: h.ip_address,
-    os: detectOS(h.hostname),
+    os: osDisplayLabel(h.os_family),
     status: reachable ? 'online' : 'down',
     monitoring,
     maintenance: h.maintenance_mode === true,

--- a/app/frontend/src/utils/osLabel.ts
+++ b/app/frontend/src/utils/osLabel.ts
@@ -1,0 +1,26 @@
+// osLabel — pure mapping from the denormalized hosts.os_family column
+// (populated by system-host-discovery via Kensa) onto the user-facing
+// OS display label used by HostsListPage and HostDetailPage. The
+// mapping is intentionally closed; unrecognized families fall through
+// to "Unknown" so a pre-Discovery host or an unsupported distro never
+// gets silently labelled with a confidently-wrong guess.
+//
+// Spec: frontend-host-list-os C-02 + AC-01..AC-03.
+
+const KENSA_FAMILY_TO_LABEL: Record<string, string> = {
+  rhel: 'RHEL',
+  centos: 'RHEL',
+  rocky: 'RHEL',
+  almalinux: 'RHEL',
+  ubuntu: 'Ubuntu',
+  debian: 'Debian',
+  opensuse: 'SUSE',
+  sles: 'SUSE',
+};
+
+export function osDisplayLabel(family: string | null | undefined): string {
+  if (!family) return 'Unknown';
+  const key = family.trim().toLowerCase();
+  if (!key) return 'Unknown';
+  return KENSA_FAMILY_TO_LABEL[key] ?? 'Unknown';
+}

--- a/app/frontend/tests/pages/hosts-list-os.test.ts
+++ b/app/frontend/tests/pages/hosts-list-os.test.ts
@@ -5,6 +5,7 @@
 //   AC-04  test('frontend-host-list-os/AC-04 — apiHostToDev derives OS from os_family, not hostname')
 //   AC-05  test('frontend-host-list-os/AC-05 — detectOS heuristic is removed from the page')
 //   AC-06  test('frontend-host-list-os/AC-06 — osDisplayLabel is imported and used by apiHostToDev')
+//   AC-07  test('frontend-host-list-os/AC-07 — OSChip falls back to OS_COLOR_FALLBACK for unmapped families')
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -67,5 +68,17 @@ describe('frontend-host-list-os — structural', () => {
     expect(fnMatch).not.toBeNull();
     expect(fnMatch![1]).toContain('osDisplayLabel');
     expect(fnMatch![1]).toContain('os_family');
+  });
+
+  // @ac AC-07
+  test('frontend-host-list-os/AC-07 — OSChip falls back to OS_COLOR_FALLBACK for unmapped families', () => {
+    // The fallback constant exists
+    expect(PAGE_SRC).toMatch(/const\s+OS_COLOR_FALLBACK\s*=/);
+    // OS_COLOR is typed as an open string-keyed map (widened from the
+    // closed union so unmapped families are well-typed at the lookup
+    // site).
+    expect(PAGE_SRC).toMatch(/OS_COLOR\s*:\s*Record<string,\s*string>/);
+    // OSChip uses the ?? fallback pattern
+    expect(PAGE_SRC).toMatch(/OS_COLOR\[[^\]]+\]\s*\?\?\s*OS_COLOR_FALLBACK/);
   });
 });

--- a/app/frontend/tests/pages/hosts-list-os.test.ts
+++ b/app/frontend/tests/pages/hosts-list-os.test.ts
@@ -1,0 +1,71 @@
+// @spec frontend-host-list-os
+//
+// AC traceability (this file):
+//
+//   AC-04  test('frontend-host-list-os/AC-04 — apiHostToDev derives OS from os_family, not hostname')
+//   AC-05  test('frontend-host-list-os/AC-05 — detectOS heuristic is removed from the page')
+//   AC-06  test('frontend-host-list-os/AC-06 — osDisplayLabel is imported and used by apiHostToDev')
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { apiHostToDev, type ApiHost } from '@/pages/HostsListPage';
+
+const PAGE_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/HostsListPage.tsx'),
+  'utf8',
+);
+
+function makeApiHost(overrides: Partial<ApiHost> = {}): ApiHost {
+  return {
+    id: 'h-1',
+    hostname: 'owas-rhn01',
+    ip_address: '10.0.0.1',
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('frontend-host-list-os — behavioral', () => {
+  // @ac AC-04
+  test('frontend-host-list-os/AC-04 — apiHostToDev derives OS from os_family, not hostname', () => {
+    // Hostname suggests RHEL but os_family is null -> Unknown.
+    // This is the proof-positive that the hostname heuristic is gone.
+    const preDiscovery = apiHostToDev(
+      makeApiHost({ hostname: 'owas-rhn01', os_family: null }),
+    );
+    expect(preDiscovery.os).toBe('Unknown');
+
+    // Real os_family wins.
+    const discovered = apiHostToDev(
+      makeApiHost({ hostname: 'random-name', os_family: 'rhel' }),
+    );
+    expect(discovered.os).toBe('RHEL');
+
+    const ubuntuHost = apiHostToDev(
+      makeApiHost({ hostname: 'doesnt-matter', os_family: 'ubuntu' }),
+    );
+    expect(ubuntuHost.os).toBe('Ubuntu');
+  });
+});
+
+describe('frontend-host-list-os — structural', () => {
+  // @ac AC-05
+  test('frontend-host-list-os/AC-05 — detectOS heuristic is removed from the page', () => {
+    expect(PAGE_SRC).not.toContain('detectOS');
+  });
+
+  // @ac AC-06
+  test('frontend-host-list-os/AC-06 — osDisplayLabel is imported and used by apiHostToDev', () => {
+    // Imported from the shared util
+    expect(PAGE_SRC).toMatch(/import\s*\{[^}]*osDisplayLabel[^}]*\}\s*from\s*['"]@\/utils\/osLabel['"]/);
+    // apiHostToDev body references the helper
+    const fnMatch = PAGE_SRC.match(
+      /function\s+apiHostToDev\s*\([^)]*\)[^{]*\{([\s\S]*?)\n\}/,
+    );
+    expect(fnMatch).not.toBeNull();
+    expect(fnMatch![1]).toContain('osDisplayLabel');
+    expect(fnMatch![1]).toContain('os_family');
+  });
+});

--- a/app/frontend/tests/utils/osLabel.test.ts
+++ b/app/frontend/tests/utils/osLabel.test.ts
@@ -1,0 +1,45 @@
+// @spec frontend-host-list-os
+//
+// AC traceability (this file):
+//
+//   AC-01  test('frontend-host-list-os/AC-01 — RHEL family maps to RHEL (case-insensitive)')
+//   AC-02  test('frontend-host-list-os/AC-02 — ubuntu/debian/suse families map to expected labels')
+//   AC-03  test('frontend-host-list-os/AC-03 — null/undefined/empty/unknown families fall back to Unknown')
+
+import { describe, expect, test } from 'vitest';
+import { osDisplayLabel } from '@/utils/osLabel';
+
+describe('frontend-host-list-os — osDisplayLabel', () => {
+  // @ac AC-01
+  test('frontend-host-list-os/AC-01 — RHEL family maps to RHEL (case-insensitive)', () => {
+    expect(osDisplayLabel('rhel')).toBe('RHEL');
+    expect(osDisplayLabel('centos')).toBe('RHEL');
+    expect(osDisplayLabel('rocky')).toBe('RHEL');
+    expect(osDisplayLabel('almalinux')).toBe('RHEL');
+    // case folding
+    expect(osDisplayLabel('RHEL')).toBe('RHEL');
+    expect(osDisplayLabel('Rhel')).toBe('RHEL');
+    expect(osDisplayLabel('  CentOS  ')).toBe('RHEL');
+  });
+
+  // @ac AC-02
+  test('frontend-host-list-os/AC-02 — ubuntu/debian/suse families map to expected labels', () => {
+    expect(osDisplayLabel('ubuntu')).toBe('Ubuntu');
+    expect(osDisplayLabel('debian')).toBe('Debian');
+    expect(osDisplayLabel('opensuse')).toBe('SUSE');
+    expect(osDisplayLabel('sles')).toBe('SUSE');
+  });
+
+  // @ac AC-03
+  test('frontend-host-list-os/AC-03 — null/undefined/empty/unknown families fall back to Unknown', () => {
+    expect(osDisplayLabel(null)).toBe('Unknown');
+    expect(osDisplayLabel(undefined)).toBe('Unknown');
+    expect(osDisplayLabel('')).toBe('Unknown');
+    expect(osDisplayLabel('   ')).toBe('Unknown');
+    // Fedora is intentionally excluded (development stream, not enterprise)
+    expect(osDisplayLabel('fedora')).toBe('Unknown');
+    // Other unsupported families
+    expect(osDisplayLabel('arch')).toBe('Unknown');
+    expect(osDisplayLabel('freebsd')).toBe('Unknown');
+  });
+});

--- a/app/specs/frontend/host-list-os.spec.yaml
+++ b/app/specs/frontend/host-list-os.spec.yaml
@@ -46,13 +46,13 @@ spec:
       Unknown fallback + the source-inspection that detectOS is gone.
     scope:
       includes:
-        - osDisplayLabel(family: string | null) helper exported from the page module (or co-located util)
-        - OSChip rendering "Unknown" with a neutral color when family is unmapped or null
-        - apiHostToDev mapping the real os_family (NOT hostname) onto DevHost.os
+        - "osDisplayLabel(family: string | null) helper exported from the page module (or co-located util)"
+        - 'OSChip rendering "Unknown" with a neutral color when family is unmapped or null'
+        - "apiHostToDev mapping the real os_family (NOT hostname) onto DevHost.os"
       excludes:
-        - os_version display — owned by PR 6 (host detail panel)
-        - group-by-OS aggregation semantics — out of scope here; lives in the filterbar spec
-        - Color choices for known families — already locked by the OS_COLOR map; this spec only widens it to fall back to neutral
+        - "os_version display — owned by PR 6 (host detail panel)"
+        - "group-by-OS aggregation semantics — out of scope here; lives in the filterbar spec"
+        - "Color choices for known families — already locked by the OS_COLOR map; this spec only widens it to fall back to neutral"
 
   constraints:
     - id: C-01
@@ -97,3 +97,7 @@ spec:
       description: 'Source inspection: HostsListPage.tsx contains a function named osDisplayLabel (declaration or const arrow). The function is called from apiHostToDev. Verified by reading the file source and asserting both occurrences'
       priority: critical
       references_constraints: [C-02, C-04]
+    - id: AC-07
+      description: 'Source inspection: HostsListPage.tsx declares an OS_COLOR_FALLBACK constant referenced by OSChip via the "?? OS_COLOR_FALLBACK" lookup pattern. Proves the neutral-fallback wiring is in place — OS_COLOR is typed Record<string, string> (open map) and the bracket access is guarded against the unmapped/undefined case'
+      priority: high
+      references_constraints: [C-03]

--- a/app/specs/frontend/host-list-os.spec.yaml
+++ b/app/specs/frontend/host-list-os.spec.yaml
@@ -1,0 +1,99 @@
+spec:
+  id: frontend-host-list-os
+  title: Host list OS column — sourced from real os_family (no hostname heuristic)
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Host list /hosts page renders the OS column from the denormalized hosts.os_family column populated by Discovery (system-host-discovery v1.0.0)
+    description: >
+      Pre-PR 5c the host list rendered the OS column via detectOS(hostname),
+      a string-match heuristic ('rh' -> RHEL, 'deb' -> Debian, 'suse' -> SUSE,
+      everything else -> Ubuntu). The heuristic was a placeholder while the
+      denormalized OS columns were not yet exposed by the API. Now that
+      api-hosts v1.4.0 (PR 5a) carries os_family on every list item, the
+      heuristic MUST be replaced with the real value. Hosts that have not
+      run Discovery yet have os_family = null and MUST display "Unknown"
+      with the neutral chip color — never a guessed value from the hostname.
+
+      Mapping table (Kensa families → display label):
+
+        rhel, centos, rocky, almalinux  ->  'RHEL'
+        ubuntu                          ->  'Ubuntu'
+        debian                          ->  'Debian'
+        opensuse, sles                  ->  'SUSE'
+        anything else (incl. null)      ->  'Unknown'
+
+      The mapping is intentionally narrow. Fedora is excluded from the
+      'RHEL' bucket because Fedora is a development stream, not an
+      enterprise-tracked target; lumping it in would distort the
+      group-by-OS rollup that the prototype's filterbar drives. New
+      families MUST be added explicitly — the default branch returns
+      'Unknown', not a silent best-effort guess.
+
+    related_specs:
+      - api-hosts
+      - system-host-discovery
+      - frontend-live-events
+
+  objective:
+    summary: >
+      Source of truth for the os_family -> display-label mapping used by
+      HostsListPage and for the rule that the hostname heuristic
+      (detectOS) is FORBIDDEN. Tests assert each mapping branch + the
+      Unknown fallback + the source-inspection that detectOS is gone.
+    scope:
+      includes:
+        - osDisplayLabel(family: string | null) helper exported from the page module (or co-located util)
+        - OSChip rendering "Unknown" with a neutral color when family is unmapped or null
+        - apiHostToDev mapping the real os_family (NOT hostname) onto DevHost.os
+      excludes:
+        - os_version display — owned by PR 6 (host detail panel)
+        - group-by-OS aggregation semantics — out of scope here; lives in the filterbar spec
+        - Color choices for known families — already locked by the OS_COLOR map; this spec only widens it to fall back to neutral
+
+  constraints:
+    - id: C-01
+      description: 'HostsListPage MUST NOT import or call any function that maps a hostname string to an OS label. The detectOS(hostname) helper MUST NOT exist in the file. Reason: the heuristic produced confidently-wrong labels for hosts whose hostnames did not match the pattern (every host without "rh", "deb", or "suse" in the name silently became "Ubuntu")'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'A pure mapping function osDisplayLabel(family: string | null) MUST exist in the page module and MUST be the only path that produces the DevHost.os string. Case-insensitive match on the family value. Mapping table is the closed set in the spec context; everything else (including null, undefined, empty string, unknown family) returns "Unknown"'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'OSChip MUST render the neutral chip color (var(--ow-fg-dim) or equivalent neutral gray) when the os label is "Unknown" or when the OS_COLOR lookup returns undefined. No throw, no missing-key warning, no fallback to a known-family color'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'apiHostToDev MUST read h.os_family (the denormalized column landed in api-hosts v1.4.0 / PR 5a). It MUST NOT consult h.hostname for OS detection. Verified by source inspection: the function body MUST reference os_family and MUST NOT reference detectOS'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'osDisplayLabel("rhel"), osDisplayLabel("centos"), osDisplayLabel("rocky"), osDisplayLabel("almalinux") each return "RHEL". Case folding: osDisplayLabel("RHEL") and osDisplayLabel("Rhel") also return "RHEL"'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-02
+      description: 'osDisplayLabel("ubuntu") returns "Ubuntu"; osDisplayLabel("debian") returns "Debian"; osDisplayLabel("opensuse") and osDisplayLabel("sles") return "SUSE"'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: 'osDisplayLabel(null), osDisplayLabel(undefined), osDisplayLabel(""), osDisplayLabel("fedora"), osDisplayLabel("arch") all return "Unknown". The mapping is closed; unrecognized families MUST NOT pass through unchanged'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: 'apiHostToDev called on a host with os_family="rhel" produces DevHost.os="RHEL". apiHostToDev called on a host with os_family=null produces DevHost.os="Unknown". The hostname is irrelevant — a host named "owas-rhn01" with os_family=null still gets "Unknown", proving the heuristic is gone'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-05
+      description: 'Source inspection of frontend/src/pages/HostsListPage.tsx: the file MUST NOT contain the string "detectOS" anywhere. The function and all callers MUST be deleted'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-06
+      description: 'Source inspection: HostsListPage.tsx contains a function named osDisplayLabel (declaration or const arrow). The function is called from apiHostToDev. Verified by reading the file source and asserting both occurrences'
+      priority: critical
+      references_constraints: [C-02, C-04]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -49,6 +49,7 @@ domains:
             - frontend-live-events
             - api-hosts
             - frontend-host-detail
+            - frontend-host-list-os
             - api-openapi-docs
             - release-admin-signoff
             - system-worker-subcommand


### PR DESCRIPTION
## Summary

PR 5c removes the placeholder hostname-string heuristic (`detectOS`) from the host list and replaces it with a closed mapping from the real `os_family` column landed by **PR 5a** (api-hosts v1.4.0). Pre-Discovery hosts now render "Unknown" instead of a confidently-wrong guess.

New spec **`frontend-host-list-os` v1.0.0** (Tier 2, 4 C / 6 AC) locks the mapping table and forbids any future hostname-based OS detection.

### The heuristic was wrong

```ts
// before (HostsListPage.tsx)
function detectOS(hostname: string): DevHost['os'] {
  const h = hostname.toLowerCase();
  if (h.includes('rhn') || h.includes('rhel') || h.includes('rh')) return 'RHEL';
  if (h.includes('deb')) return 'Debian';
  if (h.includes('suse')) return 'SUSE';
  return 'Ubuntu';  // <-- silently mislabels every non-matching host
}
```

### Mapping table (closed)

| `os_family`                          | Display label |
| ------------------------------------ | ------------- |
| `rhel` / `centos` / `rocky` / `almalinux` | RHEL          |
| `ubuntu`                             | Ubuntu        |
| `debian`                             | Debian        |
| `opensuse` / `sles`                  | SUSE          |
| anything else (incl. `null`)         | Unknown       |

Fedora is intentionally excluded — it's a development stream, not an enterprise target. Adding it would distort the group-by-OS rollup.

### Changes

- New util `src/utils/osLabel.ts` exporting `osDisplayLabel(family)` — single source of truth, case-insensitive, trims whitespace, closed mapping
- `apiHostToDev` now reads `h.os_family` and exports for direct testing; hostname is no longer consulted for OS
- `OSChip` falls back to `var(--ow-fg-dim)` for unmapped families so the `OS_COLOR` lookup cannot crash
- `DevHost.os` widened from closed union → `string` (still a display label, just not constrained to 4 known vendors)
- `schema.d.ts` regenerated to pick up the 5 OS fields api-hosts v1.4.0 added
- 6 vitest tests: 3 direct on `osDisplayLabel`, 3 source-inspect + behavioral

### Unblocks

- **PR 6** — host detail OS panel (Distribution / Kernel / FQDN / Uptime) + Re-run Discovery button
- **PR 7** — host detail Intelligence events feed + activated Packages/Services/Users/Network tabs

## Test plan

- [x] 6 new tests pass — `frontend/tests/utils/osLabel.test.ts` + `frontend/tests/pages/hosts-list-os.test.ts`
- [x] Full frontend suite green (57 tests, 9 files)
- [x] `tsc --noEmit` clean
- [x] Spec validates
- [ ] CI: spec-checks, frontend-tests