### PR TITLE
feat(ssh): extend sudo-S password fallback to liveness probe + discovery firewall queries

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -332,6 +332,15 @@
         "line_number": 71
       }
     ],
+    "app/internal/intelligence/discovery/firewall_fallback_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/internal/intelligence/discovery/firewall_fallback_test.go",
+        "hashed_secret": "b9042ff97324570798584f0d7fc157136e958932",
+        "is_verified": false,
+        "line_number": 89
+      }
+    ],
     "app/internal/license/testdata/license-privkey-test.pem": [
       {
         "type": "Private Key",
@@ -1890,6 +1899,20 @@
         "hashed_secret": "e038248aaba7d6df9d363f2c4e2807530f4a3923",
         "is_verified": false,
         "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/specs/system/ssh-connectivity.spec.yaml",
+        "hashed_secret": "4d40f45984f4afb490af725698bd96294f664ab6",
+        "is_verified": false,
+        "line_number": 149
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/specs/system/ssh-connectivity.spec.yaml",
+        "hashed_secret": "37badbea15195cb7e3902b93be544d3bbea47efd",
+        "is_verified": false,
+        "line_number": 153
       }
     ],
     "backend/.env.example": [
@@ -2232,5 +2255,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-03T03:14:52Z"
+  "generated_at": "2026-06-03T10:34:34Z"
 }

--- a/app/cmd/openwatch/main.go
+++ b/app/cmd/openwatch/main.go
@@ -327,7 +327,11 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	}
 
 	credSvc := credential.NewService(pool)
-	privProbe := sshprivilege.Probe(credSvc)
+	// Spec system-ssh-connectivity v1.2.0 C-09 / AC-18: thread the
+	// SecurityConfig reader so the privilege probe can retry sudo -n
+	// failures via sudo -S -k with the credential password — same
+	// gating as the collector + discovery firewall probe.
+	privProbe := sshprivilege.Probe(credSvc, sshprivilege.WithPolicyLoader(cfgStore))
 
 	liveSvc := liveness.NewService(pool, audit.Emit, bus).
 		WithConfigLoader(cfgStore.LoadConnectivity).
@@ -343,7 +347,12 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	// worker that drains host.discovery jobs. Spec system-host-discovery.
 	discoSvc := discovery.NewService(pool, audit.Emit, bus).
 		WithHostLookup(discovery.PoolHostLookup{Pool: pool}).
-		WithCredentialService(credSvc)
+		WithCredentialService(credSvc).
+		// Spec system-ssh-connectivity v1.2.0 C-09 / AC-20: thread the
+		// SecurityConfig reader so the firewall probe can retry a
+		// sudo -n failure via sudo -S -k with the credential password
+		// — same gating as the collector + the privilege probe.
+		WithPolicyLoader(cfgStore)
 
 	// OS Intelligence collector — runs one RunCycle per host: SSH
 	// session, snapshot.Collect (packages/services/users/network/etc.),

--- a/app/internal/intelligence/discovery/discovery.go
+++ b/app/internal/intelligence/discovery/discovery.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/eventbus"
 	"github.com/Hanalyx/openwatch/internal/intelligence/probe"
 	owssh "github.com/Hanalyx/openwatch/internal/ssh"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -138,6 +139,15 @@ type Addr struct {
 }
 
 // Service runs Discovery for a host. Construct via NewService.
