### PR TITLE
fix(release): drop per-DEB signing (dpkg-sig removed from Ubuntu)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,18 @@ jobs:
             echo "cosign=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Per-package GPG signatures. rpmsign embeds the signature in each RPM
-      # header (operators verify with `rpm --import KEYS` + `rpm -K`, or dnf
-      # gpgcheck); dpkg-sig adds a builder signature to each DEB. Runs BEFORE
-      # SBOM/checksums because it rewrites the package bytes. The default
-      # %__gpg points at gpg2, absent on Ubuntu runners, so set it explicitly.
-      - name: GPG-sign packages
+      # Per-package GPG signatures for the RPMs. rpmsign embeds the signature in
+      # each RPM header (operators verify with `rpm --import KEYS` + `rpm -K`, or
+      # dnf gpgcheck). Runs BEFORE SBOM/checksums because it rewrites the package
+      # bytes. The default %__gpg points at gpg2, absent on Ubuntu runners, so set
+      # it explicitly.
+      #
+      # DEBs are NOT signed per-package: apt/dpkg never verify standalone-.deb
+      # signatures, and the tooling that produced them (dpkg-sig) was removed from
+      # Ubuntu. Each .deb's authenticity instead rides on its SHA256 in the
+      # GPG-signed (and cosign-signed) SHA256SUMS manifest below. A signed apt
+      # repo is the proper next step if per-DEB trust is ever required.
+      - name: GPG-sign RPMs
         if: steps.keys.outputs.gpg == 'true'
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -91,7 +97,7 @@ jobs:
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
           key_id="$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/{print $5; exit}')"
           gpg_bin="$(command -v gpg)"
-          # RPM: non-interactive rpmsign with a loopback-passphrase sign command.
+          # Non-interactive rpmsign with a loopback-passphrase sign command.
           cat > "$HOME/.rpmmacros" <<RPMMACROS
           %__gpg ${gpg_bin}
           %_signature gpg
@@ -99,11 +105,6 @@ jobs:
           %__gpg_sign_cmd %{__gpg} --batch --no-armor --pinentry-mode loopback --passphrase ${GPG_PASSPHRASE} --no-secmem-warning --digest-algo sha256 -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
           RPMMACROS
           rpmsign --addsign dist/openwatch-*.rpm
-          # DEB: dpkg-sig builder signature (passes the loopback passphrase to gpg).
-          sudo apt-get update -qq
-          sudo apt-get install -y dpkg-sig
-          dpkg-sig -g "--pinentry-mode loopback --passphrase ${GPG_PASSPHRASE}" \
-            -k "${key_id}" --sign builder dist/openwatch_*.deb
 
       # SBOM: syft scans the actual (signed) binary and packages and emits
       # CycloneDX 1.5 JSON — supply-chain AC-08 / AC-09.

--- a/docs/runbooks/RELEASING.md
+++ b/docs/runbooks/RELEASING.md
@@ -21,7 +21,7 @@ and a human signs off.
 
 | Tag | Workflow | Produces |
 |-----|----------|----------|
-| `v*` | [`release.yml`](../../.github/workflows/release.yml) | RPM+DEB (amd64+arm64, GPG-signed per-package), CycloneDX SBOMs, `SHA256SUMS` (GPG `.asc` + cosign `.sig`), `KEYS` → GitHub Release |
+| `v*` | [`release.yml`](../../.github/workflows/release.yml) | RPM+DEB (amd64+arm64; RPMs GPG-signed per-package), CycloneDX SBOMs, `SHA256SUMS` (GPG `.asc` + cosign `.sig`), `KEYS` → GitHub Release |
 | `v*` / packaging PRs | [`package-smoke.yml`](../../.github/workflows/package-smoke.yml) | per-distro install + binary smoke |
 | every PR | [`go-ci.yml`](../../.github/workflows/go-ci.yml) | vet/lint/vuln/test-race + specter 100% AC coverage |
 
@@ -106,15 +106,22 @@ Then bump `packaging/version.env` to the next `-dev`/`-rc` and announce.
 
 ## Signing model
 
-When the signing keys are configured, `release.yml` signs at three layers (and
+When the signing keys are configured, `release.yml` signs at these layers (and
 skips each layer gracefully if its key is absent — releases still publish,
 unsigned):
 
 | Layer | How | Operator verifies |
 |---|---|---|
 | **Each RPM** | `rpmsign --addsign` (GPG, in the RPM header) | `rpm --import KEYS` then `rpm -K openwatch-*.rpm` → "signatures OK"; or dnf `gpgcheck=1` |
-| **Each DEB** | `dpkg-sig --sign builder` (GPG) | `dpkg-sig --verify openwatch_*.deb` (standalone-`.deb` verification is niche; the signed checksums below are the primary DEB authenticity path until a signed apt repo exists) |
+| **Each DEB** | *not* signed per-package — see note | covered by the signed `SHA256SUMS` below |
 | **`SHA256SUMS`** | detached GPG (`.asc`) **and** cosign (`.cosign.sig`) | `gpg --verify SHA256SUMS.asc SHA256SUMS`; `cosign verify-blob --key cosign.pub --signature SHA256SUMS.cosign.sig SHA256SUMS` |
+
+> **Why DEBs aren't signed per-package:** `apt`/`dpkg` never verify a
+> standalone `.deb`'s embedded signature, and the tool that produced them
+> (`dpkg-sig`) was removed from Ubuntu. Each `.deb`'s authenticity instead
+> comes from its SHA256 entry in the GPG- (and cosign-) signed `SHA256SUMS`.
+> A signed apt **repository** is the proper path if per-DEB trust is ever
+> required.
 
 The Hanalyx GPG public key ships in the repo as [`KEYS`](../../KEYS) and is
 attached to every release.


### PR DESCRIPTION
## What broke

The `v0.2.0-rc.4` release pipeline failed at **GPG-sign packages**:
```
E: Unable to locate package dpkg-sig
```
`dpkg-sig` was removed from the Ubuntu archive, so it can't be installed on the runner. **RPM signing (`rpmsign`) succeeded** — both `.rpm` files were signed cleanly; only the DEB-specific tool is gone. No release was published (publish step skipped).

## Fix

Drop per-DEB signing rather than chase a replacement tool:
- `apt`/`dpkg` **never verify** a standalone `.deb`'s embedded signature.
- Every `.deb` is **already authenticated** by its SHA256 in the GPG- and cosign-signed `SHA256SUMS`.
- RPMs keep their per-package `rpmsign` signatures (verified working in the rc.4 run).

Renames the step to **GPG-sign RPMs**, removes the `dpkg-sig` install + sign block, and updates `RELEASING.md`'s signing model (DEB row + pipeline summary). A signed apt **repository** remains the proper path if per-DEB trust is ever required.

actionlint-clean; YAML valid.

## Next

After merge: delete + re-push `v0.2.0-rc.4` (it published nothing) to re-run the pipeline through to a published, signed pre-release.