### PR TITLE
Fix invalid release.yml (secrets not allowed in if)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,28 @@ jobs:
           sha256sum openwatch-*.rpm openwatch_*.deb sbom/*.cdx.json > SHA256SUMS
           cat SHA256SUMS
 
+      # The `secrets` context is not allowed in `if:`, so detect the signing key
+      # in a step (where secrets ARE allowed, via env) and gate the signing step
+      # on its output.
+      - name: Detect signing key
+        id: signing
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          if [ -n "$GPG_PRIVATE_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No GPG_PRIVATE_KEY secret set — publishing checksums without a signature."
+          fi
+
       # Detached GPG signature over the checksum manifest, so operators can
       # verify authenticity of every artifact with one key. Skipped when no
       # signing key is configured (set the GPG_PRIVATE_KEY / GPG_PASSPHRASE repo
       # secrets to enable). Per-package rpm --addsign / debsign can be layered on
       # once a hosted dnf/apt repo exists.
       - name: GPG-sign checksums
-        if: ${{ secrets.GPG_PRIVATE_KEY != '' }}
+        if: steps.signing.outputs.enabled == 'true'
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
**Surfaced by monitoring GH Actions after #492 merged:** every push to `main` was
producing a *failed* `release.yml` run — even though the workflow is tag-only.

## Cause
`release.yml` was an **invalid workflow**. The GPG-sign step used
`if: ${{ secrets.GPG_PRIVATE_KEY != '' }}`, but the **`secrets` context is not
allowed in `if`** conditions (`actionlint`:
`context "secrets" is not allowed here`). GitHub flagged the file as invalid and
emitted a failed run on every push — and crucially, **it would have failed to run
on a release tag, so no release could ever publish.**

## Fix
Detect the key in a step where `secrets` is available (via `env`), write a
`steps.signing.outputs.enabled` output, and gate the signing step on that.
Behavior is unchanged: sign when `GPG_PRIVATE_KEY` is set, else publish
checksums-only with a notice. `release.yml` is now `actionlint`-clean and valid.

## Follow-up worth doing
This class of bug (valid YAML, invalid Actions semantics) isn't caught by the
pre-commit `check-yaml` hook. Adding **actionlint** to CI/pre-commit would catch
it before merge. (Found one pre-existing, unrelated `actionlint` warning in
`claude-code-alerts.yml` — script-injection via PR title — left out of scope.)