+// PolicyLoader returns the current SecurityConfig — the sudo-password
+// fallback (system-ssh-connectivity v1.2.0 C-09 / AC-20) consults
+// AllowCredentialSudoPassword via this seam. Production wires
+// systemconfig.Store.LoadSecurity; tests pass a closure or leave it
+// nil (in which case the fallback path is OFF by default).
+type PolicyLoader interface {
+	LoadSecurity(ctx context.Context) (systemconfig.SecurityConfig, error)
+}
+
 type Service struct {
 	pool      *pgxpool.Pool
 	credSvc   *credential.Service
@@ -145,6 +155,7 @@ type Service struct {
 	bus       Publisher
 	lookup    HostLookup
 	transport SSHTransport
+	policy    PolicyLoader
 }
 
 // NewService constructs a Service. emit + bus may be nil — Discover
@@ -180,6 +191,14 @@ func (s *Service) WithCredentialService(c *credential.Service) *Service {
 // WithHostLookup wires the host-row reader. Required for Discover.
 func (s *Service) WithHostLookup(h HostLookup) *Service {
 	s.lookup = h
+	return s
+}
+
+// WithPolicyLoader wires the SecurityConfig reader. When unset, the
+// sudo-password fallback (v1.2.0 AC-20) stays OFF — probeFirewall
+// behaves exactly as in v1.1.0.
+func (s *Service) WithPolicyLoader(p PolicyLoader) *Service {
+	s.policy = p
 	return s
 }
 
@@ -307,8 +326,16 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 
 	// Firewall introspection — needs sudo on most distros. Per spec C-03
 	// + AC-05, sudo failure is partial success: leave fields empty and
-	// continue. Try each known firewall in order; first to answer wins.
-	if svc, status, ok := probeFirewall(ctx, sess); ok {
+	// continue. v1.2.0 — when AllowCredentialSudoPassword is set,
+	// runSudoWithFallback retries a sudo -n failure as sudo -S -k -p ''
+	// with the credential password before the probe falls through.
+	cfg := sudoFallbackConfig{cred: hf.Cred}
+	if s.policy != nil {
+		if sec, lerr := s.policy.LoadSecurity(ctx); lerr == nil {
+			cfg.policy = sec
+		}
+	}
+	if svc, status, ok := probeFirewall(ctx, sess, cfg); ok {
 		facts.FirewallService = svc
 		facts.FirewallStatus = status
 	}

--- a/app/internal/intelligence/discovery/firewall_fallback_test.go
+++ b/app/internal/intelligence/discovery/firewall_fallback_test.go
@@ -1,0 +1,145 @@
+// @spec system-ssh-connectivity
+//
+// AC traceability (this file):
+//
+//   AC-20  TestProbeFirewall_PasswordFallback_UFWSuccess
+//          TestProbeFirewall_PasswordFallback_PolicyOff
+//   AC-21  TestProbeFirewall_NoFallbackOnSudoNSuccess
+//
+// system-host-discovery AC-05 (v1.2.0 sudo-S retry before partial-success)
+// is covered indirectly: these tests exercise the same probeFirewall
+// helper the host-discovery flow calls into.
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+)
+
+// validHostCred builds a credential that satisfies the password-fallback
+// preconditions (AuthMethod ∈ {password, both} with a non-empty Password).
+func validHostCred() *credential.Credential {
+	return &credential.Credential{
+		Username:   "owadmin",
+		AuthMethod: credential.AuthBoth,
+		Password:   "secret-pw",
+	}
+}
+
+// @ac AC-20
+// AC-20 (success): sudo -n ufw status fails → policy on + cred has
+// password → probeFirewall retries via sudo -S -k -p ” ufw status with
+// the password fed via stdin → returns service="ufw", status="active".
+func TestProbeFirewall_PasswordFallback_UFWSuccess(t *testing.T) {
+	t.Run("system-ssh-connectivity/AC-20", func(t *testing.T) {
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+		// First firewall attempt (systemctl is-active firewalld) returns
+		// 127 from the SeedAll default — not present on this Ubuntu host.
+		// Then sudo -n ufw status fails; the fallback sudo -S -k -p ''
+		// ufw status succeeds.
+		stub.FailCommand("sudo -n ufw status", "a password is required", 1)
+		stub.outputs["sudo -S -k -p '' ufw status"] = stubResult{
+			out:      []byte("Status: active\n"),
+			exitCode: 0,
+		}
+
+		sess, err := stub.Dial(testCtx(t), "host", 22, validHostCred())
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+
+		cfg := sudoFallbackConfig{
+			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true},
+			cred:   validHostCred(),
+		}
+		svc, status, ok := probeFirewall(testCtx(t), sess, cfg)
+		if !ok {
+			t.Fatalf("ok: want true (fallback succeeded), got false")
+		}
+		if svc != "ufw" {
+			t.Errorf("service: want ufw, got %q", svc)
+		}
+		if status != "active" {
+			t.Errorf("status: want active, got %q", status)
+		}
+		// The fallback call MUST have been issued through RunWithStdin
+		// with the credential password on stdin.
+		if got := len(stub.stdinCalls); got == 0 {
+			t.Fatal("no RunWithStdin calls recorded — fallback did not engage")
+		}
+		found := false
+		for _, c := range stub.stdinCalls {
+			if c.cmd == "sudo -S -k -p '' ufw status" && string(c.stdin) == "secret-pw\n" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected RunWithStdin(sudo -S -k -p '' ufw status, %q\\n), recorded calls: %+v",
+				"secret-pw", stub.stdinCalls)
+		}
+	})
+}
+
+// @ac AC-20
+// AC-20 (policy off): same stub setup but AllowCredentialSudoPassword=false.
+// The sudo -n exit 1 propagates and probeFirewall falls through to the
+// next firewall — ultimately returning ("", "", false) when none are
+// programmed to succeed. NO sudo -S -k call is issued.
+func TestProbeFirewall_PasswordFallback_PolicyOff(t *testing.T) {
+	t.Run("system-ssh-connectivity/AC-20", func(t *testing.T) {
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+		stub.FailCommand("sudo -n ufw status", "a password is required", 1)
+		// Seed sudo -S -k success — should NOT be reached.
+		stub.outputs["sudo -S -k -p '' ufw status"] = stubResult{out: []byte("Status: active\n"), exitCode: 0}
+		stub.FailCommand("sudo -n nft list ruleset", "denied", 1)
+		stub.FailCommand("sudo -n iptables -L", "denied", 1)
+		stub.FailCommand("sudo -n firewall-cmd --state", "denied", 1)
+
+		sess, _ := stub.Dial(testCtx(t), "host", 22, validHostCred())
+		cfg := sudoFallbackConfig{
+			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: false},
+			cred:   validHostCred(),
+		}
+		_, _, ok := probeFirewall(testCtx(t), sess, cfg)
+		if ok {
+			t.Errorf("ok: want false (policy off, no sudo path succeeded), got true")
+		}
+		if got := len(stub.stdinCalls); got != 0 {
+			t.Errorf("RunWithStdin called %d times with policy off; want 0", got)
+		}
+	})
+}
+
+// @ac AC-21
+// AC-21 (discovery half): firewalld is already active via systemctl
+// (sudoless) → probeFirewall returns immediately. The sudo -S -k path
+// MUST NOT execute even with policy + password available.
+func TestProbeFirewall_NoFallbackOnSudoNSuccess(t *testing.T) {
+	t.Run("system-ssh-connectivity/AC-21", func(t *testing.T) {
+		stub := newStubSSHTransport()
+		stub.SeedAll()
+		stub.outputs["systemctl is-active firewalld"] = stubResult{
+			out: []byte("active\n"), exitCode: 0,
+		}
+
+		sess, _ := stub.Dial(testCtx(t), "host", 22, validHostCred())
+		cfg := sudoFallbackConfig{
+			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true},
+			cred:   validHostCred(),
+		}
+		svc, status, ok := probeFirewall(testCtx(t), sess, cfg)
+		if !ok || svc != "firewalld" || status != "active" {
+			t.Errorf("first-firewall hit: svc=%q status=%q ok=%v", svc, status, ok)
+		}
+		// Zero RunWithStdin calls — fallback never engaged.
+		if got := len(stub.stdinCalls); got != 0 {
+			t.Errorf("RunWithStdin called %d times though sudo -n was not even attempted", got)
+		}
+	})
+}

--- a/app/internal/intelligence/discovery/helpers.go
+++ b/app/internal/intelligence/discovery/helpers.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"strconv"
 	"strings"
