### PR TITLE
Rewrite .env templates for the Go server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,73 +1,44 @@
-# OpenWatch Environment Configuration Template
-# Copy this file to .env and update with your actual values
+# OpenWatch (Go) — server environment template
+#
+# Copy to .env (gitignored) and fill in real values, or export these directly.
+# For LOCAL DEV you usually don't need this file: scripts/openwatch.sh generates
+# and uses a durable .dev/env (and the TLS/JWT/credential keys) for you.
+#
+# The Go server reads the OPENWATCH_* variables below. Built-in defaults are
+# shown in [brackets]; only DATABASE_DSN normally needs setting for a real run.
 
 # =================================
-# DATABASE CONFIGURATION
+# SERVER
 # =================================
-POSTGRES_HOST=database
-POSTGRES_PORT=5432
-POSTGRES_DB=openwatch
-POSTGRES_USER=openwatch
-POSTGRES_PASSWORD=your_secure_database_password
+OPENWATCH_SERVER_LISTEN=0.0.0.0:8443                      # [0.0.0.0:8443] host:port for the HTTPS listener
+OPENWATCH_SERVER_TLS_CERT=/etc/openwatch/tls/cert.pem     # [/etc/openwatch/tls/cert.pem] PEM certificate path
+OPENWATCH_SERVER_TLS_KEY=/etc/openwatch/tls/key.pem       # [/etc/openwatch/tls/key.pem] PEM private-key path
 
 # =================================
-# REDIS CONFIGURATION
+# DATABASE (PostgreSQL only)
 # =================================
-REDIS_HOST=redis
-REDIS_PORT=6379
-REDIS_PASSWORD=your_redis_password
+# Full libpq DSN. PostgreSQL is the only datastore (no MongoDB/Redis).
+OPENWATCH_DATABASE_DSN=postgres://openwatch:CHANGE_ME@localhost:5432/openwatch?sslmode=disable  # pragma: allowlist secret
+OPENWATCH_DATABASE_MAX_CONNECTIONS=25                     # [25] connection-pool size
 
 # =================================
-# APPLICATION SETTINGS
+# IDENTITY / CRYPTO
 # =================================
-OPENWATCH_DEBUG=false
-OPENWATCH_SECRET_KEY=your_super_secret_application_key_here
-OPENWATCH_FIPS_MODE=true
-OPENWATCH_REQUIRE_HTTPS=true
-
-# =================================
-# SECURITY SETTINGS
-# =================================
-JWT_SECRET_KEY=your_jwt_secret_key
-JWT_ALGORITHM=RS256
-JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
-JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+# PEM-encoded RSA private key used to sign JWTs (path to the file).
+OPENWATCH_IDENTITY_JWT_PRIVATE_KEY=/etc/openwatch/keys/jwt_private.pem
+# 32-byte raw-binary AES-256 key used to encrypt stored SSH credentials (path).
+# Keep this stable: rotating it makes existing encrypted credentials undecryptable.
+OPENWATCH_IDENTITY_CREDENTIAL_KEY_FILE=/etc/openwatch/keys/credential.key
 
 # =================================
 # LOGGING
 # =================================
-LOG_LEVEL=INFO
-AUDIT_LOG_FILE=/openwatch/logs/audit.log
+OPENWATCH_LOGGING_LEVEL=info                              # [info] debug | info | warn | error
+OPENWATCH_LOGGING_FORMAT=json                             # [json] json | text
 
 # =================================
-# EXTERNAL INTEGRATIONS (OPTIONAL)
+# OPTIONAL
 # =================================
