### PR TITLE
fix(release): mark pre-release tags as GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,9 @@ jobs:
           tag_name: ${{ github.event.inputs.version || github.ref_name }}
           generate_release_notes: true
           fail_on_unmatched_files: false
+          # Any version with a pre-release suffix (e.g. -rc.4, -beta.1) is a
+          # pre-release; a bare vX.Y.Z (no hyphen) is a GA release.
+          prerelease: ${{ contains(github.event.inputs.version || github.ref_name, '-') }}
           files: |
             dist/openwatch-*.rpm
             dist/openwatch_*.deb


### PR DESCRIPTION
rc.4 published with `prerelease: false`, showing a candidate as GA (fixed on the live release via `gh release edit`). This sets `prerelease` from the tag: a hyphen suffix (`-rc.N`/`-beta.N`) → pre-release; bare `vX.Y.Z` → GA. actionlint-clean.