### PR TITLE
feat(frontend): wire Server intelligence card to real events feed (PR 7)

### DIFF
--- a/app/frontend/src/pages/HostDetailPage.tsx
+++ b/app/frontend/src/pages/HostDetailPage.tsx
@@ -27,6 +27,7 @@ import api from '@/api/client';
 import { EditHostModal } from '@/components/hosts/EditHostModal';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { CardSystem } from '@/pages/host-detail/CardSystem';
+import { CardServerIntel } from '@/pages/host-detail/CardServerIntel';
 
 // HostDetailPage — prototype-faithful Host Detail surface (v1.0.0).
 //
@@ -390,7 +391,7 @@ export function HostDetailPage() {
               >
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
                   <CardTopFailed />
-                  <CardServerIntel />
+                  <CardServerIntel hostId={detailQuery.data.host.id} />
                   <CardComplianceTrend />
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 14, minWidth: 0 }}>
@@ -1184,17 +1185,6 @@ function CardTopFailed() {
       <EmptyState
         primary="No scan results yet"
         secondary="Populated by the compliance scanner (Kensa). Until a scan completes, host_rule_state is empty for this host."
-      />
-    </Card>
-  );
-}
-
-function CardServerIntel() {
-  return (
-    <Card title="Server intelligence">
-      <EmptyState
-        primary="Not yet collected"
-        secondary="Server intelligence collection (packages, services, users, network, firewall, audit events) is deferred — see BACKLOG."
       />
     </Card>
   );

--- a/app/frontend/src/pages/host-detail/CardServerIntel.tsx
+++ b/app/frontend/src/pages/host-detail/CardServerIntel.tsx
@@ -1,0 +1,286 @@
+// CardServerIntel — Host detail left-column "Server intelligence" card.
+//
+// Replaces the "Not yet collected (BACKLOG)" empty-state with a real
+// feed sourced from GET /api/v1/intelligence/events?host_id=X&limit=10.
+// The query key matches the invalidation target used by
+// useLiveEvents.ts (intelligence.event handler) so SSE-driven
+// auto-refresh works without any polling.
+//
+// Three explicit visual states (loading / error+Retry / empty):
+// operators need to distinguish "not loaded" from "no signal".
+//
+// Spec: frontend-host-detail-intelligence-feed v1.0.0.
+
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { RefreshCw } from 'lucide-react';
+import api from '@/api/client';
+
+type EventSeverity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+interface IntelligenceEvent {
+  id: string;
+  host_id: string;
+  event_code: string;
+  severity: EventSeverity;
+  detail?: Record<string, unknown>;
+  occurred_at: string;
+  detected_at: string;
+  correlation_id?: string;
+}
+
+interface IntelligenceEventsPage {
+  items: IntelligenceEvent[];
+  next_cursor?: string | null;
+}
+
+interface CardServerIntelProps {
+  hostId: string;
+}
+
+const LIMIT = 10;
+
+export function CardServerIntel({ hostId }: CardServerIntelProps) {
+  // Spec C-01 + C-02: single endpoint, query key matches
+  // useLiveEvents intelligence.event invalidation target.
+  const query = useQuery({
+    queryKey: ['host_intelligence_events', hostId],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        '/api/v1/intelligence/events',
+        { params: { query: { host_id: hostId, limit: LIMIT } } },
+      );
+      if (error) throw error;
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return (data as unknown as IntelligenceEventsPage) ?? { items: [] };
+    },
+    retry: 0,
+  });
+
+  return (
+    <CardServerIntelView
+      isLoading={query.isLoading}
+      isError={query.isError}
+      items={query.data?.items ?? []}
+      onRetry={() => query.refetch()}
+    />
+  );
+}
+
+// Pure view component — split out so component tests can mount it
+// with explicit state without needing to mock useQuery internals.
+// Spec AC-03..AC-06 exercise this directly.
+interface CardServerIntelViewProps {
+  isLoading: boolean;
+  isError: boolean;
+  items: IntelligenceEvent[];
+  onRetry: () => void;
+}
+
+export function CardServerIntelView({
+  isLoading,
+  isError,
+  items,
+  onRetry,
+}: CardServerIntelViewProps) {
+  return (
+    <Card title="Server intelligence">
+      {isLoading ? (
+        <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12 }}>
+          Loading…
+        </div>
+      ) : isError ? (
+        <ErrorState onRetry={onRetry} />
+      ) : items.length === 0 ? (
+        <EmptyState
+          primary="No intelligence activity yet"
+          secondary="The OS Intelligence collector populates this feed (package updates, service state changes, listening-port shifts). Each cycle that detects a change writes an event."
+        />
+      ) : (
+        <ol
+          style={{
+            listStyle: 'none',
+            padding: 0,
+            margin: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          {items.map((e) => (
+            <EventRow key={e.id} event={e} />
+          ))}
+        </ol>
+      )}
+    </Card>
+  );
+}
+
+function EventRow({ event }: { event: IntelligenceEvent }) {
+  const sev = severityFor(event.severity);
+  return (
+    <li
+      style={{
+        display: 'flex',
+        gap: 10,
+        alignItems: 'flex-start',
+        padding: '8px 0',
+        borderBottom: '1px solid var(--ow-line)',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 8,
+          height: 8,
+          marginTop: 6,
+          borderRadius: '50%',
+          background: sev.dot,
+          flexShrink: 0,
+        }}
+      />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div
+          style={{
+            color: 'var(--ow-fg-1)',
+            fontSize: 12,
+            fontFamily: 'var(--ow-font-mono)',
+            wordBreak: 'break-word',
+          }}
+        >
+          {event.event_code}
+        </div>
+      </div>
+      <div
+        style={{
+          color: 'var(--ow-fg-3)',
+          fontSize: 11,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {relativeTime(event.occurred_at)}
+      </div>
+    </li>
+  );
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        color: 'var(--ow-crit)',
+        fontSize: 12,
+        display: 'flex',
+        gap: 8,
+        alignItems: 'center',
+      }}
+    >
+      Failed to load intelligence events{' '}
+      <button
+        type="button"
+        onClick={onRetry}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '2px 8px',
+          background: 'transparent',
+          color: 'var(--ow-fg-2)',
+          border: '1px solid var(--ow-line)',
+          borderRadius: 4,
+          fontSize: 11,
+          cursor: 'pointer',
+        }}
+      >
+        <RefreshCw size={11} /> Retry
+      </button>
+    </div>
+  );
+}
+
+function severityFor(s: EventSeverity): { dot: string } {
+  switch (s) {
+    case 'critical':
+    case 'high':
+      return { dot: 'var(--ow-crit)' };
+    case 'medium':
+      return { dot: 'var(--ow-warn)' };
+    case 'low':
+    case 'info':
+    default:
+      return { dot: 'var(--ow-fg-3)' };
+  }
+}
+
+// relativeTime — "Xm ago" / "Xh ago" / "Xd ago" / "just now".
+// Pure given a fixed Date.now(); jsdom freezes time per-test.
+function relativeTime(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '—';
+  const minutes = Math.max(0, Math.round((Date.now() - t) / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+// ── Layout primitives ─────────────────────────────────────────────────────
+// Mirror the CardSystem inline primitives — same comment applies: a
+// deduping pass that moves Card / EmptyState into a shared module is
+// a follow-up (BACKLOG).
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section
+      style={{
+        background: 'var(--ow-bg-1)',
+        border: '1px solid var(--ow-line)',
+        borderRadius: 'var(--ow-radius)',
+        padding: 18,
+      }}
+    >
+      <header style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between' }}>
+        <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>{title}</h3>
+      </header>
+      <div>{children}</div>
+    </section>
+  );
+}
+
+function EmptyState({
+  primary,
+  secondary,
+}: {
+  primary: string;
+  secondary: string;
+}) {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: '20px 0',
+        textAlign: 'center',
+        color: 'var(--ow-fg-2)',
+      }}
+    >
+      <div style={{ color: 'var(--ow-fg-1)', fontSize: 13, fontWeight: 500, marginBottom: 4 }}>
+        {primary}
+      </div>
+      <div
+        style={{
+          fontSize: 11,
+          color: 'var(--ow-fg-3)',
+          maxWidth: 360,
+          margin: '0 auto',
+          lineHeight: 1.5,
+        }}
+      >
+        {secondary}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/tests/hooks/useLiveEvents.test.tsx
+++ b/app/frontend/tests/hooks/useLiveEvents.test.tsx
@@ -10,7 +10,7 @@
 //   AC-06  test('frontend-live-events/AC-06 — missing host_id falls back to list-only')
 //   AC-07  test('frontend-live-events/AC-07 — source-inspect: exactly one new EventSource(...) call')
 
