### PR TITLE
Multi-arch packaging: build arm64 RPM and DEB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,20 @@ rpm:
 deb:
 	@bash packaging/deb/build-deb.sh
 
+# Cross-compiled arm64 variants (CGO disabled; no C cross-toolchain needed).
+.PHONY: rpm-arm64
+rpm-arm64:
+	@ARCH=arm64 bash packaging/rpm/build-rpm.sh
+
+.PHONY: deb-arm64
+deb-arm64:
+	@ARCH=arm64 bash packaging/deb/build-deb.sh
+
+# All four release artifacts: RPM + DEB for amd64 and arm64.
+.PHONY: packages
+packages: rpm rpm-arm64 deb deb-arm64
+	@echo "built RPM + DEB (amd64 + arm64) in $(DIST_DIR)/"
+
 # -----------------------------------------------------------------------------
 # FIPS build (Day 12: microsoft/go toolchain)
 # -----------------------------------------------------------------------------

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Build the OpenWatch DEB.
 #
-# Usage:   bash packaging/deb/build-deb.sh
-# Output:  app/dist/openwatch_<version>_<arch>.deb
+# Usage:   bash packaging/deb/build-deb.sh            # host arch (amd64)
+#          ARCH=arm64 bash packaging/deb/build-deb.sh # cross-compile arm64
+# Output:  dist/openwatch_<version>_<arch>.deb
 #
-# Spec: app/specs/release/package-build.spec.yaml AC-02, AC-06, AC-13.
+# Spec: specs/release/package-build.spec.yaml AC-02, AC-06, AC-13.
 
 set -euo pipefail
 
@@ -26,14 +27,21 @@ if [ -z "${VERSION:-}" ]; then
 fi
 # DEB allows hyphens; reuse upstream version as-is.
 DEB_VERSION="$VERSION"
+# Target architecture (Debian names, which match GOARCH for our targets).
 ARCH="${ARCH:-amd64}"
+case "$ARCH" in
+    amd64 | arm64) ;;
+    *) echo "build-deb.sh: unsupported ARCH=$ARCH (use amd64 | arm64)" >&2; exit 1 ;;
+esac
 DIST_DIR="${APP_DIR}/dist"
 
 mkdir -p "$DIST_DIR"
 
-# Step 1: build the Go binary.
-echo ">> building openwatch binary (version=${DEB_VERSION})"
-make build VERSION="$DEB_VERSION" >/dev/null
+# Step 1: build the Go binary for the target arch. CGO is disabled so the
+# binary is portable and cross-compiles without a C toolchain (the embedded
+# frontend SPA is arch-independent).
+echo ">> building openwatch binary (version=${DEB_VERSION}, arch=${ARCH})"
+GOOS=linux GOARCH="$ARCH" CGO_ENABLED=0 make build VERSION="$DEB_VERSION" >/dev/null
 
 # Step 2: stage the package tree.
 STAGE="$(mktemp -d)"
@@ -55,8 +63,9 @@ install -m 0644 "$APP_DIR/packaging/common/openwatch.service" "$STAGE/etc/system
 bash "$APP_DIR/packaging/common/gen-demo-cert.sh" "$STAGE/etc/openwatch/tls" >/dev/null
 
 # Step 3: control + maintainer scripts.
-# Render control with the actual version inserted.
-sed "s/^Version: .*/Version: ${DEB_VERSION}/" \
+# Render control with the actual version and target arch inserted.
+sed -e "s/^Version: .*/Version: ${DEB_VERSION}/" \
+    -e "s/^Architecture: .*/Architecture: ${ARCH}/" \
     "$APP_DIR/packaging/deb/control" > "$STAGE/DEBIAN/control"
 
 install -m 0644 "$APP_DIR/packaging/deb/conffiles" "$STAGE/DEBIAN/conffiles"

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Build the OpenWatch RPM.
 #
-# Usage:   bash packaging/rpm/build-rpm.sh
-# Output:  app/dist/openwatch-<version>-<release>.<arch>.rpm
+# Usage:   bash packaging/rpm/build-rpm.sh            # host arch (x86_64)
+#          ARCH=arm64 bash packaging/rpm/build-rpm.sh # cross-compile aarch64
+# Output:  dist/openwatch-<version>-<release>.<arch>.rpm
 #
-# Spec: app/specs/release/package-build.spec.yaml AC-01, AC-04, AC-13.
+# Spec: specs/release/package-build.spec.yaml AC-01, AC-04, AC-13.
 
 set -euo pipefail
 
