### PR TITLE
chore(release): cut 0.2.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.2.0-rc.5] Eyrie — 2026-06-08
+
+Package-refresh candidate: re-cuts the signed RPM/DEB from `main` so the
+published artifacts include the version-endpoint and auth-redirect fixes
+that landed after rc.4. Still a pre-release — not GA.
+
+### Added
+
+- `GET /api/v1/version` (anonymous) reporting the OpenWatch, Kensa, and Go
+  versions plus commit/build-time, all sourced from build metadata rather
+  than constants. Settings → About now renders these live instead of
+  hardcoded strings (#500).
+
+### Fixed
+
+- Frontend: an expired/invalid session now always redirects to `/login`
+  instead of leaving the user on a raw error envelope. A global, code-aware
+  QueryCache/MutationCache handler covers every query and mutation;
+  authorization (permission) errors are excluded so they never log a user
+  out (#501).
+- Release: `v*` tags with a pre-release suffix now publish as GitHub
+  pre-releases (a bare `vX.Y.Z` is GA) (#499).
+
+---
+
 ## [0.2.0-rc.4] Eyrie — 2026-06-08
 
 The release-readiness candidate: OpenWatch Go is now a single, installable

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.4"
+VERSION="0.2.0-rc.5"
 CODENAME="Eyrie"


### PR DESCRIPTION
## What

Re-cut the signed RPM/DEB packages from `main` as a new **pre-release** (`v0.2.0-rc.5`). rc.4's published packages predate #499/#500/#501, so this refreshes them. **Not GA.**

- `packaging/version.env`: `0.2.0-rc.4` → `0.2.0-rc.5` (verified: the binary reports `openwatch 0.2.0-rc.5`).
- CHANGELOG `[0.2.0-rc.5]` entry.

## What it adds over rc.4

- `GET /api/v1/version` + dynamic Settings → About (#500)
- Auth-failure → `/login` redirect (#501)
- Pre-release tag auto-flag (#499)

## After merge

Tag `v0.2.0-rc.5` → `release.yml` builds the 4 packages (RPM/DEB × amd64/arm64), GPG-signs the RPMs, generates SBOMs, GPG-signs `SHA256SUMS`, and publishes a **pre-release** GitHub Release. This is the proven rc.4 pipeline, now carrying the post-rc.4 fixes.