+
+	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
 )
 
 // deriveOSFamily collapses ID + ID_LIKE down to a single rollup label
@@ -75,29 +78,82 @@ func parseGB(s string) int {
 	return n
 }
 
+// sudoFallbackConfig carries the policy + credential context the
+// password-fallback path needs. Passed by the caller so probeFirewall
+// stays decoupled from systemconfig + credential resolution.
+//
+// Spec system-ssh-connectivity v1.2.0 C-09.
+type sudoFallbackConfig struct {
+	policy systemconfig.SecurityConfig
+	cred   *credential.Credential
+}
+
+// canFallback returns true iff (a) the policy allows the credential
+// password to be fed to sudo, (b) the credential carries a non-empty
+// Password, and (c) the auth method permits password material. Spec
+// AC-19 forbids the fallback when any of these is false.
+func (c sudoFallbackConfig) canFallback() bool {
+	if !c.policy.AllowCredentialSudoPassword || c.cred == nil {
+		return false
+	}
+	if c.cred.Password == "" {
+		return false
+	}
+	return c.cred.AuthMethod == credential.AuthPassword || c.cred.AuthMethod == credential.AuthBoth
+}
+
+// runSudoWithFallback wraps a `sudo -n <cmd>` invocation with the
+// credential-password fallback documented in system-ssh-connectivity
+// v1.2.0 C-09 / AC-20. The retry is opt-in via cfg.
+//
+// Returns (out, code, err). When the fallback engages it issues
+// exactly one extra call — `sudo -S -k -p ” <cmd>` — and never
+// reattempts on a failed retry (-k invalidates the host's sudo
+// timestamp cache so a wrong password trips pam once, not three
+// times). Spec C-11 / AC-17.
+func runSudoWithFallback(ctx context.Context, sess SSHSession, sudoCmd string, cfg sudoFallbackConfig) ([]byte, int, error) {
+	out, code, err := sess.Run(ctx, "sudo -n "+sudoCmd)
+	if err == nil && code == 0 {
+		return out, code, nil
+	}
+	if !cfg.canFallback() {
+		return out, code, err
+	}
+	// Pipe the password (with a trailing newline so sudo flushes
+	// the line) into the remote process's stdin.
+	pw := append([]byte(cfg.cred.Password), '\n')
+	return sess.RunWithStdin(ctx, "sudo -S -k -p '' "+sudoCmd, pw)
+}
+
 // probeFirewall tries each known firewall service in order. The first
 // one to answer (exit 0) wins. Returns ("", "", false) when none answer
 // — typically because the credential lacks sudo. Per spec C-03 + AC-05
 // this is partial success, not a probe failure.
