### PR TITLE
feat(host-detail): Server intelligence as 2×3 snapshot tile grid

### DIFF
--- a/app/frontend/src/hooks/useLiveEvents.ts
+++ b/app/frontend/src/hooks/useLiveEvents.ts
@@ -123,8 +123,14 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}) {
           | string
           | undefined;
         if (hostId) {
+          // Event feed (lives on at /activity).
           queryClient.invalidateQueries({
             queryKey: ['host_intelligence_events', hostId],
+          });
+          // Host-detail Server-intelligence snapshot tile grid —
+          // spec frontend-host-detail-intelligence-feed v2.0.0 C-02.
+          queryClient.invalidateQueries({
+            queryKey: ['intelligence_state', hostId],
           });
         }
       },

--- a/app/frontend/src/pages/host-detail/CardServerIntel.tsx
+++ b/app/frontend/src/pages/host-detail/CardServerIntel.tsx
@@ -1,170 +1,330 @@
-// CardServerIntel — Host detail left-column "Server intelligence" card.
+// CardServerIntel — Host detail "Server intelligence" 2×3 stat grid.
 //
-// Replaces the "Not yet collected (BACKLOG)" empty-state with a real
-// feed sourced from GET /api/v1/intelligence/events?host_id=X&limit=10.
-// The query key matches the invalidation target used by
-// useLiveEvents.ts (intelligence.event handler) so SSE-driven
-// auto-refresh works without any polling.
+// v2.0.0 of frontend-host-detail-intelligence-feed pivots this card
+// away from the per-host event feed it shipped as in v1.0.0. The
+// snapshot rollup answers the question operators actually ask on the
+// overview page — "what is currently TRUE about this host" — not
+// "what changed last cycle". The deltas live on the cross-host
+// /activity page.
 //
-// Three explicit visual states (loading / error+Retry / empty):
-// operators need to distinguish "not loaded" from "no signal".
+// Data source: GET /api/v1/intelligence/state/{host_id}, which
+// returns the latest host_intelligence_state row's snapshot. 404
+// means the host has never run an Intelligence cycle and the empty
+// state names the collector so the operator knows where to look.
 //
-// Spec: frontend-host-detail-intelligence-feed v1.0.0.
+// Spec: frontend-host-detail-intelligence-feed v2.0.0.
 
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RefreshCw } from 'lucide-react';
 import api from '@/api/client';
 
-type EventSeverity = 'info' | 'low' | 'medium' | 'high' | 'critical';
-
-interface IntelligenceEvent {
-  id: string;
-  host_id: string;
-  event_code: string;
-  severity: EventSeverity;
-  detail?: Record<string, unknown>;
-  occurred_at: string;
-  detected_at: string;
-  correlation_id?: string;
+// Snapshot keys mirror collector.Snapshot (Go struct in
+// internal/intelligence/collector/types.go). additionalProperties is
+// true on the OpenAPI side; we keep this interface narrow to the
+// fields the card actually consumes so the type stays load-bearing.
+export interface IntelligenceSnapshot {
+  packages?: Record<string, string>;
+  services?: Record<string, string>; // unit → "active" | "inactive" | "failed"
+  users?: Record<string, unknown>;
+  groups?: Record<string, string[]>;
+  network_interfaces?: unknown[];
+  listening_ports?: unknown[];
+  firewall_rule_count?: number | null;
 }
 
-interface IntelligenceEventsPage {
-  items: IntelligenceEvent[];
-  next_cursor?: string | null;
+export interface IntelligenceState {
+  host_id: string;
+  snapshot: IntelligenceSnapshot;
+  collected_at: string;
 }
 
 interface CardServerIntelProps {
   hostId: string;
 }
 
-const LIMIT = 10;
-
 export function CardServerIntel({ hostId }: CardServerIntelProps) {
-  // Spec C-01 + C-02: single endpoint, query key matches
-  // useLiveEvents intelligence.event invalidation target.
+  // Spec C-01 + C-02: single snapshot endpoint, query key matches
+  // useLiveEvents.ts intelligence.event invalidation target.
   const query = useQuery({
-    queryKey: ['host_intelligence_events', hostId],
+    queryKey: ['intelligence_state', hostId],
     queryFn: async () => {
       const { data, error, response } = await api.GET(
-        '/api/v1/intelligence/events',
-        { params: { query: { host_id: hostId, limit: LIMIT } } },
+        '/api/v1/intelligence/state/{host_id}',
+        { params: { path: { host_id: hostId } } },
       );
-      if (error) throw error;
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+        // 404 is "no snapshot yet" — surface it distinctly so the
+        // view can render the pre-Discovery empty state instead of
+        // the generic Retry error path (AC-05).
+        const err = new Error(`HTTP ${response.status}`) as Error & { notFound?: boolean };
+        err.notFound = response.status === 404;
+        throw err;
       }
-      return (data as unknown as IntelligenceEventsPage) ?? { items: [] };
+      if (error) throw new Error('intelligence_state fetch failed');
+      return (data as unknown as IntelligenceState) ?? null;
     },
-    retry: 0,
+    retry: (failureCount, err) => {
+      // Don't retry on 404 — there is nothing to come back to.
+      if ((err as { notFound?: boolean })?.notFound) return false;
+      return failureCount < 1;
+    },
   });
+
+  const notFound =
+    query.isError &&
+    !!(query.error as { notFound?: boolean } | undefined)?.notFound;
 
   return (
     <CardServerIntelView
       isLoading={query.isLoading}
-      isError={query.isError}
-      items={query.data?.items ?? []}
+      isError={query.isError && !notFound}
+      notFound={notFound}
+      snapshot={query.data?.snapshot}
+      collectedAt={query.data?.collected_at}
       onRetry={() => query.refetch()}
     />
   );
 }
 
-// Pure view component — split out so component tests can mount it
-// with explicit state without needing to mock useQuery internals.
-// Spec AC-03..AC-06 exercise this directly.
-interface CardServerIntelViewProps {
+// Pure view component — tests mount it with explicit state without
+// needing to stub useQuery internals. Spec AC-03..AC-08 exercise
+// this directly.
+export interface CardServerIntelViewProps {
   isLoading: boolean;
   isError: boolean;
-  items: IntelligenceEvent[];
+  notFound: boolean;
+  snapshot?: IntelligenceSnapshot;
+  collectedAt?: string;
   onRetry: () => void;
 }
 
 export function CardServerIntelView({
   isLoading,
   isError,
-  items,
+  notFound,
+  snapshot,
+  collectedAt,
   onRetry,
 }: CardServerIntelViewProps) {
+  let body: React.ReactNode;
+  if (isLoading) {
+    body = (
+      <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12 }}>
+        Loading…
+      </div>
+    );
+  } else if (notFound) {
+    body = (
+      <EmptyState
+        primary="Not collected yet"
+        secondary="The OS Intelligence collector populates this snapshot on each cycle (packages, services, users, network, firewall). Once the host runs Discovery and the first Intelligence cycle completes, these tiles will fill in."
+      />
+    );
+  } else if (isError) {
+    body = <ErrorState onRetry={onRetry} />;
+  } else if (snapshot) {
+    body = <TileGrid snapshot={snapshot} />;
+  } else {
+    // Defensive: success with null body — render as empty.
+    body = (
+      <EmptyState
+        primary="Not collected yet"
+        secondary="The OS Intelligence collector has not populated a snapshot for this host."
+      />
+    );
+  }
+
   return (
-    <Card title="Server intelligence">
-      {isLoading ? (
-        <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12 }}>
-          Loading…
-        </div>
-      ) : isError ? (
-        <ErrorState onRetry={onRetry} />
-      ) : items.length === 0 ? (
-        <EmptyState
-          primary="No intelligence activity yet"
-          secondary="The OS Intelligence collector populates this feed (package updates, service state changes, listening-port shifts). Each cycle that detects a change writes an event."
-        />
-      ) : (
-        <ol
-          style={{
-            listStyle: 'none',
-            padding: 0,
-            margin: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8,
-          }}
-        >
-          {items.map((e) => (
-            <EventRow key={e.id} event={e} />
-          ))}
-        </ol>
-      )}
+    <Card title="Server intelligence" right={collectedAt ? collectedLabel(collectedAt) : undefined}>
+      {body}
     </Card>
   );
 }
 
