### PR TITLE
feat(frontend): Settings OS Intelligence scheduler config section (PR 8b)

### DIFF
--- a/app/frontend/src/api/schema.d.ts
+++ b/app/frontend/src/api/schema.d.ts
@@ -748,6 +748,39 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/system/intelligence/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read the OS Intelligence scheduler runtime config + baked-in defaults
+         * @description Returns the persisted IntelligenceConfig (or DefaultIntelligence
+         *     when no row exists) PLUS the baked-in defaults sub-object so the
+         *     UI can render a "reset to defaults" affordance without a
+         *     round-trip. Mirrors api-system-connectivity v1.0.
+         *     Spec api-system-intelligence-config.
+         */
+        get: operations["getSystemIntelligenceConfig"];
+        /**
+         * Update OS Intelligence scheduler runtime config
+         * @description Persists the new config (interval_sec 300..86400, rate_limit
+         *     1..200, maintenance_global boolean). Emits
+         *     system.config.changed in the same write transaction. The
+         *     in-process scheduler picks up the new values at the top of
+         *     its next cycle — no hot-reload signal needed.
+         *     Spec api-system-intelligence-config.
+         */
+        put: operations["putSystemIntelligenceConfig"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/system/connectivity/status": {
         parameters: {
             query?: never;
@@ -1425,6 +1458,18 @@ export interface components {
         ConnectivityConfigResponse: {
             config: components["schemas"]["ConnectivityConfig"];
             defaults: components["schemas"]["ConnectivityConfig"];
+        };
+        IntelligenceConfig: {
+            /** @description Per-host cadence the scheduler advances next_intelligence_at by after a successful RunCycle (300..86400). Default 3600 (1h) */
+            interval_sec: number;
+            /** @description Max concurrent RunCycles per scheduler instance (1..200). Default 10 */
+            rate_limit: number;
+            /** @description When true, the scheduler loop ticks but RunCycles no hosts */
+            maintenance_global: boolean;
+        };
+        IntelligenceConfigResponse: {
+            config: components["schemas"]["IntelligenceConfig"];
+            defaults: components["schemas"]["IntelligenceConfig"];
         };
         ConnectivityStatus: {
             /**
@@ -3347,6 +3392,69 @@ export interface operations {
             };
             400: components["responses"]["BadRequest"];
             /** @description Caller lacks system:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getSystemIntelligenceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current config + defaults sub-object */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelligenceConfigResponse"];
+                };
+            };
+            /** @description Caller lacks system:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    putSystemIntelligenceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IntelligenceConfig"];
+            };
+        };
+        responses: {
+            /** @description Updated config snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntelligenceConfig"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks system:config:write permission */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/app/frontend/src/components/settings/OSIntelligenceSection.tsx
+++ b/app/frontend/src/components/settings/OSIntelligenceSection.tsx
@@ -16,7 +16,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { RotateCcw } from 'lucide-react';
+import { RefreshCw, RotateCcw } from 'lucide-react';
 import api from '@/api/client';
 import {
   Section,
@@ -39,6 +39,24 @@ interface IntelligenceConfigResponse {
   defaults: IntelligenceConfig;
 }
 
+// openapi-fetch returns the raw response body as `error` for non-2xx
+// statuses — it's NOT an Error instance, so `(err as Error).message`
+// is undefined. Normalize the value into a single string that always
+// leads with the HTTP status, so the alert never reads "Failed to
+// load — Failed to load" again. Pulls the message from the
+// ErrorEnvelope shape when present, otherwise just surfaces the code.
+function formatApiError(status: number, error: unknown): string {
+  let detail = '';
+  if (error && typeof error === 'object') {
+    const env = error as { error?: { code?: string; message?: string } };
+    if (env.error?.message) detail = env.error.message;
+    else if (env.error?.code) detail = env.error.code;
+  } else if (typeof error === 'string' && error.length > 0) {
+    detail = error;
+  }
+  return `HTTP ${status}${detail ? ` — ${detail}` : ''}`;
+}
+
 // Container — wires the queries + mutation and delegates rendering to
 // the pure view below.
 export function OSIntelligenceSection() {
@@ -51,8 +69,9 @@ export function OSIntelligenceSection() {
         '/api/v1/system/intelligence/config',
         {},
       );
-      if (error) throw error;
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      if (error || !response.ok) {
+        throw new Error(formatApiError(response.status, error));
+      }
       return data as IntelligenceConfigResponse;
     },
     retry: 0,
@@ -71,14 +90,28 @@ export function OSIntelligenceSection() {
         '/api/v1/system/intelligence/config',
         { body },
       );
-      if (error) throw error;
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      if (error || !response.ok) {
+        throw new Error(formatApiError(response.status, error));
+      }
       return data as IntelligenceConfig;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['system', 'intelligence', 'config'] });
     },
   });
