### PR TITLE
feat(frontend): wire System card to real OS data + Re-run Discovery (PR 6)

### DIFF
--- a/app/frontend/src/pages/HostDetailPage.tsx
+++ b/app/frontend/src/pages/HostDetailPage.tsx
@@ -26,6 +26,7 @@ import type { LucideIcon } from 'lucide-react';
 import api from '@/api/client';
 import { EditHostModal } from '@/components/hosts/EditHostModal';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
+import { CardSystem } from '@/pages/host-detail/CardSystem';
 
 // HostDetailPage — prototype-faithful Host Detail surface (v1.0.0).
 //
@@ -66,6 +67,13 @@ interface HostResponse {
   username?: string;
   maintenance_mode?: boolean;
   check_priority?: number;
+  // v1.4.0 (api-hosts) — denormalized OS columns populated by
+  // system-host-discovery. NULL until Discovery has run.
+  os_family?: string | null;
+  os_version?: string | null;
+  architecture?: string | null;
+  platform_identifier?: string | null;
+  os_discovered_at?: string | null;
 }
 
 type MonitoringBand =
@@ -253,6 +261,27 @@ export function HostDetailPage() {
     retry: false,
   });
 
+  // IntelligenceState feeds the System card (kernel_release, uptime_seconds).
+  // 404 = no snapshot yet OR host unknown (handler intentionally
+  // collapses both per api-os-intelligence C-04). We treat it as
+  // "no snapshot" — the host-detail query owns the unknown-host path.
+  // Query key matches frontend-host-detail-system-card C-05 / AC-06.
+  const intelligenceStateQuery = useQuery({
+    queryKey: ['intelligence_state', hostId],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        '/api/v1/intelligence/state/{host_id}',
+        { params: { path: { host_id: hostId } } },
+      );
+      if (response.status === 404) return null;
+      if (error) throw error;
+      const raw = data as unknown as { snapshot?: Record<string, unknown> } | null;
+      return raw?.snapshot ?? null;
+    },
+    enabled: !!hostId,
+    retry: false,
+  });
+
   // Topbar breadcrumb — pushes "Infrastructure / Hosts / <hostname>"
   // into the global useBreadcrumbStore so the sticky header renders
   // it (same pattern as HostsListPage). AC-27.
@@ -365,7 +394,10 @@ export function HostDetailPage() {
                   <CardComplianceTrend />
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
-                  <CardSystem host={detailQuery.data.host} />
+                  <CardSystem
+                    host={detailQuery.data.host}
+                    intelligenceSnapshot={intelligenceStateQuery.data ?? null}
+                  />
                   <CardRecentActivity
                     isLoading={historyQuery.isLoading}
                     isError={historyQuery.isError}
@@ -1179,45 +1211,6 @@ function CardComplianceTrend() {
   );
 }
 
