### PR TITLE
fix(sshprivilege): dial offers both key + password when AuthMethod=both

### DIFF
--- a/app/internal/sshprivilege/privilege.go
+++ b/app/internal/sshprivilege/privilege.go
@@ -190,9 +190,14 @@ func canFallback(ctx context.Context, loader PolicyLoader, cred *credential.Cred
 type realDialer struct{}
 
 func (realDialer) Dial(_ context.Context, cred *credential.Credential, addr string, timeout time.Duration) (SessionExecutor, error) {
+	methods, merr := buildAuthMethods(cred)
+	if merr != nil {
+		return nil, merr
+	}
 	cfg := &ssh.ClientConfig{
 		User:    cred.Username,
 		Timeout: timeout,
+		Auth:    methods,
 		// #nosec G106 -- this probe answers "would sudo work
 		// today?" and is decoupled from compliance scans. Host-key
 		// pinning belongs on the real scan path (internal/ssh's
@@ -201,24 +206,51 @@ func (realDialer) Dial(_ context.Context, cred *credential.Credential, addr stri
 		// the cross-cutting coupling we kept out of the package.
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
-	switch cred.AuthMethod {
-	case credential.AuthSSHKey, credential.AuthBoth:
-		signer, perr := parseSigner(cred)
-		if perr != nil {
-			return nil, perr
-		}
-		cfg.Auth = []ssh.AuthMethod{ssh.PublicKeys(signer)}
-	case credential.AuthPassword:
-		cfg.Auth = []ssh.AuthMethod{ssh.Password(cred.Password)}
-	default:
-		return nil, fmt.Errorf("unknown auth method %q", cred.AuthMethod)
-	}
 
 	client, derr := ssh.Dial("tcp", addr, cfg)
 	if derr != nil {
 		return nil, derr
 	}
 	return &realSession{client: client}, nil
+}
+
+// buildAuthMethods translates the resolved credential into the ssh
+// auth-method list crypto/ssh will try in order. For AuthBoth we offer
+// BOTH the public key AND the password so a host that rejects the key
+// (e.g. a sudoer where /home was mounted but ~/.ssh/authorized_keys is
+// stale) still falls back to password auth. Returning a key-only list
+// for AuthBoth was the dialer bug behind the post-v1.2.0 regression
+// where the probe never made it past handshake on password-fallback
+// hosts.
+func buildAuthMethods(cred *credential.Credential) ([]ssh.AuthMethod, error) {
+	switch cred.AuthMethod {
+	case credential.AuthSSHKey:
+		signer, perr := parseSigner(cred)
+		if perr != nil {
+			return nil, perr
+		}
+		return []ssh.AuthMethod{ssh.PublicKeys(signer)}, nil
+	case credential.AuthPassword:
+		return []ssh.AuthMethod{ssh.Password(cred.Password)}, nil
+	case credential.AuthBoth:
+		var methods []ssh.AuthMethod
+		if cred.PrivateKey != "" {
+			signer, perr := parseSigner(cred)
+			if perr != nil {
+				return nil, perr
+			}
+			methods = append(methods, ssh.PublicKeys(signer))
+		}
+		if cred.Password != "" {
+			methods = append(methods, ssh.Password(cred.Password))
+		}
+		if len(methods) == 0 {
+			return nil, fmt.Errorf("auth method 'both' but credential carries neither key nor password")
+		}
+		return methods, nil
+	default:
+		return nil, fmt.Errorf("unknown auth method %q", cred.AuthMethod)
+	}
 }
 
 type realSession struct {

--- a/app/internal/sshprivilege/privilege_test.go
+++ b/app/internal/sshprivilege/privilege_test.go
@@ -263,6 +263,115 @@ func TestPrivilegeProbe_PasswordFallback_NoPassword_NoSecondCall(t *testing.T) {
 	})
 }
 
+// TestBuildAuthMethods covers the realDialer's auth-method construction
+// for every credential.AuthMethod branch. AuthBoth is the regression
+// guard: the dialer must offer BOTH PublicKeys AND Password so a host
+// where the key isn't authorized still falls back to password auth.
+// The prior bug returned a key-only list for AuthBoth, leaving hosts
+// stuck on "unable to authenticate, attempted methods [none publickey]"
+// even though their credential carried a valid password.
+func TestBuildAuthMethods(t *testing.T) {
+	keyPEM := testEd25519PEM(t)
+
+	t.Run("AuthSSHKey returns one method", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthSSHKey,
+			PrivateKey: keyPEM,
+		}
+		methods, err := buildAuthMethods(cred)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got := len(methods); got != 1 {
+			t.Errorf("methods: want 1, got %d", got)
+		}
+	})
+
+	t.Run("AuthPassword returns one method", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthPassword,
+			Password:   "p",
+		}
+		methods, err := buildAuthMethods(cred)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got := len(methods); got != 1 {
+			t.Errorf("methods: want 1, got %d", got)
+		}
+	})
+
+	t.Run("AuthBoth with key+password returns BOTH methods (regression guard)", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthBoth,
+			PrivateKey: keyPEM,
+			Password:   "p",
+		}
+		methods, err := buildAuthMethods(cred)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got := len(methods); got != 2 {
+			t.Errorf("methods: want 2 (PublicKeys + Password), got %d -- this is the dialer bug from post-v1.2.0 regression", got)
+		}
+	})
+
+	t.Run("AuthBoth with key only returns one method", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthBoth,
+			PrivateKey: keyPEM,
+		}
+		methods, err := buildAuthMethods(cred)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got := len(methods); got != 1 {
+			t.Errorf("methods: want 1 (PublicKeys), got %d", got)
+		}
+	})
+
+	t.Run("AuthBoth with password only returns one method", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthBoth,
+			Password:   "p",
+		}
+		methods, err := buildAuthMethods(cred)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got := len(methods); got != 1 {
+			t.Errorf("methods: want 1 (Password), got %d", got)
+		}
+	})
+
+	t.Run("AuthBoth with neither key nor password errors", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthBoth,
+		}
+		_, err := buildAuthMethods(cred)
+		if err == nil {
+			t.Errorf("err: want non-nil for empty AuthBoth credential")
+		}
+	})
+
+	t.Run("unknown AuthMethod errors", func(t *testing.T) {
+		cred := &credential.Credential{
+			Username:   "u",
+			AuthMethod: credential.AuthMethod("bogus"),
+		}
+		_, err := buildAuthMethods(cred)
+		if err == nil {
+			t.Errorf("err: want non-nil for unknown auth method")
+		}
+	})
+}
+
 // @ac AC-21
 // AC-21 (sshprivilege half): sudo -n succeeds → fallback path MUST NOT
 // execute even with policy + password available. Negative invariant.


