### PR TITLE
fix(correlation): read clock under the lock to keep IDs unique

### DIFF
--- a/internal/correlation/correlation.go
+++ b/internal/correlation/correlation.go
@@ -70,10 +70,7 @@ var (
 // Panics on rand.Read failure — that condition signals the OS RNG is broken,
 // which is not recoverable.
 func Generate(prefix Prefix) string {
-	// UnixMilli() returns a non-negative int64 for any time after the
-	// Unix epoch (1970-01-01). Safe to widen to uint64.
-	nowMs := uint64(time.Now().UnixMilli()) //nolint:gosec // post-epoch wall clock is non-negative
-	c := nextCounter(nowMs)
+	nowMs, c := nextStamp()
 
 	var u [8]byte
 	u[0] = byte(nowMs >> 40)
@@ -87,17 +84,31 @@ func Generate(prefix Prefix) string {
 	return string(prefix) + "-" + hex.EncodeToString(u[:])
 }
 
-// nextCounter returns the next monotonic counter value for the given ms.
-// If ms advanced since the last call, the counter is reseeded with random
-// bits. Otherwise it increments. A wrap (back to 0) in the same ms is
-// theoretically possible at extreme rates and would produce a duplicate
-// ID; in practice this would require ~65M generates per millisecond.
-func nextCounter(nowMs uint64) uint16 {
+// nextStamp returns the (millisecond, counter) pair to embed in an ID. The
+// pair is unique across every call: monoLastMs is monotonic non-decreasing,
+// and within a given millisecond the counter strictly increments from a
+// random seed.
+//
+// The clock MUST be read here, under the same lock that guards the counter.
+// The earlier design read the timestamp in Generate (outside the lock) and
+// passed it in; concurrent callers crossing a millisecond boundary could
+// then present out-of-order ms values at lock-acquisition time, reseeding
+// the per-ms counter more than once for the same ms — two independent random
+// sequences for one ms that could collide. Reading the clock inside the lock,
+// and only ever advancing monoLastMs, closes that window (a backward
+// wall-clock jump folds into the increment branch and never repeats a pair).
+//
+// A counter wrap (back to its seed) within one ms would require ~65536
+// generates in that ms and is treated as out of scope, as before.
+func nextStamp() (uint64, uint16) {
 	monoMu.Lock()
 	defer monoMu.Unlock()
 
-	if nowMs != monoLastMs {
-		// New millisecond: reseed.
+	// UnixMilli() returns a non-negative int64 for any time after the
+	// Unix epoch (1970-01-01). Safe to widen to uint64.
+	nowMs := uint64(time.Now().UnixMilli()) //nolint:gosec // post-epoch wall clock is non-negative
+	if nowMs > monoLastMs {
+		// First ID in a new millisecond: reseed the counter.
 		monoLastMs = nowMs
 		var r [2]byte
 		if _, err := rand.Read(r[:]); err != nil {
@@ -105,9 +116,10 @@ func nextCounter(nowMs uint64) uint16 {
 		}
 		monoCounter = uint16(r[0])<<8 | uint16(r[1])
 	} else {
+		// Same ms, or a backward clock jump: keep monoLastMs and increment.
 		monoCounter++
 	}
-	return monoCounter
+	return monoLastMs, monoCounter
 }
 
 // SanitizeOrGenerate inspects a client-supplied X-Correlation-Id header

--- a/internal/correlation/correlation_test.go
+++ b/internal/correlation/correlation_test.go
@@ -65,24 +65,34 @@ func TestGenerate_UniquenessSequential(t *testing.T) {
 func TestGenerate_UniquenessConcurrent(t *testing.T) {
 	t.Run("system-correlation/AC-03", func(t *testing.T) {
 
-		const n = 1000
-		ids := make([]string, n)
-		var wg sync.WaitGroup
-		wg.Add(n)
-		for i := 0; i < n; i++ {
-			go func(i int) {
-				defer wg.Done()
-				ids[i] = Generate(PrefixRequest)
-			}(i)
-		}
-		wg.Wait()
-
-		seen := make(map[string]struct{}, n)
-		for _, id := range ids {
-			if _, dup := seen[id]; dup {
-				t.Fatalf("duplicate id under concurrency: %s", id)
+		// The hard case is concurrent generation across millisecond
+		// boundaries: goroutines that read the clock on different sides of
+		// a tick must still never collide. A single burst only crosses a
+		// boundary or two, so run many rounds and assert uniqueness across
+		// ALL of them — this spans enough boundaries to surface a
+		// reseed-twice-per-ms regression rather than passing by luck.
+		const (
+			rounds = 50
+			n      = 2000
+		)
+		seen := make(map[string]struct{}, rounds*n)
+		for r := 0; r < rounds; r++ {
+			ids := make([]string, n)
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for i := 0; i < n; i++ {
+				go func(i int) {
+					defer wg.Done()
+					ids[i] = Generate(PrefixRequest)
+				}(i)
 			}
-			seen[id] = struct{}{}
+			wg.Wait()
+			for _, id := range ids {
+				if _, dup := seen[id]; dup {
+					t.Fatalf("duplicate id under concurrency (round %d): %s", r, id)
+				}
+				seen[id] = struct{}{}
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Real bug, not a flake

`make test-race` on `main` (after the rc.5 merge) failed:
```
TestGenerate_UniquenessConcurrent/system-correlation/AC-03
  duplicate id under concurrency: req-019eaa3f82849e2c
```
The same commit passed on the PR run — the classic "passed by luck" signature. This is a genuine correlation-ID collision under concurrency.

## Root cause

`Generate()` read `time.Now().UnixMilli()` **outside** the counter lock and passed it to `nextCounter`. The "monotonic counter per ms" scheme guarantees uniqueness only if `monoLastMs` tracks the current ms monotonically — but with the timestamp captured before the lock, two goroutines crossing a millisecond boundary can present **out-of-order** ms values at lock-acquisition time. That makes `monoLastMs` flip backward and **reseed the per-ms counter twice for the same ms** → two independent random sequences for one millisecond that can overlap → duplicate ID.

## Fix

Read the clock **inside** the lock (`nextStamp`) and only ever advance `monoLastMs`, so the embedded timestamp and counter are chosen atomically. A backward wall-clock jump (NTP) folds into the increment branch instead of reseeding, so a `(ms, counter)` pair is never repeated.

## Verification

- Strengthened AC-03 to 50 rounds × 2000 goroutines with **global** uniqueness across rounds (spans many ms boundaries).
- New test **fails deterministically on the old code** (round ~2) and **passes 200×+ under `-race`** with the fix.
- `go vet` + `gofmt` clean.

No spec change — same AC-03, just a stronger test.