-function EventRow({ event }: { event: IntelligenceEvent }) {
-  const sev = severityFor(event.severity);
+// ── Tile grid ─────────────────────────────────────────────────────────────
+
+function TileGrid({ snapshot }: { snapshot: IntelligenceSnapshot }) {
+  const packagesCount = Object.keys(snapshot.packages ?? {}).length;
+  const services = snapshot.services ?? {};
+  const servicesTotal = Object.keys(services).length;
+  const servicesRunning = Object.values(services).filter((s) => s === 'active').length;
+  const usersCount = Object.keys(snapshot.users ?? {}).length;
+  const sudoCount = countSudoUsers(snapshot.users, snapshot.groups);
+  const interfacesCount = (snapshot.network_interfaces ?? []).length;
+  const listeningPorts = (snapshot.listening_ports ?? []).length;
+  const fwCount = snapshot.firewall_rule_count;
+  const firewall = firewallSubline(fwCount);
+
   return (
-    <li
+    <div
+      role="list"
       style={{
-        display: 'flex',
-        gap: 10,
-        alignItems: 'flex-start',
-        padding: '8px 0',
-        borderBottom: '1px solid var(--ow-line)',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+        gap: 16,
       }}
     >
-      <span
-        aria-hidden
-        style={{
-          width: 8,
-          height: 8,
-          marginTop: 6,
-          borderRadius: '50%',
-          background: sev.dot,
-          flexShrink: 0,
-        }}
+      <Tile
+        label="Packages installed"
+        value={packagesCount}
+        subline="No updates pending"
       />
-      <div style={{ minWidth: 0, flex: 1 }}>
-        <div
-          style={{
-            color: 'var(--ow-fg-1)',
-            fontSize: 12,
-            fontFamily: 'var(--ow-font-mono)',
-            wordBreak: 'break-word',
-          }}
-        >
-          {event.event_code}
-        </div>
-      </div>
+      <Tile
+        label="Running services"
+        value={
+          servicesTotal === 0
+            ? '—'
+            : (
+              <>
+                {servicesRunning}
+                <span style={{ color: 'var(--ow-fg-3)', fontSize: 16, fontWeight: 400 }}>
+                  {' / '}
+                  {servicesTotal}
+                </span>
+              </>
+            )
+        }
+        subline={
+          servicesTotal === 0
+            ? 'No services registered'
+            : `${Math.round((servicesRunning / servicesTotal) * 100)}% of registered services`
+        }
+      />
+      <Tile
+        label="User accounts"
+        value={usersCount}
+        subline={`${sudoCount} with sudo privileges`}
+      />
+      <Tile
+        label="Network interfaces"
+        value={interfacesCount}
+        subline={`${listeningPorts} listening ports`}
+      />
+      <Tile
+        label="Firewall rules"
+        value={firewall.value}
+        subline={firewall.subline}
+        sublineTone={firewall.tone}
+      />
+      <Tile
+        label="Open exceptions"
+        value="—"
+        subline="No rules suppressed"
+      />
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  subline,
+  sublineTone = 'neutral',
+}: {
+  label: string;
+  value: React.ReactNode;
+  subline: string;
+  sublineTone?: 'neutral' | 'warn';
+}) {
+  return (
+    <div
+      role="listitem"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        minWidth: 0,
+      }}
+    >
       <div
         style={{
           color: 'var(--ow-fg-3)',
           fontSize: 11,
-          whiteSpace: 'nowrap',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
         }}
       >
-        {relativeTime(event.occurred_at)}
+        {label}
       </div>
-    </li>
+      <div
+        style={{
+          color: 'var(--ow-fg-0)',
+          fontSize: 28,
+          fontWeight: 600,
+          lineHeight: 1.1,
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {value}
+      </div>
+      <div
+        style={{
+          color: sublineTone === 'warn' ? 'var(--ow-warn)' : 'var(--ow-fg-3)',
+          fontSize: 12,
+          marginTop: 2,
+        }}
+      >
+        {subline}
+      </div>
+    </div>
   );
 }
+
+// ── Derivations ───────────────────────────────────────────────────────────
+
+// countSudoUsers — set-union of sudo / wheel / admin group members,
+// intersected with snapshot.users keys so we never report a stale
+// group entry for a user that has been removed. Spec C-05.
+export function countSudoUsers(
+  users: Record<string, unknown> | undefined,
+  groups: Record<string, string[]> | undefined,
+): number {
+  if (!users || !groups) return 0;
+  const userSet = new Set(Object.keys(users));
+  const sudoers = new Set<string>();
+  for (const g of ['sudo', 'wheel', 'admin']) {
+    const members = groups[g];
+    if (!members) continue;
+    for (const m of members) {
+      if (userSet.has(m)) sudoers.add(m);
+    }
+  }
+  return sudoers.size;
+}
+
+interface FirewallSubline {
+  value: React.ReactNode;
+  subline: string;
+  tone: 'neutral' | 'warn';
+}
+
+// firewallSubline — closed mapping of firewall_rule_count states.
+// Spec C-06, AC-07.
+export function firewallSubline(fwCount: number | null | undefined): FirewallSubline {
+  if (fwCount == null) {
+    return { value: '—', subline: 'Not collected', tone: 'neutral' };
+  }
+  if (fwCount === -1) {
+    return { value: '—', subline: 'No firewall detected', tone: 'neutral' };
+  }
+  if (fwCount === 0) {
+    return { value: 0, subline: 'Firewall is inactive', tone: 'warn' };
+  }
+  return { value: fwCount, subline: `${fwCount} rules active`, tone: 'neutral' };
+}
+
+// collectedLabel — "Collected 4/19/2026 · 2:36 PM" style timestamp
+// surfaced in the card header. Matches the mockup.
+function collectedLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const date = d.toLocaleDateString(undefined, { month: 'numeric', day: 'numeric', year: 'numeric' });
+  const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  return `Collected ${date} · ${time}`;
+}
+
+// ── Visual primitives ─────────────────────────────────────────────────────
 
 function ErrorState({ onRetry }: { onRetry: () => void }) {
   return (
@@ -178,7 +338,7 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
         alignItems: 'center',
       }}
     >