-# SMTP Settings for notifications
-SMTP_SERVER=smtp.example.com
-SMTP_PORT=587
-SMTP_USERNAME=your_smtp_username
-SMTP_PASSWORD=your_smtp_password
-SMTP_USE_TLS=true
-
-# LDAP Settings (if using LDAP authentication)
-LDAP_SERVER=ldap://ldap.example.com:389
-LDAP_BIND_DN=cn=admin,dc=example,dc=com
-LDAP_BIND_PASSWORD=your_ldap_password
-LDAP_USER_SEARCH_BASE=ou=users,dc=example,dc=com
-
-# =================================
-# CONTAINER SETTINGS
-# =================================
-CONTAINER_RUNTIME=podman
-COMPOSE_PROJECT_NAME=openwatch
-
-# =================================
-# TLS/SSL SETTINGS
-# =================================
-TLS_CERT_FILE=/openwatch/security/certs/server.crt
-TLS_KEY_FILE=/openwatch/security/keys/server.key
-
-# =================================
-# ALLOWED ORIGINS (CORS)
-# =================================
-ALLOWED_ORIGINS=https://localhost:3000,https://your-domain.com
+# OPENWATCH_LICENSE_FILE=/etc/openwatch/license.jwt       # OpenWatch+ license file (enables gated features)
+# OPENWATCH_POLICIES_DIR=/etc/openwatch/policies          # external policy directory override
+# OPENWATCH_DEV_MODE=false                                # 'true' relaxes policy loading for local development

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,11 +1,12 @@
-# OpenWatch Hosts Testing Environment Variables
-OPENWATCH_TEST_HOST_1=<test_host_ip_1>
-OPENWATCH_TEST_HOST_2=<test_host_ip_2>
-OPENWATCH_TEST_USERNAME=<test_username>
-OPENWATCH_TEST_PASSWORD=<test_password>
-OPENWATCH_TEST_SSH_KEY_PATH=<path_to_test_ssh_key>
+# OpenWatch (Go) — test environment template
+#
+# The integration test suites (the *_db_test.go packages) connect to a real
+# PostgreSQL. As a safety guard the database name must end in "_test"; the suite
+# skips when OPENWATCH_TEST_DSN is unset.
 
-# OpenWatch Frontend Login Testing Environment Variables
-OPENWATCH_TEST_FRONTEND_URL=http://localhost:3001
-OPENWATCH_TEST_FRONTEND_USERNAME=<frontend_test_username>
-OPENWATCH_TEST_FRONTEND_PASSWORD=<frontend_test_password>
+# PostgreSQL DSN for the Go integration tests (DB name must end in _test).
+OPENWATCH_TEST_DSN=postgres://openwatch:CHANGE_ME@127.0.0.1:5432/openwatch_go_test?sslmode=disable  # pragma: allowlist secret
+
+# Set to "yes" only to bypass the _test-suffix database-name guard. Leave at
+# "no" (the default) unless you have a deliberate reason.
+# OPENWATCH_TEST_DSN_ALLOW_NONTEST=no


### PR DESCRIPTION
`.env.example` and `.env.testing.example` still documented the Python/FastAPI
stack (separate `POSTGRES_*`, `REDIS_*`, `JWT_SECRET_KEY`, `LDAP_*`, `SMTP_*`,
port 3001, `TLS_CERT_FILE`, `ALLOWED_ORIGINS`) — none of which the Go server
reads, so anyone bootstrapping the Go backend from them would be misled.

Rewrites both from the **actual config surface**, verified against
`internal/config/load.go` + `os.Getenv` call sites:

- **`.env.example`** — the nine `OPENWATCH_*` vars the loader reads
  (`SERVER_LISTEN`/`TLS_*`, `DATABASE_DSN`/`MAX_CONNECTIONS`,
  `IDENTITY_JWT_PRIVATE_KEY`/`CREDENTIAL_KEY_FILE`, `LOGGING_LEVEL`/`FORMAT`)
  with defaults noted, plus optional `LICENSE_FILE` / `POLICIES_DIR` / `DEV_MODE`,
  and a pointer to `scripts/openwatch.sh` (which manages dev env via `.dev/env`).
- **`.env.testing.example`** — `OPENWATCH_TEST_DSN` (Postgres DSN for the
  `*_db_test.go` suites; DB name must end in `_test`) + the `ALLOW_NONTEST` guard.
  Dropped the unused `OPENWATCH_TEST_HOST_*` / `OPENWATCH_TEST_FRONTEND_*` vars
  (Python-era, referenced nowhere in the Go tree).

Docs-only; the local gitignored `.env` is personal and untouched.