### PR TITLE
chore(specter): reword malformed AC prose; gate check --test in CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -154,6 +154,25 @@ jobs:
         if: steps.paths.outputs.go == 'true'
         run: make test-race
 
+      # Annotation hygiene: cross-reference every test's @spec / @ac
+      # annotation against the spec registry and fail on a dangling spec
+      # ref, unknown AC id, malformed AC id, or unreachable annotation
+      # error. This catches the class of drift where a spec is renamed or
+      # dropped but its test annotations linger (exactly what happened when
+      # the connectivity specs were lost in a squash-merge). Gate on the
+      # printed error count, not the exit code: `specter check --test`
+      # returns 0 on some builds even with errors present.
+      - name: specter check --test (annotation hygiene)
+        if: steps.paths.outputs.go == 'true'
+        run: |
+          out=$(specter check --test 2>&1) || true
+          echo "$out"
+          n=$(echo "$out" | grep -cE 'error \[' || true)
+          if [ "$n" -gt 0 ]; then
+            echo "::error::specter check --test found $n test-annotation error(s) — fix the dangling @spec / @ac refs listed above."
+            exit 1
+          fi
+
       # Spec coverage gate. Split into discrete steps so a failure
       # attributes to the actual command (go test vs. ingest vs. sync)
       # instead of getting hidden behind a single bundled step.

--- a/internal/audit/emit_test.go
+++ b/internal/audit/emit_test.go
@@ -300,7 +300,7 @@ func TestEvent_UUIDv7Monotonic(t *testing.T) {
 	})
 }
 
-// @ac AC-04  (Emit p99 latency < 10µs per spec AC-04. Measured via per-call)
+// @ac AC-04  (Emit p99 latency budget; measured via per-call)
 // wall-clock timing over 1000 calls; channel send is the dominant cost.
 func TestEmit_Latency(t *testing.T) {
 	t.Run("system-audit-emission/AC-04", func(t *testing.T) {

--- a/internal/db/audit_queries_test.go
+++ b/internal/db/audit_queries_test.go
@@ -1,9 +1,9 @@
 // @spec system-db
 //
 // AC traceability (DB integration tests; skipped without OPENWATCH_TEST_DSN):
-// @ac AC-01  (AC-3, AC-4  TestInsertAndGetAuditEvent (pool + migrate idempotent))
-// @ac AC-07  (AC-8        TestInsertAndGetAuditEvent (insert returns row; round-trip))
-// @ac AC-09  (AC-10       TestListAuditEvents (newest-first ordering; cursor))
+// @ac AC-01  (TestInsertAndGetAuditEvent: pool + migrate idempotent)
+// @ac AC-07  (TestInsertAndGetAuditEvent: insert returns row, round-trip)
+// @ac AC-09  (TestListAuditEvents: newest-first ordering, cursor)
 // @ac AC-11  (TestCountAuditEvents)
 //   (AC-2 unreachable-host: not yet implemented as a test — Day 4 follow-up)
 //   (AC-5, AC-6 schema: verified by migrate-and-read in TestInsertAndGetAuditEvent
@@ -34,7 +34,7 @@ func testDSN(t *testing.T) string {
 	return dsn
 }
 
-// @ac AC-01  (AC-3, AC-4, AC-7, AC-8: pool ping, migrate apply + idempotent re-run)
+// @ac AC-01  (pool ping; migrate apply + idempotent re-run)
 // insert returns row, round-trip via GetAuditEventByID.
 func TestInsertAndGetAuditEvent(t *testing.T) {
 	t.Run("system-db/AC-01", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestInsertAndGetAuditEvent(t *testing.T) {
 	})
 }
 
-// @ac AC-09  (AC-10: newest-first ordering; cursor returns only older rows.)
+// @ac AC-09  (newest-first ordering; cursor returns only older rows)
 func TestListAuditEvents(t *testing.T) {
 	t.Run("system-db/AC-09", func(t *testing.T) {
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,10 +3,10 @@
 // AC traceability:
 // @ac AC-02  (TestServer_TimeoutsLocked)
 // @ac AC-03  (TestServer_TLSMinVersion)
-// @ac AC-08  (TestServer_CorrelationMiddlewareMounted (verified via AC-9 fixture))
+// @ac AC-08  (TestServer_CorrelationMiddlewareMounted)
 // @ac AC-09  (TestServer_CorrelationHeaderEchoed)
 //
-// @ac AC-01  ((real bind) and AC-10/AC-11 (graceful shutdown, error propagation))
+// @ac AC-01  (real bind; graceful shutdown, error propagation)
 // require live TLS listener tests and are exercised in main.go integration
 // via the Day-4 acceptance scenarios.
 
@@ -144,7 +144,7 @@ func TestServer_TLSMinVersion(t *testing.T) {
 	})
 }
 
-// @ac AC-08  (AC-9: chi router has correlation middleware mounted first;)
+// @ac AC-08  (chi router has correlation middleware mounted first;)
 // every response carries X-Correlation-Id.
 func TestServer_CorrelationHeaderEchoed(t *testing.T) {
 	t.Run("system-http-server/AC-08", func(t *testing.T) {

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -10,7 +10,7 @@
 //   AC-07  (covered by AC-02 + AC-05 — persisted maintenance_global is
 //          read back; the live-service maintenance check is exercised
 //          in liveness/service_test.go)
-//   AC-09  TestConcurrentSet_LastWriterWins_NoDeadlock
+//   AC-06  TestConcurrentSet_LastWriterWins_NoDeadlock
 
 package systemconfig
 


### PR DESCRIPTION
Mechanical cleanup + CI gate, the second half of the `specter check --test` remediation. The spec restoration (#510) has merged to `main`; this builds on it.

(Supersedes #511, which GitHub auto-closed when its stacked base branch was deleted after #510's squash-merge. Same commit, now rebased directly onto `main`.)

## What
Thirteen test annotations carried bare `AC-N` tokens inside the *prose* after a valid `// @ac AC-NN` — e.g. `// @ac AC-01  (AC-3, AC-4  TestInsertAndGetAuditEvent …)`. specter's scanner read those prose tokens as malformed AC ids and flagged them as errors, even though the **declared** `@ac` on each line was valid and the prose contributed **no** coverage. Reworded all 13 to drop the stray tokens — declared `@ac` and coverage unchanged.

Files: `internal/audit/emit_test.go`, `internal/db/audit_queries_test.go`, `internal/server/server_test.go`. Plus a stale `AC-09→AC-06` fix in `internal/systemconfig/store_test.go`'s header prose, left over from #510's retarget.

## The gate
Added a `specter check --test (annotation hygiene)` step to `go-ci.yml`, grouped with the existing spec gates. It cross-references every test's `@spec`/`@ac` against the registry and fails on a dangling spec ref, unknown/malformed AC id, or unreachable-annotation error — the exact drift that let the connectivity specs vanish in a squash-merge. Gates on the **printed error count**, not the exit code (`specter check --test` doesn't set it reliably on all builds).

## Scope note
Deliberately does **not** strip the ~185 redundant header `// @ac` traceability blocks (the `unreachable_annotation` *warnings*). They're non-blocking under the non-strict gate, and de-annotating them risks dropping source-walk coverage for ACs covered only via the header block — that needs a careful per-AC pass, separate from this error-clearing change.

## Verified (on the rebased tree, with #510's specs in main)
- `specter check --test`: **0 errors** (was 13).
- `specter coverage`: **74/74 specs, 100%**.
- `gofmt` / `go build` clean.