### PR TITLE
chore(specter): reword malformed AC prose; gate check --test in CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -154,6 +154,25 @@ jobs:
         if: steps.paths.outputs.go == 'true'
         run: make test-race
 
+      # Annotation hygiene: cross-reference every test's @spec / @ac
+      # annotation against the spec registry and fail on a dangling spec
+      # ref, unknown AC id, malformed AC id, or unreachable annotation
+      # error. This catches the class of drift where a spec is renamed or
+      # dropped but its test annotations linger (exactly what happened when
+      # the connectivity specs were lost in a squash-merge). Gate on the
+      # printed error count, not the exit code: `specter check --test`
+      # returns 0 on some builds even with errors present.
+      - name: specter check --test (annotation hygiene)
+        if: steps.paths.outputs.go == 'true'
+        run: |
+          out=$(specter check --test 2>&1) || true
+          echo "$out"
+          n=$(echo "$out" | grep -cE 'error \[' || true)
+          if [ "$n" -gt 0 ]; then
+            echo "::error::specter check --test found $n test-annotation error(s) — fix the dangling @spec / @ac refs listed above."
+            exit 1
+          fi
+
       # Spec coverage gate. Split into discrete steps so a failure
       # attributes to the actual command (go test vs. ingest vs. sync)
       # instead of getting hidden behind a single bundled step.

--- a/internal/audit/emit_test.go
+++ b/internal/audit/emit_test.go
@@ -300,7 +300,7 @@ func TestEvent_UUIDv7Monotonic(t *testing.T) {
 	})
 }
 
