### PR TITLE
chore(test): isolate integration tests onto a dedicated _test database

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -59,6 +59,58 @@ $(DIST_DIR):
 test: internal/server/openapi_embed.yaml
 	go test ./...
 
+# test-integration: runs the full suite (including DB-backed integration
+# tests) against a dedicated TEST database. The DSN is constructed here
+# so the operator can never accidentally point it at the dev or prod
+# DB. These tests TRUNCATE tables between cases — pointing at a non-test
+# DB would destroy real data. Run `make test-db-create` first if the
+# database does not exist yet.
+.PHONY: test-integration
+test-integration: internal/server/openapi_embed.yaml
+	@DB="$${OPENWATCH_TEST_DB:-openwatch_go_test}"; \
+	case "$$DB" in *_test) ;; \
+	  *) echo "ERROR: OPENWATCH_TEST_DB ($$DB) must end with _test"; exit 1 ;; esac; \
+	HOST="$${OPENWATCH_TEST_DB_HOST:-127.0.0.1}"; \
+	PORT="$${OPENWATCH_TEST_DB_PORT:-5432}"; \
+	USER="$${OPENWATCH_TEST_DB_USER:-openwatch}"; \
+	PASS="$${OPENWATCH_TEST_DB_PASS:-openwatch_secure_db_2025}"; \
+	DSN="postgres://$$USER:$$PASS@$$HOST:$$PORT/$$DB?sslmode=disable"; \
+	echo "Using test DB: $$DB on $$HOST:$$PORT"; \
+	OPENWATCH_TEST_DSN="$$DSN" go test -race -p 1 ./...
+
+# test-db-create: provisions the test database (idempotent — exits 0
+# if it already exists) and applies all migrations.
+.PHONY: test-db-create
+test-db-create: $(DIST_DIR)/$(BINARY)
+	@DB="$${OPENWATCH_TEST_DB:-openwatch_go_test}"; \
+	case "$$DB" in *_test) ;; \
+	  *) echo "ERROR: OPENWATCH_TEST_DB ($$DB) must end with _test"; exit 1 ;; esac; \
+	HOST="$${OPENWATCH_TEST_DB_HOST:-127.0.0.1}"; \
+	PORT="$${OPENWATCH_TEST_DB_PORT:-5432}"; \
+	USER="$${OPENWATCH_TEST_DB_USER:-openwatch}"; \
+	PASS="$${OPENWATCH_TEST_DB_PASS:-openwatch_secure_db_2025}"; \
+	PGPASSWORD="$$PASS" psql -h $$HOST -p $$PORT -U $$USER -d postgres \
+	  -tc "SELECT 1 FROM pg_database WHERE datname='$$DB'" | grep -q 1 \
+	  || PGPASSWORD="$$PASS" psql -h $$HOST -p $$PORT -U $$USER -d postgres \
+	     -c "CREATE DATABASE $$DB OWNER $$USER;"; \
+	DSN="postgres://$$USER:$$PASS@$$HOST:$$PORT/$$DB?sslmode=disable"; \
+	echo "Migrating test DB to current schema..."; \
+	OPENWATCH_DATABASE_DSN="$$DSN" ./$(DIST_DIR)/$(BINARY) migrate
+
+# test-db-drop: tears down the test database. Refuses any DB name that
+# does not end in _test.
+.PHONY: test-db-drop
+test-db-drop:
+	@DB="$${OPENWATCH_TEST_DB:-openwatch_go_test}"; \
+	case "$$DB" in *_test) ;; \
+	  *) echo "ERROR: $$DB must end with _test"; exit 1 ;; esac; \
+	HOST="$${OPENWATCH_TEST_DB_HOST:-127.0.0.1}"; \
+	PORT="$${OPENWATCH_TEST_DB_PORT:-5432}"; \
+	USER="$${OPENWATCH_TEST_DB_USER:-openwatch}"; \
+	PASS="$${OPENWATCH_TEST_DB_PASS:-openwatch_secure_db_2025}"; \
+	PGPASSWORD="$$PASS" psql -h $$HOST -p $$PORT -U $$USER -d postgres \
+	  -c "DROP DATABASE IF EXISTS $$DB;"
+
 .PHONY: tidy
 tidy:
 	go mod tidy

