### PR TITLE
Release automation: build, SBOM, sign, publish to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+# Cut a release on a v* tag (or manually via workflow_dispatch). Builds the
+# native RPM + DEB for amd64 and arm64 (each a complete API+UI binary — the SPA
+# is embedded), generates a CycloneDX SBOM per artifact with syft, writes signed
+# checksums, and publishes everything to a GitHub Release.
+#
+# Distribution model: GitHub Releases. Operators download and
+# `sudo dnf install ./openwatch-*.rpm` / `sudo apt install ./openwatch_*.deb`.
+#
+# Spec: specs/system/supply-chain.spec.yaml AC-08 (syft SBOM) / AC-09 (CycloneDX
+#       1.5); specs/release/package-build.spec.yaml.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. v0.2.0 (tag is created on publish)'
+        required: true
+        type: string
+
+permissions:
+  contents: write # create the release + upload assets
+
+jobs:
+  release:
+    name: Build, SBOM, sign, publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.4'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install rpmbuild
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
+      # Builds all four artifacts: RPM + DEB for amd64 and arm64. arm64 is a
+      # CGO-disabled cross-compile, so no C cross-toolchain is required.
+      - name: Build packages (amd64 + arm64)
+        run: make packages
+
+      # SBOM: syft scans the actual built binary and packages (not just the Go
+      # module graph) and emits CycloneDX 1.5 JSON — supply-chain AC-08 / AC-09.
+      - name: Install syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b "$HOME/.local/bin"
+
+      - name: Generate CycloneDX SBOMs
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          mkdir -p dist/sbom
+          # CycloneDX 1.5 schema the emitted SBOMs validate against:
+          #   https://cyclonedx.org/schema/bom-1.5.schema.json
+          for art in dist/openwatch dist/openwatch-*.rpm dist/openwatch_*.deb; do
+            [ -e "$art" ] || continue
+            name="$(basename "$art")"
+            syft scan "file:$art" -o "cyclonedx-json=dist/sbom/${name}.cdx.json"
+          done
+          ls -l dist/sbom
+
+      - name: Checksums
+        run: |
+          cd dist
+          sha256sum openwatch-*.rpm openwatch_*.deb sbom/*.cdx.json > SHA256SUMS
+          cat SHA256SUMS
+
+      # Detached GPG signature over the checksum manifest, so operators can
+      # verify authenticity of every artifact with one key. Skipped when no
+      # signing key is configured (set the GPG_PRIVATE_KEY / GPG_PASSPHRASE repo
+      # secrets to enable). Per-package rpm --addsign / debsign can be layered on
+      # once a hosted dnf/apt repo exists.
+      - name: GPG-sign checksums
+        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          cd dist
+          gpg --batch --yes --pinentry-mode loopback \
+            --passphrase "$GPG_PASSPHRASE" \
+            --armor --detach-sign --output SHA256SUMS.asc SHA256SUMS
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.version || github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: false
+          files: |
+            dist/openwatch-*.rpm
+            dist/openwatch_*.deb
+            dist/SHA256SUMS
+            dist/SHA256SUMS.asc
+            dist/sbom/*.cdx.json

--- a/specs/system/supply-chain.spec.yaml
+++ b/specs/system/supply-chain.spec.yaml
@@ -3,11 +3,11 @@ spec:
   title: Supply-chain governance — module allowlist, vulnerability, SBOM
   version: "1.0.0"
   status: draft
-  # Draft, tier 2 (80%): AC-08/AC-09 (release-workflow SBOM via syft/CycloneDX,
-  # constraint C-06) are deferred — the release workflow was archived with the
-  # Python CI and a Go-native release workflow is a tracked follow-up. Restore
-  # to tier 1 (100%) when that workflow lands and the SBOM ACs are covered.
-  tier: 2
+  # Back to tier 1: AC-08/AC-09 (release-workflow SBOM via syft/CycloneDX) are
+  # satisfied again now that .github/workflows/release.yml runs syft and emits
+  # CycloneDX 1.5. (They were temporarily deferred to tier 2 while the Go-native
+  # release workflow was being built after the Python CI was archived.)
+  tier: 1
 
   context:
     system: openwatch-go


### PR DESCRIPTION
Step 5 of the release-readiness work — the release pipeline. Cutting a `v*` tag
(or manual dispatch) now builds and publishes a full release.

## What the workflow does
1. **`make packages`** → all four native artifacts (RPM + DEB × amd64/arm64),
   each a complete API+UI binary (SPA embedded).
2. **syft** scans each binary/package → **CycloneDX 1.5** SBOM (`dist/sbom/*.cdx.json`).
3. **`SHA256SUMS`** over everything; **detached GPG signature** (`SHA256SUMS.asc`)
   when the `GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` repo secrets are set — **skipped
   gracefully** when they're not, so the workflow runs before a key exists.
4. **`softprops/action-gh-release`** publishes packages + SBOMs + checksums with
   auto-generated release notes.

Distribution model (your choice): **GitHub Releases** — operators download and
`sudo dnf install ./openwatch-*.rpm` / `sudo apt install ./openwatch_*.deb`.

## Spec impact
Satisfies **system-supply-chain AC-08** (syft SBOM) and **AC-09** (CycloneDX 1.5),
which were temporarily deferred to tier 2 while this workflow was being built →
**restored to tier 1** (11/11, 100%).

## Verification note
The workflow only runs on tags, so it's verified by inspection + the
locally-verified `make packages` targets (all four artifacts build with correct
arch + embedded SPA). The **first `-rc` tag is the true end-to-end test**, which
is exactly the RC step in the pre-release process (step 6).

## Action needed to enable signing
Provide a release GPG key as the `GPG_PRIVATE_KEY` (+ `GPG_PASSPHRASE`) repo
secrets. Until then, releases publish unsigned (checksums only).