### PR TITLE
fix(activity): wire service in main + stop crashing on host_id-filtered union

### DIFF
--- a/app/cmd/openwatch/main.go
+++ b/app/cmd/openwatch/main.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/activity"
 	"github.com/Hanalyx/openwatch/internal/alertrouter"
 	stdoutchan "github.com/Hanalyx/openwatch/internal/alertrouter/channels/stdout"
 	"github.com/Hanalyx/openwatch/internal/audit"
@@ -418,7 +419,8 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	srv := server.New(cfg, pool).
 		WithConnectivityConfig(cfgStore, liveSvc).
 		WithDiscovery(discoSvc).
-		WithEventBus(bus)
+		WithEventBus(bus).
+		WithActivity(activity.NewService(pool))
 	runErr := srv.Run(ctx)
 
 	// Shutdown order REVERSE of boot (C-02). liveness.Run + alertrouter

--- a/app/internal/activity/service.go
+++ b/app/internal/activity/service.go
@@ -117,7 +117,14 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 	// commonWhere is the per-leg filter snippet. timeCol is the column
 	// each leg uses as the "when" timestamp (occurred_at uniformly,
 	// but kept as a parameter in case a future source uses detected_at).
-	commonWhere := func(severityCol, timeCol, hostCol string, hostNullable bool) string {
+	// hasHostCol=false means the leg has no host_id column (e.g.
+	// audit_events) and MUST be excluded when a host_id filter is
+	// applied — emitting a FALSE predicate keeps the column shape of
+	// the UNION while skipping every row. The previous shape passed
+	// hostCol="''" and "''=$hostPH" which crashed Postgres with
+	// `invalid input syntax for type uuid: ""` whenever host_id was
+	// set (the parameter is a uuid.UUID and PG won't cast '' to uuid).
+	commonWhere := func(severityCol, timeCol, hostCol string, hasHostCol bool) string {
 		parts := []string{}
 		if severityPH != "" {
 			parts = append(parts, severityCol+" = "+severityPH)
@@ -129,10 +136,10 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 			parts = append(parts, timeCol+" < "+untilPH)
 		}
 		if hostPH != "" {
-			if hostNullable {
+			if hasHostCol {
 				parts = append(parts, hostCol+" = "+hostPH)
 			} else {
-				parts = append(parts, hostCol+" = "+hostPH)
+				parts = append(parts, "FALSE")
 			}
 		}
 		if cursorPH != "" {
@@ -153,7 +160,7 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 			       occurred_at
 			  FROM alerts
 			 WHERE state != 'dismissed'`+
-			commonWhere("severity", "occurred_at", "host_id", true))
+			commonWhere("severity", "occurred_at", "host_id", true /* hasHostCol */))
 	}
 	if includeTxn {
 		legs = append(legs, `
@@ -165,7 +172,7 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 			       occurred_at
 			  FROM transactions
 			 WHERE 1=1`+
-			commonWhere("COALESCE(severity, 'info')", "occurred_at", "host_id", false))
+			commonWhere("COALESCE(severity, 'info')", "occurred_at", "host_id", true /* hasHostCol */))
 	}
 	if includeIntel {
 		legs = append(legs, `
@@ -176,7 +183,7 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 			       occurred_at
 			  FROM host_intelligence_events
 			 WHERE 1=1`+
-			commonWhere("severity", "occurred_at", "host_id", false))
+			commonWhere("severity", "occurred_at", "host_id", true /* hasHostCol */))
 	}
 	if includeAudit {
 		// audit_events severity is info|warning|error|critical — map
@@ -195,7 +202,7 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 			       occurred_at
 			  FROM audit_events
 			 WHERE 1=1`+
-			commonWhere(auditSev, "occurred_at", "''", true))
+			commonWhere(auditSev, "occurred_at", "", false))
 	}
 
 	if len(legs) == 0 {
@@ -268,7 +275,10 @@ func (s *Service) countHidden(ctx context.Context, f Filter, supAlerts, supTxn, 
 		}
 	}
 
-	commonWhere := func(severityCol, timeCol, hostCol string) string {
+	// Mirrors queryUnion.commonWhere — hasHostCol=false makes the leg
+	// evaluate to FALSE when a host_id filter is applied, avoiding the
+	// `'' = $uuid` type-cast crash on the audit leg.
+	commonWhere := func(severityCol, timeCol, hostCol string, hasHostCol bool) string {
 		parts := []string{}
 		if severityPH != "" {
 			parts = append(parts, severityCol+" = "+severityPH)
@@ -280,7 +290,11 @@ func (s *Service) countHidden(ctx context.Context, f Filter, supAlerts, supTxn, 
 			parts = append(parts, timeCol+" < "+untilPH)
 		}
 		if hostPH != "" {
-			parts = append(parts, hostCol+" = "+hostPH)
+			if hasHostCol {
+				parts = append(parts, hostCol+" = "+hostPH)
+			} else {
+				parts = append(parts, "FALSE")
+			}
 		}
 		if cursorPH != "" {
 			parts = append(parts, timeCol+" < "+cursorPH)
@@ -294,20 +308,20 @@ func (s *Service) countHidden(ctx context.Context, f Filter, supAlerts, supTxn, 
 	parts := []string{}
 	if supAlerts {
 		parts = append(parts, `SELECT count(*) FROM alerts WHERE state != 'dismissed'`+
-			commonWhere("severity", "occurred_at", "host_id"))
+			commonWhere("severity", "occurred_at", "host_id", true))
 	}
 	if supTxn {
 		parts = append(parts, `SELECT count(*) FROM transactions WHERE 1=1`+
-			commonWhere("COALESCE(severity, 'info')", "occurred_at", "host_id"))
+			commonWhere("COALESCE(severity, 'info')", "occurred_at", "host_id", true))
 	}
 	if supIntel {
 		parts = append(parts, `SELECT count(*) FROM host_intelligence_events WHERE 1=1`+
-			commonWhere("severity", "occurred_at", "host_id"))
+			commonWhere("severity", "occurred_at", "host_id", true))
 	}
 	if supAudit {
 		auditSev := `CASE severity WHEN 'warning' THEN 'medium' WHEN 'error' THEN 'high' ELSE COALESCE(severity, 'info') END`
 		parts = append(parts, `SELECT count(*) FROM audit_events WHERE 1=1`+
-			commonWhere(auditSev, "occurred_at", "''"))
+			commonWhere(auditSev, "occurred_at", "", false))
 	}
 	if len(parts) == 0 {
 		return 0, nil

--- a/app/internal/activity/service_db_test.go
+++ b/app/internal/activity/service_db_test.go
@@ -351,9 +351,9 @@ func TestList_CursorPagination(t *testing.T) {
 }
 
 // @ac AC-13
-// Regression: an earlier version of commonWhere passed hostCol="''"
-// for the audit leg and emitted `'' = $hostPH` when host_id was set.
-// pgx encodes the parameter as a uuid, so Postgres tried to cast ''
+// Regression: an earlier version of commonWhere passed hostCol="”"
+// for the audit leg and emitted `” = $hostPH` when host_id was set.
+// pgx encodes the parameter as a uuid, so Postgres tried to cast ”
 // to uuid and the whole UNION crashed with
 // `invalid input syntax for type uuid: ""`. The host-filtered list
 // MUST now succeed and include rows from sources that DO have a

--- a/app/internal/activity/service_db_test.go
+++ b/app/internal/activity/service_db_test.go
@@ -350,6 +350,63 @@ func TestList_CursorPagination(t *testing.T) {
 	})
 }
 
+// @ac AC-13
+// Regression: an earlier version of commonWhere passed hostCol="''"
+// for the audit leg and emitted `'' = $hostPH` when host_id was set.
+// pgx encodes the parameter as a uuid, so Postgres tried to cast ''
+// to uuid and the whole UNION crashed with
+// `invalid input syntax for type uuid: ""`. The host-filtered list
+// MUST now succeed and include rows from sources that DO have a
+// host_id column (alert + transaction + intelligence) while excluding
+// audit rows (host-agnostic source).
+func TestList_HostIDFilter_ExcludesAuditWithoutCrashing(t *testing.T) {
+	t.Run("system-activity/AC-13", func(t *testing.T) {
+		pool, creator := freshDB(t)
+		hostA := seedHost(t, pool, creator)
+		base := time.Now().UTC()
+		seedAllSources(t, pool, hostA, base)
+
+		// A second host with its own alert — must NOT appear under
+		// hostA's filter.
+		hostB := seedHost(t, pool, creator)
+		store := alertrouter.NewPgxStore(pool)
+		if _, err := store.Insert(context.Background(), alertrouter.Alert{
+			Type: alertrouter.AlertTypeHostUnreachable, Severity: alertrouter.SeverityLow,
+			HostID: hostB, OccurredAt: base.Add(-90 * time.Second),
+			Title: "hostB alert", Tags: map[string]string{"severity": "low"},
+		}); err != nil {
+			t.Fatalf("seed hostB alert: %v", err)
+		}
+
+		svc := NewService(pool)
+		rows, _, _, err := svc.List(context.Background(),
+			Filter{Limit: 50, HostID: &hostA},
+			Caller{CanReadAlerts: true, CanReadHosts: true, CanReadAudit: true})
+		if err != nil {
+			t.Fatalf("List: %v (regression: '' = $uuid crash)", err)
+		}
+		// Expect 3 rows: alert + transaction + intelligence for hostA.
+		// Audit MUST be excluded (no host_id column). hostB's alert
+		// MUST be excluded (different host).
+		if len(rows) != 3 {
+			t.Fatalf("rows=%d, want 3 (alert+txn+intel for hostA)", len(rows))
+		}
+		seen := map[Source]bool{}
+		for _, r := range rows {
+			seen[r.Source] = true
+			if r.HostID == nil || *r.HostID != hostA {
+				t.Errorf("row source=%s host_id=%v, want hostA=%v", r.Source, r.HostID, hostA)
+			}
+		}
+		if !seen[SourceAlert] || !seen[SourceTransaction] || !seen[SourceIntelligence] {
+			t.Errorf("missing source(s): %v", seen)
+		}
+		if seen[SourceAudit] {
+			t.Errorf("audit rows leaked into host-filtered result")
+		}
+	})
+}
+
 // stringFromInt avoids importing strconv just for a tiny helper.
 func stringFromInt(n int) string {
 	if n == 0 {

--- a/app/specs/system/activity.spec.yaml
+++ b/app/specs/system/activity.spec.yaml
@@ -145,3 +145,7 @@ spec:
       description: 'internal/activity source MUST NOT import internal/server OR net/http. Verified by walking the import set of every .go file under internal/activity/'
       priority: high
       references_constraints: [C-07]
+    - id: AC-13
+      description: 'Service.List with HostID set MUST NOT crash on the audit leg. Audit has no host_id column; when HostID is set the audit leg MUST evaluate to FALSE (or be skipped) and the response MUST contain only rows from sources that DO carry a host_id column (alert + transaction + intelligence) for the requested host. Regression: a prior implementation emitted `'''' = $hostPH` against a uuid-typed parameter which crashed the union with `invalid input syntax for type uuid: ""`.'
+      priority: critical
+      references_constraints: [C-01, C-02]


### PR DESCRIPTION
## Summary

Two latent bugs prevented `GET /api/v1/activity` from returning anything useful — which is why the host-detail Recent Activity card had no path forward.

### Bug 1 — Service never wired

`internal/server.WithActivity` / `WithAlerts` have existed since `api-activity v1.0.0` but neither was called from `cmd/openwatch/main.go`'s server-construction chain. Every request returned **503 `server.unavailable` "activity service not wired"** — the nil-check at `activity_handler.go:28` short-circuited before any data was read.

**Fix:** thread `activity.NewService(pool)` into the `.With` chain alongside `WithConnectivityConfig` / `WithDiscovery` / `WithEventBus`.

### Bug 2 — `host_id` filter crashed the union

The `audit_events` table has no `host_id` column. The audit leg projected `NULL::uuid AS host_id` and called `commonWhere(..., hostCol="''", hostNullable=true)` — using a literal empty string as a stand-in for the missing column. The intent was that `hostNullable=true` would gate the host predicate.

But the two `if hostNullable` branches were **identical** — both emitted `<hostCol> = $hostPH`. When a caller set `HostID`, the audit leg ended up with `'' = $1` where `$1` is a `uuid.UUID`. Postgres tried to cast `''` to `uuid` and the whole UNION crashed:

```
ERROR: invalid input syntax for type uuid: "" at character 1170
```

surfacing as **HTTP 500 `server.internal` "activity query failed"**.

**Fix:** repurpose the flag as `hasHostCol`. When `hasHostCol=false` AND a host filter is set, the leg adds `FALSE` to its `WHERE` — type-safe, returns nothing, leaves the UNION intact. The four call sites pass:
- `hasHostCol=true` for alert / transaction / intelligence (real `host_id` columns)
- `hasHostCol=false` for audit

The mirrored `commonWhere` in `countHidden` gets the same treatment.

## Spec

`system-activity v1.0.0` gains **AC-13** — the host_id + audit no-crash invariant.

## Tests

`TestList_HostIDFilter_ExcludesAuditWithoutCrashing` seeds all four sources for `hostA` and a second alert for `hostB`, filters by `hostA`, and asserts exactly **3 rows** (alert + transaction + intelligence for hostA, no audit leakage, no hostB leakage) **AND no error**.

## Verification

Live-tested against `owas-rhn01` (host with 11 intelligence events):
- Before: `GET /api/v1/activity?host_id=X` → HTTP 503 → after wiring → HTTP 500
- After both fixes: HTTP 200 with the intel rows
- `?host_id=X` returns alert + transaction + intelligence rows, excludes audit ✓
- `source=audit&host_id=X` returns empty ✓
- `?limit=N` (unfiltered) returns mixed-source rows ✓

## Follow-up

This unblocks option B — extending the activity service with a fifth leg for `host_monitoring_history` so the per-host activity feed surfaces band transitions alongside scan / intel / alert / audit events. Will be a separate PR once this lands.