### PR TITLE
fix(frontend): clear live CodeQL warnings + ignore prototype mockups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          # Prototype mockups are not shipped code; their inline JS produces
+          # noise alerts (unused vars, demo origin checks). Exclude them so
+          # CodeQL only scans the real frontend/ + scripts.
+          config: |
+            paths-ignore:
+              - docs/engineering/prototypes
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/frontend/src/components/settings/OSDiscoverySection.tsx
+++ b/frontend/src/components/settings/OSDiscoverySection.tsx
@@ -306,13 +306,13 @@ export function OSDiscoverySectionView(props: {
             <Btn onClick={onRunNow} disabled={isSweeping}>
               <PlayCircle size={12} /> {isSweeping ? 'Sweeping…' : 'Run now'}
             </Btn>
-            <Btn onClick={onResetToDefaults} disabled={isLoading || isSaving}>
+            <Btn onClick={onResetToDefaults} disabled={isSaving}>
               <RotateCcw size={12} /> Reset to defaults
             </Btn>
             <Btn onClick={onResetToLive} disabled={!dirty || isSaving}>
               Discard changes
             </Btn>
-            <Btn variant="primary" onClick={onSave} disabled={isLoading || !dirty || isSaving}>
+            <Btn variant="primary" onClick={onSave} disabled={!dirty || isSaving}>
               {isSaving ? 'Saving…' : 'Save changes'}
             </Btn>
           </div>

--- a/frontend/src/components/settings/OSIntelligenceSection.tsx
+++ b/frontend/src/components/settings/OSIntelligenceSection.tsx
@@ -255,13 +255,13 @@ export function OSIntelligenceSectionView(props: {
                 {saveError}
               </div>
             )}
-            <Btn onClick={onResetToDefaults} disabled={isLoading || isSaving}>
+            <Btn onClick={onResetToDefaults} disabled={isSaving}>
               <RotateCcw size={12} /> Reset to defaults
             </Btn>
             <Btn onClick={onResetToLive} disabled={!dirty || isSaving}>
               Discard changes
             </Btn>
-            <Btn variant="primary" onClick={onSave} disabled={isLoading || !dirty || isSaving}>
+            <Btn variant="primary" onClick={onSave} disabled={!dirty || isSaving}>
               {isSaving ? 'Saving…' : 'Save changes'}
             </Btn>
           </div>

--- a/frontend/tests/pages/add-host-bulk.test.ts
+++ b/frontend/tests/pages/add-host-bulk.test.ts
@@ -137,8 +137,10 @@ describe('frontend-add-host — bulk parse + validate', () => {
 
   // @ac AC-14
   test('frontend-add-host/AC-14 — applyMappings produces valid + invalid rows; valid count formatting matches Preview step button label', () => {
-    const validCount: number = 4;
-    const buttonLabel = `Import ${validCount} valid row${validCount === 1 ? '' : 's'}`;
-    expect(buttonLabel).toBe('Import 4 valid rows');
+    const buttonLabel = (validCount: number) =>
+      `Import ${validCount} valid row${validCount === 1 ? '' : 's'}`;
+    // Exercise both the plural and singular branches of the pluralization.
+    expect(buttonLabel(4)).toBe('Import 4 valid rows');
+    expect(buttonLabel(1)).toBe('Import 1 valid row');
   });
 });


### PR DESCRIPTION
Final step of the code-scanning cleanup. After deleting ~7,720 stale alerts (Trivy/Grype on the archived `openwatch-backend` image + ~705 archived-Python CodeQL), **10 CodeQL alerts remained** — 5 live frontend, 5 prototype-doc noise. This clears all 10.

## Live frontend (5 — real, fixed in code)
- **`OSDiscoverySection.tsx` / `OSIntelligenceSection.tsx`** (4× `js/trivial-conditional`): the Save/Reset buttons render only inside the `isLoading ? <loading> : <form>` **else** branch, so `isLoading` is always false there. Dropped the dead `isLoading ||` from the two `disabled` expressions in each file. Behavior-preserving — `isLoading` is still used to choose the branch (verified still referenced, no unused-var).
- **`add-host-bulk.test.ts` AC-14** (`js/useless-comparison-test`): the test hardcoded `validCount = 4`, so `validCount === 1` was dead and the singular label was never tested. Made the label a function and asserted **both** plural and singular — resolves the alert and adds the missing case. Test passes (7/7); AC-14 annotation preserved.

## Prototype noise (5 — excluded)
Added `paths-ignore: docs/engineering/prototypes` to `codeql.yml`. The inline JS in those UI mockups isn't shipped code; the 5 alerts there (`unused-local-variable`, demo `missing-origin-check`, etc.) auto-close on the next scan and won't recur.

## Verified
- Changed test passes; `isLoading` still used in both components.
- Diff is 4 files; the `tsc` errors in `settings.test.ts` are pre-existing on main (unrelated regex `string|undefined` typing) and go-ci doesn't gate on tsc.

Net: code-scanning dashboard goes from ~7,730 open alerts → **0** once this and the next scan land.