--- a/app/internal/server/api_helpers_test.go
+++ b/app/internal/server/api_helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,6 +60,35 @@ func apiTestDSN(t *testing.T) string {
 	dsn := os.Getenv("OPENWATCH_TEST_DSN")
 	if dsn == "" {
 		t.Skip("set OPENWATCH_TEST_DSN to run API integration tests")
+	}
+	// SAFETY GATE: these tests TRUNCATE the schema between cases. Refuse
+	// to run against a dev / production-looking database, even if the
+	// operator pointed OPENWATCH_TEST_DSN there. The DSN MUST name a
+	// database whose name ends with "_test" (e.g. openwatch_go_test).
+	// Override with OPENWATCH_TEST_DSN_ALLOW_NONTEST=yes at your own
+	// risk; this exists for CI environments that use ephemeral DBs.
+	if strings.Contains(dsn, "/openwatch_go_dev") ||
+		(!strings.Contains(dsn, "_test?") && !strings.HasSuffix(dsn, "_test")) {
+		if os.Getenv("OPENWATCH_TEST_DSN_ALLOW_NONTEST") != "yes" {
+			t.Fatalf(
+				"OPENWATCH_TEST_DSN points at a non-test database (%s) — "+
+					"these tests TRUNCATE tables and would destroy real data. "+
+					"Use a database whose name ends with _test, or set "+
+					"OPENWATCH_TEST_DSN_ALLOW_NONTEST=yes if you know what you're doing.",
+				redactDSN(dsn),
+			)
+		}
+	}
+	return dsn
+}
+
+// redactDSN strips the password from a postgres DSN for safe logging.
+func redactDSN(dsn string) string {
+	// Replace any "user:password@" with "user:***@".
+	if i := strings.Index(dsn, "@"); i > 0 {
+		if j := strings.LastIndex(dsn[:i], ":"); j > 0 {
+			return dsn[:j+1] + "***" + dsn[i:]
+		}
 	}
 	return dsn
 }


### PR DESCRIPTION
## Summary
Closes the gap that wiped the operator's hosts + credentials when I ran the full integration suite against \`OPENWATCH_TEST_DSN\` pointing at \`openwatch_go_dev\` earlier today. The tests' \`freshAPIServer\` helper TRUNCATEs the schema between cases by design — that's safe on an ephemeral test DB and catastrophic on a dev DB.

## Two layers of protection

### 1. Runtime guard (`internal/server/api_helpers_test.go`)
\`apiTestDSN\` refuses to run when the DSN's database name doesn't end with \`_test\` OR contains \`openwatch_go_dev\`. Default is fail-closed:
\`\`\`
OPENWATCH_TEST_DSN points at a non-test database (postgres://openwatch:***@127.0.0.1:5432/openwatch_go_dev?sslmode=disable) — these tests TRUNCATE tables and would destroy real data.
\`\`\`
Bypass for CI environments: \`OPENWATCH_TEST_DSN_ALLOW_NONTEST=yes\`.

### 2. Make targets that hide \`OPENWATCH_TEST_DSN\` from the operator
| Target | What it does |
|---|---|
| \`make test-db-create\` | Creates \`openwatch_go_test\` if missing, applies all migrations |
| \`make test-integration\` | Full suite (\`-race -p 1\`) with DSN hardcoded to a \`_test\` DB |
| \`make test-db-drop\` | Tears down the test DB (refuses non-\`_test\` names) |

## Test plan
- [x] Run tests with DSN=...openwatch_go_dev → guard fires, tests fail fast, no TRUNCATE
- [x] Run tests with DSN=...openwatch_go_test → suite passes
- [x] Dev DB host + credential counts unchanged after both runs

## Going forward
Use \`make test-integration\` from \`app/\`. Don't pass \`OPENWATCH_TEST_DSN\` by hand.