### PR TITLE
test(perf): make latency budgets non-gating to stop CI flakes

### DIFF
--- a/internal/audit/emit_test.go
+++ b/internal/audit/emit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
 	"github.com/Hanalyx/openwatch/internal/internalrace"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -127,7 +128,7 @@ func TestEmitSync_Latency(t *testing.T) {
 		// real-DB ceiling; race detector multiplies it.
 		budget := 10 * time.Millisecond * time.Duration(internalrace.Multiplier())
 		if p99 > budget {
-			t.Errorf("EmitSync p99 = %v, want < %v (spec target 500µs)", p99, budget)
+			perftest.Budgetf(t, "EmitSync p99 = %v, want < %v (spec target 500µs)", p99, budget)
 		}
 		t.Logf("EmitSync p99 = %v (spec target 500µs)", p99)
 	})
@@ -322,7 +323,7 @@ func TestEmit_Latency(t *testing.T) {
 		// "noticeable regression" ceiling; race detector multiplies it.
 		budget := 50 * time.Microsecond * time.Duration(internalrace.Multiplier())
 		if p99 > budget {
-			t.Errorf("Emit p99 = %v, want < %v (spec target 10µs)", p99, budget)
+			perftest.Budgetf(t, "Emit p99 = %v, want < %v (spec target 10µs)", p99, budget)
 		}
 		t.Logf("Emit p99 = %v (spec target 10µs)", p99)
 	})

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Hanalyx/openwatch/internal/perftest"
 )
 
 // @ac AC-01
@@ -254,7 +256,7 @@ func TestRequirePermission_HotPathLatency(t *testing.T) {
 		// 5µs envelope. Spec target 1µs (registry lookup only); httptest
 		// recorder + handler invocation overhead adds 2-3µs typically.
 		if p99 > 50*time.Microsecond {
-			t.Errorf("RequirePermission p99 = %v, want < 50µs (spec target 1µs)", p99)
+			perftest.Budgetf(t, "RequirePermission p99 = %v, want < 50µs (spec target 1µs)", p99)
 		}
 		t.Logf("RequirePermission p99 = %v (spec target 1µs)", p99)
 	})

--- a/internal/idempotency/middleware_test.go
+++ b/internal/idempotency/middleware_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -363,7 +364,7 @@ func TestIdempotency_LookupLatencyP99(t *testing.T) {
 		}
 		p99 := durs[int(float64(n)*0.99)]
 		if p99 > 5*time.Millisecond {
-			t.Errorf("Cache lookup p99 = %v, want < 5ms", p99)
+			perftest.Budgetf(t, "Cache lookup p99 = %v, want < 5ms", p99)
 		}
 		t.Logf("Cache lookup p99 = %v over %d replays", p99, n)
 	})

--- a/internal/identity/jwt_test.go
+++ b/internal/identity/jwt_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/internalrace"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/google/uuid"
 )
 
@@ -217,7 +218,7 @@ func TestJWT_RoundTripLatency(t *testing.T) {
 		p99 := durs[idx]
 		budget := 5 * time.Millisecond * time.Duration(internalrace.Multiplier())
 		if p99 > budget {
-			t.Errorf("JWT round-trip p99 = %v, want < %v (spec target 5ms)", p99, budget)
+			perftest.Budgetf(t, "JWT round-trip p99 = %v, want < %v (spec target 5ms)", p99, budget)
 		}
 		t.Logf("JWT round-trip p99 = %v over %d calls (budget %v)", p99, n, budget)
 	})

--- a/internal/identity/password_test.go
+++ b/internal/identity/password_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/internalrace"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 )
 
 // @ac AC-01
@@ -156,7 +157,7 @@ func TestPassword_VerifyLatency(t *testing.T) {
 		p99 := durs[idx]
 		budget := 200 * time.Millisecond * time.Duration(internalrace.Multiplier())
 		if p99 > budget {
-			t.Errorf("VerifyPassword p99 = %v, want < %v (spec target 200ms)", p99, budget)
+			perftest.Budgetf(t, "VerifyPassword p99 = %v, want < %v (spec target 200ms)", p99, budget)
 		}
 		t.Logf("VerifyPassword p99 = %v over %d calls (budget %v)", p99, n, budget)
 	})

--- a/internal/license/features_test.go
+++ b/internal/license/features_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/internalrace"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 )
 
 // resetState clears the package-level state. Each test starts clean.
@@ -274,7 +275,7 @@ func TestIsEnabled_P99Latency(t *testing.T) {
 		// hot-path atomic loads; multiplier compensates.
 		budget := 250 * time.Nanosecond * time.Duration(internalrace.Multiplier())
 		if p99 > budget {
-			t.Errorf("IsEnabled p99 = %v, want < %v (spec target 50ns)", p99, budget)
+			perftest.Budgetf(t, "IsEnabled p99 = %v, want < %v (spec target 50ns)", p99, budget)
 		}
 		t.Logf("IsEnabled p99 = %v over %d calls (budget %v)", p99, n, budget)
 	})

--- a/internal/license/validator_test.go
+++ b/internal/license/validator_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -307,7 +308,7 @@ func TestVerify_P99Latency(t *testing.T) {
 		}
 		p99 := durs[int(float64(n)*0.99)]
 		if p99 > 1*time.Millisecond {
-			t.Errorf("Verify p99 = %v, want < 1ms", p99)
+			perftest.Budgetf(t, "Verify p99 = %v, want < 1ms", p99)
 		}
 		t.Logf("Verify p99 = %v over %d calls", p99, n)
 	})