### PR DESCRIPTION
## Summary

Fast-follow on #469. PR #469 added the v1.2.0 `sudo -S -k -p ''` fallback to `internal/sshprivilege.Probe`, but a latent bug in that package's standalone `realDialer` prevented the retry from ever firing on `AuthMethod=both` credentials: the dialer returned a **key-only** `ssh.AuthMethod` list when AuthBoth was the auth method, so the SSH handshake failed with `unable to authenticate, attempted methods [none publickey]` before the probe could even reach `sudo -n true`.

- The shared connectivity dialer at `internal/ssh/dial.go#authMethodsFor` already does the right thing (appends PublicKeys when `cred.PrivateKey != ""` and Password when `cred.Password != ""`, ignoring `AuthMethod`). The bug was confined to the `sshprivilege` package's own `realDialer`.
- Fix: extract `buildAuthMethods` so AuthBoth now offers **both** PublicKeys AND Password (in that order) when the credential carries both; falls back to whichever single method is populated when only one is set; errors when neither is set.
- Debug logging used to diagnose the issue has been removed.

## Why it matters

Without this fix, every host using `AuthMethod=both` credentials (the recommended setup for mixed fleets where the SSH key may or may not be authorized but the user always has a password) silently fell out of the privilege probe path. Hosts owas-rhl10/ub22/ub24/ub26 in the local fleet stayed Degraded for hours after #469 deployed; with this fix all four returned to Online after 3 consecutive probes.

## Test plan

- [x] `go test ./internal/sshprivilege/... -count=1` — full package passes
- [x] `TestBuildAuthMethods` — 7 subtests covering AuthSSHKey, AuthPassword, AuthBoth (key+pw, key only, pw only, neither), and unknown AuthMethod. The AuthBoth+key+pw case is the explicit regression guard for this bug.
- [x] `gofmt -l`, `go vet`, `specter check`, `specter coverage` (70 specs, 100%)
- [x] Live verification: applied fix to dev server, all 4 previously-Degraded hosts (`owas-rhl10/ub22/ub24/ub26`) transitioned to `online` after 3 consecutive successes.

## No spec amendment

`system-ssh-connectivity` describes the connectivity-layer dialer at `internal/ssh/dial.go` which always handled this correctly. The `sshprivilege` package's standalone dialer is an implementation detail with no explicit AC. The new unit tests are the durable guard.