+
+  // Re-sync the draft to the server config on the post-save edge.
+  // Without this, a server-side clamp (or any future divergence
+  // between client and server validation) would leave the user with a
+  // stale draft that looks "saved" but doesn't match server truth.
+  // The clobber is gated on mutation.isSuccess so an in-flight edit
+  // is never overwritten by an unrelated refetch.
+  useEffect(() => {
+    if (mutation.isSuccess && configQuery.data) {
+      setDraft({ ...configQuery.data.config });
+      mutation.reset();
+    }
+  }, [mutation, configQuery.data]);
 
   const dirty = useMemo(() => {
     if (!draft || !configQuery.data) return false;
@@ -114,6 +147,7 @@ export function OSIntelligenceSection() {
           ? (configQuery.error as Error)?.message ?? 'Failed to load'
           : null
       }
+      onRetry={() => configQuery.refetch()}
       config={configQuery.data?.config ?? null}
       defaults={configQuery.data?.defaults ?? null}
       draft={draft}
@@ -138,10 +172,11 @@ export function OSIntelligenceSectionView(props: {
   isLoading: boolean;
   isError: boolean;
   errorMessage: string | null;
+  onRetry?: () => void;
   config: IntelligenceConfig | null;
   defaults: IntelligenceConfig | null;
   draft: IntelligenceConfig | null;
-  setDraft: (d: IntelligenceConfig | null | ((prev: IntelligenceConfig | null) => IntelligenceConfig | null)) => void;
+  setDraft: React.Dispatch<React.SetStateAction<IntelligenceConfig | null>>;
   onResetToLive: () => void;
   onResetToDefaults: () => void;
   onSave: () => void;
@@ -153,6 +188,7 @@ export function OSIntelligenceSectionView(props: {
     isLoading,
     isError,
     errorMessage,
+    onRetry,
     draft,
     setDraft,
     onResetToLive,
@@ -172,9 +208,23 @@ export function OSIntelligenceSectionView(props: {
       ) : isError ? (
         <div
           role="alert"
-          style={{ color: 'var(--ow-crit)', fontSize: 12, padding: '8px 0' }}
+          style={{
+            color: 'var(--ow-crit)',
+            fontSize: 12,
+            padding: '8px 0',
+            display: 'flex',
+            gap: 10,
+            alignItems: 'center',
+          }}
         >
-          Failed to load intelligence config{errorMessage ? ` — ${errorMessage}` : ''}
+          <span>
+            Failed to load intelligence config{errorMessage ? ` — ${errorMessage}` : ''}
+          </span>
+          {onRetry && (
+            <Btn size="sm" onClick={onRetry}>
+              <RefreshCw size={11} /> Retry
+            </Btn>
+          )}
         </div>
       ) : draft ? (
         <>
@@ -243,7 +293,7 @@ export function OSIntelligenceSectionView(props: {
               <RotateCcw size={12} /> Reset to defaults
             </Btn>
             <Btn onClick={onResetToLive} disabled={!dirty || isSaving}>
-              Cancel
+              Discard changes
             </Btn>
             <Btn variant="primary" onClick={onSave} disabled={isLoading || !dirty || isSaving}>
               {isSaving ? 'Saving…' : 'Save changes'}

--- a/app/frontend/src/components/settings/OSIntelligenceSection.tsx
+++ b/app/frontend/src/components/settings/OSIntelligenceSection.tsx
@@ -1,0 +1,256 @@
+// OSIntelligenceSection — Settings > Scanning page section that exposes
+// the three OS Intelligence scheduler knobs landed by
+// api-system-intelligence-config v1.0 (PR 8).
+//
+// Spec: frontend-settings-intelligence-config v1.0.0.
+//
+// Three knobs:
+//
+//   interval_sec       — per-host cadence (300..86400, default 3600)
+//   rate_limit         — concurrent RunCycles cap (1..200, default 10)
+//   maintenance_global — boolean kill-switch
+//
+// Section-local Save/Reset controls (not the page-level SaveBar) — the
+// page-level bar is already scoped to the connectivity draft state;
+// coupling another draft into it would muddy dirty/save semantics.
+
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { RotateCcw } from 'lucide-react';
+import api from '@/api/client';
+import {
+  Section,
+  SettingCard,
+  FirstSettingRow,
+  SettingRow,
+  Stepper,
+  Toggle,
+  Btn,
+} from './primitives';
+
+interface IntelligenceConfig {
+  interval_sec: number;
+  rate_limit: number;
+  maintenance_global: boolean;
+}
+
+interface IntelligenceConfigResponse {
+  config: IntelligenceConfig;
+  defaults: IntelligenceConfig;
+}
+
+// Container — wires the queries + mutation and delegates rendering to
+// the pure view below.
+export function OSIntelligenceSection() {
+  const queryClient = useQueryClient();
+
+  const configQuery = useQuery<IntelligenceConfigResponse>({
+    queryKey: ['system', 'intelligence', 'config'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET(
+        '/api/v1/system/intelligence/config',
+        {},
+      );
+      if (error) throw error;
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return data as IntelligenceConfigResponse;
+    },
+    retry: 0,
+  });
+
+  const [draft, setDraft] = useState<IntelligenceConfig | null>(null);
+  useEffect(() => {
+    if (configQuery.data && draft === null) {
+      setDraft({ ...configQuery.data.config });
+    }
+  }, [configQuery.data, draft]);
+
+  const mutation = useMutation({
+    mutationFn: async (body: IntelligenceConfig) => {
+      const { data, error, response } = await api.PUT(
+        '/api/v1/system/intelligence/config',
+        { body },
+      );
+      if (error) throw error;
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return data as IntelligenceConfig;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['system', 'intelligence', 'config'] });
+    },
+  });
+
+  const dirty = useMemo(() => {
+    if (!draft || !configQuery.data) return false;
+    const live = configQuery.data.config;
+    return (
+      draft.interval_sec !== live.interval_sec ||
+      draft.rate_limit !== live.rate_limit ||
+      draft.maintenance_global !== live.maintenance_global
+    );
+  }, [draft, configQuery.data]);
+
+  const onResetToLive = () => {
+    if (configQuery.data) setDraft({ ...configQuery.data.config });
+    mutation.reset();
+  };
+
+  const onResetToDefaults = () => {
+    if (configQuery.data) setDraft({ ...configQuery.data.defaults });
+    mutation.reset();
+  };
+
+  const onSave = () => {
+    if (!draft) return;
+    mutation.mutate(draft);
+  };
+
+  return (
+    <OSIntelligenceSectionView
+      isLoading={configQuery.isLoading}
+      isError={configQuery.isError}
+      errorMessage={
+        configQuery.error
+          ? (configQuery.error as Error)?.message ?? 'Failed to load'
+          : null
+      }
+      config={configQuery.data?.config ?? null}
+      defaults={configQuery.data?.defaults ?? null}
+      draft={draft}
+      setDraft={setDraft}
+      onResetToLive={onResetToLive}
+      onResetToDefaults={onResetToDefaults}
+      onSave={onSave}
+      isSaving={mutation.isPending}
+      saveError={
+        mutation.error
+          ? (mutation.error as Error)?.message ?? 'Save failed'
+          : null
+      }
+      dirty={dirty}
+    />
+  );
+}
+
+// Pure view — accepts every state slice as props so tests can exercise
+// the rendering logic without mocking useQuery or HTTP.
+export function OSIntelligenceSectionView(props: {
+  isLoading: boolean;
+  isError: boolean;
+  errorMessage: string | null;
+  config: IntelligenceConfig | null;
+  defaults: IntelligenceConfig | null;
+  draft: IntelligenceConfig | null;
+  setDraft: (d: IntelligenceConfig | null | ((prev: IntelligenceConfig | null) => IntelligenceConfig | null)) => void;
+  onResetToLive: () => void;
+  onResetToDefaults: () => void;
+  onSave: () => void;
+  isSaving: boolean;
+  saveError: string | null;
+  dirty: boolean;
+}) {
+  const {
+    isLoading,
+    isError,
+    errorMessage,
+    draft,
+    setDraft,
+    onResetToLive,
+    onResetToDefaults,
+    onSave,
+    isSaving,
+    saveError,
+    dirty,
+  } = props;
+
+  return (
+    <Section title="OS Intelligence scheduler" badge="Wired" badgeTier="ok">
+      {isLoading ? (
+        <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12, padding: '8px 0' }}>
+          Loading…
+        </div>
+      ) : isError ? (
+        <div
+          role="alert"
+          style={{ color: 'var(--ow-crit)', fontSize: 12, padding: '8px 0' }}
+        >
+          Failed to load intelligence config{errorMessage ? ` — ${errorMessage}` : ''}
+        </div>
+      ) : draft ? (
+        <>
+          <SettingCard>
+            <FirstSettingRow
+              name="Cycle interval"
+              description="How often the scheduler advances next_intelligence_at for a host after a successful RunCycle. Bounds: 5 min .. 24 h."
+              control={
+                <Stepper
+                  value={draft.interval_sec}
+                  min={300}
+                  max={86400}
+                  step={300}
+                  unit="sec"
+                  onChange={(v) =>
+                    setDraft((d) => (d ? { ...d, interval_sec: v } : d))
+                  }
+                />
+              }
+            />
+            <SettingRow
+              name="Concurrent workers"
+              description="Cap on simultaneous RunCycles per scheduler instance. Bounds: 1 .. 200."
+              control={
+                <Stepper
+                  value={draft.rate_limit}
+                  min={1}
+                  max={200}
+                  step={1}
+                  onChange={(v) =>
+                    setDraft((d) => (d ? { ...d, rate_limit: v } : d))
+                  }
+                />
+              }
+            />
+            <SettingRow
+              name="Pause scheduler globally"
+              description="When on, the scheduler loop ticks but no host is polled. Kill-switch for incident response."
+              control={
+                <Toggle
+                  value={draft.maintenance_global}
+                  onChange={(v) =>
+                    setDraft((d) => (d ? { ...d, maintenance_global: v } : d))
+                  }
+                  ariaLabel="Pause scheduler globally"
+                />
+              }
+            />
+          </SettingCard>
+
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              justifyContent: 'flex-end',
+              alignItems: 'center',
+              marginTop: 12,
+            }}
+          >
+            {saveError && (
+              <div role="alert" style={{ color: 'var(--ow-crit)', fontSize: 12, marginRight: 'auto' }}>
+                {saveError}
+              </div>
+            )}
+            <Btn onClick={onResetToDefaults} disabled={isLoading || isSaving}>
+              <RotateCcw size={12} /> Reset to defaults
+            </Btn>
+            <Btn onClick={onResetToLive} disabled={!dirty || isSaving}>
+              Cancel
+            </Btn>
+            <Btn variant="primary" onClick={onSave} disabled={isLoading || !dirty || isSaving}>
+              {isSaving ? 'Saving…' : 'Save changes'}
+            </Btn>
+          </div>
+        </>
+      ) : null}
+    </Section>
+  );
+}

--- a/app/frontend/src/pages/settings/ScanningPage.tsx
+++ b/app/frontend/src/pages/settings/ScanningPage.tsx
@@ -26,6 +26,7 @@ import {
   BackendPendingBanner,
   Callout,
 } from '@/components/settings/primitives';
+import { OSIntelligenceSection } from '@/components/settings/OSIntelligenceSection';
 
 // Settings → Scanning & monitoring.
 //
@@ -679,6 +680,10 @@ export function ScanningPage() {
           />
         </SettingCard>
       </Section>
+
+      {/* ────────── OS Intelligence scheduler (wired) ────────── */}
+      {/* Spec: frontend-settings-intelligence-config v1.0 */}
+      <OSIntelligenceSection />
 
       {/* ────────── Maintenance (global flag wired; groups UI only) ────────── */}
       <Section title="Maintenance">

--- a/app/frontend/tests/pages/settings-intelligence-config.test.tsx
+++ b/app/frontend/tests/pages/settings-intelligence-config.test.tsx
@@ -9,6 +9,9 @@
 //   AC-05  test('frontend-settings-intelligence-config/AC-05 — visual states: loading, error, success-clean')
 //   AC-06  test('frontend-settings-intelligence-config/AC-06 — edit -> Save flow toggles dirty/disabled')
 //   AC-07  test('frontend-settings-intelligence-config/AC-07 — ScanningPage mounts OSIntelligenceSection between OS discovery and Maintenance')
+//   AC-08  test('frontend-settings-intelligence-config/AC-08 — error alert surfaces the HTTP status (no "Failed to load — Failed to load")')
+//   AC-09  test('frontend-settings-intelligence-config/AC-09 — error state renders a Retry button that invokes onRetry')
+//   AC-10  test('frontend-settings-intelligence-config/AC-10 — post-save useEffect re-syncs draft from configQuery.data.config')
 
 import { describe, expect, test, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -64,6 +67,17 @@ describe('frontend-settings-intelligence-config — structural', () => {
     expect(SECTION_SRC).toMatch(/isLoading/);
     expect(SECTION_SRC).toMatch(/dirty/);
     expect(SECTION_SRC).toMatch(/isPending/);
+  });
+
+  // @ac AC-10
+  test('frontend-settings-intelligence-config/AC-10 — post-save useEffect re-syncs draft from configQuery.data.config', () => {
+    // The post-save re-sync MUST exist and MUST be gated on
+    // mutation.isSuccess so an in-flight edit is never clobbered by an
+    // unrelated refetch. Look for both the dependency and the setDraft
+    // call referencing configQuery.data.config inside a useEffect.
+    expect(SECTION_SRC).toMatch(
+      /useEffect\(\s*\(\)\s*=>\s*\{[\s\S]*?mutation\.isSuccess[\s\S]*?setDraft\(\s*\{[\s\S]*?configQuery\.data\??\.config[\s\S]*?\}\s*\)[\s\S]*?\}/,
+    );
   });
 
   // @ac AC-07
@@ -144,5 +158,45 @@ describe('frontend-settings-intelligence-config — behavioral (pure view)', () 
     // label change is itself the spinner affordance).
     render(<OSIntelligenceSectionView {...viewProps({ dirty: true, isSaving: true })} />);
     expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+  });
+
+  // @ac AC-08
+  test('frontend-settings-intelligence-config/AC-08 — error alert surfaces the HTTP status (no "Failed to load — Failed to load")', () => {
+    render(
+      <OSIntelligenceSectionView
+        {...viewProps({
+          isError: true,
+          errorMessage: 'HTTP 404',
+          config: null,
+          draft: null,
+        })}
+      />,
+    );
+    const alert = screen.getByRole('alert');
+    // The alert MUST include the HTTP status. The buggy original would
+    // have rendered "Failed to load intelligence config — Failed to load"
+    // — assert the actual status is in there.
+    expect(alert.textContent).toMatch(/HTTP\s+404/);
+    // And it MUST NOT degenerate to the duplicated fallback.
+    expect(alert.textContent).not.toMatch(/—\s*Failed to load$/i);
+  });
+
+  // @ac AC-09
+  test('frontend-settings-intelligence-config/AC-09 — error state renders a Retry button that invokes onRetry', () => {
+    const onRetry = vi.fn();
+    render(
+      <OSIntelligenceSectionView
+        {...viewProps({
+          isError: true,
+          errorMessage: 'HTTP 500',
+          onRetry,
+          config: null,
+          draft: null,
+        })}
+      />,
+    );
+    const retry = screen.getByRole('button', { name: /retry/i });
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/frontend/tests/pages/settings-intelligence-config.test.tsx
+++ b/app/frontend/tests/pages/settings-intelligence-config.test.tsx
@@ -1,0 +1,148 @@
+// @spec frontend-settings-intelligence-config
+//
+// AC traceability (this file):
+//
+//   AC-01  test('frontend-settings-intelligence-config/AC-01 — useQuery wired to /system/intelligence/config with ["system","intelligence","config"] key')
+//   AC-02  test('frontend-settings-intelligence-config/AC-02 — Cancel resets to config, Reset-to-defaults resets to defaults (distinct paths)')
+//   AC-03  test('frontend-settings-intelligence-config/AC-03 — Stepper bounds: interval_sec 300..86400, rate_limit 1..200')
+//   AC-04  test('frontend-settings-intelligence-config/AC-04 — save mutation invalidates the right query key; Save disabled triple-checked')
+//   AC-05  test('frontend-settings-intelligence-config/AC-05 — visual states: loading, error, success-clean')
+//   AC-06  test('frontend-settings-intelligence-config/AC-06 — edit -> Save flow toggles dirty/disabled')
+//   AC-07  test('frontend-settings-intelligence-config/AC-07 — ScanningPage mounts OSIntelligenceSection between OS discovery and Maintenance')
+
+import { describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { OSIntelligenceSectionView } from '@/components/settings/OSIntelligenceSection';
+
+const SECTION_SRC = readFileSync(
+  resolve(process.cwd(), 'src/components/settings/OSIntelligenceSection.tsx'),
+  'utf8',
+);
+
+const SCANNING_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/settings/ScanningPage.tsx'),
+  'utf8',
+);
+
+const liveConfig = { interval_sec: 1800, rate_limit: 20, maintenance_global: false };
+const defaults = { interval_sec: 3600, rate_limit: 10, maintenance_global: false };
+
+describe('frontend-settings-intelligence-config — structural', () => {
+  // @ac AC-01
+  test('frontend-settings-intelligence-config/AC-01 — useQuery wired to /system/intelligence/config with ["system","intelligence","config"] key', () => {
+    expect(SECTION_SRC).toContain("'/api/v1/system/intelligence/config'");
+    expect(SECTION_SRC).toMatch(
+      /queryKey:\s*\[\s*['"]system['"]\s*,\s*['"]intelligence['"]\s*,\s*['"]config['"]\s*\]/,
+    );
+    expect(SECTION_SRC).toContain('useQuery');
+  });
+
+  // @ac AC-02
+  test('frontend-settings-intelligence-config/AC-02 — Cancel resets to config, Reset-to-defaults resets to defaults (distinct paths)', () => {
+    // Both the .config and .defaults sub-objects must be referenced by
+    // distinct reset paths. Look for both substrings.
+    expect(SECTION_SRC).toMatch(/configQuery\.data\??\.config/);
+    expect(SECTION_SRC).toMatch(/configQuery\.data\??\.defaults/);
+  });
+
+  // @ac AC-03
+  test('frontend-settings-intelligence-config/AC-03 — Stepper bounds: interval_sec 300..86400, rate_limit 1..200', () => {
+    expect(SECTION_SRC).toMatch(/min=\{300\}/);
+    expect(SECTION_SRC).toMatch(/max=\{86400\}/);
+    expect(SECTION_SRC).toMatch(/min=\{1\}/);
+    expect(SECTION_SRC).toMatch(/max=\{200\}/);
+  });
+
+  // @ac AC-04
+  test('frontend-settings-intelligence-config/AC-04 — save mutation invalidates the right query key; Save disabled triple-checked', () => {
+    expect(SECTION_SRC).toMatch(
+      /invalidateQueries\s*\(\s*\{\s*queryKey:\s*\[\s*['"]system['"]\s*,\s*['"]intelligence['"]\s*,\s*['"]config['"]\s*\]\s*\}\s*\)/,
+    );
+    // Save disabled triple: loading + dirty + mutation pending. All three terms appear.
+    expect(SECTION_SRC).toMatch(/isLoading/);
+    expect(SECTION_SRC).toMatch(/dirty/);
+    expect(SECTION_SRC).toMatch(/isPending/);
+  });
+
+  // @ac AC-07
+  test('frontend-settings-intelligence-config/AC-07 — ScanningPage mounts OSIntelligenceSection between OS discovery and Maintenance', () => {
+    expect(SCANNING_SRC).toMatch(
+      /import\s*\{[^}]*OSIntelligenceSection[^}]*\}\s*from\s*['"]@\/components\/settings\/OSIntelligenceSection['"]/,
+    );
+    expect(SCANNING_SRC).toContain('<OSIntelligenceSection');
+    const osDiscoveryIdx = SCANNING_SRC.indexOf('"OS discovery"');
+    const intelIdx = SCANNING_SRC.indexOf('<OSIntelligenceSection');
+    const maintenanceIdx = SCANNING_SRC.indexOf('"Maintenance"');
+    expect(osDiscoveryIdx).toBeGreaterThan(-1);
+    expect(intelIdx).toBeGreaterThan(osDiscoveryIdx);
+    expect(maintenanceIdx).toBeGreaterThan(intelIdx);
+  });
+});
+
+describe('frontend-settings-intelligence-config — behavioral (pure view)', () => {
+  function viewProps(overrides: Partial<Parameters<typeof OSIntelligenceSectionView>[0]> = {}) {
+    return {
+      isLoading: false,
+      isError: false,
+      errorMessage: null,
+      config: liveConfig,
+      defaults: defaults,
+      draft: liveConfig,
+      setDraft: vi.fn(),
+      onResetToLive: vi.fn(),
+      onResetToDefaults: vi.fn(),
+      onSave: vi.fn(),
+      isSaving: false,
+      saveError: null,
+      dirty: false,
+      ...overrides,
+    };
+  }
+
+  // @ac AC-05
+  test('frontend-settings-intelligence-config/AC-05 — visual states: loading, error, success-clean', () => {
+    // Loading
+    const { unmount: u1 } = render(
+      <OSIntelligenceSectionView {...viewProps({ isLoading: true, config: null, draft: null })} />,
+    );
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    u1();
+
+    // Error: alert + NO setting card / Stepper
+    const { unmount: u2 } = render(
+      <OSIntelligenceSectionView
+        {...viewProps({ isError: true, errorMessage: 'HTTP 500', config: null, draft: null })}
+      />,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save/i })).toBeNull();
+    u2();
+
+    // Success-clean: Save disabled
+    render(<OSIntelligenceSectionView {...viewProps()} />);
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
+  // @ac AC-06
+  test('frontend-settings-intelligence-config/AC-06 — edit -> Save flow toggles dirty/disabled', () => {
+    // With dirty=true, Save is enabled
+    const onSave = vi.fn();
+    const { unmount } = render(
+      <OSIntelligenceSectionView {...viewProps({ dirty: true, onSave })} />,
+    );
+    const saveBtn = screen.getByRole('button', { name: /save/i });
+    expect(saveBtn).not.toBeDisabled();
+    fireEvent.click(saveBtn);
+    expect(onSave).toHaveBeenCalledTimes(1);
+    unmount();
+
+    // With isSaving=true, Save is disabled even when dirty. The Save
+    // button label flips to "Saving…" while in-flight; we look for it
+    // via the disabled-button query rather than the name regex (the
+    // label change is itself the spinner affordance).
+    render(<OSIntelligenceSectionView {...viewProps({ dirty: true, isSaving: true })} />);
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+  });
+});

--- a/app/specs/frontend/settings-intelligence-config.spec.yaml
+++ b/app/specs/frontend/settings-intelligence-config.spec.yaml
@@ -1,0 +1,114 @@
+spec:
+  id: frontend-settings-intelligence-config
+  title: Settings Scanning page — OS Intelligence scheduler config section
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Settings > Scanning & monitoring page exposes the three OS Intelligence scheduler knobs landed by api-system-intelligence-config v1.0 (PR 8)
+    description: >
+      The Scanning & monitoring page already exposes a connectivity-
+      monitor config section wired to api-system-connectivity. PR 8
+      landed the parallel backend surface for the OS Intelligence
+      scheduler (GET/PUT /api/v1/system/intelligence/config). PR 8b
+      adds the matching frontend section so operators can see and
+      change the three knobs without hitting the API directly.
+
+      Three knobs, all bounded server-side by
+      system-intelligence-scheduler v1.0:
+
+        interval_sec       — per-host cadence (300..86400, default 3600)
+        rate_limit         — concurrent RunCycles cap (1..200, default 10)
+        maintenance_global — boolean kill-switch
+
+      Section structure mirrors the existing connectivity section's
+      visual pattern (SettingCard + FirstSettingRow + SettingRow +
+      controls), but the save affordance is local to the section
+      (inline Reset + Save buttons) rather than feeding the
+      page-level SaveBar. Two reasons: (a) the page-level SaveBar is
+      already scoped to the connectivity draft state — coupling
+      another draft into it would muddy the dirty/save semantics;
+      (b) section-local controls match the prototype Settings.html
+      layout better (each section is independently editable).
+
+    related_specs:
+      - api-system-intelligence-config
+      - api-system-connectivity
+      - system-intelligence-scheduler
+
+  objective:
+    summary: >
+      Lock the section layout, data binding, edit/save/reset/dirty
+      semantics, and bounds-aware Stepper ranges so the section stays
+      consistent with the backend contract. Tests cover the rendering
+      states (loading / error / dirty=false / dirty=true), the
+      save-success refetch, and the Stepper bounds.
+    scope:
+      includes:
+        - "OSIntelligenceSection component co-located in components/settings/"
+        - "GET /api/v1/system/intelligence/config wiring (TanStack Query)"
+        - "PUT /api/v1/system/intelligence/config wiring with cache invalidation"
+        - "Reset-to-defaults affordance reading from the GET response's defaults sub-object"
+        - "Section mounted in ScanningPage between OS discovery and Maintenance"
+      excludes:
+        - "Status endpoint — IntelligenceConfig has no in-process metrics surface (the scheduler exposes none today)"
+        - "Hot-reload signal — scheduler reads config at the top of each cycle (no client-side signal needed)"
+        - "Per-host overrides — interval_sec is fleet-wide; per-host cadence is managed by next_intelligence_at"
+
+  constraints:
+    - id: C-01
+      description: 'The section MUST issue exactly ONE useQuery against /api/v1/system/intelligence/config with the query key ["system", "intelligence", "config"]. The query key must be stable across renders so cache invalidation (in onSuccess) targets the right cache slot'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'A local draft state buffers in-flight edits. The draft MUST initialize from configQuery.data.config on first load and reset to the same source when the user clicks Cancel/Reset (NOT to defaults). A separate "Reset to defaults" affordance sets draft to configQuery.data.defaults — distinct UX from "Cancel changes"'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'The Stepper for interval_sec MUST clamp 300..86400 (5min..24h). The Stepper for rate_limit MUST clamp 1..200. The Toggle for maintenance_global is unbounded boolean. These bounds match system-intelligence-scheduler C-06/C-07 verbatim — typing them on the frontend prevents 400 round-trips for trivially out-of-range inputs'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'The Save button MUST be disabled when (a) configQuery is loading, (b) the draft equals the live config (dirty=false), or (c) the save mutation is in flight. On successful save the query key ["system", "intelligence", "config"] MUST be invalidated so the next render shows the round-tripped values'
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: 'A failed save MUST render the error message inline next to the buttons (use the envelope.error.message when present, fall back to the Error.message). The draft MUST NOT be reset on error — the operator keeps their input to retry or correct'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'The section MUST be mounted in ScanningPage.tsx BETWEEN the existing "OS discovery" section and the "Maintenance" section. Order matters: OS discovery is the one-shot fingerprint, OS Intelligence is the recurring snapshot collector — operators read top-down and expect them adjacent'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'Source inspection: components/settings/OSIntelligenceSection.tsx imports useQuery + useMutation from @tanstack/react-query. Its useQuery call uses queryKey ["system", "intelligence", "config"] AND fetches "/api/v1/system/intelligence/config"'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: 'Source inspection: OSIntelligenceSection.tsx contains BOTH a draft-reset path keyed off configQuery.data.config (Cancel) AND a separate draft-reset path keyed off configQuery.data.defaults (Reset to defaults). The two paths MUST be distinct functions/closures'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: "Source inspection: OSIntelligenceSection.tsx contains Stepper min/max props 300 and 86400 for the interval_sec control, and 1 and 200 for the rate_limit control. Verified by reading the file and matching the literal numbers next to the field names"
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-04
+      description: 'Source inspection: the save mutation onSuccess calls queryClient.invalidateQueries with queryKey ["system", "intelligence", "config"]. The Save button''s disabled prop combines (configQuery.isLoading), (!dirty), and (mutation.isPending) — all three terms appear in the disabled expression'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-05
+      description: 'Rendering: mounted with isError=true (mocked configQuery state) the section renders the error message AND does NOT render the SettingCard rows. Mounted with isLoading=true the section renders a loading affordance. Mounted with isSuccess=true and the three controls visible, the Save button is disabled (dirty=false on initial load)'
+      priority: critical
+      references_constraints: [C-04, C-05]
+    - id: AC-06
+      description: 'Rendering: mounted with isSuccess=true and the operator changes the interval_sec value, the Save button transitions to enabled (dirty=true). Clicking Save invokes the mutation. After mutation.isSuccess fires, the section re-renders with the new value and Save is disabled again'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-07
+      description: 'Source inspection: ScanningPage.tsx imports OSIntelligenceSection from @/components/settings/OSIntelligenceSection AND mounts it as JSX. The mount site MUST appear AFTER the "OS discovery" Section literal AND BEFORE the "Maintenance" Section literal'
+      priority: critical
+      references_constraints: [C-06]

--- a/app/specs/frontend/settings-intelligence-config.spec.yaml
+++ b/app/specs/frontend/settings-intelligence-config.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings-intelligence-config
   title: Settings Scanning page — OS Intelligence scheduler config section
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -82,6 +82,18 @@ spec:
       description: 'The section MUST be mounted in ScanningPage.tsx BETWEEN the existing "OS discovery" section and the "Maintenance" section. Order matters: OS discovery is the one-shot fingerprint, OS Intelligence is the recurring snapshot collector — operators read top-down and expect them adjacent'
       type: technical
       enforcement: error
+    - id: C-07
+      description: 'v1.1.0 — The error alert text MUST surface the HTTP status code (e.g. "HTTP 404") and SHOULD include the ErrorEnvelope.error.message when present. The buggy original "(error as Error)?.message" returned undefined for openapi-fetch errors (which are response-body objects, not Error instances) and degenerated to the duplicated fallback "Failed to load — Failed to load". The fix normalizes error → "HTTP <status>[ — <env.error.message>]" before throwing so the alert text is always operator-actionable'
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: 'v1.1.0 — The error state MUST render a Retry button that calls configQuery.refetch(). Without it the operator has to reload the entire page to recover from a transient 5xx — mirrors the recovery affordance in frontend-host-detail-intelligence-feed C-04'
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: 'v1.1.0 — On the post-save edge (mutation.isSuccess && configQuery.data), the draft MUST be re-synced from configQuery.data.config so a server-side clamp (or any future drift between client and server validation) cannot leave the operator with a stale draft that looks "saved" but does not match server truth. The re-sync MUST be gated on mutation.isSuccess specifically — never clobber an in-flight edit during an unrelated refetch'
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -112,3 +124,15 @@ spec:
       description: 'Source inspection: ScanningPage.tsx imports OSIntelligenceSection from @/components/settings/OSIntelligenceSection AND mounts it as JSX. The mount site MUST appear AFTER the "OS discovery" Section literal AND BEFORE the "Maintenance" Section literal'
       priority: critical
       references_constraints: [C-06]
+    - id: AC-08
+      description: 'v1.1.0 — Rendering: mounted with isError=true and errorMessage="HTTP 404" the alert text contains "HTTP 404". The alert text MUST NOT match the buggy pattern "— Failed to load$" (the duplicated fallback that the original implementation produced for openapi-fetch errors that are not Error instances)'
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-09
+      description: 'v1.1.0 — Rendering: mounted with isError=true the alert renders a button matching role="button" name=/retry/i. Clicking the button invokes the onRetry prop exactly once'
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-10
+      description: 'v1.1.0 — Source inspection: OSIntelligenceSection.tsx contains a useEffect that depends on mutation.isSuccess AND calls setDraft from configQuery.data.config inside the effect body. This is the post-save re-sync (C-09) — without it, server-side clamps would leave the operator with a stale "saved" draft'
+      priority: critical
+      references_constraints: [C-09]

--- a/app/specter.yaml
+++ b/app/specter.yaml
@@ -49,6 +49,7 @@ domains:
             - frontend-live-events
             - api-hosts
             - api-system-intelligence-config
+            - frontend-settings-intelligence-config
             - frontend-host-detail
             - frontend-host-list-os
             - frontend-host-detail-system-card


### PR DESCRIPTION
## Summary

PR 8b wires the Settings → Scanning & monitoring page to consume the new `GET`/`PUT /api/v1/system/intelligence/config` endpoints landed by **PR 8 (#452)**. Operators can now see and change the three OS Intelligence scheduler knobs without hitting the API directly.

New spec **`frontend-settings-intelligence-config` v1.0.0** (Tier 2, 6 constraints / 7 ACs) locks the section layout, data binding, and edit/save/reset/dirty semantics.

### Three knobs

| Field | Control | Bounds |
| --- | --- | --- |
| `interval_sec` | Stepper (step 300, "sec" unit) | 300..86400 |
| `rate_limit` | Stepper | 1..200 |
| `maintenance_global` | Toggle | bool |

Bounds match `system-intelligence-scheduler` C-06/C-07 verbatim — typing them on the frontend prevents 400 round-trips for trivially out-of-range inputs.

### Two distinct reset paths

- **Cancel** → `draft = configQuery.data.config` (revert to live)
- **Reset to defaults** → `draft = configQuery.data.defaults` (use the response's defaults sub-object)

Distinct UX from each other — Cancel is "undo my edits", Reset is "go back to the baked-in 1h / 10-worker defaults".

### Mount site

Section mounted in `ScanningPage.tsx` **between** the existing "OS discovery" Section and the "Maintenance" Section (spec C-06). Section-local Save/Reset/Cancel buttons rather than feeding the page-level `SaveBar` (which is already scoped to the connectivity draft state — coupling another draft would muddy dirty/save semantics).

### Stacking

Stacks on **PR 8 (#452)**. Rebase on main once PR 8 lands.

Lineage: main → PR 8 → **PR 8b**.

### schema.d.ts

Regenerated to pick up the new endpoint types added by PR 8.

## Test plan

- [x] 7 vitest tests pass — `settings-intelligence-config.test.tsx`
- [x] Full frontend suite green (58 tests, 8 files)
- [x] `tsc --noEmit` clean
- [x] `specter coverage`: 54 specs at 100% coverage
- [ ] CI: spec-checks, frontend-tests