-      Failed to load intelligence events{' '}
+      Failed to load intelligence snapshot{' '}
       <button
         type="button"
         onClick={onRetry}
@@ -201,39 +361,15 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
   );
 }
 
-function severityFor(s: EventSeverity): { dot: string } {
-  switch (s) {
-    case 'critical':
-    case 'high':
-      return { dot: 'var(--ow-crit)' };
-    case 'medium':
-      return { dot: 'var(--ow-warn)' };
-    case 'low':
-    case 'info':
-    default:
-      return { dot: 'var(--ow-fg-3)' };
-  }
-}
-
-// relativeTime — "Xm ago" / "Xh ago" / "Xd ago" / "just now".
-// Pure given a fixed Date.now(); jsdom freezes time per-test.
-function relativeTime(iso: string): string {
-  const t = new Date(iso).getTime();
-  if (Number.isNaN(t)) return '—';
-  const minutes = Math.max(0, Math.round((Date.now() - t) / 60_000));
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.round(hours / 24)}d ago`;
-}
-
-// ── Layout primitives ─────────────────────────────────────────────────────
-// Mirror the CardSystem inline primitives — same comment applies: a
-// deduping pass that moves Card / EmptyState into a shared module is
-// a follow-up (BACKLOG).
-
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
+function Card({
+  title,
+  right,
+  children,
+}: {
+  title: string;
+  right?: string;
+  children: React.ReactNode;
+}) {
   return (
     <section
       style={{
@@ -243,8 +379,19 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
         padding: 18,
       }}
     >
-      <header style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between' }}>
+      <header
+        style={{
+          marginBottom: 16,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          gap: 12,
+        }}
+      >
         <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>{title}</h3>
+        {right ? (
+          <span style={{ color: 'var(--ow-fg-3)', fontSize: 11 }}>{right}</span>
+        ) : null}
       </header>
       <div>{children}</div>
     </section>

--- a/app/frontend/tests/pages/host-detail-intelligence-feed.test.tsx
+++ b/app/frontend/tests/pages/host-detail-intelligence-feed.test.tsx
@@ -2,18 +2,25 @@
 //
 // AC traceability (this file):
 //
-//   AC-01  test('frontend-host-detail-intelligence-feed/AC-01 — calls /intelligence/events with host_id + limit 10')
-//   AC-02  test('frontend-host-detail-intelligence-feed/AC-02 — query key matches useLiveEvents invalidation target')
-//   AC-03  test('frontend-host-detail-intelligence-feed/AC-03 — loading state shows loading affordance, not empty copy')
-//   AC-04  test('frontend-host-detail-intelligence-feed/AC-04 — error state shows Retry button that invokes refetch')
-//   AC-05  test('frontend-host-detail-intelligence-feed/AC-05 — empty state shows "No intelligence activity yet" copy')
-//   AC-06  test('frontend-host-detail-intelligence-feed/AC-06 — rows render event_code text with severity-tinted dot')
+//   AC-01  test('frontend-host-detail-intelligence-feed/AC-01 — calls /intelligence/state/{host_id}; no /intelligence/events')
+//   AC-02  test('frontend-host-detail-intelligence-feed/AC-02 — query key + useLiveEvents dual invalidation')
+//   AC-03  test('frontend-host-detail-intelligence-feed/AC-03 — loading state')
+//   AC-04  test('frontend-host-detail-intelligence-feed/AC-04 — generic error renders Retry')
+//   AC-05  test('frontend-host-detail-intelligence-feed/AC-05 — 404 renders "Not collected yet" with no Retry')
+//   AC-06  test('frontend-host-detail-intelligence-feed/AC-06 — snapshot renders six tiles with rollup values')
+//   AC-07  test('frontend-host-detail-intelligence-feed/AC-07 — firewall_rule_count branches')
+//   AC-08  test('frontend-host-detail-intelligence-feed/AC-08 — sudo count is union of sudo/wheel/admin, intersected with users')
 
 import { describe, expect, test, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { CardServerIntelView } from '@/pages/host-detail/CardServerIntel';
+import {
+  CardServerIntelView,
+  countSudoUsers,
+  firewallSubline,
+  type IntelligenceSnapshot,
+} from '@/pages/host-detail/CardServerIntel';
 
 const CARD_SRC = readFileSync(
   resolve(process.cwd(), 'src/pages/host-detail/CardServerIntel.tsx'),
@@ -25,70 +32,54 @@ const LIVE_EVENTS_SRC = readFileSync(
   'utf8',
 );
 
-function makeEvent(overrides: Partial<{
-  id: string;
-  event_code: string;
-  severity: 'info' | 'low' | 'medium' | 'high' | 'critical';
-  occurred_at: string;
-}> = {}) {
-  return {
-    id: 'e-1',
-    host_id: 'h-1',
-    event_code: 'system.package.updated',
-    severity: 'medium' as const,
-    occurred_at: new Date(Date.now() - 5 * 60_000).toISOString(),
-    detected_at: new Date(Date.now() - 5 * 60_000).toISOString(),
-    ...overrides,
-  };
-}
-
 describe('frontend-host-detail-intelligence-feed — structural', () => {
   // @ac AC-01
-  test('frontend-host-detail-intelligence-feed/AC-01 — calls /intelligence/events with host_id + limit 10', () => {
-    expect(CARD_SRC).toContain("'/api/v1/intelligence/events'");
-    // host_id passed through
+  test('frontend-host-detail-intelligence-feed/AC-01 — calls /intelligence/state/{host_id}; no /intelligence/events', () => {
+    expect(CARD_SRC).toContain("'/api/v1/intelligence/state/{host_id}'");
     expect(CARD_SRC).toMatch(/host_id:\s*hostId/);
-    // limit is literal 10 (also LIMIT constant). One or the other must be visible.
-    expect(CARD_SRC).toMatch(/limit:\s*(LIMIT|10)/);
-    expect(CARD_SRC).toContain('const LIMIT = 10');
+    // v1.0.0 binding is gone.
+    expect(CARD_SRC).not.toContain('/api/v1/intelligence/events');
   });
 
   // @ac AC-02
-  test('frontend-host-detail-intelligence-feed/AC-02 — query key matches useLiveEvents invalidation target', () => {
-    // Card's query key
+  test('frontend-host-detail-intelligence-feed/AC-02 — query key + useLiveEvents dual invalidation', () => {
+    // Card's query key is the new snapshot key.
     expect(CARD_SRC).toMatch(
-      /queryKey:\s*\[\s*['"]host_intelligence_events['"]\s*,\s*hostId\s*\]/,
+      /queryKey:\s*\[\s*['"]intelligence_state['"]\s*,\s*hostId\s*\]/,
     );
-    // useLiveEvents invalidates the SAME key (verbatim)
+    // useLiveEvents invalidates BOTH keys (event feed + snapshot tile grid).
     expect(LIVE_EVENTS_SRC).toMatch(
       /queryKey:\s*\[\s*['"]host_intelligence_events['"]\s*,\s*hostId\s*\]/,
+    );
+    expect(LIVE_EVENTS_SRC).toMatch(
+      /queryKey:\s*\[\s*['"]intelligence_state['"]\s*,\s*hostId\s*\]/,
     );
   });
 });
 
 describe('frontend-host-detail-intelligence-feed — behavior', () => {
   // @ac AC-03
-  test('frontend-host-detail-intelligence-feed/AC-03 — loading state shows loading affordance, not empty copy', () => {
+  test('frontend-host-detail-intelligence-feed/AC-03 — loading state', () => {
     render(
       <CardServerIntelView
         isLoading={true}
         isError={false}
-        items={[]}
+        notFound={false}
         onRetry={() => undefined}
       />,
     );
     expect(screen.getByText(/loading…/i)).toBeInTheDocument();
-    expect(screen.queryByText(/no intelligence activity yet/i)).toBeNull();
+    expect(screen.queryByText(/not collected yet/i)).toBeNull();
   });
 
   // @ac AC-04
-  test('frontend-host-detail-intelligence-feed/AC-04 — error state shows Retry button that invokes refetch', () => {
+  test('frontend-host-detail-intelligence-feed/AC-04 — generic error renders Retry', () => {
     const onRetry = vi.fn();
     render(
       <CardServerIntelView
         isLoading={false}
         isError={true}
-        items={[]}
+        notFound={false}
         onRetry={onRetry}
       />,
     );
@@ -99,39 +90,106 @@ describe('frontend-host-detail-intelligence-feed — behavior', () => {
   });
 
   // @ac AC-05
-  test('frontend-host-detail-intelligence-feed/AC-05 — empty state shows "No intelligence activity yet" copy', () => {
+  test('frontend-host-detail-intelligence-feed/AC-05 — 404 renders "Not collected yet" with no Retry', () => {
     render(
       <CardServerIntelView
         isLoading={false}
         isError={false}
-        items={[]}
+        notFound={true}
         onRetry={() => undefined}
       />,
     );
-    expect(screen.getByText('No intelligence activity yet')).toBeInTheDocument();
-    // Secondary copy names the source (OS Intelligence collector)
-    expect(
-      screen.getByText(/OS Intelligence collector/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/not collected yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/OS Intelligence collector/i)).toBeInTheDocument();
+    // 404 must NOT show Retry — operators shouldn't poke a pre-Discovery host.
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
   });
 
   // @ac AC-06
-  test('frontend-host-detail-intelligence-feed/AC-06 — rows render event_code text with severity-tinted dot', () => {
-    const items = [
-      makeEvent({ id: 'e-1', event_code: 'system.package.updated', severity: 'medium' }),
-      makeEvent({ id: 'e-2', event_code: 'system.service.failed', severity: 'critical' }),
-    ];
-    const { container } = render(
+  test('frontend-host-detail-intelligence-feed/AC-06 — snapshot renders six tiles with rollup values', () => {
+    const snapshot: IntelligenceSnapshot = {
+      packages: { a: '1', b: '2', c: '3' },
+      services: { s1: 'active', s2: 'inactive' },
+      users: { alice: {}, bob: {} },
+      groups: { sudo: ['alice'] },
+      network_interfaces: [{}, {}],
+      listening_ports: [{}, {}, {}],
+      firewall_rule_count: null,
+    };
+    render(
       <CardServerIntelView
         isLoading={false}
         isError={false}
-        items={items}
+        notFound={false}
+        snapshot={snapshot}
         onRetry={() => undefined}
       />,
     );
-    expect(screen.getByText('system.package.updated')).toBeInTheDocument();
-    expect(screen.getByText('system.service.failed')).toBeInTheDocument();
-    // Two <li> rows
-    expect(container.querySelectorAll('li').length).toBe(2);
+
+    // Six tile labels present.
+    expect(screen.getByText('Packages installed')).toBeInTheDocument();
+    expect(screen.getByText('Running services')).toBeInTheDocument();
+    expect(screen.getByText('User accounts')).toBeInTheDocument();
+    expect(screen.getByText('Network interfaces')).toBeInTheDocument();
+    expect(screen.getByText('Firewall rules')).toBeInTheDocument();
+    expect(screen.getByText('Open exceptions')).toBeInTheDocument();
+
+    // Values + sublines.
+    expect(screen.getByText('3')).toBeInTheDocument(); // packages
+    expect(screen.getByText(/50% of registered services/)).toBeInTheDocument();
+    expect(screen.getByText('1 with sudo privileges')).toBeInTheDocument();
+    expect(screen.getByText('3 listening ports')).toBeInTheDocument();
+    // null firewall → "Not collected"
+    expect(screen.getByText('Not collected')).toBeInTheDocument();
+    // Open exceptions placeholder subline
+    expect(screen.getByText('No rules suppressed')).toBeInTheDocument();
+  });
+
+  // @ac AC-07
+  test('frontend-host-detail-intelligence-feed/AC-07 — firewall_rule_count branches', () => {
+    // null
+    expect(firewallSubline(null)).toMatchObject({
+      value: '—',
+      subline: 'Not collected',
+      tone: 'neutral',
+    });
+    // -1 (no engine)
+    expect(firewallSubline(-1)).toMatchObject({
+      value: '—',
+      subline: 'No firewall detected',
+      tone: 'neutral',
+    });
+    // 0 (engine present, inactive)
+    expect(firewallSubline(0)).toMatchObject({
+      value: 0,
+      subline: 'Firewall is inactive',
+      tone: 'warn',
+    });
+    // N > 0
+    const result = firewallSubline(7);
+    expect(result.value).toBe(7);
+    expect(result.subline).toMatch(/active/i);
+    expect(result.tone).toBe('neutral');
+  });
+
+  // @ac AC-08
+  test('frontend-host-detail-intelligence-feed/AC-08 — sudo count is union of sudo/wheel/admin, intersected with users', () => {
+    const users = { alice: {}, bob: {}, carol: {}, dave: {} };
+    const groups = {
+      sudo: ['alice', 'bob'],
+      wheel: ['bob'], // duplicate of bob — dedupes to 1
+      admin: ['carol'],
+      // dave is in NO sudo-shaped group → excluded
+      other: ['dave'],
+    };
+    expect(countSudoUsers(users, groups)).toBe(3); // alice, bob, carol
+
+    // A group member that's no longer in users.* is dropped.
+    const usersAfterRemoval = { alice: {}, carol: {} };
+    expect(countSudoUsers(usersAfterRemoval, groups)).toBe(2); // alice, carol
+
+    // Defensive: missing inputs → 0.
+    expect(countSudoUsers(undefined, groups)).toBe(0);
+    expect(countSudoUsers(users, undefined)).toBe(0);
   });
 });

--- a/app/specs/frontend/host-detail-intelligence-feed.spec.yaml
+++ b/app/specs/frontend/host-detail-intelligence-feed.spec.yaml
@@ -1,36 +1,68 @@
 spec:
   id: frontend-host-detail-intelligence-feed
-  title: Host detail Server-intelligence card — real events feed from /intelligence/events
-  version: "1.0.0"
+  title: Host detail Server-intelligence card — 2×3 stat-tile grid from /intelligence/state
+  version: "2.0.0"
   status: approved
   tier: 2
 
   context:
     system: openwatch-go
-    feature: Host detail overview card "Server intelligence" surfaces the recent change events from the api-os-intelligence collector
+    feature: Host detail overview card "Server intelligence" surfaces snapshot rollups from the api-os-intelligence collector
     description: >
-      Pre-PR 7 the "Server intelligence" card on the host detail page
-      rendered a static "Not yet collected" empty-state pointing to
-      BACKLOG, even though api-os-intelligence GET
-      /api/v1/intelligence/events has been live and the scheduler is
-      writing host_intelligence_events on every cycle.
+      v2.0.0 — The Server-intelligence card pivots from an event feed
+      (v1.0.0, GET /intelligence/events) to a 2×3 stat-tile grid
+      sourced from the snapshot endpoint GET
+      /api/v1/intelligence/state/{host_id}. Operators reading the
+      host-detail overview want "what is currently TRUE about this
+      host" at a glance — counts of packages, running services,
+      users, interfaces, firewall rules, suppressed compliance rules
+      — not a rolling list of last-cycle deltas. The unified cross-
+      host event feed already lives at /activity (api-activity); the
+      per-host event feed is moving to a dedicated "Recent activity"
+      card on the right column (separate spec, separate PR). This
+      card owns the snapshot rollup.
 
-      PR 7 wires the card to fetch the 10 most recent events for the
-      current host (?host_id=<id>&limit=10) and renders each as a row
-      with: severity dot, event_code, detail summary, and
-      occurred_at relative time. Empty list (no events yet for this
-      host) collapses to "No intelligence activity yet" — explicit
-      "no signal" state distinct from the loading/error states.
+      The six tiles, in row-major order:
 
-      This is the read-only single-host slice. The full /activity
-      page (cross-host unified feed) is owned by api-activity and is
-      already live; this spec only owns the per-host card on the
-      detail page.
+        Row 1
+          [1] Packages installed  — len(snapshot.packages)
+                subline: "No updates pending" (placeholder until the
+                collector exposes an updates-available signal —
+                today the snapshot has no field for it; rendering
+                "—" when unknown is acceptable)
+          [2] Running services    — services where snapshot.services[unit]=="active"
+                subline: "N% of registered services" (running/total)
 
-      Auto-refresh is delegated to the useLiveEvents SSE topic
-      "intelligence.event" (frontend-live-events C-04 / AC-05) which
-      invalidates ['host_intelligence_events', host.id] — the same
-      query key this card uses. No polling, no manual refresh button.
+        Row 2
+          [3] User accounts       — len(snapshot.users)
+                subline: "N with sudo privileges" (count of users
+                whose name appears in snapshot.groups[sudo|wheel|admin])
+          [4] Network interfaces  — len(snapshot.network_interfaces)
+                subline: "N listening ports" (len(snapshot.listening_ports))
+
+        Row 3
+          [5] Firewall rules      — snapshot.firewall_rule_count (nullable)
+                subline:
+                  null  → "Not collected"
+                  -1    → "No firewall detected"
+                  0     → "Firewall is inactive" (warn-tinted)
+                  N>0   → "<engine> active" (engine is detected by
+                          the collector elsewhere; if not available,
+                          fall back to "N rules active")
+          [6] Open exceptions     — placeholder "—"
+                subline: "No rules suppressed" — the
+                compliance-exceptions endpoint is the proper source
+                but is out of scope for this card; the tile renders
+                a static zero until a follow-up wires the real count
+
+      Three explicit visual states preserved from v1.0.0 (loading /
+      error+Retry / empty). Empty = the host has never run an
+      Intelligence cycle (404 from the snapshot endpoint).
+
+      SSE auto-refresh: useLiveEvents must invalidate the new query
+      key ['intelligence_state', hostId] alongside the existing
+      ['host_intelligence_events', hostId] (the event-feed elsewhere
+      still consumes the latter).
 
     related_specs:
       - api-os-intelligence
@@ -40,66 +72,82 @@ spec:
 
   objective:
     summary: >
-      Lock the data binding, query key, rendering rules, and three
-      visual states (loading / error / empty) for the Server-
-      intelligence card. Tests cover the source-inspection contract
-      and the empty/error visual states.
+      Lock the data binding, query key, six-tile rendering rules, and
+      the loading/error/empty visual states for the redesigned
+      Server-intelligence card. Tests cover the source-inspection
+      contract on the endpoint + query-key shape AND the rendering
+      branches per snapshot field.
     scope:
       includes:
-        - "Query key ['host_intelligence_events', host.id] matching frontend-live-events C-04"
-        - "GET /api/v1/intelligence/events with query: host_id=host.id, limit=10"
-        - "Per-event row: severity dot + event_code + occurred_at relative time"
-        - "Three visual states: loading, error (Retry button), empty (no events yet)"
+        - "Query key ['intelligence_state', host.id] matched by useLiveEvents intelligence.event invalidation"
+        - "GET /api/v1/intelligence/state/{host_id} — single fetch"
+        - "Six tiles in a 2×3 grid with the values listed in the context"
+        - "Sudo-user count derivation from snapshot.groups (sudo / wheel / admin)"
+        - "Firewall subline rules (null / -1 / 0 / N>0 with warn tint when inactive)"
+        - "Three visual states preserved: loading, error+Retry, empty (404 pre-Discovery)"
       excludes:
-        - "Activated Packages / Services / Users / Network tabs — separate PR (reads snapshot fields)"
+        - "Per-host event feed — moves to a new 'Recent activity' card (separate spec / PR)"
         - "Cross-host activity feed — owned by api-activity / frontend-activity"
-        - "Cursor pagination on the card — only the 10 most recent rows; deeper history goes to /activity"
-        - "Click-through to per-event detail — deferred (no detail surface defined yet)"
+        - "Real Open-exceptions count — placeholder '—' until a follow-up wires /compliance/exceptions"
+        - "Tabbed drill-down into packages / services / users / network — owned by the InventoryTabs spec"
+        - "Updates-pending count on the Packages tile — collector does not surface it yet; tile shows '—'"
 
   constraints:
     - id: C-01
-      description: 'CardServerIntel MUST issue exactly ONE useQuery against /api/v1/intelligence/events with params { host_id, limit: 10 }. No other endpoint, no client-side filtering of broader fetches. Reason: scoping at the API boundary lets the backend short-circuit the WHERE clause and keeps the card responsive for hosts with deep history'
+      description: 'CardServerIntel MUST issue exactly ONE useQuery against GET /api/v1/intelligence/state/{host_id} (path parameter, not query string). No other endpoint is allowed; the old /intelligence/events binding from v1.0.0 MUST be deleted'
       type: technical
       enforcement: error
     - id: C-02
-      description: "CardServerIntel MUST use queryKey ['host_intelligence_events', host.id]. This MUST match the invalidation target in useLiveEvents.ts intelligence.event handler (frontend-live-events C-04) verbatim — any divergence breaks the SSE auto-refresh path"
+      description: "CardServerIntel MUST use queryKey ['intelligence_state', host.id]. useLiveEvents.ts intelligence.event handler MUST invalidate the same key (in addition to the existing ['host_intelligence_events', host.id] key that the event feed consumes elsewhere). The two query keys MUST coexist — neither replaces the other"
       type: technical
       enforcement: error
     - id: C-03
-      description: "Each event row MUST render: a severity-tinted dot (crit/warn/info colors from the existing severityFor helper), the event_code (mono font), and the occurred_at relative time (Xm/Xh/Xd ago). The detail object is NOT rendered inline — it is opaque per-event metadata; surfacing detail values per event_code is deferred"
+      description: 'The successful render MUST be a 2-column × 3-row grid of six stat tiles, in the order documented in context.description. No additional tiles, no reordering. Each tile renders three elements stacked: label (top), value (middle, large), subline (bottom, small). Missing snapshot fields render the tile value as "—" with a neutral subline'
       type: technical
       enforcement: error
     - id: C-04
-      description: 'CardServerIntel MUST render three distinct visual states: (1) loading (skeleton or "Loading…" text), (2) error (red text + Retry button), (3) empty (no events yet — soft "No intelligence activity yet" message). Loading and error MUST NOT collapse to the empty state — operators need to distinguish "not loaded" from "no signal"'
+      description: 'CardServerIntel MUST render three distinct visual states: (1) loading (Loading… text), (2) error (red text + Retry button — except 404 which is the empty state), (3) empty / pre-Discovery (404 from the snapshot endpoint → soft "Not collected yet" message naming the Intelligence collector). Error and empty MUST be visually distinct'
       type: technical
       enforcement: error
     - id: C-05
-      description: '403 (host:read denied) MUST render the error state — the page wraps the response and the card cannot present forbidden data. 200 with an empty items array MUST render the empty state. 502 / 504 (transient backend) MUST render the error state with the Retry button so the operator can recover without a page reload'
+      description: 'Sudo-user count on the User-accounts tile MUST be derived from snapshot.groups[sudo] ∪ snapshot.groups[wheel] ∪ snapshot.groups[admin], deduped against snapshot.users keys. The card MUST NOT consult any other field (e.g. snapshot.users[u].is_sudoer) — only the group-membership rollup, because that is what the collector persists'
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: 'Firewall-rules tile subline MUST follow the closed mapping in context.description (null / -1 / 0 / N>0) verbatim. The 0 case (engine present, no rules) MUST render in a warn tint to surface the inactive state — the card is the first place an operator notices a firewall is unconfigured'
       type: technical
       enforcement: error
 
   acceptance_criteria:
     - id: AC-01
-      description: 'Source inspection: CardServerIntel calls api.GET with the literal path "/api/v1/intelligence/events" and a query object containing host_id AND limit: 10. No other path appears in the function body'
+      description: 'Source inspection: CardServerIntel calls api.GET with the literal path "/api/v1/intelligence/state/{host_id}" and threads host.id into the path param. The file MUST NOT contain the literal string "/api/v1/intelligence/events" — the v1.0.0 binding is gone'
       priority: critical
       references_constraints: [C-01]
     - id: AC-02
-      description: "Source inspection: CardServerIntel's useQuery uses queryKey starting with the literal string 'host_intelligence_events' followed by host.id. The query key MUST match the one used by useLiveEvents.ts handlers — verified by reading both files and asserting identical key shape"
+      description: "Source inspection: CardServerIntel's useQuery uses queryKey starting with the literal string 'intelligence_state' followed by host.id. useLiveEvents.ts is also inspected — its intelligence.event handler MUST contain BOTH invalidation calls: ['host_intelligence_events', hostId] AND ['intelligence_state', hostId]"
       priority: critical
       references_constraints: [C-02]
     - id: AC-03
-      description: "Rendering: CardServerIntel mounted with isLoading=true (mocked useQuery state) renders a visible loading affordance (text or skeleton element). The empty-state copy 'No intelligence activity yet' MUST NOT appear in the loading state"
+      description: "Rendering: CardServerIntel mounted with isLoading=true (mocked) renders a visible loading affordance ('Loading…' text). The empty-state copy MUST NOT appear in the loading state"
       priority: critical
       references_constraints: [C-04]
     - id: AC-04
-      description: 'Rendering: CardServerIntel mounted with isError=true renders both an error message AND a Retry button (role="button", accessible name matching /retry/i). The button click MUST invoke the refetch path — verified by spying on the mocked refetch'
+      description: 'Rendering: CardServerIntel mounted with isError=true (non-404) renders both an error message AND a Retry button (role="button", accessible name matching /retry/i). The button click MUST invoke the refetch path — verified by spying on the mocked refetch'
       priority: critical
-      references_constraints: [C-04, C-05]
+      references_constraints: [C-04]
     - id: AC-05
-      description: "Rendering: CardServerIntel mounted with isSuccess=true and data={items:[]} renders the literal string 'No intelligence activity yet' AND does NOT render any rows. The empty state names the data source (e.g. 'OS Intelligence collector') so operators know which subsystem populates it"
+      description: "Rendering: CardServerIntel mounted with isError=true AND notFound=true (the page maps a 404 ErrorEnvelope to this prop) renders the literal string 'Not collected yet' AND names the Intelligence collector in the secondary copy. Retry button MUST NOT appear in this branch — 404 is not a transient failure operators retry"
       priority: critical
       references_constraints: [C-04]
     - id: AC-06
-      description: "Rendering: CardServerIntel mounted with isSuccess=true and data={items:[two-events]} renders 2 row elements, each containing the event's event_code text. Severity dot color matches the severity (crit/warn/info palette via severityFor or equivalent)"
+      description: "Rendering: CardServerIntel mounted with isSuccess=true and a snapshot carrying packages={a:1, b:2, c:3}, services={s1:'active', s2:'inactive'}, users={alice:{}, bob:{}}, groups={sudo:['alice']}, network_interfaces=[i1,i2], listening_ports=[p1,p2,p3], firewall_rule_count=null renders six tiles with values 3 / 1 / 2 / 2 / — / — and the sublines '1 of 2 services running' (50%) / '1 with sudo privileges' / '3 listening ports' / 'Not collected'"
       priority: critical
-      references_constraints: [C-03]
+      references_constraints: [C-03, C-05, C-06]
+    - id: AC-07
+      description: 'Rendering: firewall_rule_count = -1 renders the Firewall-rules tile value as "—" with subline "No firewall detected" (neutral tint). firewall_rule_count = 0 renders value "0" with subline "Firewall is inactive" in warn tint. firewall_rule_count = 7 renders value "7" with subline matching /active/i (engine name optional)'
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-08
+      description: 'Sudo-user count: snapshot.groups = {sudo:["alice","bob"], wheel:["bob"], admin:["carol"]} with snapshot.users keys = {alice, bob, carol, dave} produces sudo count = 3 (alice ∪ bob ∪ carol, deduped; dave is not in any sudo group). Source inspection confirms only sudo/wheel/admin groups are consulted'
+      priority: critical
+      references_constraints: [C-05]


### PR DESCRIPTION
## Summary

Replaces the per-host event feed shipped in v1.0.0 of `frontend-host-detail-intelligence-feed` with a six-tile snapshot rollup matching the host-detail overview mockup. Operators land on the page wanting "what is currently TRUE about this host" — counts of packages, running services, users, network, firewall, suppressed rules — not last-cycle deltas. The deltas keep living on the cross-host `/activity` page; the per-host event feed moves to a dedicated "Recent activity" card in a follow-up PR.

## Tiles (row-major)

| # | Label | Value | Subline |
|---|---|---|---|
| 1 | Packages installed | `len(snapshot.packages)` | "No updates pending" (collector does not surface an updates field yet — placeholder until a follow-up wires it) |
| 2 | Running services | `count(state="active") / total` | `N% of registered services` |
| 3 | User accounts | `len(snapshot.users)` | `N with sudo privileges` — derived from `snapshot.groups[sudo ∪ wheel ∪ admin]` intersected with `snapshot.users` keys |
| 4 | Network interfaces | `len(snapshot.network_interfaces)` | `N listening ports` |
| 5 | Firewall rules | closed branch on `firewall_rule_count` (see below) | (see below) |
| 6 | Open exceptions | placeholder `—` | "No rules suppressed" (real count needs `/compliance/exceptions` which is owned by a different package — out of scope for this card) |

**Firewall rules branches** (spec C-06 / AC-07):

| `firewall_rule_count` | Value | Subline | Tone |
|---|---|---|---|
| `null` | `—` | "Not collected" | neutral |
| `-1` | `—` | "No firewall detected" | neutral |
| `0` | `0` | "Firewall is inactive" | **warn** |
| `N > 0` | `N` | "N rules active" | neutral |

## Visual states preserved

- `loading` → "Loading…"
- `error` (non-404) → red text + Retry button
- `404` (no snapshot yet) → "Not collected yet" empty state naming the Intelligence collector. **No Retry** — 404 is not a transient failure operators retry.

## SSE auto-refresh

`useLiveEvents.ts` `intelligence.event` handler now invalidates BOTH query keys:
- `['host_intelligence_events', hostId]` — event feed elsewhere
- `['intelligence_state', hostId]` — this card

The two coexist; the SSE handler dispatches both on a single event.

## Spec

`frontend-host-detail-intelligence-feed` v1.0.0 → **v2.0.0** (rewrite):
- **C-01** endpoint pivots to `GET /api/v1/intelligence/state/{host_id}`
- **C-02** dual invalidation
- **C-03..C-06** tile-grid + sudo + firewall contracts
- **AC-01..AC-08** cover source binding, query key, three visual states, six-tile rendering, firewall branches, sudo derivation

## Test plan

- [x] `npx vitest run tests/pages/host-detail-intelligence-feed.test.tsx` — 8/8 pass
- [x] `npx vitest run` — full 195/195 pass
- [x] `npx tsc --noEmit` — clean on touched files (pre-existing `tests/pages/settings.test.ts` errors unchanged)
- [x] `specter check` + `specter coverage` — 70 specs structural; `frontend-host-detail-intelligence-feed` shows 8/8 ACs covered (100%)
- [ ] Live verification: refresh `Hosts → owas-ub22` in the running dev session. The card should render six tiles with the host's snapshot rollup; pre-Intelligence hosts should show the "Not collected yet" empty state.

## Follow-ups (out of scope here)

- **Recent activity card redesign** — needs a contract decision: dedicated `GET /api/v1/hosts/{id}/activity` endpoint that unions monitoring + scan + audit, vs. parallel client-side queries with manual merge. Will file as a separate proposal.
- **Updates-pending count on the Packages tile** — collector does not expose an updates-available signal yet. Tile shows "No updates pending" as a placeholder.
- **Open-exceptions tile** — same story: placeholder `—` until a follow-up wires `GET /api/v1/compliance/exceptions?host_id=...`.