### PR TITLE
feat(host-detail): polish Recent activity card to match mockup

### DIFF
--- a/app/frontend/src/pages/HostDetailPage.tsx
+++ b/app/frontend/src/pages/HostDetailPage.tsx
@@ -3,8 +3,11 @@ import { useParams, useSearch, useNavigate, Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react';
 import {
   Activity as ActivityIcon,
+  AlertTriangle,
   Bell,
+  CheckCircle2,
   ChevronLeft,
+  ChevronRight,
   Circle,
   Clock,
   FileText,
@@ -210,7 +213,6 @@ const DEFAULT_SUMMARY: ComplianceSummary = {
   total: 0,
 };
 
-const PAGE_SIZE = 50;
 
 // ─────────────────────────────────────────────────────────────────────────
 // Page
@@ -451,6 +453,7 @@ export function HostDetailPage() {
                     systemInfo={systemInfoQuery.data ?? null}
                   />
                   <CardRecentActivity
+                    hostId={detailQuery.data.host.id}
                     isLoading={activityQuery.isLoading}
                     isError={activityQuery.isError}
                     items={activityQuery.data ?? []}
@@ -1323,20 +1326,46 @@ function CardComplianceTrend() {
   );
 }
 
+// RECENT_LIMIT caps the overview card at the most-recent N rows.
+// The mockup shows exactly 5; deeper history is reached via the
+// "View all" link that routes to the activity tab.
+const RECENT_LIMIT = 5;
+
 function CardRecentActivity({
+  hostId,
   isLoading,
   isError,
   items,
   onRetry,
 }: {
+  hostId: string;
   isLoading: boolean;
   isError: boolean;
   items: ActivityItem[];
   onRetry: () => void;
 }) {
-  const visible = useMemo(() => items.slice(0, PAGE_SIZE), [items]);
+  const visible = useMemo(() => items.slice(0, RECENT_LIMIT), [items]);
   return (
-    <Card title="Recent activity">
+    <Card
+      title="Recent activity"
+      headerRight={
+        <Link
+          to="/hosts/$hostId"
+          params={{ hostId }}
+          search={{ tab: 'activity' }}
+          style={{
+            color: 'var(--ow-link)',
+            fontSize: 12,
+            textDecoration: 'none',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 2,
+          }}
+        >
+          View all <ChevronRight size={12} />
+        </Link>
+      }
+    >
       {isLoading ? (
         <div style={{ color: 'var(--ow-fg-2)', fontSize: 12 }}>Loading…</div>
       ) : isError ? (
@@ -1380,7 +1409,7 @@ function CardRecentActivity({
 }
 
 function ActivityRow({ item }: { item: ActivityItem }) {
-  const sev = activitySeverityColors(item.severity);
+  const { Icon, color } = activityIconFor(item);
   return (
     <li
       style={{
@@ -1391,7 +1420,7 @@ function ActivityRow({ item }: { item: ActivityItem }) {
         borderBottom: '1px solid var(--ow-line)',
       }}
     >
-      <Circle size={8} fill={sev.dot} color={sev.dot} style={{ marginTop: 5 }} />
+      <Icon size={14} color={color} style={{ marginTop: 2, flexShrink: 0 }} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ color: 'var(--ow-fg-0)', fontSize: 13 }}>{item.title}</div>
         {item.summary ? (
@@ -1408,16 +1437,14 @@ function ActivityRow({ item }: { item: ActivityItem }) {
         ) : null}
       </div>
       <div style={{ color: 'var(--ow-fg-3)', fontSize: 11, whiteSpace: 'nowrap' }}>
-        {relativeMinutes(item.occurred_at)}
+        {activityRelativeTime(item.occurred_at)}
       </div>
     </li>
   );
 }
 
 // activitySeverityColors maps the closed severity enum onto the
-// existing OW color tokens. The prior MonitoringBand → color table
-// (severityFor below) is still used by the liveness state-machine
-// chips elsewhere on the page — kept untouched.
+// existing OW color tokens.
 function activitySeverityColors(s: ActivitySeverity): { fg: string; dot: string } {
   switch (s) {
     case 'critical':
@@ -1434,12 +1461,73 @@ function activitySeverityColors(s: ActivitySeverity): { fg: string; dot: string 
   }
 }
 
+// activityIconFor picks the lucide glyph per source. Color follows
+// severity — a downed host renders red WifiOff, an online recovery
+// renders green Wifi. Sources without strong glyph semantics (alert,
+// audit, intel) fall back to a representative icon per source.
+function activityIconFor(item: ActivityItem): { Icon: LucideIcon; color: string } {
+  const c = activitySeverityColors(item.severity);
+  switch (item.source) {
+    case 'monitoring':
+      if (item.severity === 'critical' || item.severity === 'high') {
+        return { Icon: WifiOff, color: c.fg };
+      }
+      if (item.severity === 'medium') {
+        return { Icon: AlertTriangle, color: c.fg };
+      }
+      return { Icon: Wifi, color: c.fg };
+    case 'transaction':
+      if (item.severity === 'info' || item.severity === 'low') {
+        return { Icon: CheckCircle2, color: c.fg };
+      }
+      return { Icon: RefreshCw, color: c.fg };
+    case 'audit':
+      return { Icon: FileText, color: c.fg };
+    case 'intelligence':
+      return { Icon: Package, color: c.fg };
+    case 'alert':
+      return { Icon: Bell, color: c.fg };
+    default:
+      return { Icon: ActivityIcon, color: c.fg };
+  }
+}
+
+// activityRelativeTime renders the right-side timestamp. The mockup
+// uses relative wording for fresh events (m / h / d ago) and an
+// absolute date for events older than 30 days — a sensible cutoff
+// that prevents "412d ago" cells while keeping the recent feed
+// chatty.
+function activityRelativeTime(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '—';
+  const minutes = Math.max(0, Math.round((Date.now() - t) / 60_000));
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days <= 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
 
 // ─────────────────────────────────────────────────────────────────────────
 // Reusable bits (cards, kv rows, empty states, etc.)
 // ─────────────────────────────────────────────────────────────────────────
 
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
+function Card({
+  title,
+  headerRight,
+  children,
+}: {
+  title: string;
+  headerRight?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <section
       style={{
@@ -1449,8 +1537,17 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
         padding: 18,
       }}
     >
-      <header style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between' }}>
+      <header
+        style={{
+          marginBottom: 12,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 12,
+        }}
+      >
         <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>{title}</h3>
+        {headerRight ? <div>{headerRight}</div> : null}
       </header>
       <div>{children}</div>
     </section>

--- a/app/frontend/tests/pages/host-detail-shell.test.ts
+++ b/app/frontend/tests/pages/host-detail-shell.test.ts
@@ -240,11 +240,21 @@ describe('frontend-host-detail — prototype shell', () => {
   });
 
   // @ac AC-26
-  test('frontend-host-detail/AC-26 — recent activity card sources from monitoring history', () => {
+  test('frontend-host-detail/AC-26 — recent activity card sources from unified /activity feed, slices to 5, links to Activity tab', () => {
     expect(PAGE_SRC).toContain('CardRecentActivity');
-    // The card fetches GET /hosts/{id}/monitoring/history.
-    expect(PAGE_SRC).toContain('/api/v1/hosts/{host_id}/monitoring/history');
-    // Empty-state copy.
+    // The card fetches GET /api/v1/activity scoped by host_id —
+    // system-activity v1.1.0 union (alert + transaction +
+    // intelligence + audit + monitoring). The legacy
+    // /monitoring/history binding is gone.
+    expect(PAGE_SRC).toContain("'/api/v1/activity'");
+    expect(PAGE_SRC).toMatch(/host_id:\s*hostId/);
+    expect(PAGE_SRC).not.toContain('/monitoring/history');
+    // Slice cap.
+    expect(PAGE_SRC).toMatch(/RECENT_LIMIT\s*=\s*5/);
+    // "View all" affordance routes to the host's Activity tab.
+    expect(PAGE_SRC).toMatch(/View all/);
+    expect(PAGE_SRC).toMatch(/tab:\s*['"]activity['"]/);
+    // Empty-state copy preserved.
     expect(PAGE_SRC).toMatch(/No activity yet/i);
   });
 

--- a/app/specs/frontend/host-detail.spec.yaml
+++ b/app/specs/frontend/host-detail.spec.yaml
@@ -89,7 +89,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-09
-      description: 'Recent activity card MUST source events from host_monitoring_history (band transitions) + transactions (compliance state changes). Each event MUST have a severity tint matching its band (crit for down/critical, warn for degraded/skipped, ok for online/pass, neutral for everything else). Renders empty state when both sources are empty'
+      description: 'Recent activity card MUST source events from the unified GET /api/v1/activity feed scoped to the current host (host_id=X). The endpoint UNIONs alert + transaction + intelligence + audit + monitoring per system-activity v1.1.0; each event carries a closed-enum severity which the card tints (crit for critical/high, warn for medium, ok for info, neutral for low). The card MUST render at most 5 rows (the overview slice) and provide a "View all" link to the host''s Activity tab. Empty feed renders the "No activity yet" empty state.'
       type: technical
       enforcement: error
     - id: C-10
@@ -178,7 +178,7 @@ spec:
       priority: critical
       references_constraints: [C-06]
     - id: AC-26
-      description: 'Recent activity card sources events from host_monitoring_history (via GET /hosts/{id}/monitoring/history) and shows them with severity tints matching the band (crit for down/critical, warn for degraded, ok for online). When the history is empty, renders the prototype''s "No activity yet" empty-state.'
+      description: 'Recent activity card sources events from GET /api/v1/activity?host_id=X (the unified five-source feed per system-activity v1.1.0). It MUST slice the response to at most 5 rows (the overview limit) and render a "View all" link in the card header that routes to the host''s Activity tab. Severity tinting MUST follow the closed enum mapping (critical/high → crit color, medium → warn, info → ok, low → neutral). Empty response renders the "No activity yet" empty-state.'
       priority: critical
       references_constraints: [C-09]
     - id: AC-27


### PR DESCRIPTION
## Summary

Five visual + structural changes after the unified-feed plumbing landed in #478:

1. **Slice cap of 5 rows** (`RECENT_LIMIT`). Overview card is a glance surface, not a deep history.
2. **`View all` link** in the card header → `/hosts/{hostId}?tab=activity`. The Activity tab is currently a `TabStub` but the link is semantically correct and unblocks fleshing out that tab in a follow-up.
3. **Per-source lucide icons** replace the generic colored `Circle`:

| Source + severity | Icon | Color |
|---|---|---|
| monitoring + crit/high | `WifiOff` | crit |
| monitoring + medium | `AlertTriangle` | warn |
| monitoring + info/low | `Wifi` | ok |
| transaction + info/low | `CheckCircle2` | ok |
| transaction + crit/high | `RefreshCw` | crit |
| audit | `FileText` | severity tint |
| intelligence | `Package` | severity tint |
| alert | `Bell` | severity tint |
| fallback | `Activity` | severity tint |

4. **Long-form date** for events older than 30 days: `M/D/YYYY` instead of `412d ago`. Below 30d the prior `m/h/d ago` wording stays.
5. **`Card` primitive** extended with an optional `headerRight` prop so the "View all" affordance can sit on the right of the title row without reshaping other call sites (CardSystem etc. pass nothing and the header collapses to its prior layout).

## Spec

`frontend-host-detail` **C-09** and **AC-26** rewritten to match the new contract: unified `/api/v1/activity` path, 5-row slice, "View all" affordance, closed-enum severity tinting.

## Test plan

- [x] `tests/pages/host-detail-shell.test.ts` AC-26 — source-walk now locks the unified-feed path, the 5-row slice, the "View all" + `tab:'activity'` search param, and the empty-state copy. Old `/monitoring/history` binding is explicitly forbidden.
- [x] `npx vitest run` — 195/195 pass
- [x] `npx tsc --noEmit` — clean on touched files (pre-existing settings.test.ts errors unchanged)
- [x] Live verification on `owas-ub24`: card collapses to 5 rows, "View all" link present in header, navigation works.

## Removed

- `const PAGE_SIZE = 50` — was only used by the old activity slice; inlined as the 5-row `RECENT_LIMIT`.

## Follow-up (not in this PR)

- Build out the Activity tab at `/hosts/{id}?tab=activity` so "View all" lands somewhere real. Currently lands on `TabStub`.