@@ -30,12 +31,22 @@ RPM_VERSION="${VERSION%%-*}"
 RPM_RELEASE="${RPM_RELEASE:-1}"
 DIST_DIR="${APP_DIR}/dist"
 
+# Target architecture: GOARCH name in, RPM arch name out.
+ARCH="${ARCH:-amd64}"
+case "$ARCH" in
+    amd64) GOARCH=amd64; RPM_ARCH=x86_64 ;;
+    arm64) GOARCH=arm64; RPM_ARCH=aarch64 ;;
+    *) echo "build-rpm.sh: unsupported ARCH=$ARCH (use amd64 | arm64)" >&2; exit 1 ;;
+esac
+
 mkdir -p "$DIST_DIR"
 
-# Step 1: build the Go binary (release flags). Done outside rpmbuild's
-# %build so the chroot doesn't need the Go toolchain.
-echo ">> building openwatch binary (version=${RPM_VERSION})"
-make build VERSION="$RPM_VERSION" >/dev/null
+# Step 1: build the Go binary (release flags) for the target arch. Done
+# outside rpmbuild's %build so the chroot needs no Go toolchain. CGO is
+# disabled for a portable binary that cross-compiles without a C toolchain
+# (the embedded frontend SPA is arch-independent).
+echo ">> building openwatch binary (version=${RPM_VERSION}, arch=${RPM_ARCH})"
+GOOS=linux GOARCH="$GOARCH" CGO_ENABLED=0 make build VERSION="$RPM_VERSION" >/dev/null
 
 # Step 2: stage the rpmbuild tree.
 RPMTOP="$(mktemp -d)"
@@ -63,6 +74,7 @@ rpmbuild \
     --define "_topdir $RPMTOP" \
     --define "ow_version ${RPM_VERSION}" \
     --define "ow_release ${RPM_RELEASE}" \
+    --target "${RPM_ARCH}" \
     -bb "$APP_DIR/packaging/rpm/openwatch.spec" >/dev/null
 
 # Step 5: copy the artifact into app/dist/.

--- a/packaging/rpm/openwatch.spec
+++ b/packaging/rpm/openwatch.spec
@@ -7,6 +7,12 @@
 # Disable shebang stripping (no shebang in compiled binary, but be safe).
 %global __brp_mangle_shebangs %{nil}
 
+# Don't strip the binary. The Go binary is self-contained and prebuilt outside
+# the chroot, so RPM's brp-strip adds nothing — and for cross-arch builds
+# (e.g. aarch64 RPM on an x86_64 host) the host `strip` cannot process the
+# target binary and aborts %install. A no-op keeps cross-builds working.
+%global __strip /bin/true
+
 # Allow override via rpmbuild --define "ow_version X.Y.Z".
 %{!?ow_version: %global ow_version 0.1.0}
 %{!?ow_release: %global ow_release 1}

--- a/packaging/tests/package_test.go
+++ b/packaging/tests/package_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -369,6 +370,43 @@ func TestMake_RPMAndDEBTargetsExit0(t *testing.T) {
 		haveTool(t, "dpkg-deb")
 		runMake(t, dir, "rpm")
 		runMake(t, dir, "deb")
+	})
+}
+
+// @ac AC-14
+// AC-14: both build scripts cross-compile for arm64. Source-inspection (an
+// actual aarch64 build needs the target rpm/dpkg arch which is not portable in
+// CI) — assert the scripts map ARCH=arm64 to the right GOARCH/package arch and
+// build with CGO disabled.
+func TestBuild_MultiArchSupport(t *testing.T) {
+	t.Run("release-package-build/AC-14", func(t *testing.T) {
+		dir := appDir(t)
+		read := func(p string) string {
+			b, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			return string(b)
+		}
+		rpm := read(filepath.Join(dir, "packaging", "rpm", "build-rpm.sh"))
+		deb := read(filepath.Join(dir, "packaging", "deb", "build-deb.sh"))
+
+		for name, src := range map[string]string{"build-rpm.sh": rpm, "build-deb.sh": deb} {
+			if !strings.Contains(src, "ARCH") || !strings.Contains(src, "arm64") {
+				t.Errorf("%s does not parameterize ARCH for arm64", name)
+			}
+			if !regexp.MustCompile(`GOARCH=.*CGO_ENABLED=0|CGO_ENABLED=0.*GOARCH=`).MatchString(src) {
+				t.Errorf("%s does not cross-compile with GOARCH + CGO_ENABLED=0", name)
+			}
+		}
+		// RPM maps arm64 -> aarch64 and passes it to rpmbuild --target.
+		if !strings.Contains(rpm, "aarch64") || !regexp.MustCompile(`--target`).MatchString(rpm) {
+			t.Error("build-rpm.sh must map arm64 -> aarch64 and pass --target to rpmbuild")
+		}
+		// DEB renders the target arch into the control file.
+		if !regexp.MustCompile(`Architecture:.*ARCH|ARCH.*Architecture`).MatchString(deb) {
+			t.Error("build-deb.sh must render the target arch into the DEB control Architecture field")
+		}
 	})
 }
 

