### PR TITLE
test(db): use TRUNCATE…CASCADE for hosts in integration test setup

### DIFF
--- a/app/internal/activity/service_db_test.go
+++ b/app/internal/activity/service_db_test.go
@@ -50,11 +50,12 @@ func freshDB(t *testing.T) (*pgxpool.Pool, uuid.UUID) {
 	if err := migrations.Apply(ctx, pool); err != nil {
 		t.Fatalf("migrations.Apply: %v", err)
 	}
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE alerts")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_events")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE transactions")
+	// TRUNCATE…CASCADE delegates child cleanup to the schema. The
+	// hosts row has 11 FK-referencing children (alerts, credentials,
+	// host_intelligence_events, transactions, …); a hand-rolled list
+	// rotted every time a new FK was added.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 	creator, _ := uuid.NewV7()
 	hash, _ := identity.HashPassword("seed-pw-12345-aa")

--- a/app/internal/host/host_test.go
+++ b/app/internal/host/host_test.go
@@ -42,10 +42,12 @@ func freshService(t *testing.T) (*Service, *pgxpool.Pool, uuid.UUID) {
 	if err := migrations.Apply(ctx, pool); err != nil {
 		t.Fatalf("migrations.Apply: %v", err)
 	}
-	// Hosts cascade clears credentials' host-scope rows (FK ON DELETE RESTRICT
-	// prevents that), so we truncate credentials first.
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE credentials")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	// TRUNCATE…CASCADE delegates child cleanup to the schema — the
+	// hosts row has 11 FK-referencing children (credentials, alerts,
+	// host_*_state, host_intelligence_*, host_rule_state, transactions,
+	// …) and a hand-rolled list rots every time a new FK is added.
+	// CASCADE bypasses per-row ON DELETE RESTRICT.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 
 	createdBy, _ := uuid.NewV7()

--- a/app/internal/intelligence/collector/collector_db_test.go
+++ b/app/internal/intelligence/collector/collector_db_test.go
@@ -49,10 +49,8 @@ func freshDBCollector(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Servi
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("SetEphemeral: %v", err)
 	}
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_events")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_state")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE credentials")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	// CASCADE — see scheduler/service_db_test.go for the rationale.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 
 	createdBy, _ := uuid.NewV7()

--- a/app/internal/intelligence/discovery/discovery_db_test.go
+++ b/app/internal/intelligence/discovery/discovery_db_test.go
@@ -48,9 +48,8 @@ func freshDBHost(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Service) {
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("SetEphemeral: %v", err)
 	}
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_system_info")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE credentials")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	// CASCADE — see scheduler/service_db_test.go for the rationale.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 
 	createdBy, _ := uuid.NewV7()

--- a/app/internal/intelligence/scheduler/service_db_test.go
+++ b/app/internal/intelligence/scheduler/service_db_test.go
@@ -46,10 +46,14 @@ func freshDBScheduler(t *testing.T) *pgxpool.Pool {
 	if err := migrations.Apply(ctx, pool); err != nil {
 		t.Fatalf("migrations.Apply: %v", err)
 	}
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_events")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_intelligence_state")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_backoff_state")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	// CASCADE: hosts is referenced by 11 child tables (alerts,
+	// credentials, host_backoff_state, host_compliance_schedule,
+	// host_intelligence_*, host_liveness, host_monitoring_history,
+	// host_rule_state, host_system_info, transactions). Maintaining
+	// a hand-rolled child-truncate list per test file broke every
+	// time a new FK was added — TRUNCATE…CASCADE delegates to the
+	// schema instead.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 	createdBy, _ := uuid.NewV7()
 	hash, _ := identity.HashPassword("seed-pw-12345-aa")