-function CardSystem({ host }: { host: HostResponse }) {
-  return (
-    <Card title="System">
-      <SpecGroup title="Operating system">
-        <DefList
-          rows={[
-            ['Distribution', <span key="d">unknown</span>],
-            ['Kernel', <span key="k" style={{ fontFamily: 'var(--ow-font-mono)' }}>unknown</span>],
-            ['FQDN', <span key="f" style={{ fontFamily: 'var(--ow-font-mono)' }}>{host.hostname}</span>],
-            ['Uptime', <span key="u">unknown</span>],
-          ]}
-        />
-      </SpecGroup>
-      <SpecGroup title="Hardware">
-        <EmptyState
-          primary="Hardware metrics not collected"
-          secondary="Populated by Server Intelligence (CPU / disk / memory). Deferred — see BACKLOG."
-          compact
-        />
-      </SpecGroup>
-      <SpecGroup title="Network">
-        <DefList
-          rows={[
-            ['Primary IP', <span key="ip" style={{ fontFamily: 'var(--ow-font-mono)' }}>{host.ip_address}</span>],
-            [
-              'SSH endpoint',
-              <span key="ssh" style={{ fontFamily: 'var(--ow-font-mono)' }}>
-                {host.username ? `${host.username}@` : ''}
-                {host.ip_address}:{host.port ?? 22}
-              </span>,
-            ],
-            ['Firewall', <span key="fw">unknown</span>],
-          ]}
-        />
-      </SpecGroup>
-    </Card>
-  );
-}
-
 function CardRecentActivity({
   isLoading,
   isError,
@@ -1338,51 +1331,6 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
       <div>{children}</div>
     </section>
   );
-}
-
-function SpecGroup({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div style={{ marginBottom: 14 }}>
-      <h4
-        style={{
-          margin: '0 0 8px',
-          fontSize: 11,
-          textTransform: 'uppercase',
-          letterSpacing: '0.06em',
-          color: 'var(--ow-fg-2)',
-        }}
-      >
-        {title}
-      </h4>
-      {children}
-    </div>
-  );
-}
-
-function DefList({ rows }: { rows: [string, React.ReactNode][] }) {
-  return (
-    <dl
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'max-content 1fr',
-        rowGap: 6,
-        columnGap: 14,
-        margin: 0,
-        fontSize: 12,
-      }}
-    >
-      {rows.map(([k, v]) => (
-        <ReactFrag key={k}>
-          <dt style={{ color: 'var(--ow-fg-3)' }}>{k}</dt>
-          <dd style={{ margin: 0, color: 'var(--ow-fg-1)', minWidth: 0 }}>{v}</dd>
-        </ReactFrag>
-      ))}
-    </dl>
-  );
-}
-
-function ReactFrag({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
 }
 
 function EmptyState({

--- a/app/frontend/src/pages/host-detail/CardSystem.tsx
+++ b/app/frontend/src/pages/host-detail/CardSystem.tsx
@@ -1,0 +1,350 @@
+// CardSystem — Host detail right-rail "System" card.
+//
+// Replaces the prior "unknown / unknown / unknown / unknown" placeholder
+// rows with real data sourced from:
+//
+//   • HostResponse (denormalized hosts.os_family / os_version) — populated
+//     by system-host-discovery via Kensa, exposed by api-hosts v1.4.0.
+//   • IntelligenceState.snapshot.kernel_release + uptime_seconds —
+//     populated by the scheduled intelligence cycle (api-os-intelligence).
+//
+// Pre-Discovery hosts (os_family null AND no IntelligenceState row)
+// collapse to a single "Not discovered yet" empty state with a Re-run
+// Discovery button (gated on host:write).
+//
+// Spec: frontend-host-detail-system-card v1.0.0.
+
+import React, { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { RefreshCw } from 'lucide-react';
+import api from '@/api/client';
+import { useAuthStore } from '@/store/useAuthStore';
+import { osDisplayLabel } from '@/utils/osLabel';
+import { formatUptime } from '@/utils/formatUptime';
+
+// Minimal host shape needed by CardSystem. Mirrors the relevant subset
+// of HostResponse — declared inline so the card stays testable without
+// pulling in the full page-level type.
+export interface CardSystemHost {
+  id: string;
+  hostname: string;
+  ip_address: string;
+  port?: number;
+  username?: string;
+  os_family?: string | null;
+  os_version?: string | null;
+}
+
+interface CardSystemProps {
+  host: CardSystemHost;
+  /** snapshot field of IntelligenceState; null when no IntelligenceState row exists yet. */
+  intelligenceSnapshot: Record<string, unknown> | null;
+}
+
+const UNREACHABLE_MSG = 'Host unreachable — check SSH credentials and connectivity';
+
+export function CardSystem({ host, intelligenceSnapshot }: CardSystemProps) {
+  const canWrite = useAuthStore((s) => s.hasPermission('host:write'));
+  const queryClient = useQueryClient();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Spec C-02: a host is "discovered" once Discovery has populated the
+  // denormalized OS columns. Pre-Discovery → single empty state.
+  const isDiscovered = !!host.os_family || !!host.os_version;
+
+  // Pluck the two snapshot fields we render (kernel_release, uptime_seconds).
+  const kernelRelease = pickString(intelligenceSnapshot, 'kernel_release');
+  const uptimeSeconds = pickNumber(intelligenceSnapshot, 'uptime_seconds');
+
+  const distribution = isDiscovered
+    ? `${osDisplayLabel(host.os_family)}${host.os_version ? ` ${host.os_version}` : ''}`
+    : null;
+
+  async function onRerunDiscovery() {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const idempotencyKey = crypto.randomUUID();
+      const { response, error: apiErr } = await api.POST(
+        '/api/v1/hosts/{id}/discovery:run',
+        {
+          params: {
+            path: { id: host.id },
+            header: { 'Idempotency-Key': idempotencyKey },
+          },
+        },
+      );
+      if (!response.ok) {
+        if (response.status === 502) {
+          setError(UNREACHABLE_MSG);
+          return;
+        }
+        if (response.status === 403) {
+          setError('Permission denied');
+          return;
+        }
+        const env = apiErr as { error?: { message?: string } } | undefined;
+        setError(env?.error?.message ?? `HTTP ${response.status}`);
+        return;
+      }
+      // Spec C-05: both queries must refresh — denormalized OS fields
+      // came from HostResponse, kernel/uptime from IntelligenceState.
+      queryClient.invalidateQueries({ queryKey: ['host', host.id] });
+      queryClient.invalidateQueries({ queryKey: ['intelligence_state', host.id] });
+    } catch (e) {
+      setError((e as Error)?.message ?? 'Network error');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Card title="System">
+      <SpecGroup title="Operating system">
+        {isDiscovered ? (
+          <DefList
+            rows={[
+              ['Distribution', <span key="d">{distribution}</span>],
+              [
+                'Kernel',
+                <span key="k" style={{ fontFamily: 'var(--ow-font-mono)' }}>
+                  {kernelRelease ?? '—'}
+                </span>,
+              ],
+              [
+                'FQDN',
+                <span key="f" style={{ fontFamily: 'var(--ow-font-mono)' }}>
+                  {host.hostname}
+                </span>,
+              ],
+              ['Uptime', <span key="u">{formatUptime(uptimeSeconds)}</span>],
+            ]}
+          />
+        ) : (
+          <NotDiscoveredState
+            canWrite={canWrite}
+            pending={pending}
+            error={error}
+            onClick={onRerunDiscovery}
+          />
+        )}
+      </SpecGroup>
+
+      <SpecGroup title="Hardware">
+        <EmptyState
+          primary="Hardware metrics not collected"
+          secondary="Populated by Server Intelligence (CPU / disk / memory). Deferred — see BACKLOG."
+          compact
+        />
+      </SpecGroup>
+
+      <SpecGroup title="Network">
+        <DefList
+          rows={[
+            [
+              'Primary IP',
+              <span key="ip" style={{ fontFamily: 'var(--ow-font-mono)' }}>
+                {host.ip_address}
+              </span>,
+            ],
+            [
+              'SSH endpoint',
+              <span key="ssh" style={{ fontFamily: 'var(--ow-font-mono)' }}>
+                {host.username ? `${host.username}@` : ''}
+                {host.ip_address}:{host.port ?? 22}
+              </span>,
+            ],
+            ['Firewall', <span key="fw">—</span>],
+          ]}
+        />
+      </SpecGroup>
+    </Card>
+  );
+}
+
+function NotDiscoveredState({
+  canWrite,
+  pending,
+  error,
+  onClick,
+}: {
+  canWrite: boolean;
+  pending: boolean;
+  error: string | null;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: '14px 0',
+        textAlign: 'center',
+        color: 'var(--ow-fg-2)',
+      }}
+    >
+      <div style={{ color: 'var(--ow-fg-1)', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>
+        Not discovered yet
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: 'var(--ow-fg-3)',
+          maxWidth: 360,
+          margin: '0 auto 10px',
+          lineHeight: 1.5,
+        }}
+      >
+        OS fingerprint, kernel, and uptime appear after the first Discovery run.
+      </div>
+      {canWrite && (
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={pending}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '6px 12px',
+            background: 'var(--ow-bg-2)',
+            color: 'var(--ow-fg-1)',
+            border: '1px solid var(--ow-line)',
+            borderRadius: 6,
+            fontSize: 12,
+            cursor: pending ? 'wait' : 'pointer',
+            opacity: pending ? 0.6 : 1,
+          }}
+        >
+          <RefreshCw size={12} /> {pending ? 'Running…' : 'Re-run Discovery'}
+        </button>
+      )}
+      {error && (
+        <div
+          role="alert"
+          style={{
+            color: 'var(--ow-crit)',
+            fontSize: 11,
+            marginTop: 8,
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function pickString(snap: Record<string, unknown> | null, key: string): string | null {
+  if (!snap) return null;
+  const v = snap[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function pickNumber(snap: Record<string, unknown> | null, key: string): number | null {
+  if (!snap) return null;
+  const v = snap[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+// ── Layout primitives ─────────────────────────────────────────────────────
+// Inlined so CardSystem stays self-contained for testing. Behavior
+// matches the page-local Card / SpecGroup / DefList / EmptyState
+// exactly — moving them out of HostDetailPage in a follow-up would
+// dedupe (BACKLOG).
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section
+      style={{
+        background: 'var(--ow-bg-1)',
+        border: '1px solid var(--ow-line)',
+        borderRadius: 'var(--ow-radius)',
+        padding: 18,
+      }}
+    >
+      <header style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between' }}>
+        <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>{title}</h3>
+      </header>
+      <div>{children}</div>
+    </section>
+  );
+}
+
+function SpecGroup({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <h4
+        style={{
+          margin: '0 0 8px',
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          color: 'var(--ow-fg-2)',
+        }}
+      >
+        {title}
+      </h4>
+      {children}
+    </div>
+  );
+}
+
+function DefList({ rows }: { rows: [string, React.ReactNode][] }) {
+  return (
+    <dl
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'max-content 1fr',
+        rowGap: 6,
+        columnGap: 14,
+        margin: 0,
+        fontSize: 12,
+      }}
+    >
+      {rows.map(([k, v]) => (
+        <React.Fragment key={k}>
+          <dt style={{ color: 'var(--ow-fg-3)' }}>{k}</dt>
+          <dd style={{ margin: 0, color: 'var(--ow-fg-1)', minWidth: 0 }}>{v}</dd>
+        </React.Fragment>
+      ))}
+    </dl>
+  );
+}
+
+function EmptyState({
+  primary,
+  secondary,
+  compact,
+}: {
+  primary: string;
+  secondary: string;
+  compact?: boolean;
+}) {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: compact ? '12px 0' : '20px 0',
+        textAlign: 'center',
+        color: 'var(--ow-fg-2)',
+      }}
+    >
+      <div style={{ color: 'var(--ow-fg-1)', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>
+        {primary}
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: 'var(--ow-fg-3)',
+          maxWidth: 360,
+          margin: '0 auto',
+          lineHeight: 1.5,
+        }}
+      >
+        {secondary}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/utils/formatUptime.ts
+++ b/app/frontend/src/utils/formatUptime.ts
@@ -1,0 +1,29 @@
+// formatUptime — pure, timezone-independent uptime formatter for the
+// host detail System card. Maps a uptime-in-seconds integer (sourced
+// from host_intelligence_state.snapshot.uptime_seconds) to a compact
+// human-readable string. Bucketing favors operational signal:
+//   <1m  -> just rebooted, signal-worthy
+//   m    -> recent boot
+//   h Ym -> normal day-of-operation
+//   d Yh -> long-running host
+//
+// Spec: frontend-host-detail-system-card C-01 / AC-01.
+
+export function formatUptime(seconds: number | null | undefined): string {
+  if (seconds == null) return '—';
+  if (!Number.isFinite(seconds) || seconds < 0) return '—';
+  const s = Math.floor(seconds);
+  if (s < 60) return '<1m';
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    return `${m}m`;
+  }
+  if (s < 86400) {
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    return `${h}h ${m}m`;
+  }
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  return `${d}d ${h}h`;
+}

--- a/app/frontend/tests/pages/host-detail-shell.test.ts
+++ b/app/frontend/tests/pages/host-detail-shell.test.ts
@@ -223,14 +223,20 @@ describe('frontend-host-detail — prototype shell', () => {
   });
 
   // @ac AC-25
-  test('frontend-host-detail/AC-25 — system card has 3 spec-groups with placeholders', () => {
+  test('frontend-host-detail/AC-25 — system card has 3 spec-groups (Operating system / Hardware / Network)', () => {
+    // CardSystem is now extracted to its own file (PR 6 / frontend-host-detail-system-card v1.0.0).
+    // The page imports + mounts it; the three group headings live there.
     expect(PAGE_SRC).toContain('CardSystem');
-    // The three group headings.
-    expect(PAGE_SRC).toMatch(/Operating system/);
-    expect(PAGE_SRC).toMatch(/Hardware/);
-    expect(PAGE_SRC).toMatch(/Network/);
-    // Placeholders for missing values.
-    expect(PAGE_SRC).toMatch(/unknown/);
+    const cardSrc = readFileSync(
+      resolve(process.cwd(), 'src/pages/host-detail/CardSystem.tsx'),
+      'utf8',
+    );
+    expect(cardSrc).toMatch(/Operating system/);
+    expect(cardSrc).toMatch(/Hardware/);
+    expect(cardSrc).toMatch(/Network/);
+    // v1.0.5: the prior "unknown" placeholder string is gone — pre-Discovery
+    // hosts collapse to a "Not discovered yet" empty state instead.
+    expect(cardSrc).toMatch(/Not discovered yet/);
   });
 
   // @ac AC-26

--- a/app/frontend/tests/pages/host-detail-system-card.test.tsx
+++ b/app/frontend/tests/pages/host-detail-system-card.test.tsx
@@ -1,0 +1,155 @@
+// @spec frontend-host-detail-system-card
+//
+// AC traceability (this file):
+//
+//   AC-02  test('frontend-host-detail-system-card/AC-02 — discovered host shows distribution + dashes for kernel/uptime')
+//   AC-03  test('frontend-host-detail-system-card/AC-03 — pre-Discovery host renders Not discovered yet + Re-run button')
+//   AC-04  test('frontend-host-detail-system-card/AC-04 — Re-run button hidden when caller lacks host:write')
+//   AC-05  test('frontend-host-detail-system-card/AC-05 — Re-run click mints fresh idempotency key via crypto.randomUUID')
+//   AC-06  test('frontend-host-detail-system-card/AC-06 — Re-run success invalidates both host + intelligence_state queries')
+//   AC-07  test('frontend-host-detail-system-card/AC-07 — 502 surfaces Host unreachable inline')
+
+import { describe, expect, test, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CardSystem, type CardSystemHost } from '@/pages/host-detail/CardSystem';
+import { useAuthStore } from '@/store/useAuthStore';
+
+const PAGE_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/host-detail/CardSystem.tsx'),
+  'utf8',
+);
+
+function withWriter(): void {
+  useAuthStore.setState({
+    identity: {
+      id: 'u-1',
+      username: 'op',
+      email: 'op@example.com',
+      role: 'operator',
+      permissions: ['host:read', 'host:write'],
+      mfaEnabled: false,
+    },
+    loading: false,
+  });
+}
+
+function withReadOnly(): void {
+  useAuthStore.setState({
+    identity: {
+      id: 'u-2',
+      username: 'viewer',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      permissions: ['host:read'],
+      mfaEnabled: false,
+    },
+    loading: false,
+  });
+}
+
+function makeHost(overrides: Partial<CardSystemHost> = {}): CardSystemHost {
+  return {
+    id: 'h-1',
+    hostname: 'owas-rhn01',
+    ip_address: '10.0.0.1',
+    port: 22,
+    username: 'opadmin',
+    ...overrides,
+  };
+}
+
+function renderWith(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  useAuthStore.getState().clear();
+});
+
+describe('frontend-host-detail-system-card — behavior', () => {
+  // @ac AC-02
+  test('frontend-host-detail-system-card/AC-02 — discovered host shows distribution + dashes for kernel/uptime', () => {
+    withWriter();
+    renderWith(
+      <CardSystem
+        host={makeHost({ os_family: 'rhel', os_version: '9.2' })}
+        intelligenceSnapshot={null}
+      />,
+    );
+    // Distribution row populated from os_family + os_version
+    expect(screen.getByText('RHEL 9.2')).toBeInTheDocument();
+    // Kernel and Uptime fall back to em-dash because no IntelligenceState
+    // Use queryAllByText since '—' may appear in unrelated cells
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    // No empty state — Discovery has run
+    expect(screen.queryByText('Not discovered yet')).toBeNull();
+  });
+
+  // @ac AC-03
+  test('frontend-host-detail-system-card/AC-03 — pre-Discovery host renders Not discovered yet + Re-run button', () => {
+    withWriter();
+    renderWith(
+      <CardSystem
+        host={makeHost({ os_family: null, os_version: null })}
+        intelligenceSnapshot={null}
+      />,
+    );
+    expect(screen.getByText('Not discovered yet')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /re-run discovery/i }),
+    ).toBeInTheDocument();
+  });
+
+  // @ac AC-04
+  test('frontend-host-detail-system-card/AC-04 — Re-run button hidden when caller lacks host:write', () => {
+    withReadOnly();
+    renderWith(
+      <CardSystem
+        host={makeHost({ os_family: null, os_version: null })}
+        intelligenceSnapshot={null}
+      />,
+    );
+    expect(screen.getByText('Not discovered yet')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /re-run discovery/i }),
+    ).toBeNull();
+  });
+});
+
+describe('frontend-host-detail-system-card — structural', () => {
+  // @ac AC-05
+  test('frontend-host-detail-system-card/AC-05 — Re-run click mints fresh idempotency key via crypto.randomUUID', () => {
+    // The mutation handler MUST call crypto.randomUUID() inline so
+    // each click produces a distinct key (no module-level constant).
+    expect(PAGE_SRC).toMatch(/crypto\.randomUUID\s*\(\)/);
+    // POSTs to the discovery:run endpoint
+    expect(PAGE_SRC).toContain("'/api/v1/hosts/{id}/discovery:run'");
+    // Passes the host id through path params
+    expect(PAGE_SRC).toMatch(/path:\s*\{\s*id:\s*host\.id\s*\}/);
+    // Sets the Idempotency-Key header
+    expect(PAGE_SRC).toMatch(/['"]Idempotency-Key['"]/);
+  });
+
+  // @ac AC-06
+  test('frontend-host-detail-system-card/AC-06 — Re-run success invalidates both host + intelligence_state queries', () => {
+    // Both invalidateQueries calls MUST appear; partial invalidation
+    // would leave the snapshot stale on the page.
+    expect(PAGE_SRC).toMatch(
+      /invalidateQueries\s*\(\s*\{\s*queryKey:\s*\[\s*['"]host['"]\s*,\s*host\.id\s*\]\s*\}\s*\)/,
+    );
+    expect(PAGE_SRC).toMatch(
+      /invalidateQueries\s*\(\s*\{\s*queryKey:\s*\[\s*['"]intelligence_state['"]\s*,\s*host\.id\s*\]\s*\}\s*\)/,
+    );
+  });
+
+  // @ac AC-07
+  test('frontend-host-detail-system-card/AC-07 — 502 surfaces Host unreachable inline', () => {
+    expect(PAGE_SRC).toContain(
+      'Host unreachable — check SSH credentials and connectivity',
+    );
+  });
+});

--- a/app/frontend/tests/utils/formatUptime.test.ts
+++ b/app/frontend/tests/utils/formatUptime.test.ts
@@ -1,0 +1,35 @@
+// @spec frontend-host-detail-system-card
+//
+// AC traceability (this file):
+//
+//   AC-01  test('frontend-host-detail-system-card/AC-01 — formatUptime boundary table')
+
+import { describe, expect, test } from 'vitest';
+import { formatUptime } from '@/utils/formatUptime';
+
+describe('frontend-host-detail-system-card — formatUptime', () => {
+  // @ac AC-01
+  test('frontend-host-detail-system-card/AC-01 — formatUptime boundary table', () => {
+    // Null-ish
+    expect(formatUptime(undefined)).toBe('—');
+    expect(formatUptime(null)).toBe('—');
+    expect(formatUptime(-1)).toBe('—');
+
+    // <1m bucket
+    expect(formatUptime(0)).toBe('<1m');
+    expect(formatUptime(30)).toBe('<1m');
+    expect(formatUptime(59)).toBe('<1m');
+
+    // Minutes bucket
+    expect(formatUptime(60)).toBe('1m');
+    expect(formatUptime(3599)).toBe('59m');
+
+    // Hours bucket
+    expect(formatUptime(3600)).toBe('1h 0m');
+    expect(formatUptime(86399)).toBe('23h 59m');
+
+    // Days bucket
+    expect(formatUptime(86400)).toBe('1d 0h');
+    expect(formatUptime(1_000_000)).toBe('11d 13h');
+  });
+});

--- a/app/specs/frontend/host-detail-system-card.spec.yaml
+++ b/app/specs/frontend/host-detail-system-card.spec.yaml
@@ -1,0 +1,130 @@
+spec:
+  id: frontend-host-detail-system-card
+  title: Host detail System card — Distribution / Kernel / Uptime from real data
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Host detail /hosts/{id} System card surfaces the real OS discovery + intelligence snapshot data instead of "unknown" placeholders
+    description: >
+      Pre-PR 6 the System card on the host detail page rendered the
+      strings "unknown" for Distribution / Kernel / Uptime — the data
+      sources were not yet wired even though both the api-hosts v1.4.0
+      denormalized columns (PR 5a) and the api-os-intelligence
+      GET /api/v1/intelligence/state/{host_id} endpoint were live.
+
+      PR 6 wires both sources:
+
+        - Distribution: os_family + os_version from HostResponse
+          (denormalized hosts columns, populated by Discovery).
+          osDisplayLabel maps the Kensa family → display label
+          (RHEL / Ubuntu / Debian / SUSE / Unknown).
+        - Kernel: snapshot.kernel_release from IntelligenceState
+          (host_intelligence_state row, populated by the intelligence
+          scheduler).
+        - Uptime: snapshot.uptime_seconds from IntelligenceState,
+          rendered as "Xd Yh" / "Xh Ym" / "<1m" via formatUptime().
+        - FQDN: not yet exposed on any API surface; keep the
+          host.hostname fallback so the row is never empty (the
+          dedicated host_system_info.fqdn read endpoint is deferred).
+
+      Pre-Discovery hosts (os_family = null AND no IntelligenceState
+      row) get a single "Not discovered yet" empty state in the
+      Operating-system SpecGroup, with a Re-run Discovery button
+      inline. This replaces the prior mix of 4 separate "unknown"
+      strings, which was both noisy and misleading (the operator
+      could not tell whether the host had been probed and the values
+      were genuinely missing, or whether Discovery had simply never
+      run).
+
+      The Re-run Discovery button is gated on host:write (matches the
+      backend RBAC enforcement in PostHostDiscoveryRun). On click it
+      sends an idempotency key minted from crypto.randomUUID() and on
+      success invalidates ['host', id] AND ['intelligence_state', id]
+      so both data sources refresh. 502 (host unreachable) is
+      surfaced inline so the operator sees the SSH failure rather
+      than a silent no-op.
+
+    related_specs:
+      - api-hosts
+      - api-os-intelligence
+      - system-host-discovery
+      - frontend-host-list-os
+      - frontend-host-detail
+
+  objective:
+    summary: >
+      Lock the data sources and formatting rules for the System card
+      Operating-system SpecGroup + the Re-run Discovery button. Tests
+      cover the pure formatter, the pre-Discovery empty state, the
+      RBAC gate on the button, and the idempotency-key + invalidation
+      contract.
+    scope:
+      includes:
+        - formatUptime(seconds) helper
+        - "Operating-system SpecGroup data binding: HostResponse + IntelligenceState"
+        - "Pre-Discovery empty state with single Re-run Discovery CTA"
+        - "Re-run Discovery button: host:write gate, crypto.randomUUID idempotency key, post-success query invalidation, 502 inline error"
+      excludes:
+        - PageHead inline OS/Kernel/Uptime band — kept as-is; will be migrated in a follow-up once IntelligenceState data flow stabilizes
+        - Hardware SpecGroup (CPU/disk/memory) — needs a new backend GET endpoint; deferred
+        - Network SpecGroup firewall row — same backend gap; deferred
+        - Re-run flow via the SSE host.discovered topic — happens already (see frontend-live-events C-03); this spec only owns the synchronous POST path
+
+  constraints:
+    - id: C-01
+      description: 'formatUptime(seconds) MUST return "—" for null/undefined/negative input, "<1m" for seconds < 60, "Xm" for seconds < 3600, "Xh Ym" for seconds < 86400, and "Xd Yh" otherwise. Pure function — no Date.now, no locale-sensitive formatting. Reason: the System card MUST render identically across timezones'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'CardSystem Distribution row MUST be derived from osDisplayLabel(host.os_family) + " " + host.os_version. When os_family is null/unknown AND os_version is null, the entire Operating-system SpecGroup renders a single "Not discovered yet" empty state with the Re-run Discovery button — NOT four "unknown" cells'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'Re-run Discovery button MUST be gated on useAuthStore().hasPermission("host:write"). When the caller lacks the permission, the button MUST NOT render. Reason: matches the backend RBAC bar (auth.HostWrite enforced by PostHostDiscoveryRun) — surfacing a 403-bound button is poor UX'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'Re-run Discovery click MUST send a fresh Idempotency-Key minted from crypto.randomUUID() per attempt. The key MUST NOT be reused across attempts (operator can retry; each click is a distinct discovery run). Reason: api-host-discovery requires the header and the idempotency middleware caches per-key results — reuse would silently return the prior result'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: 'On a successful POST /hosts/{id}/discovery:run, the handler MUST invalidate both ["host", host.id] (the HostResponse query) AND ["intelligence_state", host.id] (the IntelligenceState query) so the new os_family/os_version and any newly-captured kernel_release/uptime_seconds appear without a manual reload'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'A 502 response (host unreachable) MUST surface inline next to the button with the message "Host unreachable — check SSH credentials and connectivity". A 403 MUST NOT happen at runtime because of C-03 but if it does, the message is "Permission denied". All other failures show the generic envelope.error.message'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'formatUptime: formatUptime(undefined)==="—", formatUptime(null)==="—", formatUptime(0)==="<1m", formatUptime(30)==="<1m", formatUptime(60)==="1m", formatUptime(3599)==="59m", formatUptime(3600)==="1h 0m", formatUptime(86399)==="23h 59m", formatUptime(86400)==="1d 0h", formatUptime(1000000)==="11d 13h"'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: 'CardSystem rendered with a host carrying os_family="rhel" + os_version="9.2" and no IntelligenceState (snapshot=null) shows "RHEL 9.2" as the Distribution row, "—" for Kernel + Uptime, and DOES NOT render the "Not discovered yet" empty state (Discovery has run, intel just has not)'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: 'CardSystem rendered with a host where os_family=null AND os_version=null renders ONE "Not discovered yet" empty state in place of the four-row Operating-system DefList, with a Re-run Discovery button when host:write is held'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: 'CardSystem rendered with the same null/null host BUT with the caller lacking host:write renders the "Not discovered yet" empty state WITHOUT the Re-run Discovery button'
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-05
+      description: 'Source inspection: the Re-run Discovery click handler calls crypto.randomUUID() (or globalThis.crypto.randomUUID()) for the Idempotency-Key value, and api.POST is called with path={ id: host.id } AND a header value containing the freshly-minted key'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: 'Source inspection: the success branch of the Re-run handler invokes queryClient.invalidateQueries with queryKey ["host", host.id] AND queryKey ["intelligence_state", host.id]. Both calls MUST appear in the same handler block — partial invalidation is forbidden'
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-07
+      description: 'A 502 response surfaces the exact string "Host unreachable — check SSH credentials and connectivity" inline next to the Re-run Discovery button. Verified by source inspection — the constant string appears in the file'
+      priority: high
+      references_constraints: [C-06]

--- a/app/specs/frontend/host-detail.spec.yaml
+++ b/app/specs/frontend/host-detail.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-detail
   title: Host Detail page layout, behavior, and empty-state contracts
-  version: "1.0.4"
+  version: "1.0.5"
   status: approved
   tier: 2
 
@@ -174,7 +174,7 @@ spec:
       priority: high
       references_constraints: [C-06]
     - id: AC-25
-      description: 'System card has three spec-groups in this order: Operating system, Hardware, Network. Each group renders the prototype''s definition-list layout with placeholder values ("unknown") for fields that are not yet collected by Server Intelligence.'
+      description: 'System card has three spec-groups in this order: Operating system, Hardware, Network. The Operating-system group is owned by frontend-host-detail-system-card v1.0.0 (wired to real Discovery + IntelligenceState data); the Hardware group renders the "Hardware metrics not collected" empty state; the Network group renders Primary IP + SSH endpoint + a Firewall placeholder. v1.0.5: "unknown" placeholder strings replaced with em-dash / "Not discovered yet" empty state — see frontend-host-detail-system-card.'
       priority: critical
       references_constraints: [C-06]
     - id: AC-26

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -50,6 +50,7 @@ domains:
             - api-hosts
             - frontend-host-detail
             - frontend-host-list-os
+            - frontend-host-detail-system-card
             - api-openapi-docs
             - release-admin-signoff
             - system-worker-subcommand


### PR DESCRIPTION
## Summary

PR 6 in the OS Discovery + Intelligence frontend wiring sequence. Replaces 4 placeholder "unknown" strings on the host detail System card with real Discovery + Intelligence data, and adds an inline Re-run Discovery button for pre-Discovery hosts.

New spec **`frontend-host-detail-system-card` v1.0.0** (Tier 2, 6 constraints / 7 ACs) locks the data sources, the formatter boundaries, and the Re-run button contract.

### Before → After

| Row | Before | After |
| --- | --- | --- |
| Distribution | `unknown` | `osDisplayLabel(host.os_family) + " " + host.os_version` — e.g. "RHEL 9.2" |
| Kernel | `unknown` | `IntelligenceState.snapshot.kernel_release` (em-dash when no snapshot) |
| FQDN | `host.hostname` | unchanged (dedicated `host_system_info.fqdn` read endpoint deferred) |
| Uptime | `unknown` | `formatUptime(snapshot.uptime_seconds)` — `<1m` / `Xm` / `Xh Ym` / `Xd Yh` |
| Pre-Discovery state | 4 separate "unknown" rows | One "Not discovered yet" empty state + Re-run Discovery button |

### Re-run Discovery button

- Gated on `host:write` (matches backend `PostHostDiscoveryRun` RBAC — surfacing a 403-bound button is poor UX)
- Fresh `Idempotency-Key` minted via `crypto.randomUUID()` per click — the idempotency middleware caches per-key results so reuse would silently return the prior result
- On success, invalidates both `['host', id]` AND `['intelligence_state', id]` so OS fields AND snapshot refresh in one shot
- `502` surfaces "Host unreachable — check SSH credentials and connectivity" inline

### Spec churn

- New: `frontend-host-detail-system-card` v1.0.0
- Existing `frontend-host-detail` v1.0.4 → v1.0.5: AC-25 reframed to acknowledge that "unknown" placeholders are gone and the Operating-system SpecGroup is now owned by the new spec

### Code churn

- New `src/utils/formatUptime.ts` (pure timezone-independent formatter)
- New `src/pages/host-detail/CardSystem.tsx` (extracted from HostDetailPage for testability)
- `HostDetailPage.tsx`: adds `intelligenceStateQuery`; extends `HostResponse` with 5 OS fields; removes local `CardSystem` + dead helpers (`SpecGroup`, `DefList`, `ReactFrag`)

### Stacking

Stacks on **PR 5c** (`feat/host-list-os-column-phase-5c`) which exports `osDisplayLabel` and bumps `ApiHost`. Rebase on main once PR 5c lands.

## Test plan

- [x] 7 new tests pass — `formatUptime.test.ts` + `host-detail-system-card.test.tsx`
- [x] Full frontend suite green (65 tests, 11 files)
- [x] `tsc --noEmit` clean
- [x] `specter coverage`: 54 specs at 100% coverage
- [ ] CI: spec-checks, frontend-tests