--- a/specs/release/package-build.spec.yaml
+++ b/specs/release/package-build.spec.yaml
@@ -35,10 +35,10 @@ spec:
         - Demo cert under /etc/openwatch/tls/ (operators replace)
         - Post-install systemd reload
         - Pre-uninstall stop+disable
+        - Multi-arch builds (amd64 + arm64) via ARCH, cross-compiled with CGO disabled
       excludes:
         - Signed package distribution (separate release infra)
         - FIPS variant (Day 12 ships a second binary build)
-        - Multi-arch (arm64 deferred)
 
   constraints:
     - id: C-01
@@ -71,6 +71,10 @@ spec:
       enforcement: error
     - id: C-08
       description: Build scripts MUST be invoked via make rpm and make deb targets — the Makefile is the orchestration surface
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: Build scripts MUST support a target architecture via ARCH (amd64 | arm64), cross-compiling the binary with the matching GOARCH and CGO disabled, and labeling the artifact with the correct package arch (x86_64/aarch64 for RPM, amd64/arm64 for DEB)
       type: technical
       enforcement: error
 
@@ -125,3 +129,7 @@ spec:
       description: make rpm and make deb invoke the corresponding build scripts and exit 0 on success.
       priority: high
       references_constraints: [C-08]
+    - id: AC-14
+      description: Both build scripts accept ARCH=arm64 and cross-compile the binary via GOARCH with CGO disabled, mapping to the correct package arch (aarch64 RPM / arm64 DEB); source-inspection verifies the arch mapping and the GOARCH/CGO_ENABLED=0 build invocation.
+      priority: high
+      references_constraints: [C-09]


### PR DESCRIPTION
Step 4 of the release-readiness work. The RPM/DEB build scripts now cross-compile
for **arm64** in addition to amd64, so the release ships packages for both
architectures across RHEL/Rocky/Fedora/Oracle (x86_64 + aarch64) and
Ubuntu/Debian (amd64 + arm64). Each package is a complete product — the binary
already embeds the SPA (step 2).

## Changes
- **`build-rpm.sh` / `build-deb.sh`** — `ARCH={amd64|arm64}` selects GOARCH and
  cross-compiles with `CGO_ENABLED=0` (pure-Go binary, no C cross-toolchain). RPM
  maps `arm64`→`aarch64` and passes `rpmbuild --target`; DEB renders the arch into
  the control `Architecture`. **Host arch (amd64) stays the default** so
  `make rpm`/`make deb` are unchanged.
- **`openwatch.spec`** — `%global __strip /bin/true`: RPM's `brp-strip` runs the
  host `strip`, which can't process a cross-compiled aarch64 binary and aborted
  `%install`. Go binaries need no RPM ELF post-processing.
- **`Makefile`** — `rpm-arm64`, `deb-arm64`, and a `packages` target (all four).
- **Spec `release-package-build`** — arm64 moved from excludes to scope;
  constraint **C-09** + **AC-14** (multi-arch cross-compile), covered by
  `TestBuild_MultiArchSupport` (source-inspection — an actual aarch64 build needs
  target rpm/dpkg arch tooling that isn't portable in CI).

## Verified locally (rpmbuild + dpkg-deb)
All four artifacts build with the correct package arch, a matching-machine-type
binary, and the SPA embedded:
```
openwatch-0.2.0-1.x86_64.rpm    -> x86-64 binary,  SPA ✓
openwatch-0.2.0-1.aarch64.rpm   -> ARM aarch64,    SPA ✓
openwatch_0.2.0-rc.3_amd64.deb  -> x86-64,         SPA ✓
openwatch_0.2.0-rc.3_arm64.deb  -> ARM aarch64,    SPA ✓
```
Existing amd64 package tests still pass; specter 70/70, package-build 14/14.