### PR TITLE
test(daemon): guard that every server builder is wired in main.go

### DIFF
--- a/cmd/openwatch/source_test.go
+++ b/cmd/openwatch/source_test.go
@@ -10,6 +10,7 @@
 //   AC-08  TestCmdServe_DiscoveryServiceWired
 //   AC-09  TestCmdServe_IntelligenceSchedulerWired
 //   AC-10  TestCmdServe_MaintenancePauseWarnLog
+//   AC-11  TestCmdServe_AllServerBuildersWired
 //
 // These tests are source-inspection — they read app/cmd/openwatch/main.go
 // and the Slice B package directories and assert structural invariants.
@@ -292,6 +293,52 @@ func TestCmdServe_MaintenancePauseWarnLog(t *testing.T) {
 		warnRe := regexp.MustCompile(`slog\.WarnContext\(bootCtx,\s*"intelligence scheduler paused at startup"`)
 		if !warnRe.MatchString(src) {
 			t.Error(`main.go missing slog.WarnContext(bootCtx, "intelligence scheduler paused at startup", ...)`)
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: every server.Server WithX builder must be invoked in the
+// serve chain. Generic guard - enumerates builders from server.go
+// source so a newly added builder is covered automatically. This is
+// the regression backstop for the class of gap that left every
+// /api/v1/alerts endpoint 503 (alerts service defined a builder but
+// main.go never called it).
+func TestCmdServe_AllServerBuildersWired(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-11", func(t *testing.T) {
+		_, file, _, _ := runtime.Caller(0)
+		serverDir := filepath.Join(filepath.Dir(file), "..", "..", "internal", "server")
+		entries, err := os.ReadDir(serverDir)
+		if err != nil {
+			t.Fatalf("read server dir: %v", err)
+		}
+
+		builderRe := regexp.MustCompile(`func \(s \*Server\) (With[A-Za-z]+)\(`)
+		builders := map[string]bool{}
+		for _, e := range entries {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			b, err := os.ReadFile(filepath.Join(serverDir, name))
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			for _, m := range builderRe.FindAllStringSubmatch(string(b), -1) {
+				builders[m[1]] = true
+			}
+		}
+		if len(builders) == 0 {
+			t.Fatal("found no Server WithX builders — enumeration regex is broken")
+		}
+
+		main := mainGoSource(t)
+		for b := range builders {
+			// The chain formats each call on its own line ("\n\t\tWithX(")
+			// so match the bare token followed by '('.
+			if !regexp.MustCompile(`\b` + b + `\(`).MatchString(main) {
+				t.Errorf("server builder %s is defined but never called in main.go — its handler field stays nil and the guarded endpoints 503 in production (the alerts-service gap)", b)
+			}
 		}
 	})
 }

--- a/specs/system/daemon-orchestration.spec.yaml
+++ b/specs/system/daemon-orchestration.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-daemon-orchestration
   title: openwatch serve daemon lifecycle and Slice B runtime wiring
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -101,6 +101,11 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-09
+      description: 'v1.2.0 - EVERY server.Server WithX builder method (the dependency injectors that populate handler fields) MUST be invoked in the cmd/openwatch/main.go serve chain. A builder defined but not called leaves its handler field nil, and the guarded handlers return 503 server.unavailable in production while passing tests that wire it in their fixture - the exact gap that left every /api/v1/alerts endpoint 503 until the alerts service was wired. The guard is generic (enumerates builders from server.go source) so a newly added builder is covered automatically'
+      type: technical
+      enforcement: error
+
   acceptance_criteria:
     - id: AC-01
       description: openwatch serve binary builds cleanly with the Slice B imports — alertrouter, alertrouter/channels/stdout, eventbus, liveness — present in cmd/openwatch/main.go's import block.
@@ -142,3 +147,7 @@ spec:
       description: 'v1.1.0 — Source-inspection: cmd/openwatch/main.go contains a slog.WarnContext call inside cmdServe whose msg contains "intelligence scheduler paused at startup" (or "paused" in the message), AND whose body references cfgStore.LoadIntelligence + MaintenanceGlobal. Verified by reading the file and asserting both patterns appear next to each other'
       priority: critical
       references_constraints: [C-08]
+    - id: AC-11
+      description: 'v1.2.0 - Source-inspection: enumerate every "func (s *Server) WithX" builder declared in internal/server/*.go (excluding _test files) and assert each WithX token appears in cmd/openwatch/main.go. Fails if any builder is unwired - the generic regression guard that the per-service AC-08/AC-09 checks specialize. Catches the alerts-service class of gap for every current and future builder'
+      priority: critical
+      references_constraints: [C-09]


### PR DESCRIPTION
## Service-wiring audit

Follow-up to the alerts-service gap found while wiring the Watchlist tile: every `/api/v1/alerts*` endpoint returned 503 in production because `main.go` never called `WithAlerts`, while the test fixture did — so tests passed and the gap shipped.

### Audit result (clean after the alerts fix)

Compared all three sets — the `Server` builder methods, what `main.go` wires, and what the test fixture wires:

- **All 9 builders are wired in `main.go`**: Activity, Alerts, ConnectivityConfig, Discovery, EventBus, RuleCatalog, ScanQueue, ScanWorker, VariableCatalog — each with a non-nil constructed argument
- **5 handler fields are constructed in `New()` itself** (pool, users, credentials, hosts, fleet) — never nil in either path
- **Every 503 nil-guard** (`h.sysCfg`, `h.alertsSvc`, `h.activitySvc`, `h.scanQueueKey`, `h.bus`, `h.liveSvc`, `h.discoSvc`) maps to a populated dependency
- Alerts was the only gap; already fixed on main

### The permanent guard

The existing `source_test.go` had **per-service** wiring checks (AC-08 discovery, AC-09 intelligence scheduler) but alerts simply never got one. This generalizes them: **AC-11 enumerates every `WithX` builder from `internal/server/*.go` source and asserts each is called in `main.go`** — a newly added builder is covered automatically, so this whole class of bug can't regress.

Verified the guard fires on the exact bug shape: dropping `WithAlerts` from the chain (build still clean, since builder methods don't trigger unused errors) fails the test with the builder named.

Spec: system-daemon-orchestration v1.2.0 (C-09 + AC-11).