### PR TITLE
Pre-release workflow: package-smoke install matrix + RELEASING runbook

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,97 @@
+name: Package smoke test
+
+# Install the freshly-built RPM/DEB on each target distribution and smoke-test:
+# the package installs cleanly (deps resolve), the system user + files land, and
+# the binary runs. This is the automatable half of the pre-release verification
+# gate (see docs/runbooks/RELEASING.md) — service start and functional E2E
+# against a real fleet remain a manual RC step.
+#
+# Runs on packaging changes, on release tags, and on demand. amd64 only (the
+# GitHub runners are amd64); the arm64 packages are covered by cross-build
+# correctness in package-build (AC-14) until arm64 runners/QEMU are wired in.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'packaging/**'
+      - '.github/workflows/package-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.4'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install rpmbuild
+        run: sudo apt-get update && sudo apt-get install -y rpm
+      - name: Build packages
+        run: make packages
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: |
+            dist/openwatch-*.rpm
+            dist/openwatch_*.deb
+          retention-days: 3
+
+  smoke:
+    name: ${{ matrix.distro }}
+    needs: build
+    runs-on: ubuntu-latest
+    container: ${{ matrix.distro }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { distro: 'rockylinux:9', kind: rpm }
+          - { distro: 'almalinux:9', kind: rpm }
+          - { distro: 'fedora:41', kind: rpm }
+          - { distro: 'oraclelinux:9', kind: rpm }
+          - { distro: 'ubuntu:24.04', kind: deb }
+          - { distro: 'debian:12', kind: deb }
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages
+          path: dist
+
+      - name: Install ${{ matrix.kind }}
+        run: |
+          set -eux
+          if [ "${{ matrix.kind }}" = "rpm" ]; then
+            # dnf resolves the postgresql-server dependency from the distro repos.
+            dnf install -y ./dist/openwatch-*.x86_64.rpm
+          else
+            apt-get update
+            # apt install of a local .deb pulls declared deps.
+            apt-get install -y ./dist/openwatch_*_amd64.deb
+          fi
+
+      - name: Smoke-test the install
+        run: |
+          set -eux
+          # Files in the expected places.
+          test -x /usr/bin/openwatch
+          test -f /etc/openwatch/openwatch.toml
+          test -f /etc/systemd/system/openwatch.service
+          test -f /etc/openwatch/tls/cert.pem
+          # System user created by the post-install scriptlet.
+          id openwatch
+          # Binary runs (no DB needed for these).
+          /usr/bin/openwatch --version
+          /usr/bin/openwatch check-config

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Start here: [Introduction](INTRODUCTION.md) | [Quickstart](guides/QUICKSTART.md)
 | [Backup & Recovery](guides/BACKUP_RECOVERY.md) | PostgreSQL backup, restore, and disaster recovery |
 | [Secret Rotation](guides/SECRET_ROTATION.md) | Rotating database, Redis, JWT, and encryption keys |
 | [Upgrade Procedure](guides/UPGRADE_PROCEDURE.md) | Upgrading OpenWatch with rollback procedures |
+| [Releasing](runbooks/RELEASING.md) | Gated pre-release process: docs freeze → RC → verification gate → GA, plus signing-key setup |
 | [Compliance Controls](guides/COMPLIANCE_CONTROLS.md) | NIST, CIS, CMMC, FedRAMP control mapping |
 
 ## Incident Response Runbooks

--- a/docs/runbooks/RELEASING.md
+++ b/docs/runbooks/RELEASING.md
@@ -1,0 +1,133 @@
+# Releasing OpenWatch
+
+The gated process for cutting an OpenWatch release. Nothing reaches a GA tag
+until the docs are frozen, every automated gate is green, the packages install
+and run on each target distro, a functional pass is done against a real fleet,
+and a human signs off.
+
+---
+
+## Versioning
+
+- Semantic versioning. The single source of truth is
+  [`packaging/version.env`](../../packaging/version.env) (`VERSION`, `CODENAME`).
+  The Go binary reads it via the Makefile `ldflags`, and the RPM/DEB build
+  scripts source it for the package version.
+- Release candidates use a `-rc.N` suffix (e.g. `0.2.0-rc.4`). The RPM version
+  field strips the suffix; the DEB and the binary keep it.
+- Tags are `v<version>` (e.g. `v0.2.0-rc.4`, `v0.2.0`).
+
+## The pipeline at a glance
+
+| Tag | Workflow | Produces |
+|-----|----------|----------|
+| `v*` | [`release.yml`](../../.github/workflows/release.yml) | RPM+DEB (amd64+arm64), CycloneDX SBOMs, `SHA256SUMS`(`.asc`) → GitHub Release |
+| `v*` / packaging PRs | [`package-smoke.yml`](../../.github/workflows/package-smoke.yml) | per-distro install + binary smoke |
+| every PR | [`go-ci.yml`](../../.github/workflows/go-ci.yml) | vet/lint/vuln/test-race + specter 100% AC coverage |
+
+---
+
+## Stage 1 — Docs freeze (before any tag)
+
+1. Bump `packaging/version.env` (`VERSION`, `CODENAME`).
+2. Update `CHANGELOG.md` for the version (GitHub auto-notes supplement this).
+3. Refresh user-facing docs that changed this cycle:
+   - `README.md` (version/badges, install flow)
+   - `docs/guides/INSTALLATION.md` (supported-distro matrix, commands)
+   - DB-migration notes for any new migrations
+   - API docs if `api/openapi.yaml` changed
+4. Confirm `specter check` and `specter coverage` are clean locally.
+
+## Stage 2 — Cut the release candidate
+
+```bash
+git tag v<version>-rc.N
+git push origin v<version>-rc.N
+```
+
+This triggers `release.yml` (builds + SBOMs + publishes a pre-release) and
+`package-smoke.yml` (per-distro install matrix).
+
+## Stage 3 — Verification gate (must all pass before GA)
+
+**Automated (CI):**
+- `go-ci` green on `main` at the RC commit — includes `specter sync` at **100% AC
+  coverage** (the `release-admin-signoff` C-01 requirement) and the composition
+  E2E (`internal/server/api_admin_*signoff*_test.go`, real session cookies).
+- `package-smoke` green — RPM installs on Rocky/Alma/Fedora/Oracle, DEB installs
+  on Ubuntu/Debian; binary runs (`--version`, `check-config`); system user + files
+  land. (amd64; arm64 install is covered by cross-build correctness until arm64
+  runners are wired in.)
+
+**Manual (on the RC, against a real fleet — CI cannot reach workstation hosts):**
+1. Install the RC package on a clean VM of at least one RHEL-family and one
+   Debian-family distro: `sudo dnf install ./openwatch-<v>.x86_64.rpm` /
+   `sudo apt install ./openwatch_<v>_amd64.deb`.
+2. `sudo openwatch migrate` && `sudo openwatch create-admin …` &&
+   `sudo systemctl enable --now openwatch`; confirm
+   `curl -k https://localhost:8443/api/v1/health` is healthy and the UI loads at
+   `https://<host>:8443/`.
+3. **Upgrade path:** install the previous GA, then upgrade to the RC; confirm the
+   service comes back and data survives.
+4. **Functional walkthrough** against the test fleet (`~/Documents/openwatch/test_hosts.csv`):
+   log in → add host → run a Kensa scan → view posture → drift → exceptions →
+   export → role-based access. Record results in the sign-off checklist.
+
+**Sign-off:** complete the `release-admin-signoff` Definition-of-Done. A release
+captain records pass/fail per DoD step and signs.
+
+> If any gate fails, fix on `main`, cut the next `-rc.N`, and repeat. Never
+> promote an RC that skipped a gate.
+
+## Stage 4 — Promote to GA
+
+```bash
+git tag v<version>          # no -rc suffix
+git push origin v<version>
+```
+
+`release.yml` builds the final signed artifacts + SBOMs and publishes the GA
+GitHub Release.
+
+## Stage 5 — Post-release smoke
+
+On a clean box, install the **published** artifact and confirm it starts:
+
+```bash
+# download openwatch-<v>.x86_64.rpm from the release, then:
+sudo dnf install ./openwatch-<v>.x86_64.rpm
+sudo openwatch migrate && sudo systemctl enable --now openwatch
+curl -k https://localhost:8443/api/v1/health
+```
+
+Then bump `packaging/version.env` to the next `-dev`/`-rc` and announce.
+
+---
+
+## Release signing key (GPG)
+
+`release.yml` signs `SHA256SUMS` with a detached GPG signature **only when** the
+signing key is configured; without it, releases publish with checksums but no
+signature. To enable:
+
+1. Generate a dedicated release key (offline, RSA 4096, no expiry or a long one):
+   ```bash
+   gpg --batch --gen-key <<EOF
+   %no-protection
+   Key-Type: RSA
+   Key-Length: 4096
+   Name-Real: OpenWatch Release Signing
+   Name-Email: release@hanalyx.com
+   Expire-Date: 2y
+   %commit
+   EOF
+   gpg --armor --export-secret-keys release@hanalyx.com   # → GPG_PRIVATE_KEY
+   gpg --armor --export release@hanalyx.com               # → publish this public key
+   ```
+2. Add repo secrets **`GPG_PRIVATE_KEY`** (the armored private key) and
+   **`GPG_PASSPHRASE`** (empty if `%no-protection`).
+3. Publish the **public** key (in the repo / release notes) so operators can
+   `gpg --verify SHA256SUMS.asc SHA256SUMS`.
+
+Per-package signing (`rpm --addsign`, `debsign`) and a hosted GPG-signed dnf/apt
+repo are a follow-up for when distribution moves beyond GitHub Releases.

--- a/packaging/deb/preinst
+++ b/packaging/deb/preinst
@@ -1,13 +1,20 @@
 #!/bin/sh
 # Pre-install: create the openwatch system user and group if absent.
+#
+# Uses groupadd/useradd (from the passwd package, present on every Debian/Ubuntu
+# system including minimal container images) rather than addgroup/adduser, which
+# live in the adduser package and are NOT installed on minimal images such as
+# ubuntu:24.04 — installing there fails the preinst with "addgroup: not found".
+# This matches the RPM scriptlet.
+#
 # Spec release-package-build AC-11.
 
 set -e
 
-getent group openwatch >/dev/null || addgroup --system openwatch
+getent group openwatch >/dev/null || groupadd --system openwatch
 getent passwd openwatch >/dev/null || \
-    adduser --system --ingroup openwatch \
-            --home /var/lib/openwatch --shell /sbin/nologin \
-            --gecos "OpenWatch service" openwatch
+    useradd --system --gid openwatch \
+            --home-dir /var/lib/openwatch --shell /usr/sbin/nologin \
+            --comment "OpenWatch service" openwatch
 
 exit 0


### PR DESCRIPTION
Step 6 — the pre-release verification gate. Operationalizes the release
governance that already exists (the `release-admin-signoff` DoD, the composition
E2E tests, the 100%-AC-coverage CI gate) and adds the missing automatable piece.

## What's here
- **`.github/workflows/package-smoke.yml`** — builds the packages, then in distro
  containers installs the **RPM on Rocky/Alma/Fedora/Oracle** and the **DEB on
  Ubuntu/Debian**, and smoke-tests: files land, the `openwatch` system user is
  created, and the binary runs (`--version`, `check-config`). Runs on packaging
  changes, release tags, and on demand. (amd64 — runners are amd64; arm64 install
  is covered by cross-build correctness / AC-14 until arm64 runners land.)
- **`docs/runbooks/RELEASING.md`** — the gated process end-to-end: versioning →
  Stage 1 docs freeze → Stage 2 RC tag → **Stage 3 verification gate** (CI 100% AC
  coverage + composition E2E + package-smoke + manual fleet E2E + the
  `release-admin-signoff` DoD) → Stage 4 GA → Stage 5 post-release. Includes the
  **GPG release-signing-key setup**.

## Note
This PR changes `package-smoke.yml`, so the install matrix **runs on this PR** —
its first real validation across the six distros. `go-ci` short-circuits (no
Go-relevant paths), so the required check passes trivially.

## Why E2E stays manual
The functional fleet walkthrough runs against real hosts (`test_hosts.csv`) that
CI can't reach, so it's a documented manual RC step rather than CI-automated —
unless/until a CI-reachable staging fleet exists.