-func probeFirewall(ctx context.Context, sess SSHSession) (service, status string, ok bool) {
+//
+// v1.2.0 — Each sudo-prefixed attempt now consults the
+// AllowCredentialSudoPassword policy via cfg; a sudo -n failure that
+// the policy permits retries through `sudo -S -k -p ” <cmd>` before
+// the probe falls through to the next firewall. Spec
+// system-ssh-connectivity v1.2.0 C-09 / AC-20.
+func probeFirewall(ctx context.Context, sess SSHSession, cfg sudoFallbackConfig) (service, status string, ok bool) {
 	// firewalld via systemctl is sudoless on many distros.
 	if out, code, err := sess.Run(ctx, "systemctl is-active firewalld"); err == nil && code == 0 {
 		return "firewalld", strings.TrimSpace(string(out)), true
 	}
 	// ufw — Debian / Ubuntu. Needs sudo on most distros for `status`.
-	if out, code, err := sess.Run(ctx, "sudo -n ufw status"); err == nil && code == 0 {
+	if out, code, err := runSudoWithFallback(ctx, sess, "ufw status", cfg); err == nil && code == 0 {
 		return "ufw", firstWord(string(out)), true
 	}
 	// nftables.
-	if _, code, err := sess.Run(ctx, "sudo -n nft list ruleset"); err == nil && code == 0 {
+	if _, code, err := runSudoWithFallback(ctx, sess, "nft list ruleset", cfg); err == nil && code == 0 {
 		return "nftables", "active", true
 	}
 	// iptables fallback.
-	if _, code, err := sess.Run(ctx, "sudo -n iptables -L"); err == nil && code == 0 {
+	if _, code, err := runSudoWithFallback(ctx, sess, "iptables -L", cfg); err == nil && code == 0 {
 		return "iptables", "active", true
 	}
 	// firewall-cmd as last resort (RHEL).
-	if out, code, err := sess.Run(ctx, "sudo -n firewall-cmd --state"); err == nil && code == 0 {
+	if out, code, err := runSudoWithFallback(ctx, sess, "firewall-cmd --state", cfg); err == nil && code == 0 {
 		return "firewalld", strings.TrimSpace(string(out)), true
 	}
 	return "", "", false

--- a/app/internal/sshprivilege/privilege.go
+++ b/app/internal/sshprivilege/privilege.go
@@ -2,6 +2,15 @@
 // SSH with the host's resolved credential, run `sudo -n true`, and
 // report whether passwordless privilege escalation is configured.
 //
+// Per system-ssh-connectivity v1.2.0 the probe ALSO consults
+// systemconfig.SecurityConfig.AllowCredentialSudoPassword; when the
+// initial `sudo -n true` returns non-zero AND the credential carries
+// a non-empty Password AND the policy is on, the probe retries via
+// `sudo -S -k -p ” true` with the password fed through stdin. The
+// retry shape is identical to the scan path's ssh.RunSudo and to
+// discovery.probeFirewall — drift between the three is forbidden by
+// the spec's C-09.
+//
 // This package is kept OUT of internal/liveness because the liveness
 // package's AC-14 invariant forbids credential + crypto/ssh imports.
 // The PrivilegeProbeFunc is wired in cmd/openwatch/main.go where both
@@ -10,9 +19,11 @@
 package sshprivilege
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -20,6 +31,7 @@ import (
 
 	"github.com/Hanalyx/openwatch/internal/credential"
 	"github.com/Hanalyx/openwatch/internal/liveness"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
 	"github.com/google/uuid"
 )
 
@@ -31,6 +43,61 @@ type Resolver interface {
 	Resolve(ctx context.Context, hostID uuid.UUID) (*credential.Credential, error)
 }
 
+// PolicyLoader returns the current SecurityConfig — specifically the
+// AllowCredentialSudoPassword flag that gates the sudo -S fallback.
+// Implementations typically wrap systemconfig.Store.LoadSecurity. A
+// nil loader OR an error from the loader defaults to "policy off"
+// so the fallback path stays opt-in.
+type PolicyLoader interface {
+	LoadSecurity(ctx context.Context) (systemconfig.SecurityConfig, error)
+}
+
+// SessionExecutor is the seam between the probe and the SSH session.
+// Production wraps a real *ssh.Client (see realSession below); tests
+// stub it directly to verify the call ordering without standing up an
+// SSH server.
+//
+// RunWithStdin feeds the reader's content into the remote process's
+// stdin — used to deliver the credential password to `sudo -S`. The
+// reader is consumed once.
+type SessionExecutor interface {
+	Run(ctx context.Context, cmd string) ([]byte, int, error)
+	RunWithStdin(ctx context.Context, cmd string, stdin io.Reader) ([]byte, int, error)
+	Close() error
+}
+
+// Dialer opens an SSH session against a host. Production uses
+// realDialer (crypto/ssh.Dial); tests inject a stub.
+type Dialer interface {
+	Dial(ctx context.Context, cred *credential.Credential, addr string, timeout time.Duration) (SessionExecutor, error)
+}
+
+// probeConfig accumulates the optional dependencies a Probe needs.
+// Constructed by Probe(...) and the With* options.
+type probeConfig struct {
+	dialer Dialer
+	policy PolicyLoader
+}
+
+// ProbeOption configures the probe at construction time. Use
+// WithDialer / WithPolicyLoader.
+type ProbeOption func(*probeConfig)
+
+// WithDialer overrides the production SSH dialer. Tests pass a stub
+// that doesn't open real connections.
+func WithDialer(d Dialer) ProbeOption {
+	return func(c *probeConfig) { c.dialer = d }
+}
+
+// WithPolicyLoader wires the systemconfig reader the probe consults
+// to decide whether to engage the sudo -S fallback. A nil loader
+// (the default) is equivalent to "policy off".
+//
+// Spec system-ssh-connectivity v1.2.0 C-09 / AC-18.
+func WithPolicyLoader(p PolicyLoader) ProbeOption {
+	return func(c *probeConfig) { c.policy = p }
+}
+
 // Probe builds a liveness.PrivilegeProbeFunc backed by the given
 // resolver. The returned function:
 //
@@ -38,13 +105,22 @@ type Resolver interface {
 //     attempted=false (the multi-layer state machine leaves the
 //     privilege axis untouched).
 //  2. Dials TCP-22 with cfg.Timeout = timeout.
-//  3. Runs `sudo -n true`. Exit 0 → ok=true; any other exit → ok=false
-//     with the exit code in the error.
+//  3. Runs `sudo -n true`. Exit 0 → ok=true.
+//  4. Non-zero exit AND AllowCredentialSudoPassword AND cred.Password
+//     non-empty AND cred.AuthMethod ∈ {password, both} → retries as
+//     `sudo -S -k -p ” true` with the password fed via stdin. Exit 0
+//     from the retry → ok=true. Any other outcome → ok=false.
+//
+// Spec system-ssh-connectivity v1.2.0 C-09, AC-18, AC-19, AC-21.
 //
 // Host key verification is intentionally permissive (InsecureIgnoreHostKey)
 // because this probe is just answering "would sudo work today?" — the
 // real scan path validates host keys via internal/ssh.
-func Probe(resolver Resolver) liveness.PrivilegeProbeFunc {
+func Probe(resolver Resolver, opts ...ProbeOption) liveness.PrivilegeProbeFunc {
+	cfg := probeConfig{dialer: realDialer{}}
+	for _, o := range opts {
+		o(&cfg)
+	}
 	return func(ctx context.Context, hostID liveness.HostID, addr string, timeout time.Duration) (attempted, ok bool, err error) {
 		id, perr := uuid.Parse(string(hostID))
 		if perr != nil {
@@ -58,52 +134,146 @@ func Probe(resolver Resolver) liveness.PrivilegeProbeFunc {
 			return true, false, fmt.Errorf("resolve credential: %w", rerr)
 		}
 
-		cfg := &ssh.ClientConfig{
-			User:    cred.Username,
-			Timeout: timeout,
-			// #nosec G106 -- this probe answers "would sudo work
-			// today?" and is decoupled from compliance scans. Host-key
-			// pinning belongs on the real scan path (internal/ssh's
-			// KnownHostsManager). Verifying here would require the
-			// liveness loop to learn the host-key registry — exactly
-			// the cross-cutting coupling we kept out of the package.
-			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		}
-		switch cred.AuthMethod {
-		case credential.AuthSSHKey, credential.AuthBoth:
-			signer, perr := parseSigner(cred)
-			if perr != nil {
-				return true, false, perr
-			}
-			cfg.Auth = []ssh.AuthMethod{ssh.PublicKeys(signer)}
-		case credential.AuthPassword:
-			cfg.Auth = []ssh.AuthMethod{ssh.Password(cred.Password)}
-		default:
-			return true, false, fmt.Errorf("unknown auth method %q", cred.AuthMethod)
-		}
-
-		client, derr := ssh.Dial("tcp", addr, cfg)
+		exec, derr := cfg.dialer.Dial(ctx, cred, addr, timeout)
 		if derr != nil {
 			return true, false, fmt.Errorf("ssh dial: %w", derr)
 		}
-		defer func() { _ = client.Close() }()
+		defer func() { _ = exec.Close() }()
 
-		session, serr := client.NewSession()
-		if serr != nil {
-			return true, false, fmt.Errorf("ssh session: %w", serr)
+		// Layer 1: sudo -n true. The 80% case where NOPASSWD is set.
+		out, code, runErr := exec.Run(ctx, "sudo -n true")
+		if runErr == nil && code == 0 {
+			return true, true, nil
 		}
-		defer func() { _ = session.Close() }()
 
-		out, runErr := session.CombinedOutput("sudo -n true")
-		if runErr != nil {
-			var exitErr *ssh.ExitError
-			if errors.As(runErr, &exitErr) {
-				return true, false, fmt.Errorf("sudo -n true: exit %d: %s", exitErr.ExitStatus(), strings.TrimSpace(string(out)))
-			}
-			return true, false, fmt.Errorf("run sudo: %w", runErr)
+		// Layer 2 (v1.2.0): sudo -S -k -p '' true. Only when the
+		// policy + credential permit. Per spec C-09 / AC-19, the
+		// auth method must allow password material AND the password
+		// field must be populated.
+		if !canFallback(ctx, cfg.policy, cred) {
+			return true, false, fmt.Errorf("sudo -n true: exit %d: %s", code, strings.TrimSpace(string(out)))
 		}
-		return true, true, nil
+
+		stdin := bytes.NewReader([]byte(cred.Password + "\n"))
+		out2, code2, runErr2 := exec.RunWithStdin(ctx, "sudo -S -k -p '' true", stdin)
+		if runErr2 == nil && code2 == 0 {
+			return true, true, nil
+		}
+		return true, false, fmt.Errorf("sudo -S -k -p '' true: exit %d: %s", code2, strings.TrimSpace(string(out2)))
 	}
+}
+
+// canFallback returns true iff the policy is on AND the credential is
+// shaped to provide a password (auth method password or both, password
+// non-empty). Spec C-09 / AC-19.
+func canFallback(ctx context.Context, loader PolicyLoader, cred *credential.Credential) bool {
+	if loader == nil {
+		return false
+	}
+	sec, lerr := loader.LoadSecurity(ctx)
+	if lerr != nil || !sec.AllowCredentialSudoPassword {
+		return false
+	}
+	if cred.Password == "" {
+		return false
+	}
+	if cred.AuthMethod != credential.AuthPassword && cred.AuthMethod != credential.AuthBoth {
+		return false
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------
+// Production dialer + session executor.
+// ---------------------------------------------------------------------
+
+type realDialer struct{}
+
+func (realDialer) Dial(_ context.Context, cred *credential.Credential, addr string, timeout time.Duration) (SessionExecutor, error) {
+	cfg := &ssh.ClientConfig{
+		User:    cred.Username,
+		Timeout: timeout,
+		// #nosec G106 -- this probe answers "would sudo work
+		// today?" and is decoupled from compliance scans. Host-key
+		// pinning belongs on the real scan path (internal/ssh's
+		// KnownHostsManager). Verifying here would require the
+		// liveness loop to learn the host-key registry — exactly
+		// the cross-cutting coupling we kept out of the package.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	switch cred.AuthMethod {
+	case credential.AuthSSHKey, credential.AuthBoth:
+		signer, perr := parseSigner(cred)
+		if perr != nil {
+			return nil, perr
+		}
+		cfg.Auth = []ssh.AuthMethod{ssh.PublicKeys(signer)}
+	case credential.AuthPassword:
+		cfg.Auth = []ssh.AuthMethod{ssh.Password(cred.Password)}
+	default:
+		return nil, fmt.Errorf("unknown auth method %q", cred.AuthMethod)
+	}
+
+	client, derr := ssh.Dial("tcp", addr, cfg)
+	if derr != nil {
+		return nil, derr
+	}
+	return &realSession{client: client}, nil
+}
+
+type realSession struct {
+	client *ssh.Client
+}
+
+func (s *realSession) Run(_ context.Context, cmd string) ([]byte, int, error) {
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return nil, -1, err
+	}
+	defer func() { _ = sess.Close() }()
+	out, runErr := sess.CombinedOutput(cmd)
+	if runErr != nil {
+		var exitErr *ssh.ExitError
+		if errors.As(runErr, &exitErr) {
+			return out, exitErr.ExitStatus(), nil
+		}
+		return out, -1, runErr
+	}
+	return out, 0, nil
+}
+
+func (s *realSession) RunWithStdin(_ context.Context, cmd string, stdin io.Reader) ([]byte, int, error) {
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return nil, -1, err
+	}
+	defer func() { _ = sess.Close() }()
+
+	pipe, perr := sess.StdinPipe()
+	if perr != nil {
+		return nil, -1, perr
+	}
+	go func() {
+		_, _ = io.Copy(pipe, stdin)
+		_ = pipe.Close()
+	}()
+
+	out, runErr := sess.CombinedOutput(cmd)
+	if runErr != nil {
+		var exitErr *ssh.ExitError
+		if errors.As(runErr, &exitErr) {
+			return out, exitErr.ExitStatus(), nil
+		}
+		return out, -1, runErr
+	}
+	return out, 0, nil
+}
+
+func (s *realSession) Close() error {
+	if s.client == nil {
+		return nil
+	}
+	return s.client.Close()
 }
 
 // parseSigner builds the ssh.Signer for a key-bearing credential,

--- a/app/internal/sshprivilege/privilege_test.go
+++ b/app/internal/sshprivilege/privilege_test.go
@@ -1,0 +1,291 @@
+// @spec system-ssh-connectivity
+//
+// AC traceability (this file):
+//
+//   AC-18  TestPrivilegeProbe_PasswordFallback_SuccessAndPolicyOff
+//   AC-19  TestPrivilegeProbe_PasswordFallback_NoPassword_NoSecondCall
+//   AC-21  TestPrivilegeProbe_NoFallbackOnSudoNSuccess
+//
+// The tests substitute a stub SSH executor so the wiring can be
+// exercised without standing up a real SSH server (gliderlabs/ssh has
+// its own coverage at internal/ssh).
+
+package sshprivilege
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/liveness"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+	"github.com/google/uuid"
+)
+
+// testEd25519PEM returns a freshly-generated PKCS#8 Ed25519 private
+// key encoded as PEM. The shape is what credential.AuthSSHKey expects
+// in cred.PrivateKey.
+func testEd25519PEM(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// stubExec records every command sent through Run / RunWithStdin and
+// can be programmed to return a specific exit code per command prefix.
+// A nil reader on RunWithStdin asserts the test forgot to send a
+// password.
+type stubExec struct {
+	mu sync.Mutex
+	// programmed outcomes keyed by exact command string. Default is
+	// exit 0 with no output unless a key matches.
+	outcomes map[string]execResult
+	// recorded calls in chronological order.
+	calls []recordedCall
+}
+
+type execResult struct {
+	out  []byte
+	code int
+	err  error
+}
+
+type recordedCall struct {
+	cmd      string
+	hadStdin bool
+}
+
+func (s *stubExec) Run(_ context.Context, cmd string) ([]byte, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, recordedCall{cmd: cmd, hadStdin: false})
+	if r, ok := s.outcomes[cmd]; ok {
+		return r.out, r.code, r.err
+	}
+	return nil, 0, nil
+}
+
+func (s *stubExec) RunWithStdin(_ context.Context, cmd string, stdin io.Reader) ([]byte, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, recordedCall{cmd: cmd, hadStdin: stdin != nil})
+	if r, ok := s.outcomes[cmd]; ok {
+		return r.out, r.code, r.err
+	}
+	return nil, 0, nil
+}
+
+func (s *stubExec) Close() error { return nil }
+
+func (s *stubExec) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+// stubResolver returns a fixed credential.
+type stubResolver struct {
+	cred *credential.Credential
+	err  error
+}
+
+func (r stubResolver) Resolve(_ context.Context, _ uuid.UUID) (*credential.Credential, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.cred, nil
+}
+
+// stubPolicy returns a fixed SecurityConfig.
+type stubPolicy struct {
+	cfg systemconfig.SecurityConfig
+	err error
+}
+
+func (p stubPolicy) LoadSecurity(_ context.Context) (systemconfig.SecurityConfig, error) {
+	return p.cfg, p.err
+}
+
+// stubDialer returns a programmed stubExec without touching real SSH.
+type stubDialer struct {
+	exec    *stubExec
+	dialErr error
+}
+
+func (d *stubDialer) Dial(_ context.Context, _ *credential.Credential, _ string, _ time.Duration) (SessionExecutor, error) {
+	if d.dialErr != nil {
+		return nil, d.dialErr
+	}
+	return d.exec, nil
+}
+
+func validCred() *credential.Credential {
+	return &credential.Credential{
+		Username:   "owadmin",
+		AuthMethod: credential.AuthBoth,
+		Password:   "secret-pw",
+	}
+}
+
+// @ac AC-18
+// AC-18 (positive): sudo -n fails → policy on + cred has password →
+// sudo -S -k -p ” succeeds → probe returns ok=true.
+// AC-18 (negative): same stub responses but policy off → probe returns
+// ok=false and issues NO sudo -S call.
+func TestPrivilegeProbe_PasswordFallback_SuccessAndPolicyOff(t *testing.T) {
+	t.Run("system-ssh-connectivity/AC-18", func(t *testing.T) {
+		hostID := liveness.HostID(uuid.Must(uuid.NewV7()).String())
+
+		// Programming: sudo -n exit 1; sudo -S -k exit 0.
+		mkExec := func() *stubExec {
+			return &stubExec{
+				outcomes: map[string]execResult{
+					"sudo -n true":          {code: 1, err: errors.New("exit 1")},
+					"sudo -S -k -p '' true": {code: 0},
+				},
+			}
+		}
+
+		// Policy ON, password present → fallback engages, probe ok.
+		exec := mkExec()
+		probe := Probe(
+			stubResolver{cred: validCred()},
+			WithPolicyLoader(stubPolicy{cfg: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true}}),
+			WithDialer(&stubDialer{exec: exec}),
+		)
+		attempted, ok, err := probe(context.Background(), hostID, "192.0.2.1:22", 2*time.Second)
+		if !attempted {
+			t.Errorf("attempted: want true, got false")
+		}
+		if !ok {
+			t.Errorf("ok: want true (fallback succeeded), got false; err=%v", err)
+		}
+		if exec.callCount() != 2 {
+			t.Errorf("call count: want 2 (sudo -n + sudo -S -k), got %d", exec.callCount())
+		}
+		// Fallback call MUST carry stdin (the password).
+		if !exec.calls[1].hadStdin {
+			t.Errorf("fallback call missing stdin (password not fed)")
+		}
+		// Fallback cmd MUST carry -k.
+		if exec.calls[1].cmd != "sudo -S -k -p '' true" {
+			t.Errorf("fallback cmd = %q, want %q", exec.calls[1].cmd, "sudo -S -k -p '' true")
+		}
+
+		// Policy OFF → no fallback issued.
+		exec2 := mkExec()
+		probe2 := Probe(
+			stubResolver{cred: validCred()},
+			WithPolicyLoader(stubPolicy{cfg: systemconfig.SecurityConfig{AllowCredentialSudoPassword: false}}),
+			WithDialer(&stubDialer{exec: exec2}),
+		)
+		_, ok2, _ := probe2(context.Background(), hostID, "192.0.2.1:22", 2*time.Second)
+		if ok2 {
+			t.Errorf("policy off: want ok=false, got true")
+		}
+		if exec2.callCount() != 1 {
+			t.Errorf("policy off: want exactly 1 call (sudo -n), got %d", exec2.callCount())
+		}
+	})
+}
+
+// @ac AC-19
+// AC-19: credential cannot supply a password (ssh_key only OR empty
+// Password). Policy on but no password to feed → probe MUST NOT issue
+// sudo -S; sudo -n exit 1 surfaces as ok=false.
+func TestPrivilegeProbe_PasswordFallback_NoPassword_NoSecondCall(t *testing.T) {
+	t.Run("system-ssh-connectivity/AC-19", func(t *testing.T) {
+		hostID := liveness.HostID(uuid.Must(uuid.NewV7()).String())
+
+		// AuthMethod ssh_key with empty Password.
+		keyOnly := &credential.Credential{
+			Username:   "owadmin",
+			AuthMethod: credential.AuthSSHKey,
+			PrivateKey: testEd25519PEM(t),
+		}
+
+		exec := &stubExec{
+			outcomes: map[string]execResult{
+				"sudo -n true": {code: 1, err: errors.New("exit 1")},
+			},
+		}
+		probe := Probe(
+			stubResolver{cred: keyOnly},
+			WithPolicyLoader(stubPolicy{cfg: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true}}),
+			WithDialer(&stubDialer{exec: exec}),
+		)
+		_, ok, _ := probe(context.Background(), hostID, "192.0.2.1:22", 2*time.Second)
+		if ok {
+			t.Errorf("ok: want false (no password to fall back with), got true")
+		}
+		if exec.callCount() != 1 {
+			t.Errorf("call count: want 1 (sudo -n only), got %d", exec.callCount())
+		}
+
+		// And AuthMethod=password with EMPTY Password is the same shape.
+		emptyPw := &credential.Credential{
+			Username:   "owadmin",
+			AuthMethod: credential.AuthPassword,
+			Password:   "",
+		}
+		exec2 := &stubExec{
+			outcomes: map[string]execResult{
+				"sudo -n true": {code: 1, err: errors.New("exit 1")},
+			},
+		}
+		probe2 := Probe(
+			stubResolver{cred: emptyPw},
+			WithPolicyLoader(stubPolicy{cfg: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true}}),
+			WithDialer(&stubDialer{exec: exec2}),
+		)
+		_, ok2, _ := probe2(context.Background(), hostID, "192.0.2.1:22", 2*time.Second)
+		if ok2 {
+			t.Errorf("empty password: want ok=false, got true")
+		}
+		if exec2.callCount() != 1 {
+			t.Errorf("empty password: want 1 call, got %d", exec2.callCount())
+		}
+	})
+}
+
+// @ac AC-21
+// AC-21 (sshprivilege half): sudo -n succeeds → fallback path MUST NOT
+// execute even with policy + password available. Negative invariant.
+func TestPrivilegeProbe_NoFallbackOnSudoNSuccess(t *testing.T) {
+	t.Run("system-ssh-connectivity/AC-21", func(t *testing.T) {
+		hostID := liveness.HostID(uuid.Must(uuid.NewV7()).String())
+
+		exec := &stubExec{
+			outcomes: map[string]execResult{
+				"sudo -n true": {code: 0}, // NOPASSWD host
+			},
+		}
+		probe := Probe(
+			stubResolver{cred: validCred()},
+			WithPolicyLoader(stubPolicy{cfg: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true}}),
+			WithDialer(&stubDialer{exec: exec}),
+		)
+		_, ok, err := probe(context.Background(), hostID, "192.0.2.1:22", 2*time.Second)
+		if !ok {
+			t.Errorf("ok: want true (sudo -n succeeded), got false; err=%v", err)
+		}
+		if exec.callCount() != 1 {
+			t.Errorf("call count: want 1 (sudo -n succeeded; no fallback), got %d", exec.callCount())
+		}
+	})
+}

--- a/app/specs/system/host-discovery.spec.yaml
+++ b/app/specs/system/host-discovery.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-host-discovery
   title: Host OS fingerprint discovery via SSH
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -149,7 +149,7 @@ spec:
       priority: high
       references_constraints: [C-01]
     - id: AC-05
-      description: 'discovery.Discover with a credential whose user lacks sudo on a host where firewall introspection requires root returns the SystemFacts populated from the world-readable probes (os, kernel, meminfo, df, hostname) with empty FirewallStatus / FirewallService fields and a NIL error. The probe-level missing-sudo case is a partial success, not a hard failure.'
+      description: 'discovery.Discover with a credential whose user lacks sudo on a host where firewall introspection requires root returns the SystemFacts populated from the world-readable probes (os, kernel, meminfo, df, hostname) with empty FirewallStatus / FirewallService fields and a NIL error. v1.2.0 — when systemconfig.SecurityConfig.AllowCredentialSudoPassword is true AND the credential carries a non-empty Password, discovery.probeFirewall MUST first retry the failing sudo -n firewall command via the sudo -S -k -p '''' fallback per system-ssh-connectivity v1.2.0 C-09 / AC-20 before falling through to the next firewall service or returning partial success.'
       priority: critical
       references_constraints: [C-03]
     - id: AC-06

--- a/app/specs/system/ssh-connectivity.spec.yaml
+++ b/app/specs/system/ssh-connectivity.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-ssh-connectivity
   title: SSH connectivity check against resolved credentials
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -63,7 +63,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-09
-      description: When the collector or discovery probe issues a sudo command via ssh.RunSudo and the initial `sudo -n` returns non-zero, the dial layer MAY retry that command as `sudo -S -k -p '' <cmd>` ONLY when ALL of these hold — (a) systemconfig.SecurityConfig.AllowCredentialSudoPassword is true, (b) cred.AuthMethod ∈ {password, both}, (c) cred.Password is non-empty. Any one condition false → no retry; the original sudo -n failure propagates with usedFallback=false.
+      description: 'v1.2.0 — The credential-password sudo fallback applies to EVERY SSH-using subsystem that issues a sudo command, namely: (1) the compliance collector via ssh.RunSudo, (2) the liveness privilege probe in internal/sshprivilege, (3) OS discovery firewall queries in internal/intelligence/discovery. When the initial `sudo -n <cmd>` returns non-zero, the call site MAY retry as `sudo -S -k -p '' <cmd>` ONLY when ALL of these hold — (a) systemconfig.SecurityConfig.AllowCredentialSudoPassword is true, (b) cred.AuthMethod ∈ {password, both}, (c) cred.Password is non-empty. Any one condition false → no retry; the original sudo -n failure propagates with usedFallback=false. The conditions and the retry shape are IDENTICAL across the three call sites — drift between them is forbidden.'
       type: security
       enforcement: error
     - id: C-10
@@ -145,3 +145,19 @@ spec:
       description: Stub returns exit 1 for sudo -n then exit 1 for sudo -S -k (wrong password). ssh.RunSudo issues exactly ONE sudo -S -k call (no internal retry); usedFallback=true; the returned exit code matches the failing fallback. The -k flag is present in the fallback cmd string so the host-side sudo timestamp cache is invalidated, protecting against pam_tally2 / pam_faillock lockout.
       priority: critical
       references_constraints: [C-11]
+    - id: AC-18
+      description: 'v1.2.0 — Liveness privilege probe parity. A stubbed SSH session returns exit 1 for `sudo -n true` then exit 0 for `sudo -S -k -p '''' true` with the credential password fed via stdin. With AllowCredentialSudoPassword=true and a credential carrying a non-empty Password, internal/sshprivilege.Probe returns ok=true. With the policy off (false) the probe returns ok=false and issues no sudo -S call.'
+      priority: critical
+      references_constraints: [C-09, C-10, C-11]
+    - id: AC-19
+      description: 'v1.2.0 — Liveness privilege probe — credential cannot supply a password. cred.AuthMethod=ssh_key with empty cred.Password and AllowCredentialSudoPassword=true. The probe MUST NOT issue any sudo -S call (no Password to feed); the sudo -n exit 1 propagates as ok=false.'
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-20
+      description: 'v1.2.0 — OS discovery firewall parity. A stubbed SSH session returns exit 1 for `sudo -n ufw status` then exit 0 for `sudo -S -k -p '''' ufw status` (with active output) when fed the password via stdin. With policy on + password, discovery.probeFirewall returns service="ufw", status="active". With policy off or no password, the helper returns ok=false from this attempt (existing fall-through to the next firewall remains).'
+      priority: critical
+      references_constraints: [C-09, C-10, C-11]
+    - id: AC-21
+      description: 'v1.2.0 — Negative invariant across all three sites: a sudo -n exit 0 MUST NOT trigger the fallback. Source-walk asserts that the three call sites (ssh.RunSudo, sshprivilege.Probe, discovery.probeFirewall) all gate the sudo -S retry behind a non-zero exit code from sudo -n and a runtime policy/credential check.'
+      priority: high
+      references_constraints: [C-09, C-12]


### PR DESCRIPTION
## Summary

Closes the gap surfaced by the four Degraded hosts on this fleet (`owas-ub22 / ub24 / ub26 / rhl10`). The user `owadmin` is a sudo user on those hosts but has no `NOPASSWD` entry, so the liveness privilege probe (`sudo -n true`) always fails — even though the credential carries a usable password.

PR #460 added the `sudo -S` password fallback for the **scan** path only. This PR extends the same fallback (identical gating, identical retry shape) to the **liveness privilege probe** and the **discovery firewall queries**.

With `AllowCredentialSudoPassword=true` in `system_config.security`, those four hosts will return to **Online**.

## Spec amendments

- **`system-ssh-connectivity` v1.1.0 → v1.2.0** — C-09 widened to enumerate all three call sites with identical gating + retry shape. 4 new ACs (AC-18, AC-19, AC-20, AC-21).
- **`system-host-discovery` v1.1.0 → v1.2.0** — AC-05 extended to describe the sudo -S retry that v1.2.0 layers in before the partial-success fall-through.

## Backend changes

- `internal/sshprivilege/privilege.go` — Dialer + SessionExecutor seams + `WithPolicyLoader` / `WithDialer` options. Production path unchanged; tests stub the seams.
- `internal/intelligence/discovery/helpers.go` — new `runSudoWithFallback` helper + `sudoFallbackConfig`. Five sudo-prefixed firewall attempts route through it.
- `internal/intelligence/discovery/discovery.go` — new PolicyLoader seam + `WithPolicyLoader`; `discoverWithTransport` loads `SecurityConfig` per call (best-effort).
- `cmd/openwatch/main.go` — wires `cfgStore` as the policy loader for both `sshprivilege.Probe` and `discovery.NewService`.

## Tests

6 new tests, all green; no fixtures, no real SSH:

| AC | Location | What it pins |
|----|----------|----|
| AC-18 | sshprivilege | `sudo -n` fails → policy on + password → fallback succeeds; policy off → no fallback |
| AC-19 | sshprivilege | No password (ssh_key or empty) → fallback NEVER engages |
| AC-20 | discovery | `sudo -n ufw status` fails → fallback feeds password via stdin → ufw active |
| AC-20 | discovery | Policy off → no fallback issued, even with password available |
| AC-21 | sshprivilege | Negative invariant: `sudo -n` success skips fallback |
| AC-21 | discovery | Same negative invariant on the firewall path |

## Test plan

- [ ] After merge: set `system_config.security.allow_credential_sudo_password = true`
- [ ] Restart the backend
- [ ] Watch `host_liveness.monitoring_state` for the 4 hosts → expect Online within one tick

## Verification

```
go vet ./...                                     PASS
go build ./...                                   PASS
go test ./internal/sshprivilege/                 PASS  (3 new)
go test ./internal/intelligence/discovery/       PASS  (3 new)
go test ./internal/ssh/                          PASS  (no regressions)
go test ./internal/liveness/                     PASS  (no regressions)
specter check                                    70/70 PASS
specter coverage                                 system-ssh-connectivity 21/21
                                                 system-host-discovery 15/15
```