### PR TITLE
docs: reconcile scan/compliance docs before remediation work

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -41,8 +41,8 @@
 | Item | Priority | Status | Notes |
 |------|----------|--------|-------|
 | Top failed rules card | P1 | **Done** (PR #515) | Live against GET /hosts/{id}/compliance/failed-rules with catalog titles |
-| Compliance trend (last 30 days) card | P1 | Stub | Returns "Not enough data yet" empty state. Needs: posture-snapshot subsystem (BACKLOG). When transactions exist, can derive trend from `transactions` table via a daily aggregate query |
-| Open exceptions count on Server intelligence tile #6 | P2 | Placeholder | Renders `—`. Needs: `/api/v1/compliance/exceptions?host_id=X` wire — exceptions service exists, just no card hook yet |
+| Compliance trend (last 30 days) card | P1 | **Done** (PR #518) | Live sparkline against the 80% target line from posture_snapshots (system-posture-snapshots); GET /hosts/{id}/compliance/trend. Fleet equivalent powers the hosts-list avg-compliance delta |
+| Open exceptions count on Server intelligence tile #6 | P2 | Placeholder | Renders `—`. Exception governance is scan plan Phase 7 (suppress + skip_reason over host_rule_state); feeds this tile + the host-detail Watchlist Exceptions row + the Settings Exception-workflow stub |
 | Updates-pending count on Server intelligence tile #1 | P2 | Placeholder | Renders "No updates pending" always. Needs: collector to surface `available_updates` field on the snapshot (apt/dnf unattended-upgrades parsing) |
 
 ---
@@ -77,7 +77,7 @@
 
 | Item | Priority | Status | Notes |
 |------|----------|--------|-------|
-| Adaptive Compliance Scheduler | P1 | **Done** (PR #515) | system-scheduler v3.0.0: five-band ladder from systemconfig, RunManaged 60s tick, PersistAfterScan, Settings section wired. Remaining slice: scan-variables sub-section (needs kensa.RuleVariables endpoint) |
+| Adaptive Compliance Scheduler | P1 | **Done** (PR #515/#517) | system-scheduler v3.0.0: five-band ladder from systemconfig, RunManaged 60s tick, PersistAfterScan, Settings section wired. Scan variables shipped (PR #517) on Settings > Compliance policies |
 | Email alert notifications | P1 | Planned | SMTP/SES dispatcher. User preferences table (which alert types). RBAC-gated. The Q1 notification-channels work (Slack/email/webhook) is the foundation |
 | In-app notifications | P1 | Planned | Bell icon with unread count, drawer, mark-as-read. Sources: alerts, scan completions, exception approvals, system events. RBAC-filtered. WebSocket or SSE delivery (the existing SSE bus can carry it) |
 | Dashboard layout customization (drag/drop) | P2 | Planned | 3 tiers per spec AC-12: full (admins), limited (analysts), none (auditor). Preset structure ready, needs `@dnd-kit/core` + persistence |

--- a/docs/engineering/scan_implementation_plan.md
+++ b/docs/engineering/scan_implementation_plan.md
@@ -2,7 +2,7 @@
 
 **Status:** Phases 0-2 SHIPPED (branch feat/scan-foundation, 15 commits, live-verified) · **Updated:** 2026-06-12 · **Owner:** TBD
 
-## Status snapshot (2026-06-12)
+## Status snapshot (2026-06-13)
 
 | Phase | Status | Evidence |
 |-------|--------|----------|
@@ -10,12 +10,18 @@
 | 1 — On-demand scan | **DONE** | POST /hosts/{id}/scans (idempotency, RBAC, 409 single-flight) + Run scan button + scan.completed SSE refresh. Found+fixed a latent platform bug: http.Server WriteTimeout killed ALL SSE streams at 60s |
 | 2 — Top failed rules | **DONE** | GET /hosts/{id}/compliance/failed-rules (no-evidence C-02, multi-valued control_ids) + RuleCatalog titles + live card. Verified: hrm01's real 147 failures render with catalog titles |
 | 3 — Compliance tab lens | **DONE** | GET /hosts/{id}/compliance (+/frameworks) with C-05 reconciliation; ComplianceTab.tsx lens UI. Live: lens switch recounts 68.1% all-rules -> 71.4% under stig_rhel8 (266 rules exactly). Prototype-fidelity pass done 2026-06-12: per-lens scores on chips + overall aggregate, result-mix/scan panels, duration_seconds, catalog descriptions, search, in-strip Re-scan (specs v1.2.0 / v1.1.0) |
-| 4 — Adaptive scheduler + settings | **DONE** (2026-06-12; scan variables shipped in PR #517, surfaced on Settings > Compliance policies) | system-scheduler v3.0.0: ladder from systemconfig (RunManaged per-tick refresh), five bands + migration 0024 backfill, PersistAfterScan after every scan, dispatch logbook rows. api-system-scan-config (4 endpoints) + wired Settings section. Live: first tick auto-dispatched all 9 seeded hosts; fleet classified 3 crit / 1 non-compl / 2 partial / 2 mostly / 1 unknown. Remaining: scan-variables sub-section (needs a kensa.RuleVariables endpoint) |
+| 4 — Adaptive scheduler + settings | **DONE** (2026-06-12; scan variables shipped in PR #517, surfaced on Settings > Compliance policies) | system-scheduler v3.0.0: ladder from systemconfig (RunManaged per-tick refresh), five bands + migration 0024 backfill, PersistAfterScan after every scan, dispatch logbook rows. api-system-scan-config (6 endpoints incl. scan/variables + scan/schedule + host schedule tile) + wired Settings section. Scan variables SHIPPED (PR #517): VariableCatalog over the 20 corpus-used vars, operator overrides on Settings > Compliance policies, per-scan corpus reload. Live: first tick auto-dispatched all 9 seeded hosts; fleet classified across the five bands; a UI variable override reloaded the corpus on the next scan. **Phase 4 fully DONE.** |
 | 5 — Fleet surfaces | **mostly DONE** | Per-host Scan buttons, scan-queue KPI, hosts-list compliance_summary enrichment (real % + tier colors + critical_failing), avg/critical KPIs from real data. Remaining: bulk scan (POST /hosts:scan); the avg-compliance delta shipped with Phase 6 |
-| 6 — Trend / posture snapshots | **DONE** (2026-06-12) | posture_snapshots daily rollup (hourly cron + boot pass); GET /hosts/{id}/compliance/trend + /fleet/compliance/trend; live trend card + avg-compliance delta. History accumulates forward (no transactions replay) |
-| 7 — Remediation + exceptions | not started | DefaultWithTransportFactory available since kensa v0.3.2; transport Put/Get stubs waiting |
+| 6 — Trend / posture snapshots | **DONE** (2026-06-12, PR #518) | posture_snapshots daily rollup (hourly cron + boot pass); GET /hosts/{id}/compliance/trend + /fleet/compliance/trend; live trend card + avg-compliance delta. Shipped alongside: the host-detail hero strip went fully live (Auto-scan tile -> GET /compliance/schedule, Watchlist tile -> live active-alerts) and OS-aware framework lens filtering (api-host-compliance v1.3.0 — a RHEL 8 host no longer offers RHEL 9/10 lenses) |
+| 7 — Remediation + exceptions | **NEXT (starting 2026-06-13)** | DefaultWithTransportFactory available since kensa v0.3.2; the in-memory transport's Put/Get stubs implement here if remediation mechanisms need them. Exception governance (suppress + skip_reason over host_rule_state) feeds the host-detail Watchlist Exceptions row + the Settings Exception-workflow stub. Open Kensa ratification: rule-ordering (depends_on/conflicts/supersedes) is unexported — a new ratification if remediation sequencing needs it |
 
-All risks R1-R6 resolved. Scanned fleet so far: owas-hrm01 (367/147/25/0, 68.1%), owas-rhl10 (247/288, 45.8%), owas-rhn01. Operational follow-up noted: deadline-free SSE streams outlive graceful shutdown's 30s grace (cancel streams on shutdown ctx).
+All risks R1-R6 resolved. Fleet self-scans on the adaptive ladder (9 hosts seeded, classified across all five bands; 3 critical re-scan every 4h). Merged PRs: #515 (Phases 0-3 + scheduler core), #517 (scan variables), #518 (posture trend + live hero tiles + OS-aware lenses), #519 (service-wiring guard).
+
+Operational follow-ups still open (small, not blocking Phase 7):
+- Bulk scan endpoint (POST /hosts:scan) — the last Phase 5 item.
+- Deadline-free SSE streams outlive graceful shutdown's 30s grace (cancel on shutdown ctx).
+- Scan-context Capabilities line needs stored capability data from Kensa.
+- Found + fixed during the host-detail tile work: the alerts lifecycle service was never wired in serve (every /api/v1/alerts endpoint 503'd in production); a generic source-test (system-daemon-orchestration AC-11) now guards that EVERY server builder is wired in main.go.
 
 Covers end-to-end compliance scanning for the OpenWatch Go rebuild: wiring the
 Kensa engine, triggering scans (on-demand + adaptive auto-scan), persisting and

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -25,16 +25,16 @@ Kensa retrieves SSH credentials from OpenWatch's encrypted store
 SSH connection to target host
         |
         v
-338 YAML rules evaluated (check commands, config values, file permissions)
+539 YAML rules evaluated (check commands, config values, file permissions)
         |
         v
 Each rule returns: pass/fail, severity, detail, evidence
         |
         v
-Results stored in PostgreSQL (scan_findings table)
+Write-on-change: changed verdicts -> transactions; current state -> host_rule_state
         |
         v
-Posture snapshot updated, alerts generated if thresholds met
+Daily posture snapshot rolls up; drift alerts generated if thresholds met
 ```
 
 Key points:
@@ -58,11 +58,11 @@ Key points:
 | PCI-DSS v4.0 | pci-dss-v4.0 | 45 |
 | FedRAMP Moderate | fedramp-moderate | 87 |
 
-Framework mappings come from two sources synced to the database by
-KensaRuleSyncService:
-
-1. **Inline references** -- per-rule `references:` fields in YAML rule files.
-2. **Mapping files** -- authoritative `mappings/*.yaml` files for full coverage.
+Framework mappings are carried per-rule as Kensa's normalized `framework_refs`
+(a multi-valued framework_id -> control-ids map, since one rule can satisfy
+several controls within a framework). They are stored on each `host_rule_state`
+row as `framework_refs` JSONB and projected into the lens views at query time --
+there is no separate sync service in the Go rebuild.
 
 ---
 
@@ -72,9 +72,13 @@ KensaRuleSyncService:
 
 1. Navigate to **Hosts** and select the host you want to scan.
 2. On the host detail page, click **Run Scan**.
-3. Select a compliance framework from the dropdown (or leave blank to run all
-   338 rules without framework filtering).
-4. Click **Start Scan**.
+
+A scan always runs the **full applicable rule corpus** -- you do not pick a
+framework to scan. Frameworks (CIS, STIG, NIST, PCI) are **reporting lenses**
+applied at view time on the Compliance tab: one scan, viewed through any
+framework. The lens bar only offers frameworks compatible with the host's
+detected OS (a RHEL 8 host does not show CIS/STIG RHEL 9 or 10 lenses);
+OS-neutral frameworks (NIST, PCI, SRG) always appear.
 
 ![Running a scan from the host detail page](../images/scanning/run-scan.png)
 
@@ -206,17 +210,24 @@ compliance state. You do not need to trigger manual scans for routine monitoring
 
 ### How It Works
 
-| Compliance State | Score Range | Scan Interval |
-|------------------|-------------|---------------|
-| Compliant | 100% | Every 24 hours |
-| Mostly compliant | 80--99% | Every 12 hours |
-| Partial | 50--79% | Every 6 hours |
-| Low | 20--49% | Every 2 hours |
-| Critical | < 20% or critical findings | Every 1 hour |
-| Unknown | Never scanned | Immediate |
-| Maintenance | Paused | Every 48 hours (max) |
+A host is classified into one of five score bands (plus Unknown for
+never-scanned hosts) after every scan, and the next scan is scheduled from the
+band's interval. The intervals below are the **defaults** -- they are
+operator-editable per band under **Settings -> Scanning & monitoring ->
+Compliance scanner**, clamped to a 5-minute floor and a 48-hour ceiling.
 
-The maximum interval is 48 hours. No active host goes unscanned longer than that.
+| Compliance State | Score Range | Default Interval |
+|------------------|-------------|------------------|
+| Critical | < 20%, or any critical finding | Every 4 hours |
+| Non-compliant | 20--49% | Every 8 hours |
+| Partial | 50--69% | Every 12 hours |
+| Mostly compliant | 70--89% | Every 24 hours |
+| Compliant | >= 90% | Every 48 hours |
+| Unknown | Never scanned | Every 6 hours (due immediately on first sight) |
+
+The maximum interval is 48 hours. No active host goes unscanned longer than
+that. A per-host or fleet-wide maintenance flag pauses scheduled scans without
+affecting on-demand Run Scan.
 
 ### Viewing a Host's Schedule
 


### PR DESCRIPTION
Brings the tracked docs current with the merged compliance-scanning work (#515/#517/#518/#519) before starting Phase 7 (remediation + exceptions).

## Changes

- **`scan_implementation_plan.md`** — status snapshot to 2026-06-13: Phase 4 fully done (scan variables shipped), Phase 6 evidence plus the live hero-tile + OS-aware-lens work, Phase 7 marked **NEXT** with remediation-track readiness notes, merged-PR list, and the open follow-ups (bulk scan, SSE shutdown grace, the alerts-service gap + its generic wiring guard).
- **`BACKLOG.md`** — compliance trend card + adaptive scheduler → Done; the exceptions tile reframed as Phase 7 governance.
- **`SCANNING_AND_COMPLIANCE.md`** — fixed load-bearing factual errors that would mislead operators:
  - the Python-era `scan_findings` table → `transactions` / `host_rule_state` (write-on-change)
  - rule count `338` → `539` (full corpus)
  - the "select a framework to scan" contradiction → the **lens model** (one scan, frameworks are OS-aware query-time views)
  - framework-mapping source → per-rule normalized `framework_refs`, not the Python `KensaRuleSyncService`
  - the scheduler band table → the shipped **five bands** with operator-editable defaults (5 min..48 h clamp)

(CLAUDE.md and SESSION_LOG.md are gitignored local working notes and were also updated; they don't go through a PR.)