-// @ac AC-04  (Emit p99 latency < 10µs per spec AC-04. Measured via per-call)
+// @ac AC-04  (Emit p99 latency budget; measured via per-call)
 // wall-clock timing over 1000 calls; channel send is the dominant cost.
 func TestEmit_Latency(t *testing.T) {
 	t.Run("system-audit-emission/AC-04", func(t *testing.T) {

--- a/internal/db/audit_queries_test.go
+++ b/internal/db/audit_queries_test.go
@@ -1,9 +1,9 @@
 // @spec system-db
 //
 // AC traceability (DB integration tests; skipped without OPENWATCH_TEST_DSN):
-// @ac AC-01  (AC-3, AC-4  TestInsertAndGetAuditEvent (pool + migrate idempotent))
-// @ac AC-07  (AC-8        TestInsertAndGetAuditEvent (insert returns row; round-trip))
-// @ac AC-09  (AC-10       TestListAuditEvents (newest-first ordering; cursor))
+// @ac AC-01  (TestInsertAndGetAuditEvent: pool + migrate idempotent)
+// @ac AC-07  (TestInsertAndGetAuditEvent: insert returns row, round-trip)
+// @ac AC-09  (TestListAuditEvents: newest-first ordering, cursor)
 // @ac AC-11  (TestCountAuditEvents)
 //   (AC-2 unreachable-host: not yet implemented as a test — Day 4 follow-up)
 //   (AC-5, AC-6 schema: verified by migrate-and-read in TestInsertAndGetAuditEvent
@@ -34,7 +34,7 @@ func testDSN(t *testing.T) string {
 	return dsn
 }
 
-// @ac AC-01  (AC-3, AC-4, AC-7, AC-8: pool ping, migrate apply + idempotent re-run)
+// @ac AC-01  (pool ping; migrate apply + idempotent re-run)
 // insert returns row, round-trip via GetAuditEventByID.
 func TestInsertAndGetAuditEvent(t *testing.T) {
 	t.Run("system-db/AC-01", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestInsertAndGetAuditEvent(t *testing.T) {
 	})
 }
 
-// @ac AC-09  (AC-10: newest-first ordering; cursor returns only older rows.)
+// @ac AC-09  (newest-first ordering; cursor returns only older rows)
 func TestListAuditEvents(t *testing.T) {
 	t.Run("system-db/AC-09", func(t *testing.T) {
 

--- a/internal/server/api_system_connectivity_test.go
+++ b/internal/server/api_system_connectivity_test.go
@@ -1,4 +1,4 @@
-// @spec api-system-connectivity, api-fleet-connectivity-breakdown, api-host-connectivity-check
+// @spec api-system-connectivity
 //
 // AC traceability (this file):
 //
@@ -251,6 +251,7 @@ func TestAPI_SystemConnectivity_Status_Anonymous_Forbidden(t *testing.T) {
 
 // AC-01..AC-03: classifies online vs degraded vs critical vs down vs
 // never_probed based on consecutive_failures + reachability_status.
+// @spec api-fleet-connectivity-breakdown
 // @ac AC-02
 func TestAPI_FleetConnectivity_Breakdown_ClassifiesByHysteresisBand(t *testing.T) {
 	t.Run("api-fleet-connectivity-breakdown/AC-02", func(t *testing.T) {
@@ -396,6 +397,7 @@ func TestAPI_FleetConnectivity_Breakdown_Anonymous_Forbidden(t *testing.T) {
 // Host on-demand connectivity check
 // ---------------------------------------------------------------------
 
+// @spec api-host-connectivity-check
 // AC-03: POST against {id} that doesn't exist returns 404.
 // @ac AC-03
 func TestAPI_HostConnectivity_Check_NotFound_Returns404(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,10 +3,10 @@
 // AC traceability:
 // @ac AC-02  (TestServer_TimeoutsLocked)
 // @ac AC-03  (TestServer_TLSMinVersion)
-// @ac AC-08  (TestServer_CorrelationMiddlewareMounted (verified via AC-9 fixture))
+// @ac AC-08  (TestServer_CorrelationMiddlewareMounted)
 // @ac AC-09  (TestServer_CorrelationHeaderEchoed)
 //
-// @ac AC-01  ((real bind) and AC-10/AC-11 (graceful shutdown, error propagation))
+// @ac AC-01  (real bind; graceful shutdown, error propagation)
 // require live TLS listener tests and are exercised in main.go integration
 // via the Day-4 acceptance scenarios.
 
@@ -144,7 +144,7 @@ func TestServer_TLSMinVersion(t *testing.T) {
 	})
 }
 
-// @ac AC-08  (AC-9: chi router has correlation middleware mounted first;)
+// @ac AC-08  (chi router has correlation middleware mounted first;)
 // every response carries X-Correlation-Id.
 func TestServer_CorrelationHeaderEchoed(t *testing.T) {
 	t.Run("system-http-server/AC-08", func(t *testing.T) {

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -10,7 +10,7 @@
 //   AC-07  (covered by AC-02 + AC-05 — persisted maintenance_global is
 //          read back; the live-service maintenance check is exercised
 //          in liveness/service_test.go)
-//   AC-09  TestConcurrentSet_LastWriterWins_NoDeadlock
+//   AC-06  TestConcurrentSet_LastWriterWins_NoDeadlock
 
 package systemconfig
 

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -232,38 +232,40 @@ func TestSetConnectivity_EmitsConfigChangedWithOldAndNew(t *testing.T) {
 	})
 }
 
-// AC-09: two concurrent Set calls complete cleanly; final state is one
+// AC-06: two concurrent Set calls complete cleanly; final state is one
 // of the two writers' inputs.
-// @ac AC-09
+// @ac AC-06
 func TestConcurrentSet_LastWriterWins_NoDeadlock(t *testing.T) {
-	pool := freshPool(t)
-	s := NewStore(pool, nil)
+	t.Run("services-connectivity-config/AC-06", func(t *testing.T) {
+		pool := freshPool(t)
+		s := NewStore(pool, nil)
 
-	a := DefaultConnectivity()
-	a.OnlineSec = 600
-	b := DefaultConnectivity()
-	b.OnlineSec = 1200
+		a := DefaultConnectivity()
+		a.OnlineSec = 600
+		b := DefaultConnectivity()
+		b.OnlineSec = 1200
 
-	done := make(chan error, 2)
-	go func() { done <- s.SetConnectivity(context.Background(), a, "alice") }()
-	go func() { done <- s.SetConnectivity(context.Background(), b, "bob") }()
+		done := make(chan error, 2)
+		go func() { done <- s.SetConnectivity(context.Background(), a, "alice") }()
+		go func() { done <- s.SetConnectivity(context.Background(), b, "bob") }()
 
-	for i := 0; i < 2; i++ {
-		select {
-		case err := <-done:
-			if err != nil {
-				t.Errorf("concurrent Set returned error: %v", err)
+		for i := 0; i < 2; i++ {
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("concurrent Set returned error: %v", err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("timeout waiting for concurrent Set — possible deadlock")
 			}
-		case <-time.After(10 * time.Second):
-			t.Fatalf("timeout waiting for concurrent Set — possible deadlock")
 		}
-	}
 
-	got, err := s.LoadConnectivity(context.Background())
-	if err != nil {
-		t.Fatalf("LoadConnectivity: %v", err)
-	}
-	if got != a && got != b {
-		t.Errorf("final state %+v matched neither writer", got)
-	}
+		got, err := s.LoadConnectivity(context.Background())
+		if err != nil {
+			t.Fatalf("LoadConnectivity: %v", err)
+		}
+		if got != a && got != b {
+			t.Errorf("final state %+v matched neither writer", got)
+		}
+	})
 }

--- a/specs/api/fleet-connectivity-breakdown.spec.yaml
+++ b/specs/api/fleet-connectivity-breakdown.spec.yaml
@@ -1,0 +1,78 @@
+spec:
+  id: api-fleet-connectivity-breakdown
+  title: Fleet connectivity breakdown API — 4-state hysteresis counts
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Derived per-state connectivity counts for the fleet, classified by consecutive-failure hysteresis
+    description: >
+      GET /api/v1/fleet/connectivity/breakdown returns derived per-state host
+      counts for the Settings → Scanning & monitoring page. Bands come from
+      each host's reachability plus its consecutive_failures hysteresis:
+      online = reachable and consec=0, degraded = reachable and consec>=1,
+      critical = unreachable and consec<3, down = consec>=3, never_probed = no
+      liveness row. The counts sum to the active host count.
+
+      This spec covers the HTTP read endpoint and its classification contract.
+      It was authored and approved with PR #434 but dropped from the tree in
+      that PR's squash-merge and never restored; it is reconstructed here from
+      internal/server/api_system_connectivity_test.go and the api/openapi.yaml
+      contract. The acceptance-criteria ids follow those surviving tests, so
+      the numbering is non-contiguous.
+    related_specs:
+      - services-connectivity-config
+      - api-fleet-observability
+      - system-liveness-loop
+      - system-rbac
+
+  objective:
+    summary: >
+      The endpoint returns five integer counts (online, degraded, critical,
+      down, never_probed) derived from per-host reachability and
+      consecutive-failure hysteresis, summing to the active host count, and is
+      RBAC-gated on system:read.
+    scope:
+      includes:
+        - GET /api/v1/fleet/connectivity/breakdown
+        - Hysteresis band classification from reachability + consecutive_failures
+        - Empty-fleet handling (zeros, not an error)
+        - RBAC — system:read
+      excludes:
+        - The per-state probe cadences themselves (services-connectivity-config)
+        - The single-config CRUD surface (api-system-connectivity)
+        - Other fleet rollups (api-fleet-observability)
+
+  constraints:
+    - id: C-01
+      description: GET /api/v1/fleet/connectivity/breakdown classifies each active host into exactly one of online / degraded / critical / down / never_probed using reachability and consecutive_failures; the five counts sum to the active host count.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: A consecutive_failures value at or above the down threshold (>=3) places the host in the down band regardless of the last single reachability sample.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: The endpoint requires system:read; an anonymous caller is rejected.
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-02
+      description: With hosts spanning the bands, GET /api/v1/fleet/connectivity/breakdown returns counts that classify each host into the correct band per the hysteresis rules and sum to the active host count.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-05
+      description: A host with consecutive_failures at or above the down threshold is counted in the down band even if other signals would suggest a milder band (high-consec dominates).
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-06
+      description: For an empty fleet (no active hosts) the endpoint returns 200 with all counts zero, not an error.
+      priority: high
+      references_constraints: [C-01]
+    - id: AC-07
+      description: GET /api/v1/fleet/connectivity/breakdown by an anonymous caller is rejected (not authenticated).
+      priority: high
+      references_constraints: [C-03]

--- a/specs/api/host-connectivity-check.spec.yaml
+++ b/specs/api/host-connectivity-check.spec.yaml
@@ -1,0 +1,59 @@
+spec:
+  id: api-host-connectivity-check
+  title: On-demand host connectivity check API
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: Operator-triggered, on-demand connectivity probe for a single host
+    description: >
+      POST /api/v1/hosts/{id}/connectivity:check runs an immediate connectivity
+      probe for one host, outside the periodic liveness loop. It is a mutating
+      action (it writes a fresh liveness sample), so it requires an
+      Idempotency-Key header; an unknown host id returns 404.
+
+      This spec covers the HTTP endpoint's not-found and idempotency-key
+      contract. It was authored and approved with PR #434 but dropped from the
+      tree in that PR's squash-merge and never restored; it is reconstructed
+      here from internal/server/api_system_connectivity_test.go and the
+      api/openapi.yaml contract. The acceptance-criteria ids follow those
+      surviving tests, so the numbering is non-contiguous.
+    related_specs:
+      - system-idempotency
+      - system-liveness-loop
+      - system-rbac
+
+  objective:
+    summary: >
+      The endpoint probes one host on demand; an unknown host id returns 404,
+      and a request without the required Idempotency-Key returns 400.
+    scope:
+      includes:
+        - POST /api/v1/hosts/{id}/connectivity:check
+        - 404 for an unknown host id
+        - Idempotency-Key requirement (400 when absent)
+      excludes:
+        - The periodic liveness probe loop (system-liveness-loop)
+        - Idempotent replay semantics in general (system-idempotency)
+
+  constraints:
+    - id: C-01
+      description: POST /api/v1/hosts/{id}/connectivity:check is a mutating action and MUST require an Idempotency-Key header; a request without it returns 400.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: A request for a host id that does not exist returns 404 with the canonical hosts.not_found error envelope.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-03
+      description: POST /api/v1/hosts/{id}/connectivity:check for an unknown host id returns 404 with the canonical hosts.not_found error envelope.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-05
+      description: POST /api/v1/hosts/{id}/connectivity:check without an Idempotency-Key header returns 400.
+      priority: high
+      references_constraints: [C-01]

--- a/specs/api/system-connectivity.spec.yaml
+++ b/specs/api/system-connectivity.spec.yaml
@@ -1,0 +1,103 @@
+spec:
+  id: api-system-connectivity
+  title: System connectivity API — runtime config CRUD + live status
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: HTTP surface for the connectivity-monitor runtime config and the live status snapshot
+    description: >
+      The /api/v1/system/connectivity/* endpoints let an operator read and
+      update the host-liveness probe config (per-state intervals, timeout,
+      thresholds — owned at the service layer by services-connectivity-config)
+      and read a live status snapshot. GET config returns the active snapshot
+      plus the baked-in defaults; PUT config validates bounds at the handler
+      boundary, persists, signals the in-process liveness service to Reload,
+      and emits system.config.changed. GET status surfaces the liveness
+      MetricsSnapshot.
+
+      This spec covers the HTTP layer (routing, request/response shapes,
+      validation status codes, RBAC) on top of the service-layer contract in
+      services-connectivity-config. It was authored and approved with PR #434
+      but dropped from the tree in that PR's squash-merge and never restored;
+      it is reconstructed here from the handler tests in
+      internal/server/api_system_connectivity_test.go and the api/openapi.yaml
+      contract. The acceptance-criteria ids follow those surviving tests, so
+      the numbering is non-contiguous (only the test-covered criteria are
+      restored).
+    related_specs:
+      - services-connectivity-config
+      - system-liveness-loop
+      - system-rbac
+      - system-audit-emission
+
+  objective:
+    summary: >
+      GET /api/v1/system/connectivity/config returns the active config and
+      defaults; PUT validates and persists with audit + reload; GET status
+      returns the live snapshot. Every endpoint is RBAC-gated.
+    scope:
+      includes:
+        - GET and PUT /api/v1/system/connectivity/config
+        - GET /api/v1/system/connectivity/status
+        - Handler-boundary bounds validation (out-of-range returns 400)
+        - RBAC — system:read for reads, system:write for the PUT
+      excludes:
+        - Persistence, reload, and service-layer validation (owned by
+          services-connectivity-config)
+        - The 4-state fleet breakdown (api-fleet-connectivity-breakdown)
+        - On-demand per-host probe (api-host-connectivity-check)
+
+  constraints:
+    - id: C-01
+      description: GET /api/v1/system/connectivity/config returns the current config snapshot plus a defaults sub-object; requires system:read.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: PUT /api/v1/system/connectivity/config validates field bounds at the handler boundary (out-of-range returns 400 with the canonical error envelope), persists the snapshot, signals the liveness service to Reload, and emits system.config.changed; requires system:write.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: GET /api/v1/system/connectivity/status returns the typed liveness status snapshot; requires system:read.
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: Reads require system:read and the mutating PUT requires system:write; a caller lacking the permission gets 403, and an anonymous caller is rejected.
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: GET /api/v1/system/connectivity/config against a freshly-migrated database returns 200 with the active snapshot equal to the baked-in defaults and a populated defaults sub-object.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: PUT /api/v1/system/connectivity/config with a valid in-range body returns 200, and a subsequent GET returns the persisted snapshot (round-trip).
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: PUT /api/v1/system/connectivity/config with a field below its minimum returns 400 with the canonical validation error envelope; persisted state is unchanged.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: PUT /api/v1/system/connectivity/config with a field above its maximum returns 400 with the canonical validation error envelope.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-06
+      description: PUT /api/v1/system/connectivity/config by a viewer (lacking system:write) returns 403 authz.permission_denied.
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-07
+      description: PUT /api/v1/system/connectivity/config by an anonymous caller is rejected (not authenticated).
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-08
+      description: GET /api/v1/system/connectivity/status returns 200 with the typed connectivity status snapshot.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-09
+      description: GET /api/v1/system/connectivity/status by an anonymous caller is rejected (not authenticated).
+      priority: high
+      references_constraints: [C-04]

--- a/specs/services/connectivity-config.spec.yaml
+++ b/specs/services/connectivity-config.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: services-connectivity-config
   title: Connectivity-monitor runtime config — per-state intervals + persistence + reload
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -76,6 +76,10 @@ spec:
       description: SetConnectivity MUST emit audit.SystemConfigChanged with detail {config_key, old_value, new_value, changed_by}. The old_value is the snapshot BEFORE the write, captured in the same transaction
       type: security
       enforcement: error
+    - id: C-04
+      description: Concurrent SetConnectivity calls for the same key are serialized via a SELECT ... FOR UPDATE row lock, so they complete without deadlock and the final persisted state equals one writer's input (last-writer-wins; no torn write). Deterministic ordering between racing writers is NOT guaranteed.
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -98,3 +102,7 @@ spec:
       description: A successful SetConnectivity emits exactly one system.config.changed audit event with old_value, new_value, and changed_by populated. The old_value reflects the snapshot prior to the write.
       priority: critical
       references_constraints: [C-03]
+    - id: AC-06
+      description: Two concurrent SetConnectivity calls for the same key both return without error and without deadlock, and the final persisted state equals one of the two writers' inputs (last-writer-wins via the SELECT ... FOR UPDATE row lock; no torn write).
+      priority: high
+      references_constraints: [C-04]

--- a/specter.yaml
+++ b/specter.yaml
@@ -36,6 +36,9 @@ domains:
             - system-os-intelligence
             - system-intelligence-scheduler
             - api-os-intelligence
+            - api-system-connectivity
+            - api-fleet-connectivity-breakdown
+            - api-host-connectivity-check
             - system-alerts
             - api-alerts
             - system-activity


### PR DESCRIPTION
**PR B of 2** for the `specter check --test` remediation — the mechanical cleanup + CI gate. **Stacked on #510** (it needs #510's spec restoration for the gate to read zero errors); base will retarget to `main` automatically once #510 merges.

## What
Thirteen test annotations carried bare `AC-N` tokens inside the *prose* after a valid `// @ac AC-NN` — e.g. `// @ac AC-01  (AC-3, AC-4  TestInsertAndGetAuditEvent …)`. specter's scanner read those prose tokens as malformed AC ids and flagged them as errors, even though the **declared** `@ac` on each line was valid and the prose contributed **no** coverage. Reworded all 13 to drop the stray tokens — declared `@ac` and coverage unchanged.

Files: `internal/audit/emit_test.go`, `internal/db/audit_queries_test.go`, `internal/server/server_test.go`. Plus a stale `AC-09→AC-06` fix in `internal/systemconfig/store_test.go`'s header prose, left over from #510's retarget.

## The gate
Added a `specter check --test (annotation hygiene)` step to `go-ci.yml`, grouped with the existing spec gates. It cross-references every test's `@spec`/`@ac` against the registry and fails on a dangling spec ref, unknown/malformed AC id, or unreachable-annotation error — the exact drift that let the connectivity specs vanish in a squash-merge. It gates on the **printed error count**, not the exit code (`specter check --test` doesn't set it reliably on all builds).

## Scope note
This deliberately does **not** strip the ~185 redundant header `// @ac` traceability blocks (the `unreachable_annotation` *warnings*). Those are non-blocking under the non-strict gate, and de-annotating them risks dropping source-walk coverage for ACs that may be covered only via the header block — that needs a careful per-AC pass, separate from this error-clearing change.

## Verified
- `specter check --test`: **0 errors** (was 13).
- `specter coverage`: **74/74 specs, 100%** (unchanged).
- `gofmt` / `go build` clean.
- Local dry-run of the new CI gate logic → PASS.