-import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { expect, test, beforeEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { readFileSync } from 'node:fs';
@@ -70,19 +70,17 @@ beforeEach(() => {
     StubEventSource as unknown as typeof EventSource;
   // Auth store: stub an identity so useLiveEvents opens a connection.
   useAuthStore.setState({
-    identity: { id: 'test-user', is_anonymous: false, role: 'admin' },
+    identity: {
+      id: 'test-user',
+      username: 'test',
+      email: 'test@example.com',
+      role: 'admin',
+      permissions: ['host:read'],
+      mfaEnabled: false,
+    },
   });
 });
 
-function wrapper({ children }: { children: ReactNode }) {
-  const qc = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, staleTime: 0 },
-      mutations: { retry: false },
-    },
-  });
-  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
-}
 
 // @ac AC-01
 // AC-01: ALL_TOPICS exported as closed v1.0 set of 4 topics.

--- a/app/frontend/tests/pages/host-detail-intelligence-feed.test.tsx
+++ b/app/frontend/tests/pages/host-detail-intelligence-feed.test.tsx
@@ -1,0 +1,137 @@
+// @spec frontend-host-detail-intelligence-feed
+//
+// AC traceability (this file):
+//
+//   AC-01  test('frontend-host-detail-intelligence-feed/AC-01 — calls /intelligence/events with host_id + limit 10')
+//   AC-02  test('frontend-host-detail-intelligence-feed/AC-02 — query key matches useLiveEvents invalidation target')
+//   AC-03  test('frontend-host-detail-intelligence-feed/AC-03 — loading state shows loading affordance, not empty copy')
+//   AC-04  test('frontend-host-detail-intelligence-feed/AC-04 — error state shows Retry button that invokes refetch')
+//   AC-05  test('frontend-host-detail-intelligence-feed/AC-05 — empty state shows "No intelligence activity yet" copy')
+//   AC-06  test('frontend-host-detail-intelligence-feed/AC-06 — rows render event_code text with severity-tinted dot')
+
+import { describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CardServerIntelView } from '@/pages/host-detail/CardServerIntel';
+
+const CARD_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/host-detail/CardServerIntel.tsx'),
+  'utf8',
+);
+
+const LIVE_EVENTS_SRC = readFileSync(
+  resolve(process.cwd(), 'src/hooks/useLiveEvents.ts'),
+  'utf8',
+);
+
+function makeEvent(overrides: Partial<{
+  id: string;
+  event_code: string;
+  severity: 'info' | 'low' | 'medium' | 'high' | 'critical';
+  occurred_at: string;
+}> = {}) {
+  return {
+    id: 'e-1',
+    host_id: 'h-1',
+    event_code: 'system.package.updated',
+    severity: 'medium' as const,
+    occurred_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+    detected_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('frontend-host-detail-intelligence-feed — structural', () => {
+  // @ac AC-01
+  test('frontend-host-detail-intelligence-feed/AC-01 — calls /intelligence/events with host_id + limit 10', () => {
+    expect(CARD_SRC).toContain("'/api/v1/intelligence/events'");
+    // host_id passed through
+    expect(CARD_SRC).toMatch(/host_id:\s*hostId/);
+    // limit is literal 10 (also LIMIT constant). One or the other must be visible.
+    expect(CARD_SRC).toMatch(/limit:\s*(LIMIT|10)/);
+    expect(CARD_SRC).toContain('const LIMIT = 10');
+  });
+
+  // @ac AC-02
+  test('frontend-host-detail-intelligence-feed/AC-02 — query key matches useLiveEvents invalidation target', () => {
+    // Card's query key
+    expect(CARD_SRC).toMatch(
+      /queryKey:\s*\[\s*['"]host_intelligence_events['"]\s*,\s*hostId\s*\]/,
+    );
+    // useLiveEvents invalidates the SAME key (verbatim)
+    expect(LIVE_EVENTS_SRC).toMatch(
+      /queryKey:\s*\[\s*['"]host_intelligence_events['"]\s*,\s*hostId\s*\]/,
+    );
+  });
+});
+
+describe('frontend-host-detail-intelligence-feed — behavior', () => {
+  // @ac AC-03
+  test('frontend-host-detail-intelligence-feed/AC-03 — loading state shows loading affordance, not empty copy', () => {
+    render(
+      <CardServerIntelView
+        isLoading={true}
+        isError={false}
+        items={[]}
+        onRetry={() => undefined}
+      />,
+    );
+    expect(screen.getByText(/loading…/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no intelligence activity yet/i)).toBeNull();
+  });
+
+  // @ac AC-04
+  test('frontend-host-detail-intelligence-feed/AC-04 — error state shows Retry button that invokes refetch', () => {
+    const onRetry = vi.fn();
+    render(
+      <CardServerIntelView
+        isLoading={false}
+        isError={true}
+        items={[]}
+        onRetry={onRetry}
+      />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    const btn = screen.getByRole('button', { name: /retry/i });
+    fireEvent.click(btn);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // @ac AC-05
+  test('frontend-host-detail-intelligence-feed/AC-05 — empty state shows "No intelligence activity yet" copy', () => {
+    render(
+      <CardServerIntelView
+        isLoading={false}
+        isError={false}
+        items={[]}
+        onRetry={() => undefined}
+      />,
+    );
+    expect(screen.getByText('No intelligence activity yet')).toBeInTheDocument();
+    // Secondary copy names the source (OS Intelligence collector)
+    expect(
+      screen.getByText(/OS Intelligence collector/i),
+    ).toBeInTheDocument();
+  });
+
+  // @ac AC-06
+  test('frontend-host-detail-intelligence-feed/AC-06 — rows render event_code text with severity-tinted dot', () => {
+    const items = [
+      makeEvent({ id: 'e-1', event_code: 'system.package.updated', severity: 'medium' }),
+      makeEvent({ id: 'e-2', event_code: 'system.service.failed', severity: 'critical' }),
+    ];
+    const { container } = render(
+      <CardServerIntelView
+        isLoading={false}
+        isError={false}
+        items={items}
+        onRetry={() => undefined}
+      />,
+    );
+    expect(screen.getByText('system.package.updated')).toBeInTheDocument();
+    expect(screen.getByText('system.service.failed')).toBeInTheDocument();
+    // Two <li> rows
+    expect(container.querySelectorAll('li').length).toBe(2);
+  });
+});

--- a/app/specs/frontend/host-detail-intelligence-feed.spec.yaml
+++ b/app/specs/frontend/host-detail-intelligence-feed.spec.yaml
@@ -1,0 +1,105 @@
+spec:
+  id: frontend-host-detail-intelligence-feed
+  title: Host detail Server-intelligence card — real events feed from /intelligence/events
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Host detail overview card "Server intelligence" surfaces the recent change events from the api-os-intelligence collector
+    description: >
+      Pre-PR 7 the "Server intelligence" card on the host detail page
+      rendered a static "Not yet collected" empty-state pointing to
+      BACKLOG, even though api-os-intelligence GET
+      /api/v1/intelligence/events has been live and the scheduler is
+      writing host_intelligence_events on every cycle.
+
+      PR 7 wires the card to fetch the 10 most recent events for the
+      current host (?host_id=<id>&limit=10) and renders each as a row
+      with: severity dot, event_code, detail summary, and
+      occurred_at relative time. Empty list (no events yet for this
+      host) collapses to "No intelligence activity yet" — explicit
+      "no signal" state distinct from the loading/error states.
+
+      This is the read-only single-host slice. The full /activity
+      page (cross-host unified feed) is owned by api-activity and is
+      already live; this spec only owns the per-host card on the
+      detail page.
+
+      Auto-refresh is delegated to the useLiveEvents SSE topic
+      "intelligence.event" (frontend-live-events C-04 / AC-05) which
+      invalidates ['host_intelligence_events', host.id] — the same
+      query key this card uses. No polling, no manual refresh button.
+
+    related_specs:
+      - api-os-intelligence
+      - frontend-live-events
+      - frontend-host-detail
+      - frontend-host-detail-system-card
+
+  objective:
+    summary: >
+      Lock the data binding, query key, rendering rules, and three
+      visual states (loading / error / empty) for the Server-
+      intelligence card. Tests cover the source-inspection contract
+      and the empty/error visual states.
+    scope:
+      includes:
+        - "Query key ['host_intelligence_events', host.id] matching frontend-live-events C-04"
+        - "GET /api/v1/intelligence/events with query: host_id=host.id, limit=10"
+        - "Per-event row: severity dot + event_code + occurred_at relative time"
+        - "Three visual states: loading, error (Retry button), empty (no events yet)"
+      excludes:
+        - "Activated Packages / Services / Users / Network tabs — separate PR (reads snapshot fields)"
+        - "Cross-host activity feed — owned by api-activity / frontend-activity"
+        - "Cursor pagination on the card — only the 10 most recent rows; deeper history goes to /activity"
+        - "Click-through to per-event detail — deferred (no detail surface defined yet)"
+
+  constraints:
+    - id: C-01
+      description: 'CardServerIntel MUST issue exactly ONE useQuery against /api/v1/intelligence/events with params { host_id, limit: 10 }. No other endpoint, no client-side filtering of broader fetches. Reason: scoping at the API boundary lets the backend short-circuit the WHERE clause and keeps the card responsive for hosts with deep history'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: "CardServerIntel MUST use queryKey ['host_intelligence_events', host.id]. This MUST match the invalidation target in useLiveEvents.ts intelligence.event handler (frontend-live-events C-04) verbatim — any divergence breaks the SSE auto-refresh path"
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: "Each event row MUST render: a severity-tinted dot (crit/warn/info colors from the existing severityFor helper), the event_code (mono font), and the occurred_at relative time (Xm/Xh/Xd ago). The detail object is NOT rendered inline — it is opaque per-event metadata; surfacing detail values per event_code is deferred"
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'CardServerIntel MUST render three distinct visual states: (1) loading (skeleton or "Loading…" text), (2) error (red text + Retry button), (3) empty (no events yet — soft "No intelligence activity yet" message). Loading and error MUST NOT collapse to the empty state — operators need to distinguish "not loaded" from "no signal"'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: '403 (host:read denied) MUST render the error state — the page wraps the response and the card cannot present forbidden data. 200 with an empty items array MUST render the empty state. 502 / 504 (transient backend) MUST render the error state with the Retry button so the operator can recover without a page reload'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'Source inspection: CardServerIntel calls api.GET with the literal path "/api/v1/intelligence/events" and a query object containing host_id AND limit: 10. No other path appears in the function body'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: "Source inspection: CardServerIntel's useQuery uses queryKey starting with the literal string 'host_intelligence_events' followed by host.id. The query key MUST match the one used by useLiveEvents.ts handlers — verified by reading both files and asserting identical key shape"
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: "Rendering: CardServerIntel mounted with isLoading=true (mocked useQuery state) renders a visible loading affordance (text or skeleton element). The empty-state copy 'No intelligence activity yet' MUST NOT appear in the loading state"
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-04
+      description: 'Rendering: CardServerIntel mounted with isError=true renders both an error message AND a Retry button (role="button", accessible name matching /retry/i). The button click MUST invoke the refetch path — verified by spying on the mocked refetch'
+      priority: critical
+      references_constraints: [C-04, C-05]
+    - id: AC-05
+      description: "Rendering: CardServerIntel mounted with isSuccess=true and data={items:[]} renders the literal string 'No intelligence activity yet' AND does NOT render any rows. The empty state names the data source (e.g. 'OS Intelligence collector') so operators know which subsystem populates it"
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-06
+      description: "Rendering: CardServerIntel mounted with isSuccess=true and data={items:[two-events]} renders 2 row elements, each containing the event's event_code text. Severity dot color matches the severity (crit/warn/info palette via severityFor or equivalent)"
+      priority: critical
+      references_constraints: [C-03]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -51,6 +51,7 @@ domains:
             - frontend-host-detail
             - frontend-host-list-os
             - frontend-host-detail-system-card
+            - frontend-host-detail-intelligence-feed
             - api-openapi-docs
             - release-admin-signoff
             - system-worker-subcommand


### PR DESCRIPTION
## Summary

PR 7 replaces the host detail "Server intelligence" empty-state with a real feed from `GET /api/v1/intelligence/events?host_id=X&limit=10`. Query key matches the invalidation target in `useLiveEvents.ts`, so SSE drives the auto-refresh — no polling.

New spec **`frontend-host-detail-intelligence-feed` v1.0.0** (Tier 2, 5 constraints / 6 ACs) locks the data binding, query key, three visual states (loading / error+Retry / empty), and the per-event row layout.

### Three explicit visual states

| State | Rendering |
| --- | --- |
| loading | "Loading…" text affordance |
| error | red alert + Retry button (calls refetch) |
| empty | "No intelligence activity yet" + source attribution |

Loading and error MUST NOT collapse into the empty state — operators need to distinguish "not loaded" from "no signal."

### Auto-refresh

The card's query key is `['host_intelligence_events', hostId]` — verbatim the same key `useLiveEvents.ts` (`intelligence.event` handler, frontend-live-events C-04 / AC-05) invalidates. The SSE pipe writes into the same cache slot the card reads, so the feed refreshes on every intel cycle with no polling.

### Stacking

This PR cherry-picks PR 5b's `useLiveEvents` wiring since the auto-refresh contract is only meaningful when both ends use the same query key. Fixes a small TS-strict drift in PR 5b's test along the way (Identity shape, unused `wrapper` symbol).

Lineage: main → PR 5a (merged) → PR 5c → PR 6 → PR 5b → **PR 7**.

### Out of scope (BACKLOG)

- Cursor pagination on the card (deeper history goes to /activity)
- Click-through to per-event detail (no detail surface defined)
- Activated **Packages / Services / Users / Network** tabs — separate PR (reads `snapshot.{packages,services,users,listening_ports}`)

## Test plan

- [x] 6 new tests pass — `host-detail-intelligence-feed.test.tsx`
- [x] Full frontend suite green (78 tests, 13 files)
- [x] `tsc --noEmit` clean (TS strict mode)
- [x] `specter coverage`: 56 specs at 100% coverage
- [ ] CI: spec-checks, frontend-tests