--- a/internal/perftest/perftest.go
+++ b/internal/perftest/perftest.go
@@ -1,0 +1,39 @@
+// Package perftest gates latency-budget assertions behind an explicit opt-in.
+//
+// Tail-latency budgets — a p99 taken over a few hundred samples — are noisy
+// when measured on a shared CI runner, and more so under the `-race` detector,
+// which inflates timing by design. Gating a merge on such a budget produces
+// false failures on changes that cannot affect performance (a docs-only PR has
+// tripped the job-queue enqueue budget at 11ms vs a 10ms target).
+//
+// So by default these checks RUN and LOG their measurement but do NOT fail the
+// build. To enforce the budgets — on a quiet, dedicated runner, ideally a
+// non-`-race` build — set OPENWATCH_PERF_ASSERT=1.
+package perftest
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// envEnforce is the opt-in switch for latency-budget enforcement.
+const envEnforce = "OPENWATCH_PERF_ASSERT"
+
+// Enforce reports whether latency budgets should fail the test rather than
+// only log. False unless OPENWATCH_PERF_ASSERT=1.
+func Enforce() bool { return os.Getenv(envEnforce) == "1" }
+
+// Budgetf records a latency-budget overrun. Call it on the over-budget path
+// with the same message you would have passed to t.Errorf. When enforcement is
+// enabled it fails the test; otherwise it logs the overrun and lets the test
+// pass, so a noisy runner never produces a false failure.
+func Budgetf(t testing.TB, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if Enforce() {
+		t.Error(msg)
+		return
+	}
+	t.Logf("perf (non-gating; set %s=1 to enforce): %s", envEnforce, msg)
+}

--- a/internal/policy/loader_test.go
+++ b/internal/policy/loader_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
 	"github.com/Hanalyx/openwatch/internal/internalrace"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"
 )
@@ -502,7 +503,7 @@ func TestEvaluate_HotPathLatency(t *testing.T) {
 		// 200µs is the regression ceiling; race detector multiplies it.
 		budget := 200 * time.Microsecond * time.Duration(internalrace.Multiplier())
 		if p99 > budget {
-			t.Errorf("Evaluate p99 = %v, want < %v (spec target 50µs)", p99, budget)
+			perftest.Budgetf(t, "Evaluate p99 = %v, want < %v (spec target 50µs)", p99, budget)
 		}
 		t.Logf("Evaluate p99 = %v over %d calls (budget %v)", p99, n, budget)
 	})

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -398,7 +399,7 @@ func TestEnqueue_LatencyP99(t *testing.T) {
 		idx := int(float64(nn) * 0.99)
 		p99 := durs[idx]
 		if p99 > 10*time.Millisecond {
-			t.Errorf("Enqueue p99 = %v, want < 10ms (spec target 5ms; local DB load may push to 5-10ms)", p99)
+			perftest.Budgetf(t, "Enqueue p99 = %v, want < 10ms (spec target 5ms; local DB load may push to 5-10ms)", p99)
 		}
 		t.Logf("Enqueue p99 = %v over %d calls", p99, n)
 	})

--- a/internal/server/api_health_test.go
+++ b/internal/server/api_health_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Hanalyx/openwatch/internal/perftest"
 )
 
 // @ac AC-01
@@ -119,7 +121,7 @@ func TestAPI_Health_LatencyP99(t *testing.T) {
 		}
 		p99 := durs[int(float64(n)*0.99)]
 		if p99 > 100*time.Millisecond {
-			t.Errorf("/health p99 = %v, want < 100ms", p99)
+			perftest.Budgetf(t, "/health p99 = %v, want < 100ms", p99)
 		}
 		t.Logf("/health p99 = %v over %d calls", p99, n)
 	})


### PR DESCRIPTION
## Problem

The p99 latency tests assert hard wall-clock budgets that **gate every PR**, and they run in *both* CI test jobs (`make test-race` and the non-race `go test ./...`). A p99 over a few hundred samples on a shared CI runner — inflated further by the `-race` detector — is inherently noisy:

```
TestEnqueue_LatencyP99: Enqueue p99 = 11.303402ms, want < 10ms
```
That failure was on a **docs-only PR that changed zero Go code**. It (and `TestEmitSync_Latency`) have tripped CI repeatedly with false failures and forced reruns.

Root causes: (1) asserting wall-clock latency **under `-race`**; (2) **p99 of ~200 samples** ≈ the 2nd-slowest call, dominated by one outlier; (3) using it as a **hard merge gate** against a shared runner + co-located PostgreSQL whose commit tail is environmental.

## Fix

New `internal/perftest`: `Budgetf` logs an over-budget measurement and lets the test pass by default; set `OPENWATCH_PERF_ASSERT=1` (on a quiet, non-`-race` runner) to enforce. Converted the **11 tight p99/hot-path budgets** (queue, license ×2, auth, idempotency, server `/health`, audit ×2, policy, identity jwt/password).

The tests **still run, still cover their spec ACs (specter 100%), and still log the measurement** — they just no longer fail the build on a noisy tail. Enforcement is preserved on-demand.

**Left as hard gates** (not flaky, catch real hangs): `db NewPool < 6s`, `ssh handshake < 1s`, `liveness Run-exit < 2s`.

## Verified
- `gofmt`, `go vet` (printf-wrapper recognized), `go build ./...`, `golangci-lint` all clean on touched packages.
- Latency tests pass both default (non-gating) and with `OPENWATCH_PERF_ASSERT=1`.
- `specter check` + `coverage` 100% (ACs still covered).

Supersedes the inconsistently-applied `internalrace.Multiplier()` budget-scaling hack (left in place; harmless, now only affects the logged number).