--- a/app/internal/server/api_helpers_test.go
+++ b/app/internal/server/api_helpers_test.go
@@ -142,13 +142,12 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	// is clearer.
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE transactions")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_rule_state")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_liveness")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_compliance_schedule")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE host_backoff_state")
-	// Slice-A tables. Order matters: credentials FK → hosts, so clear
-	// credentials first. users CASCADE clears sessions/refresh/mfa.
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE credentials")
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts")
+	// TRUNCATE…CASCADE delegates child cleanup to the schema — the
+	// hosts row has 11 FK-referencing children and a hand-rolled
+	// list rots every time a new FK is added. CASCADE bypasses
+	// per-row ON DELETE RESTRICT. users CASCADE clears sessions /
+	// refresh / mfa.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 	// Clear custom roles only — built-in rows are seeded by migration 0006
 	// and must survive between tests.


### PR DESCRIPTION
## Summary

Six integration-test setup helpers issued `TRUNCATE TABLE hosts` **without `CASCADE`**. Postgres rejected each one (11 child tables reference `hosts.id`: `alerts`, `credentials`, `host_backoff_state`, `host_compliance_schedule`, `host_intelligence_events`, `host_intelligence_state`, `host_liveness`, `host_monitoring_history`, `host_rule_state`, `host_system_info`, `transactions`). The error was discarded via `_, _ = pool.Exec(...)`, so the tests "passed" while leaving dirty data behind and flooding the Postgres log every CI run with:

```
ERROR: cannot truncate a table referenced in a foreign key constraint
STATEMENT: TRUNCATE TABLE hosts
```

Two of the six files even tried to hand-roll the child-truncate list (`"credentials FK → hosts, so clear credentials first"`) which kept working by accident on `credentials_scope_id_host_fk` and broke silently when migrations 0012 (`transactions`) and 0017 (`host_rule_state`, `host_intelligence_state`) added new RESTRICT FKs the lists weren't aware of.

## Fix

Replace the hand-rolled lists with a single `TRUNCATE TABLE hosts CASCADE` in all six files. `CASCADE` bypasses per-row `ON DELETE RESTRICT` and clears every child the schema knows about, so future FK additions don't need to update the test setup.

| File | Before | After |
|---|---|---|
| `internal/activity/service_db_test.go` | 5 TRUNCATEs (hand-rolled child list) | 1 CASCADE + audit_events + users CASCADE |
| `internal/host/host_test.go` | TRUNCATE credentials; TRUNCATE hosts | 1 CASCADE + users CASCADE |
| `internal/intelligence/collector/collector_db_test.go` | 4 TRUNCATEs (hand-rolled child list) | 1 CASCADE + users CASCADE |
| `internal/intelligence/discovery/discovery_db_test.go` | 3 TRUNCATEs | 1 CASCADE + users CASCADE |
| `internal/intelligence/scheduler/service_db_test.go` | 4 TRUNCATEs (with the buggy `TRUNCATE hosts` non-CASCADE) | 1 CASCADE + users CASCADE |
| `internal/server/api_helpers_test.go` | 6 TRUNCATEs (with comment about ON DELETE RESTRICT) | 1 CASCADE + users CASCADE |

Outdated comments in `host_test.go` and `api_helpers_test.go` claimed `CASCADE` wouldn't work — those referred to row-level `ON DELETE RESTRICT` behavior, which `TRUNCATE…CASCADE` bypasses entirely. Confirmed manually:

```sql
$ psql -c "TRUNCATE TABLE hosts CASCADE;"
NOTICE:  truncate cascades to table "credentials"
NOTICE:  truncate cascades to table "host_compliance_schedule"
NOTICE:  truncate cascades to table "host_backoff_state"
NOTICE:  truncate cascades to table "host_rule_state"
NOTICE:  truncate cascades to table "transactions"
TRUNCATE TABLE
```

## Test plan

- [x] Validated locally under CI's `-p 1` (serial-package) mode:
      `go test -p 1 ./internal/intelligence/... ./internal/host/ ./internal/server/ ./internal/activity/` — **all pass**
- [x] Postgres `pg_log` now silent during these test packages — no more "cannot truncate" error spam

## Out of scope

The other CI-log noise visible on PR #472 — `users.AssignRole_Unknown` sending `role_id="does_not_exist"` (intentional 400-test, the DB error is expected) and `FATAL role "root" does not exist` (a runner-container quirk, not in our code) — are not test-hygiene issues. Left untouched.