### PR TITLE
fix(specs): restore dropped connectivity API specs + concurrency AC

### DIFF
--- a/internal/server/api_system_connectivity_test.go
+++ b/internal/server/api_system_connectivity_test.go
@@ -1,4 +1,4 @@
-// @spec api-system-connectivity, api-fleet-connectivity-breakdown, api-host-connectivity-check
+// @spec api-system-connectivity
 //
 // AC traceability (this file):
 //
@@ -251,6 +251,7 @@ func TestAPI_SystemConnectivity_Status_Anonymous_Forbidden(t *testing.T) {
 
 // AC-01..AC-03: classifies online vs degraded vs critical vs down vs
 // never_probed based on consecutive_failures + reachability_status.
+// @spec api-fleet-connectivity-breakdown
 // @ac AC-02
 func TestAPI_FleetConnectivity_Breakdown_ClassifiesByHysteresisBand(t *testing.T) {
 	t.Run("api-fleet-connectivity-breakdown/AC-02", func(t *testing.T) {
@@ -396,6 +397,7 @@ func TestAPI_FleetConnectivity_Breakdown_Anonymous_Forbidden(t *testing.T) {
 // Host on-demand connectivity check
 // ---------------------------------------------------------------------
 
+// @spec api-host-connectivity-check
 // AC-03: POST against {id} that doesn't exist returns 404.
 // @ac AC-03
 func TestAPI_HostConnectivity_Check_NotFound_Returns404(t *testing.T) {

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -232,38 +232,40 @@ func TestSetConnectivity_EmitsConfigChangedWithOldAndNew(t *testing.T) {
 	})
 }
 
-// AC-09: two concurrent Set calls complete cleanly; final state is one
+// AC-06: two concurrent Set calls complete cleanly; final state is one
 // of the two writers' inputs.
-// @ac AC-09
+// @ac AC-06
 func TestConcurrentSet_LastWriterWins_NoDeadlock(t *testing.T) {
-	pool := freshPool(t)
-	s := NewStore(pool, nil)
+	t.Run("services-connectivity-config/AC-06", func(t *testing.T) {
+		pool := freshPool(t)
+		s := NewStore(pool, nil)
 
-	a := DefaultConnectivity()
-	a.OnlineSec = 600
-	b := DefaultConnectivity()
-	b.OnlineSec = 1200
+		a := DefaultConnectivity()
+		a.OnlineSec = 600
+		b := DefaultConnectivity()
+		b.OnlineSec = 1200
 
-	done := make(chan error, 2)
-	go func() { done <- s.SetConnectivity(context.Background(), a, "alice") }()
-	go func() { done <- s.SetConnectivity(context.Background(), b, "bob") }()
+		done := make(chan error, 2)
+		go func() { done <- s.SetConnectivity(context.Background(), a, "alice") }()
+		go func() { done <- s.SetConnectivity(context.Background(), b, "bob") }()
 
-	for i := 0; i < 2; i++ {
-		select {
-		case err := <-done:
-			if err != nil {
-				t.Errorf("concurrent Set returned error: %v", err)
+		for i := 0; i < 2; i++ {
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("concurrent Set returned error: %v", err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("timeout waiting for concurrent Set — possible deadlock")
 			}
-		case <-time.After(10 * time.Second):
-			t.Fatalf("timeout waiting for concurrent Set — possible deadlock")
 		}
-	}
 
-	got, err := s.LoadConnectivity(context.Background())
-	if err != nil {
-		t.Fatalf("LoadConnectivity: %v", err)
-	}
-	if got != a && got != b {
-		t.Errorf("final state %+v matched neither writer", got)
-	}
+		got, err := s.LoadConnectivity(context.Background())
+		if err != nil {
+			t.Fatalf("LoadConnectivity: %v", err)
+		}
+		if got != a && got != b {
+			t.Errorf("final state %+v matched neither writer", got)
+		}
+	})
 }

--- a/specs/api/fleet-connectivity-breakdown.spec.yaml
+++ b/specs/api/fleet-connectivity-breakdown.spec.yaml
@@ -1,0 +1,78 @@
+spec:
+  id: api-fleet-connectivity-breakdown
+  title: Fleet connectivity breakdown API — 4-state hysteresis counts
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Derived per-state connectivity counts for the fleet, classified by consecutive-failure hysteresis
+    description: >
+      GET /api/v1/fleet/connectivity/breakdown returns derived per-state host
+      counts for the Settings → Scanning & monitoring page. Bands come from
+      each host's reachability plus its consecutive_failures hysteresis:
+      online = reachable and consec=0, degraded = reachable and consec>=1,
+      critical = unreachable and consec<3, down = consec>=3, never_probed = no
+      liveness row. The counts sum to the active host count.
+
+      This spec covers the HTTP read endpoint and its classification contract.
+      It was authored and approved with PR #434 but dropped from the tree in
+      that PR's squash-merge and never restored; it is reconstructed here from
+      internal/server/api_system_connectivity_test.go and the api/openapi.yaml
+      contract. The acceptance-criteria ids follow those surviving tests, so
+      the numbering is non-contiguous.
+    related_specs:
+      - services-connectivity-config
+      - api-fleet-observability
+      - system-liveness-loop
+      - system-rbac
+
+  objective:
+    summary: >
+      The endpoint returns five integer counts (online, degraded, critical,
+      down, never_probed) derived from per-host reachability and
+      consecutive-failure hysteresis, summing to the active host count, and is
+      RBAC-gated on system:read.
+    scope:
+      includes:
+        - GET /api/v1/fleet/connectivity/breakdown
+        - Hysteresis band classification from reachability + consecutive_failures
+        - Empty-fleet handling (zeros, not an error)
+        - RBAC — system:read
+      excludes:
+        - The per-state probe cadences themselves (services-connectivity-config)
+        - The single-config CRUD surface (api-system-connectivity)
+        - Other fleet rollups (api-fleet-observability)
+
+  constraints:
+    - id: C-01
+      description: GET /api/v1/fleet/connectivity/breakdown classifies each active host into exactly one of online / degraded / critical / down / never_probed using reachability and consecutive_failures; the five counts sum to the active host count.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: A consecutive_failures value at or above the down threshold (>=3) places the host in the down band regardless of the last single reachability sample.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: The endpoint requires system:read; an anonymous caller is rejected.
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-02
+      description: With hosts spanning the bands, GET /api/v1/fleet/connectivity/breakdown returns counts that classify each host into the correct band per the hysteresis rules and sum to the active host count.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-05
+      description: A host with consecutive_failures at or above the down threshold is counted in the down band even if other signals would suggest a milder band (high-consec dominates).
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-06
+      description: For an empty fleet (no active hosts) the endpoint returns 200 with all counts zero, not an error.
+      priority: high
+      references_constraints: [C-01]
+    - id: AC-07
+      description: GET /api/v1/fleet/connectivity/breakdown by an anonymous caller is rejected (not authenticated).
+      priority: high
+      references_constraints: [C-03]

--- a/specs/api/host-connectivity-check.spec.yaml
+++ b/specs/api/host-connectivity-check.spec.yaml
@@ -1,0 +1,59 @@
+spec:
+  id: api-host-connectivity-check
+  title: On-demand host connectivity check API
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Operator-triggered, on-demand connectivity probe for a single host
+    description: >
+      POST /api/v1/hosts/{id}/connectivity:check runs an immediate connectivity
+      probe for one host, outside the periodic liveness loop. It is a mutating
+      action (it writes a fresh liveness sample), so it requires an
+      Idempotency-Key header; an unknown host id returns 404.
+
+      This spec covers the HTTP endpoint's not-found and idempotency-key
+      contract. It was authored and approved with PR #434 but dropped from the
+      tree in that PR's squash-merge and never restored; it is reconstructed
+      here from internal/server/api_system_connectivity_test.go and the
+      api/openapi.yaml contract. The acceptance-criteria ids follow those
+      surviving tests, so the numbering is non-contiguous.
+    related_specs:
+      - system-idempotency
+      - system-liveness-loop
+      - system-rbac
+
+  objective:
+    summary: >
+      The endpoint probes one host on demand; an unknown host id returns 404,
+      and a request without the required Idempotency-Key returns 400.
+    scope:
+      includes:
+        - POST /api/v1/hosts/{id}/connectivity:check
+        - 404 for an unknown host id
+        - Idempotency-Key requirement (400 when absent)
+      excludes:
+        - The periodic liveness probe loop (system-liveness-loop)
+        - Idempotent replay semantics in general (system-idempotency)
+
+  constraints:
+    - id: C-01
+      description: POST /api/v1/hosts/{id}/connectivity:check is a mutating action and MUST require an Idempotency-Key header; a request without it returns 400.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: A request for a host id that does not exist returns 404 with the canonical hosts.not_found error envelope.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-03
+      description: POST /api/v1/hosts/{id}/connectivity:check for an unknown host id returns 404 with the canonical hosts.not_found error envelope.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-05
+      description: POST /api/v1/hosts/{id}/connectivity:check without an Idempotency-Key header returns 400.
+      priority: high
+      references_constraints: [C-01]

--- a/specs/api/system-connectivity.spec.yaml
+++ b/specs/api/system-connectivity.spec.yaml
@@ -1,0 +1,103 @@
+spec:
+  id: api-system-connectivity
+  title: System connectivity API — runtime config CRUD + live status
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: HTTP surface for the connectivity-monitor runtime config and the live status snapshot
+    description: >
+      The /api/v1/system/connectivity/* endpoints let an operator read and
+      update the host-liveness probe config (per-state intervals, timeout,
+      thresholds — owned at the service layer by services-connectivity-config)
+      and read a live status snapshot. GET config returns the active snapshot
+      plus the baked-in defaults; PUT config validates bounds at the handler
+      boundary, persists, signals the in-process liveness service to Reload,
+      and emits system.config.changed. GET status surfaces the liveness
+      MetricsSnapshot.
+
+      This spec covers the HTTP layer (routing, request/response shapes,
+      validation status codes, RBAC) on top of the service-layer contract in
+      services-connectivity-config. It was authored and approved with PR #434
+      but dropped from the tree in that PR's squash-merge and never restored;
+      it is reconstructed here from the handler tests in
+      internal/server/api_system_connectivity_test.go and the api/openapi.yaml
+      contract. The acceptance-criteria ids follow those surviving tests, so
+      the numbering is non-contiguous (only the test-covered criteria are
+      restored).
+    related_specs:
+      - services-connectivity-config
+      - system-liveness-loop
+      - system-rbac
+      - system-audit-emission
+
+  objective:
+    summary: >
+      GET /api/v1/system/connectivity/config returns the active config and
+      defaults; PUT validates and persists with audit + reload; GET status
+      returns the live snapshot. Every endpoint is RBAC-gated.
+    scope:
+      includes:
+        - GET and PUT /api/v1/system/connectivity/config
+        - GET /api/v1/system/connectivity/status
+        - Handler-boundary bounds validation (out-of-range returns 400)
+        - RBAC — system:read for reads, system:write for the PUT
+      excludes:
+        - Persistence, reload, and service-layer validation (owned by
+          services-connectivity-config)
+        - The 4-state fleet breakdown (api-fleet-connectivity-breakdown)
+        - On-demand per-host probe (api-host-connectivity-check)
+
+  constraints:
+    - id: C-01
+      description: GET /api/v1/system/connectivity/config returns the current config snapshot plus a defaults sub-object; requires system:read.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: PUT /api/v1/system/connectivity/config validates field bounds at the handler boundary (out-of-range returns 400 with the canonical error envelope), persists the snapshot, signals the liveness service to Reload, and emits system.config.changed; requires system:write.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: GET /api/v1/system/connectivity/status returns the typed liveness status snapshot; requires system:read.
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Reads require system:read and the mutating PUT requires system:write; a caller lacking the permission gets 403, and an anonymous caller is rejected.
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: GET /api/v1/system/connectivity/config against a freshly-migrated database returns 200 with the active snapshot equal to the baked-in defaults and a populated defaults sub-object.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: PUT /api/v1/system/connectivity/config with a valid in-range body returns 200, and a subsequent GET returns the persisted snapshot (round-trip).
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: PUT /api/v1/system/connectivity/config with a field below its minimum returns 400 with the canonical validation error envelope; persisted state is unchanged.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: PUT /api/v1/system/connectivity/config with a field above its maximum returns 400 with the canonical validation error envelope.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-06
+      description: PUT /api/v1/system/connectivity/config by a viewer (lacking system:write) returns 403 authz.permission_denied.
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-07
+      description: PUT /api/v1/system/connectivity/config by an anonymous caller is rejected (not authenticated).
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-08
+      description: GET /api/v1/system/connectivity/status returns 200 with the typed connectivity status snapshot.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-09
+      description: GET /api/v1/system/connectivity/status by an anonymous caller is rejected (not authenticated).
+      priority: high
+      references_constraints: [C-04]

--- a/specs/services/connectivity-config.spec.yaml
+++ b/specs/services/connectivity-config.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: services-connectivity-config
   title: Connectivity-monitor runtime config — per-state intervals + persistence + reload
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -76,6 +76,10 @@ spec:
       description: SetConnectivity MUST emit audit.SystemConfigChanged with detail {config_key, old_value, new_value, changed_by}. The old_value is the snapshot BEFORE the write, captured in the same transaction
       type: security
       enforcement: error
+    - id: C-04
+      description: Concurrent SetConnectivity calls for the same key are serialized via a SELECT ... FOR UPDATE row lock, so they complete without deadlock and the final persisted state equals one writer's input (last-writer-wins; no torn write). Deterministic ordering between racing writers is NOT guaranteed.
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -98,3 +102,7 @@ spec:
       description: A successful SetConnectivity emits exactly one system.config.changed audit event with old_value, new_value, and changed_by populated. The old_value reflects the snapshot prior to the write.
       priority: critical
       references_constraints: [C-03]
+    - id: AC-06
+      description: Two concurrent SetConnectivity calls for the same key both return without error and without deadlock, and the final persisted state equals one of the two writers' inputs (last-writer-wins via the SELECT ... FOR UPDATE row lock; no torn write).
+      priority: high
+      references_constraints: [C-04]

--- a/specter.yaml
+++ b/specter.yaml
@@ -36,6 +36,9 @@ domains:
             - system-os-intelligence
             - system-intelligence-scheduler
             - api-os-intelligence
+            - api-system-connectivity
+            - api-fleet-connectivity-breakdown
+            - api-host-connectivity-check
             - system-alerts
             - api-alerts
             - system-activity


### PR DESCRIPTION
**PR A of 2** for the `specter check --test` remediation (spec authoring; the mechanical comment/convention cleanup is a separate PR).

## What happened
PR #434 authored and **approved four** connectivity specs, but its squash-merge dropped **three** from the tree and the promised follow-up PR never landed. `api/openapi.yaml` (lines 1085/1120/1147/1285) and the 14 handler tests still reference them — so `specter check --test` flagged them as unknown spec refs. This restores them from that surviving record.

## Changes
**Restored 3 specs** (from the tests' existing `@ac` structure + the openapi contract):
- `specs/api/system-connectivity.spec.yaml` — GET/PUT `/system/connectivity/config` + GET `/status`, bounds validation, RBAC
- `specs/api/fleet-connectivity-breakdown.spec.yaml` — 4-state hysteresis counts on `/fleet/connectivity/breakdown`
- `specs/api/host-connectivity-check.spec.yaml` — on-demand probe `POST /hosts/{id}/connectivity:check` (404 + idempotency)

AC ids follow the surviving tests (non-contiguous — only the test-covered criteria are restored, with a context note explaining why). Re-added the 3 ids to `specter.yaml`.

**Fixed test attribution** — `api_system_connectivity_test.go` had one shared `// @spec a, b, c` line, so source-walk mapped every `// @ac` to the *first* spec (breakdown/check read 0%). Added per-group `// @spec` lines; the `t.Run("<spec>/AC-NN")` tokens already carried the right id for outcome coverage.

**The concurrency spec gap** — the systemconfig last-writer-wins/no-deadlock test referenced a non-existent `AC-09`. Added `AC-06` (+ constraint `C-04`) to `services-connectivity-config` for the concurrency contract — worded to match the test's *actual* guarantee (final state = one writer's input; **no** deterministic ordering) — and retargeted the test to `AC-06` with a runner-visible `t.Run` token.

## Verified
- `specter check`: **74/74 specs** pass schema.
- `specter coverage`: the 4 connectivity specs at **100%**; the 2 substantive `check --test` errors **cleared**.
- `gofmt`/`go vet`/`go build` clean.

## Next (PR B)
The remaining **13** `check --test` errors are cosmetic — parenthetical prose like `// @ac AC-01  (AC-3, AC-4 …)` mis-scanned (the declared `@ac` is valid) — plus ~185 "header `@ac` block" warnings. PR B does that mechanical cleanup and then adds `specter check --test` as a CI gate (which can only go green once both PRs land).