### PR TITLE
feat(compliance): exception governance backend (request/approve/revoke)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -369,2065 +369,2177 @@
         "filename": "internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 2074
+        "line_number": 2179
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "39d4ffb2cdfcee6afc507d1459fffc82877f5aa6",
+        "hashed_secret": "0d0f28ada977bad166bcb9afaf865e2b18d69c13",
         "is_verified": false,
-        "line_number": 5716
+        "line_number": 6097
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2a491867f605f7022638313334618bc49376e49d",
+        "hashed_secret": "da58953b2b3c693f501e7482a2c5979f781b7868",
         "is_verified": false,
-        "line_number": 5717
+        "line_number": 6098
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "db5898471494094f58e7d9a4b8096a626293fff1",
+        "hashed_secret": "54427f4afa4997a2dcc82b259b9326c347d2a645",
         "is_verified": false,
-        "line_number": 5718
+        "line_number": 6099
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5ff0e062792d3fb9e001195133fad7e4be4c38db",
+        "hashed_secret": "1d500aeba4f5ba6d02c11398d0bf80db47edce2a",
         "is_verified": false,
-        "line_number": 5719
+        "line_number": 6100
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f83207b100a34b7a1d206aedff7f71689c75f176",
+        "hashed_secret": "10addd6e8cfb6a9950cfb7424b5cfc2c1b43b7ba",
         "is_verified": false,
-        "line_number": 5720
+        "line_number": 6101
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e0f8d41aa32b2957899e0772c800b38f2662a02f",
+        "hashed_secret": "e92e144cce243090f3d88d514678a8d020bba18a",
         "is_verified": false,
-        "line_number": 5721
+        "line_number": 6102
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7f165fdf725c2673c5893bc642f24b569bbe085a",
+        "hashed_secret": "19acdd58259d3e861ad2d9816279983adb403f53",
         "is_verified": false,
-        "line_number": 5722
+        "line_number": 6103
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2b7ae086d0b94e38e101b3b9c4d59831862859ff",
+        "hashed_secret": "9637b538a44ed96f4bb95341e9b669a349e1d8c9",
         "is_verified": false,
-        "line_number": 5723
+        "line_number": 6104
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "14481b8ee929eddcb126015d88895c8fd7b6f966",
+        "hashed_secret": "28dba63b79ab18a8a05ec57739af2ea0f2f8a639",
         "is_verified": false,
-        "line_number": 5724
+        "line_number": 6105
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3aeb7be02da1a6e3bf65be38b86394dc0c9a2565",
+        "hashed_secret": "d8a9be74cba16e61c296714b380e7069b58878ab",
         "is_verified": false,
-        "line_number": 5725
+        "line_number": 6106
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5bedeea222b25e675e2056f65a35e9f9dce12e0d",
+        "hashed_secret": "099189412577babeec07f05c59a36ee6c9a54918",
         "is_verified": false,
-        "line_number": 5726
+        "line_number": 6107
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fb4282a6f3132913ef5f02be96f439e0e210ca83",
+        "hashed_secret": "56e5bc71bdb613d54a1170ce0477fdef4ed8b850",
         "is_verified": false,
-        "line_number": 5727
+        "line_number": 6108
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "92b1708f20df9381528cd4729d96ca56737d147c",
+        "hashed_secret": "12d3ba0e1ab07dcac4593d901e982e53a17c04c6",
         "is_verified": false,
-        "line_number": 5728
+        "line_number": 6109
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a31b0f4a787a916caa3b2b3eb01b5e095e3454f",
+        "hashed_secret": "43dd9d3ea59161211ccd636811a3f1656ee5084f",
         "is_verified": false,
-        "line_number": 5729
+        "line_number": 6110
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c0e6ea5046ab86beb9f54e6909481fe44ba49da7",
+        "hashed_secret": "9f79eb95933259ab81843d2d9882d0c7d5ae2618",
         "is_verified": false,
-        "line_number": 5730
+        "line_number": 6111
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b2e06ff4b77798cfa727cea99b3086d09577756e",
+        "hashed_secret": "7df2c47c9de0792c30e9cee65f372fa239712fb4",
         "is_verified": false,
-        "line_number": 5731
+        "line_number": 6112
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c55638059f481a93a4b2425d1583ed9a02e26e70",
+        "hashed_secret": "0fdfb923faa0e37b2ca717d73df13d35abb9eae6",
         "is_verified": false,
-        "line_number": 5732
+        "line_number": 6113
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "74f08a39b95c545e1fce97539b1fbcd3cc2e608d",
+        "hashed_secret": "24404ff81cccb76b698ca7d580b72034e688d31d",
         "is_verified": false,
-        "line_number": 5733
+        "line_number": 6114
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e85678046b1aba148a7207f90f1f2f4230a1f267",
+        "hashed_secret": "b1bdee5b2fffe0e26d17520cc3038c0c5f987eaa",
         "is_verified": false,
-        "line_number": 5734
+        "line_number": 6115
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "95b2a28fb5f8b3d5a3a5295aba8f3cafb5389d45",
+        "hashed_secret": "72af02668b3d8fee5c29f90476a1b8429ba11b36",
         "is_verified": false,
-        "line_number": 5735
+        "line_number": 6116
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c5bc0dab4559f562551e97c17d79ec5fc375f835",
+        "hashed_secret": "2f3c50f173a48c663c1afa7cb0b456015ae6e117",
         "is_verified": false,
-        "line_number": 5736
+        "line_number": 6117
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a8bf4533e0d410d96d795d51344d61a49689ed67",
+        "hashed_secret": "3c8a82c66ca70ddbdfb97074b611d7226da156d0",
         "is_verified": false,
-        "line_number": 5737
+        "line_number": 6118
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "72d4ae87fccc71fe393c338343a57c95b7ebcfb7",
+        "hashed_secret": "6ecec06d748c5107786a4230cc0f75722a6e4d5c",
         "is_verified": false,
-        "line_number": 5738
+        "line_number": 6119
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f07f27215502aa0d38992ee8bbb3353bdbd0db5f",
+        "hashed_secret": "bf9f9b91a83097adf41a86b326ede02211608232",
         "is_verified": false,
-        "line_number": 5739
+        "line_number": 6120
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "92ff15ccd3fe05481d70cbba66e30bf9e96741c9",
+        "hashed_secret": "2864e0cebff61036b8f409535e5104a689a1a441",
         "is_verified": false,
-        "line_number": 5740
+        "line_number": 6121
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "786a22bb508c2228bd4a2087441aee486beb5526",
+        "hashed_secret": "43f7a76fbb1fe41d4dbc24f09a945e7983715e2c",
         "is_verified": false,
-        "line_number": 5741
+        "line_number": 6122
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a2f15293d552168f5b66ee7f55b3000c165b799d",
+        "hashed_secret": "4cf030ae505b31df3ef5f4155374b6ee6a8f98aa",
         "is_verified": false,
-        "line_number": 5742
+        "line_number": 6123
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c0389cfdf88608516085d9291307351f75043544",
+        "hashed_secret": "53210e79d2cb6e6dcfa020d9f3297817eb3d7b7c",
         "is_verified": false,
-        "line_number": 5743
+        "line_number": 6124
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2b424cf83fe4cc83da191a184dda2f584ad27885",
+        "hashed_secret": "74fd25e62e2003e256c367e2b0d9211d9040b67c",
         "is_verified": false,
-        "line_number": 5744
+        "line_number": 6125
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "75c1825236863f77999e2f20f8c3a64fdcb3dfaa",
+        "hashed_secret": "0c116964e973f94f8b72248c6cf3a666ffcb358e",
         "is_verified": false,
-        "line_number": 5745
+        "line_number": 6126
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "be67796bf29c4932dec0a5c81acd1f1e456b67a0",
+        "hashed_secret": "909ef8d943b649ad01a7b9a674c3c94530396549",
         "is_verified": false,
-        "line_number": 5746
+        "line_number": 6127
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0911d871754f510eae17f439a7c0e2968ddaef24",
+        "hashed_secret": "cb4cb4399e1fa37030d2c73c58f48fc729d6ecf5",
         "is_verified": false,
-        "line_number": 5747
+        "line_number": 6128
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e62a986d968ef535d23049b02cc2159ebae697e1",
+        "hashed_secret": "240d0c8a5e04ce470ada626ff8b4c001d8f31ff9",
         "is_verified": false,
-        "line_number": 5748
+        "line_number": 6129
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2aa2548927e7b7bdb99ccaf527782fc7e2c4fdf1",
+        "hashed_secret": "cb67cccc44bdf9b0feb0864d5e05e11d938ad603",
         "is_verified": false,
-        "line_number": 5749
+        "line_number": 6130
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "07295186c9aedd6810f580fda47077ab810cff38",
+        "hashed_secret": "6d42118f49234c767fe06ba34838ac54094afe3d",
         "is_verified": false,
-        "line_number": 5750
+        "line_number": 6131
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7bbdff705c33d0e28845b1bf6f4cbeaefd248696",
+        "hashed_secret": "127fad1b13bef1353a3cdf5a27b2826727a6dede",
         "is_verified": false,
-        "line_number": 5751
+        "line_number": 6132
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0f6d0ad4ed9040cdf7a4631eecb98a27961cce41",
+        "hashed_secret": "b1e8aefea4dd566e3818e5a487e02678ffd86648",
         "is_verified": false,
-        "line_number": 5752
+        "line_number": 6133
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9161ba70ae011d7ce57db1cf3ca8078ec52738a2",
+        "hashed_secret": "6bfcb8aa9ce1d96c207f600705052d009ca275a1",
         "is_verified": false,
-        "line_number": 5753
+        "line_number": 6134
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ee8c1a64a5b3272913602bf327e69da8e8dbbb9e",
+        "hashed_secret": "e5a389fe2e254672d1453e0f88e2ee846722bbd6",
         "is_verified": false,
-        "line_number": 5754
+        "line_number": 6135
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a562818719fa4c9c69b34d770d619bf44a176f4e",
+        "hashed_secret": "024e962ec48552cb0b0b108794b4b3c59af3145e",
         "is_verified": false,
-        "line_number": 5755
+        "line_number": 6136
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b854a41e371fc9c4f150825205afdab97d30bb35",
+        "hashed_secret": "92065db18db3ccba9c911154e832c46d310e64d6",
         "is_verified": false,
-        "line_number": 5756
+        "line_number": 6137
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "299d665464cacca06442cc34b0857e8f844d5dd7",
+        "hashed_secret": "9ba6e628fc6689e7721055e798154f8ff5e97491",
         "is_verified": false,
-        "line_number": 5757
+        "line_number": 6138
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "dfe1d40d12dae95560c6e3500ad9fc3aa78f8971",
+        "hashed_secret": "c26da2ff1ba01c28780f7260377379d13bd4f487",
         "is_verified": false,
-        "line_number": 5758
+        "line_number": 6139
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7e92a8e01bc4af7bf777bb367db06dcae43d27d6",
+        "hashed_secret": "d92e1cc3e414c1d706be866ed67a932ca0565821",
         "is_verified": false,
-        "line_number": 5759
+        "line_number": 6140
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1ddccebef355b6ad06bb6ba88233ed60423587da",
+        "hashed_secret": "55ef6dc69efc4505b6020f9693d892fc8b48df5a",
         "is_verified": false,
-        "line_number": 5760
+        "line_number": 6141
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "57aa9c3e94e52541cab157874ce42d407123405d",
+        "hashed_secret": "d81c9b266f760980e057f70504ba9f4e33956ed3",
         "is_verified": false,
-        "line_number": 5761
+        "line_number": 6142
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ba6d65021031e90d4aaf378687951d2d2e923bbe",
+        "hashed_secret": "05221545416814df7f66ff5d3935b53c787d6878",
         "is_verified": false,
-        "line_number": 5762
+        "line_number": 6143
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9fa7a505499d112f9e47bedfc5481274ff780206",
+        "hashed_secret": "d6b23f9f2923ddccca7d4a59b34a341dbcee4b92",
         "is_verified": false,
-        "line_number": 5763
+        "line_number": 6144
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d3a9bd6127fb151744a673aae892948305187acf",
+        "hashed_secret": "7cdc1ecf644b9e578412b73e365be27f2bcad35c",
         "is_verified": false,
-        "line_number": 5764
+        "line_number": 6145
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "724833dd094feb4d3dca079f23b807067964af64",
+        "hashed_secret": "21f0d9e674d9cfb9c0ac52e286b2488938816bd4",
         "is_verified": false,
-        "line_number": 5765
+        "line_number": 6146
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0c705be8aefb02b545dee79f48f9aa4db8b32e8d",
+        "hashed_secret": "4d434af29a296560a6cfcbf877c482b5602b1840",
         "is_verified": false,
-        "line_number": 5766
+        "line_number": 6147
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "281a92ba08bbdd7ef111c55c9f5affa01694081b",
+        "hashed_secret": "6cd06b2bcd0dad61aeba4e50b2cf7a85e92f9895",
         "is_verified": false,
-        "line_number": 5767
+        "line_number": 6148
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3b2147a8f0a3722a07fcf686d315cd706459f932",
+        "hashed_secret": "16194ffdabebc6c0baced452fd49a8fd55644611",
         "is_verified": false,
-        "line_number": 5768
+        "line_number": 6149
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "92a8ba71b606399f3b334758a049970c90917f2f",
+        "hashed_secret": "87739727ae3c4c8f3d6e7c40cf5aa1fbb64a5ff9",
         "is_verified": false,
-        "line_number": 5769
+        "line_number": 6150
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "83da6162f32c50e50342a3ca2481ec3b32a1c423",
+        "hashed_secret": "5913ec87ac7e9ed2c8cb896513ca1b86d8d9dafb",
         "is_verified": false,
-        "line_number": 5770
+        "line_number": 6151
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "88ba8f27d8e1a05c7cf86f6e50e6ff04fa45f5a4",
+        "hashed_secret": "2158b1374c4ec953009fbd46602329d75dbc25a4",
         "is_verified": false,
-        "line_number": 5771
+        "line_number": 6152
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6539077209778e55052679f1cd2e3c16fa373f9c",
+        "hashed_secret": "7993f08941485bffcecee2521259c9049d8d9e49",
         "is_verified": false,
-        "line_number": 5772
+        "line_number": 6153
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9540e4976da61b220f6ca609d95e4154878a97cf",
+        "hashed_secret": "8e1d327ad393e77f4629b1e4be263982cf38b287",
         "is_verified": false,
-        "line_number": 5773
+        "line_number": 6154
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8dc26bb688496ca9ffa74d43453e1eb7b2d41b8b",
+        "hashed_secret": "ae22f5c2fea312b9d96be66bbd987b23854fb3ed",
         "is_verified": false,
-        "line_number": 5774
+        "line_number": 6155
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5ad1f26484e6b9cda5cd64228b5c7c0b9e353958",
+        "hashed_secret": "689e5b84a18aad1ea7d44f179f91c497b7df75d8",
         "is_verified": false,
-        "line_number": 5775
+        "line_number": 6156
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8164ff14da19605db5b58bae40b00170e2c71a2a",
+        "hashed_secret": "dc58cb17d3ea9a4d3ce1037c53e68722b0554af3",
         "is_verified": false,
-        "line_number": 5776
+        "line_number": 6157
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6458c14fd4e1f4eea0030df54a75a10bc00d58fc",
+        "hashed_secret": "6f2c67e6f40975679b9de7786f72078b5e6e150f",
         "is_verified": false,
-        "line_number": 5777
+        "line_number": 6158
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "22020b7961c4d144ccd1b5072caa5a193bd92ac8",
+        "hashed_secret": "aff8e3e7875e70f4a0747603f8fad6ae60933fb3",
         "is_verified": false,
-        "line_number": 5778
+        "line_number": 6159
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ed105471a1c0feab5404446377bfee67cd9b8880",
+        "hashed_secret": "f772773b7815ab90e53b3108273f96f52fa8fb68",
         "is_verified": false,
-        "line_number": 5779
+        "line_number": 6160
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5ddf45b87774465d15fe54eecabc7527d59bd3a8",
+        "hashed_secret": "8720564bed45983bceae0787e49c4d1ed877645d",
         "is_verified": false,
-        "line_number": 5780
+        "line_number": 6161
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9cbf62244b2ff8e7b1c8160bb62a08a9d6034de4",
+        "hashed_secret": "e344d18b46a45d3d803ff117b9c158eb4feee906",
         "is_verified": false,
-        "line_number": 5781
+        "line_number": 6162
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fdfb910b33d632d7c95095775eacfc6ea7c39cf3",
+        "hashed_secret": "9da02c5780d8fa4ff8cb7543ff5fc27571c081a4",
         "is_verified": false,
-        "line_number": 5782
+        "line_number": 6163
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8a2223bd7225050ba6f702ee71b830415990c9e3",
+        "hashed_secret": "54578d6cc8d371f5c346fbbf54b6dba88338225a",
         "is_verified": false,
-        "line_number": 5783
+        "line_number": 6164
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9f241e7dc331c9b099f0e75cc1c323e70e5df153",
+        "hashed_secret": "ddb3df8fb7c988af78be2f4b094347d46a1153e3",
         "is_verified": false,
-        "line_number": 5784
+        "line_number": 6165
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f4fba3726625f86d756a1ae8182da931ead90a77",
+        "hashed_secret": "ab1a36a304cb40fdd189ab516def965a6fa373fc",
         "is_verified": false,
-        "line_number": 5785
+        "line_number": 6166
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "39e987ad918a334390636afad3556226fca26770",
+        "hashed_secret": "5ef76c35cc37c4e22bc6acae4d2e54cc39225954",
         "is_verified": false,
-        "line_number": 5786
+        "line_number": 6167
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2ab94c824c8bae5cca5ee2fe116001d99add8421",
+        "hashed_secret": "3d6c8ffa519e5225336278cac52ced0b8574c47e",
         "is_verified": false,
-        "line_number": 5787
+        "line_number": 6168
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "99e7658c3c263f251510a184221d595f54766788",
+        "hashed_secret": "ae51bc92f1e7b8e77cadc72df9bc9c913d0df8fc",
         "is_verified": false,
-        "line_number": 5788
+        "line_number": 6169
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0383939b971576157da75b1b7ace4b95c234d081",
+        "hashed_secret": "eb334ce509e3cd25ef7230c6958d316ea268b7ab",
         "is_verified": false,
-        "line_number": 5789
+        "line_number": 6170
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "37d871ffa427b3aa3285a4d9cab7e83bfe6210e3",
+        "hashed_secret": "7c6e046df72ea68847a68a6d5b972669b70f1835",
         "is_verified": false,
-        "line_number": 5790
+        "line_number": 6171
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "da5aca7d07d8925fef241896ecdb827b42fb4332",
+        "hashed_secret": "26259a70f83f03ac8300dca09159489d2b0d0d14",
         "is_verified": false,
-        "line_number": 5791
+        "line_number": 6172
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4bcf3cabc55c62b53b9a90319c6df75def5f45d0",
+        "hashed_secret": "ce6351befa55b2ced0c7ae870b057912290aadd9",
         "is_verified": false,
-        "line_number": 5792
+        "line_number": 6173
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1cd31c01b68b5399813cd907864a264a5662cc74",
+        "hashed_secret": "3932bc73193aa250663931497fbbe43d6b168b74",
         "is_verified": false,
-        "line_number": 5793
+        "line_number": 6174
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "be00217ada6bf26fbd1000ac766e7f68cb61f8c9",
+        "hashed_secret": "c52b025d5330a3ef312570def748f4f173a55147",
         "is_verified": false,
-        "line_number": 5794
+        "line_number": 6175
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "57b29202089fce2f166048198d142d084b812904",
+        "hashed_secret": "40982053457f33aa679d4ce840e1d42f71e61839",
         "is_verified": false,
-        "line_number": 5795
+        "line_number": 6176
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bc5e22240bb84327eab8da4045a304acb3dede5d",
+        "hashed_secret": "212021941ffb3b011d550712f6864f8ace916450",
         "is_verified": false,
-        "line_number": 5796
+        "line_number": 6177
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "584da1556777d76f4e54d362a409c5a6ee9a6f28",
+        "hashed_secret": "4c986792d0812c16d670ccfaef38554ccabc03f4",
         "is_verified": false,
-        "line_number": 5797
+        "line_number": 6178
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f209d2b5669dcaadafa0df7d1fa5ced772b28c26",
+        "hashed_secret": "edb4706da9669115a3f8271789956add4d704acd",
         "is_verified": false,
-        "line_number": 5798
+        "line_number": 6179
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "369db536df7814f352b1dca8298e1b8a3beedd77",
+        "hashed_secret": "46f1dff8869252640a5b6794ca3f05c7aad44e70",
         "is_verified": false,
-        "line_number": 5799
+        "line_number": 6180
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "44026045eeccb30a71b88de3d62e3f82812456e1",
+        "hashed_secret": "13252aecf8afd1757412f3dc676620dc2fc99d18",
         "is_verified": false,
-        "line_number": 5800
+        "line_number": 6181
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4285c237af61bfcdb0d1d719245716e4558dc93c",
+        "hashed_secret": "5c77a5436d7786265824709a0c599aaf0786e1d3",
         "is_verified": false,
-        "line_number": 5801
+        "line_number": 6182
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "dd942001d55bb2467aae3e8b8a1935a50c629bf2",
+        "hashed_secret": "4a6448857aa5adbcd7ec00db9b80f6dd73d664c7",
         "is_verified": false,
-        "line_number": 5802
+        "line_number": 6183
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b690c5b7084ded2dd25ee20e64f9db4fbdc89179",
+        "hashed_secret": "17c4dffd4bc71c6dbf267ee9e723e4209ec0ce1f",
         "is_verified": false,
-        "line_number": 5803
+        "line_number": 6184
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "489b27e61c26517c8e34b448ab43956349ae01bb",
+        "hashed_secret": "5384c798cf817eb505edcf6fbedc79f9b28ad51a",
         "is_verified": false,
-        "line_number": 5804
+        "line_number": 6185
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "45819311aded0b788d47d491c22ac0b6f4b65811",
+        "hashed_secret": "aa85533da54492f27f9e138d4b72238133d5e2f3",
         "is_verified": false,
-        "line_number": 5805
+        "line_number": 6186
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "aed11df7502ee5ced2b8a4b018dfdf7e41edc98e",
+        "hashed_secret": "bf218d32c9f6befa8c1fccc6cce5d5ea6e84c121",
         "is_verified": false,
-        "line_number": 5806
+        "line_number": 6187
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5b4475c397814c3c1bccc31a56234e3c56e4d57a",
+        "hashed_secret": "faf7f2805c49525073ccc407856df23db5a40909",
         "is_verified": false,
-        "line_number": 5807
+        "line_number": 6188
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "28d77f0bc5d0f81e59666ea914d3d46d305ec9b4",
+        "hashed_secret": "2a9d9310e5c4e619b8d886490ede1e0c2f4c2b06",
         "is_verified": false,
-        "line_number": 5808
+        "line_number": 6189
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e473eb5c8e8b070fdae5f9fc5da8ee3c634021eb",
+        "hashed_secret": "4fc6462f2183806bf55ecd7a8586b3188a8b98e5",
         "is_verified": false,
-        "line_number": 5809
+        "line_number": 6190
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f198a092780914e221ff674be1cca0fb9e0ca5f3",
+        "hashed_secret": "6f13df00ead7a1d1156e17f304d98458077dadc9",
         "is_verified": false,
-        "line_number": 5810
+        "line_number": 6191
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "db0487de4a64ba7ae6c3fea24387459be2f0539c",
+        "hashed_secret": "a6664bfcab040b930425bed58ea93c7a20e6cf96",
         "is_verified": false,
-        "line_number": 5811
+        "line_number": 6192
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3360432df0fd1355dcb13c84eca238653de07885",
+        "hashed_secret": "3cea5390763167b1abf5040cf0228274442843da",
         "is_verified": false,
-        "line_number": 5812
+        "line_number": 6193
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "666aa7391d5443e88f0b3f9efd9928cb77f1e805",
+        "hashed_secret": "f2fe04168c8e5daa97c9867cc6ea8f3bc2399504",
         "is_verified": false,
-        "line_number": 5813
+        "line_number": 6194
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "67e40a1662596b25e7cdb0970c8da8dd6be323c4",
+        "hashed_secret": "94b0d995d65caaf1c56ef3edb07854c4fda4c364",
         "is_verified": false,
-        "line_number": 5814
+        "line_number": 6195
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "302413e4e34e3e97a23d9fe3e02fb5170eac07c2",
+        "hashed_secret": "8f1bf9cc5e526a18ce9a5cd773c558da706dcdb0",
         "is_verified": false,
-        "line_number": 5815
+        "line_number": 6196
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "554375d1c596d51c7b362f7b52b2306f2718fb1f",
+        "hashed_secret": "08f8a6f230228fe93d5a4c086320180d871e8c7c",
         "is_verified": false,
-        "line_number": 5816
+        "line_number": 6197
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a32466bf2b7cac9ebde7bd31df0c1c27646a61b7",
+        "hashed_secret": "92e248dbb10d0262123074a9e7fe514b8e525670",
         "is_verified": false,
-        "line_number": 5817
+        "line_number": 6198
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d773305eedce7c5a4e5fa6ffffa0f43faccd6bc6",
+        "hashed_secret": "74caa26132b222fd4149cda334535c4c6380664d",
         "is_verified": false,
-        "line_number": 5818
+        "line_number": 6199
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fbfa037b424de3fead16a5046258535cb48ba4a0",
+        "hashed_secret": "4a112eb7c53c8a6a9fadcce2cea7bb8d1d177865",
         "is_verified": false,
-        "line_number": 5819
+        "line_number": 6200
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8fdf46ca663116bec1d0296928e1199c31bdcc1c",
+        "hashed_secret": "3b2086671f6019a7b29eaa81c841150348fc1554",
         "is_verified": false,
-        "line_number": 5820
+        "line_number": 6201
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fd84a140b60a50c2c258b14fddf7bb50e7ff339f",
+        "hashed_secret": "54a6dc7d221b773d01c8332dea1e0adeb0cf7005",
         "is_verified": false,
-        "line_number": 5821
+        "line_number": 6202
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5b3a3df4072722455e2a08be0a966063bc069462",
+        "hashed_secret": "453d2f633dd813341a77a499c76411c4bb849367",
         "is_verified": false,
-        "line_number": 5822
+        "line_number": 6203
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "742c5946de149d537530414f4c6e319ec804024a",
+        "hashed_secret": "2d7e9e0a5ba3295fccdabbed2353ba0b3a305f84",
         "is_verified": false,
-        "line_number": 5823
+        "line_number": 6204
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "92e6c65cf6c5876edb7f9c252fa123d2c594ea6d",
+        "hashed_secret": "c267089f92a572d17cfc09f9765e5f25a2e55d6b",
         "is_verified": false,
-        "line_number": 5824
+        "line_number": 6205
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d206946d51f4ee20c5dc5924de8e10df4ade1f32",
+        "hashed_secret": "87e246c029d7c18f6251401c0af5d27e66c6ae3c",
         "is_verified": false,
-        "line_number": 5825
+        "line_number": 6206
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5d0d276dd80e2929a97d8ddbb2ae188efd144633",
+        "hashed_secret": "31d690d259083ab1f2c6ad6032ea905d5fa76c38",
         "is_verified": false,
-        "line_number": 5826
+        "line_number": 6207
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7d734436c223d7b4d05e0bae0628d1e382d90cf2",
+        "hashed_secret": "f0bf0a4ac95ecf5a1c32cd0d00b6f65c4699560b",
         "is_verified": false,
-        "line_number": 5827
+        "line_number": 6208
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8bf317e5e0f6eb70970e5c187b6dae5ba0e98cc4",
+        "hashed_secret": "29277f88d7138d2eb77ef1c1356ddb13aee43ad2",
         "is_verified": false,
-        "line_number": 5828
+        "line_number": 6209
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6b086132faa6bea8ec86acb21a4cf6495dbaa9c5",
+        "hashed_secret": "2811041f8ee8e4663ac5c302ba5b6bc5391c23ce",
         "is_verified": false,
-        "line_number": 5829
+        "line_number": 6210
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cc649eee740bfc01fa651b35624f73c970a6b6ee",
+        "hashed_secret": "0dcbbb7df3cbfe19630f7ba5bdf7e5f05052b27f",
         "is_verified": false,
-        "line_number": 5830
+        "line_number": 6211
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ce4d02e25722d734efdbf23b90a439b691396d70",
+        "hashed_secret": "00b36d7926b3779a123838976fed7b427376d12a",
         "is_verified": false,
-        "line_number": 5831
+        "line_number": 6212
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "26ecfbbf78a10e95019033ae048ef0a37835e9d4",
+        "hashed_secret": "876b720f373ffdea6d5d3f1a4556e32056b3bdfa",
         "is_verified": false,
-        "line_number": 5832
+        "line_number": 6213
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ba457cfdc1e1fd3fe78e4c55dbd54003a6c865ad",
+        "hashed_secret": "25fca72a4e80d2546bd852ab295b86d8785d81cd",
         "is_verified": false,
-        "line_number": 5833
+        "line_number": 6214
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b4b2ce93770fb5599cbf2933770f74edbf61b5ce",
+        "hashed_secret": "53f8f19814f739cd51736b358d8cbed998d764cf",
         "is_verified": false,
-        "line_number": 5834
+        "line_number": 6215
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8252f30387340f99005312979f4820d91ea1479b",
+        "hashed_secret": "821834664230c9b7b3ca9e8c2de62f8c0a293b73",
         "is_verified": false,
-        "line_number": 5835
+        "line_number": 6216
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cc8b9dafb8d925f0276511ae07d1444a8178ae4a",
+        "hashed_secret": "a74423d05069885d694479229cb7d26533f0d6ce",
         "is_verified": false,
-        "line_number": 5836
+        "line_number": 6217
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3ad71e41a0dbaeee072298ffcc304a05622f5ae1",
+        "hashed_secret": "833d9bf7584d83ac77a234bb5de0cd8aeedfa9d7",
         "is_verified": false,
-        "line_number": 5837
+        "line_number": 6218
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "45dbae4fefa6f22a9bed584a6a6930bb2321466d",
+        "hashed_secret": "03bbdfd133d97e4fd21117f2925e81bda7a045db",
         "is_verified": false,
-        "line_number": 5838
+        "line_number": 6219
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0d002b8a7814cfc471d6878c4d8f1e587be1ec53",
+        "hashed_secret": "9445cb5c56dba1e399a1b463f2a557350ffac78f",
         "is_verified": false,
-        "line_number": 5839
+        "line_number": 6220
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "916c77588abe323845ee11dadd5a61d7e68523c4",
+        "hashed_secret": "c00244e9203954202388e946ba7ad1ed314ef30c",
         "is_verified": false,
-        "line_number": 5840
+        "line_number": 6221
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bb3ccd691b8564b45ea187076bb298c30515ea28",
+        "hashed_secret": "acd13c84364d5819db5405ae62ad33590c0af27c",
         "is_verified": false,
-        "line_number": 5841
+        "line_number": 6222
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3d9c24a1f68af4e769901506178db36ec7249717",
+        "hashed_secret": "cc3030335bc103e9f5c184d810af4046eab0c296",
         "is_verified": false,
-        "line_number": 5842
+        "line_number": 6223
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6acbdc5d07618416d86e5ad91d720ea3647a05d0",
+        "hashed_secret": "8e58152d9957d0dcee204795da61c4769148e79d",
         "is_verified": false,
-        "line_number": 5843
+        "line_number": 6224
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5dd193c013e02b38b9f9a19709251ec3f41749b9",
+        "hashed_secret": "b4318a311d48d1c01e93796b185cc6c7fc34535c",
         "is_verified": false,
-        "line_number": 5844
+        "line_number": 6225
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "44884fef19a82422e5e731186ed6db6fa43915ca",
+        "hashed_secret": "620ea24cee30468d15e53ce795cae1fbe7f79add",
         "is_verified": false,
-        "line_number": 5845
+        "line_number": 6226
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "43be089e6a8e49f05ef0316f4c07183c5a7d828b",
+        "hashed_secret": "8c62d92a79e1c008a0e5a59b52041f2fc6051a35",
         "is_verified": false,
-        "line_number": 5846
+        "line_number": 6227
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ac6a10e80c8e122f47e65b68b8a491c6aeeffe64",
+        "hashed_secret": "31be21b2c2da9ee6e2bc2cbbcdd942c0924efac4",
         "is_verified": false,
-        "line_number": 5847
+        "line_number": 6228
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a556fdefcd7746cba93a6080d55d3dc6241c20a2",
+        "hashed_secret": "29ae5c1b975ca18fc298b65a8870349f2b41a205",
         "is_verified": false,
-        "line_number": 5848
+        "line_number": 6229
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7ac0d7d8501e060800e2b23823c81889792e4225",
+        "hashed_secret": "996d6ac4f89c78e4574925aac9aac21954f42a11",
         "is_verified": false,
-        "line_number": 5849
+        "line_number": 6230
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "73438befdd99ccb7a33c0da1bcdf8ab62f660568",
+        "hashed_secret": "cc52c9216ac6e1f63418576aa911bc5a58e6e5a3",
         "is_verified": false,
-        "line_number": 5850
+        "line_number": 6231
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8dd1e165cc8fd0525efb9081201ba60e004934df",
+        "hashed_secret": "618a4369347f8f031fd7312ffb0af0bbb2aa4f2c",
         "is_verified": false,
-        "line_number": 5851
+        "line_number": 6232
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2087a9ccdd9e156dfa6ac47346c519fbe59a4bd1",
+        "hashed_secret": "1b8052c988632490ec6148abe9c527debd344bd4",
         "is_verified": false,
-        "line_number": 5852
+        "line_number": 6233
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "817604e6a68c74118a3948d55681c1ab5f5425e2",
+        "hashed_secret": "986eca5e6b0c42b79de6da23c58d3943c5e7503b",
         "is_verified": false,
-        "line_number": 5853
+        "line_number": 6234
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5c3cd3ea0568745e28e0119a0ca89424c61dac47",
+        "hashed_secret": "c0de96cfbba2f1c9942163e6c1ed5f70688f7c10",
         "is_verified": false,
-        "line_number": 5854
+        "line_number": 6235
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6a8f33bd560ff9961a5fcfc555617962249535a5",
+        "hashed_secret": "d427b0a344ec2795fb64a8dbd4973931bcabe5ac",
         "is_verified": false,
-        "line_number": 5855
+        "line_number": 6236
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8b843069e6c174cd457d9803072fd32ced461dd3",
+        "hashed_secret": "1c27e4b1a8be6d9d9d065619defe84b7f10fa899",
         "is_verified": false,
-        "line_number": 5856
+        "line_number": 6237
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "525f1f94d77165d85db183051df81ee70dee5fcb",
+        "hashed_secret": "cf68c87c966b66ccb86579c36cd5031d31d445a3",
         "is_verified": false,
-        "line_number": 5857
+        "line_number": 6238
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8e02bb376adc82afc8ebb79c8c8f34867c6fd3db",
+        "hashed_secret": "f746a011767c6b5eb0911566d05cba76d0867ef2",
         "is_verified": false,
-        "line_number": 5858
+        "line_number": 6239
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "dfa5d35696dcc20663e5c318b783386d0fb277a9",
+        "hashed_secret": "48ca9229cbd4b643cf61d8a252036fabdaf11942",
         "is_verified": false,
-        "line_number": 5859
+        "line_number": 6240
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4b18aa5cefb7554a09932cae34cb2d4578410c06",
+        "hashed_secret": "1d8e4b3dc6f0bb4050bb415e54eb60978e84ad9e",
         "is_verified": false,
-        "line_number": 5860
+        "line_number": 6241
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6c0ad5685bd2299b7721e51f3501963e241d6102",
+        "hashed_secret": "6c1aa2126fd97a2b628b9111c28d855fc114e0e3",
         "is_verified": false,
-        "line_number": 5861
+        "line_number": 6242
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d48a726dfc73305c8672ac5c6843795e44e8f4eb",
+        "hashed_secret": "972575b7ecb0b23171b80e4d4a283e6f06056f4d",
         "is_verified": false,
-        "line_number": 5862
+        "line_number": 6243
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "61c4a1067b3ef0aa19e4e9861c68e01373e6c6c6",
+        "hashed_secret": "8a1c41acc074efdf290f3610584abb659c6ef9cc",
         "is_verified": false,
-        "line_number": 5863
+        "line_number": 6244
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c1c52dc705ebba1cb72e9840b3b6fefca2e48bd2",
+        "hashed_secret": "7dfa58f4c5292355923a3211c2bbf5347d053560",
         "is_verified": false,
-        "line_number": 5864
+        "line_number": 6245
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c940c78682a49607780766be939f0937b1de83ec",
+        "hashed_secret": "7a42ca4738a4fe6eb9955e6ce851db45acb222c4",
         "is_verified": false,
-        "line_number": 5865
+        "line_number": 6246
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "28d1f34e5d90a4224fb0798952a64f9795ea5397",
+        "hashed_secret": "1dfd8b3f216e354398c5b7d4c33f08bef4e2703a",
         "is_verified": false,
-        "line_number": 5866
+        "line_number": 6247
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "18744ebf4e88bb63d30586d8a4d99b3b978c480b",
+        "hashed_secret": "b5fb783b157cdaaed5c7f7855108e090588fab7d",
         "is_verified": false,
-        "line_number": 5867
+        "line_number": 6248
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "029fc9083ff5df768025bb306b75280688f53ae5",
+        "hashed_secret": "9caafff07cff379fe1d3bf49424c65204222b3b9",
         "is_verified": false,
-        "line_number": 5868
+        "line_number": 6249
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "74d6a7cc0ff915468ab06c3f9c1522ffbda9cd6e",
+        "hashed_secret": "7442183beff93871ae0279656c6dc2c41c6a885f",
         "is_verified": false,
-        "line_number": 5869
+        "line_number": 6250
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8da2e34d2754d6ada2a7d67a2a67d33e74ffdc93",
+        "hashed_secret": "dfac07a6715d0d30c71a3f00cd797b8abe322e76",
         "is_verified": false,
-        "line_number": 5870
+        "line_number": 6251
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "26ceecaae6ae2e3316d779928cf72c890778f116",
+        "hashed_secret": "eb6d66a06f770501c7fe3c5bcfd41010519a9226",
         "is_verified": false,
-        "line_number": 5871
+        "line_number": 6252
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "096f4947ae57e480e030470d5f61e4dbd1061ac9",
+        "hashed_secret": "4c6f0efaab76e4828d12243515329d7ba6ad7ee5",
         "is_verified": false,
-        "line_number": 5872
+        "line_number": 6253
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b702dbb9049d24b254521d6027ec00b64231eb74",
+        "hashed_secret": "e56ba1e0b0716eac63bf4d0be0afd972bda3cd18",
         "is_verified": false,
-        "line_number": 5873
+        "line_number": 6254
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8edb764eaeaab7b83eeed072fac9f5e016111fda",
+        "hashed_secret": "d89f3229423d968090e7a8182277b8ad986b8056",
         "is_verified": false,
-        "line_number": 5874
+        "line_number": 6255
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9ce3b96bdbfa7dd323f8b6038bc1cf45d7b92c23",
+        "hashed_secret": "f7f11a31454c1d8ddc51b10301a545a8046579db",
         "is_verified": false,
-        "line_number": 5875
+        "line_number": 6256
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "54f4a8c15e736c326d98bef49b63e6009e5f6466",
+        "hashed_secret": "28c870a7d28a14e796264429fbd9003182e7fd66",
         "is_verified": false,
-        "line_number": 5876
+        "line_number": 6257
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "345618135e70e8c17052405f9444390218aad019",
+        "hashed_secret": "6613f842ed213ee5c1298a658a2bc31c477f92dd",
         "is_verified": false,
-        "line_number": 5877
+        "line_number": 6258
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "72bc9f54bee7f3698fd5a523ca9a37dbd338e4b4",
+        "hashed_secret": "f3b0bbdae85b682227f8b2af704a68cff46486c7",
         "is_verified": false,
-        "line_number": 5878
+        "line_number": 6259
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "07322b2159514e4e579cb6a4477370b0f63cd8df",
+        "hashed_secret": "eeeb79e844bc2b3593d60f413f9ebc86d93f568b",
         "is_verified": false,
-        "line_number": 5879
+        "line_number": 6260
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "667c8b1690b115b68255f18e59e3a11ff12b5c3a",
+        "hashed_secret": "432260750948d6e7550f2d8c5474160a7d35c6a4",
         "is_verified": false,
-        "line_number": 5880
+        "line_number": 6261
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "41c2b42d0dfa2b73c70cd4f9d77858826b31be03",
+        "hashed_secret": "a4a83ecc972a97f763221c1f992cd05f304af624",
         "is_verified": false,
-        "line_number": 5881
+        "line_number": 6262
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "27417fe6117da775ba22789dbb50cbe3b1a5ad71",
+        "hashed_secret": "6db515f4b4d8aa2f9c60b90d2f53f46c4b62b096",
         "is_verified": false,
-        "line_number": 5882
+        "line_number": 6263
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8645ef64f9400f5b515a5f22f0051841482dfbe9",
+        "hashed_secret": "c760368043806ef8b54d25c89579ffb795bfe3b0",
         "is_verified": false,
-        "line_number": 5883
+        "line_number": 6264
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d2f46ba2bfe2a233533a2215407fed539ab4f57b",
+        "hashed_secret": "a4bc8da5afb22a0016769988ad5567941cf03d3c",
         "is_verified": false,
-        "line_number": 5884
+        "line_number": 6265
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2d3592bbc0e4694e14d2a245a1aff521106b9634",
+        "hashed_secret": "1bf9a58e218bf71ad23a87142980ba878c3f9cfb",
         "is_verified": false,
-        "line_number": 5885
+        "line_number": 6266
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "aa9d629b20209742d5a530dc67bc7cce21758ede",
+        "hashed_secret": "e40a6332fdae4efd52c7495566c93e3c39e9ced9",
         "is_verified": false,
-        "line_number": 5886
+        "line_number": 6267
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6de8dd32fb019eaf2d8cf55cbd83393d1e55a963",
+        "hashed_secret": "770cdd9b0f7fd2371afbfaed08531330fec0179a",
         "is_verified": false,
-        "line_number": 5887
+        "line_number": 6268
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "14ea458284148af3826171c691ce98b4c58a706b",
+        "hashed_secret": "989d15878442076e5eddffcfacfd0567cabfbad1",
         "is_verified": false,
-        "line_number": 5888
+        "line_number": 6269
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b5b9172b4052e0966daa1bb91d62f0d59e747d59",
+        "hashed_secret": "c2981e051182be7845caf68ea0deef7fd52566c9",
         "is_verified": false,
-        "line_number": 5889
+        "line_number": 6270
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "019aa2251dba5e03c78718baa2ff76a615e9d0f7",
+        "hashed_secret": "40485ba298952244bf11f2b1e3c154414e5d8235",
         "is_verified": false,
-        "line_number": 5890
+        "line_number": 6271
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a0581ac03ec239bfe1b9a54b5ff47eb64f175350",
+        "hashed_secret": "eaba6b5feed27cb5bab5bb35388a7b7a1d6ef8e9",
         "is_verified": false,
-        "line_number": 5891
+        "line_number": 6272
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "04e47f7192a2eab87d48502db7d4495de0b6ed71",
+        "hashed_secret": "f1fc0342e78b015def45d1b52f1e74019156f490",
         "is_verified": false,
-        "line_number": 5892
+        "line_number": 6273
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a1ecc3649a86b7a028c5d914e5681b13682f2308",
+        "hashed_secret": "8dd21b3cdec4fdfebf4827d41f42c7c7d9a888d6",
         "is_verified": false,
-        "line_number": 5893
+        "line_number": 6274
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c264033db445c17ae8ac8cd83f4d8fed2188628f",
+        "hashed_secret": "e5625936043dd9dee8498b22128f9d3c7bea363a",
         "is_verified": false,
-        "line_number": 5894
+        "line_number": 6275
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "999262cacdf738f236675dc2ff87038f049e6df7",
+        "hashed_secret": "b8a16550dc12acd68ba10c3243ba8d46c2ab20c9",
         "is_verified": false,
-        "line_number": 5895
+        "line_number": 6276
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2b7add9d8bfb419cc59bb67da01e28cee321875f",
+        "hashed_secret": "bf283762f4122413a8f81ea862f588c71024867e",
         "is_verified": false,
-        "line_number": 5896
+        "line_number": 6277
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "af15049108edf46bfd80e474ba1cd5860f2282d0",
+        "hashed_secret": "e58f55fd9eecf185ab2b0741af89f03fadfcb5fd",
         "is_verified": false,
-        "line_number": 5897
+        "line_number": 6278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6ded812bc9a375a224c66a096f7fc5cfbc1cef75",
+        "hashed_secret": "7093450ada69aec5f876199bed7fddcecf7a2117",
         "is_verified": false,
-        "line_number": 5898
+        "line_number": 6279
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6ce737e032e4f91f6f5629967178d19ccd3d66fd",
+        "hashed_secret": "08c2532e6069532466ebe4a6a584a0407fb1d8b3",
         "is_verified": false,
-        "line_number": 5899
+        "line_number": 6280
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "753235417a00fe7e0856bf1528f514e521e87f28",
+        "hashed_secret": "7093acf2defb684be9ef0b1fbe4b753da6ec2464",
         "is_verified": false,
-        "line_number": 5900
+        "line_number": 6281
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9e74d9dd83e417cf093e62afcd9b04787f86fbce",
+        "hashed_secret": "7ccb74fb965c3281e8592c18d71c6b6a49ec4277",
         "is_verified": false,
-        "line_number": 5901
+        "line_number": 6282
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2455be11ae98bfcfde9c730543faa57c47260127",
+        "hashed_secret": "224c4e993e7af7d06eaf585ef27a9288e12b6d3e",
         "is_verified": false,
-        "line_number": 5902
+        "line_number": 6283
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8dcfcb9715a3584fc72a16d0a415f93deffa5c82",
+        "hashed_secret": "88752a1f03a3212c981dfde95e3f38ee24c73c9b",
         "is_verified": false,
-        "line_number": 5903
+        "line_number": 6284
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6c7664dd8e5d8970c862bbb8c20f2ef8f06a1118",
+        "hashed_secret": "7ac9d19389fd178f821b23a91b43e6df841860f5",
         "is_verified": false,
-        "line_number": 5904
+        "line_number": 6285
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b07b9dce1d8ea92363da93a86e782950edfac4f1",
+        "hashed_secret": "b3da2302aad1f9ccdc1f91d1f9d94c4bf393f831",
         "is_verified": false,
-        "line_number": 5905
+        "line_number": 6286
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bd509722edc2b2d1f1a2820d0c2625d39216f31e",
+        "hashed_secret": "cdc3d55049ff1cbae468b8e46122859cf5755bb7",
         "is_verified": false,
-        "line_number": 5906
+        "line_number": 6287
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b06dd924ab3c3774edf053231c369fd6203bdf91",
+        "hashed_secret": "38d8f470d3772dffe8c5ab28332adad978b2b47b",
         "is_verified": false,
-        "line_number": 5907
+        "line_number": 6288
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e550606fc04978e03bca01e9cc63b891f78f9207",
+        "hashed_secret": "4073ecfa566332afbc69307cb229fcec90ef45c5",
         "is_verified": false,
-        "line_number": 5908
+        "line_number": 6289
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5ee9a610a0a735a4839461ae4b18462d1c6b7ffd",
+        "hashed_secret": "4f15b513227f793747ae93f07835bdc229f686b0",
         "is_verified": false,
-        "line_number": 5909
+        "line_number": 6290
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7f74395f47a7f8b0e7afc286c3375d177d099fff",
+        "hashed_secret": "86ac137e188808edfaab31f35e2fa0bd877616db",
         "is_verified": false,
-        "line_number": 5910
+        "line_number": 6291
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "349601e3d1eb60c2f67bf7bfd58f65a23065982e",
+        "hashed_secret": "8d71ed39b598e7ab90aae8c88f9b5c03390515f4",
         "is_verified": false,
-        "line_number": 5911
+        "line_number": 6292
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a524de4f8e69880ce6666f356a844003649f8a07",
+        "hashed_secret": "35b69d90f142db32dd82cd4b7ba4f5edeea67fb4",
         "is_verified": false,
-        "line_number": 5912
+        "line_number": 6293
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9cc0726fd0195ecfe53b8a2ed40e1145a6e83f75",
+        "hashed_secret": "694c85aa1cfa7c7287de788b9a08cba685441cbb",
         "is_verified": false,
-        "line_number": 5913
+        "line_number": 6294
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7fef105f40c0fcd0ca3dce919765dde6b4fe5204",
+        "hashed_secret": "b98ab6de02e895b5152aa53fe861746b62f33935",
         "is_verified": false,
-        "line_number": 5914
+        "line_number": 6295
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d993b57b202f97db244eefdaba8007e3df3009d6",
+        "hashed_secret": "0c78a148a4f622952b05f916f10cf9278f5d903a",
         "is_verified": false,
-        "line_number": 5915
+        "line_number": 6296
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "807dd7810aeb5c0242a7e289372b7e765b4186c3",
+        "hashed_secret": "be182d0bc33c8606f5508a5a88c69341691c23fe",
         "is_verified": false,
-        "line_number": 5916
+        "line_number": 6297
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "eefdc7f28929342f77fd437952720f91023ca95f",
+        "hashed_secret": "440d1f9f9489cf0815fc2ab1dfe6c45bd84b2a65",
         "is_verified": false,
-        "line_number": 5917
+        "line_number": 6298
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bee33914a5085e08db3cd741818f6428aad8293a",
+        "hashed_secret": "0adf0f0b2364b5a12a7e53def300c24b728e588f",
         "is_verified": false,
-        "line_number": 5918
+        "line_number": 6299
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "88aa4a920899c3cf1b9e766a92e667db07a013e3",
+        "hashed_secret": "b4a2fc1fde5829843ee7044ace737f6bcdd28cfb",
         "is_verified": false,
-        "line_number": 5919
+        "line_number": 6300
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f01da023a5cd6a84f126afa8de8135d178f22be3",
+        "hashed_secret": "e40617b2340dfe2169fc95c2dbcb6789066c4d16",
         "is_verified": false,
-        "line_number": 5920
+        "line_number": 6301
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "93ff576402aa6af9c96b4f714461fe4b68e9db99",
+        "hashed_secret": "6b57209a555435ee58b6066c4f0c25a6259d6650",
         "is_verified": false,
-        "line_number": 5921
+        "line_number": 6302
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "88e0d62364c58206c83c0d0e357044b701fce257",
+        "hashed_secret": "45ee80fc4ab1d7c55f1a4128e470429261fc1fbe",
         "is_verified": false,
-        "line_number": 5922
+        "line_number": 6303
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e16ef100b4b6321ae333bfc2acf047113e6cdbbe",
+        "hashed_secret": "7362e09644d719b91d93a71276482f45ba5a5b32",
         "is_verified": false,
-        "line_number": 5923
+        "line_number": 6304
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "57e3c0a8e76c907d574663983ca05133c35bc3aa",
+        "hashed_secret": "612ff7660b8054e50f32b6244eba3d3c1e3fa1c0",
         "is_verified": false,
-        "line_number": 5924
+        "line_number": 6305
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c8bd918a2d80281de90e1d9332c7629a51e3a9a7",
+        "hashed_secret": "5ff8ef890f22c8db21864ca7a7a6efab582a4222",
         "is_verified": false,
-        "line_number": 5925
+        "line_number": 6306
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4eca40ba46d7ececda3ef29be8651c1ef1051a89",
+        "hashed_secret": "135945f5da0ced5a1aeaff3cbc06fb51e99146aa",
         "is_verified": false,
-        "line_number": 5926
+        "line_number": 6307
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0919b2c9abc71e0ec9b72da808b6f1901b186229",
+        "hashed_secret": "dd43ac8e5f1b38d7e8f7f9eec65475323c3ef1a4",
         "is_verified": false,
-        "line_number": 5927
+        "line_number": 6308
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "918cc769c14c739d809c7a57e22104407ebd72c3",
+        "hashed_secret": "df8eed1cecb91637df57b9685852fcc3b7788783",
         "is_verified": false,
-        "line_number": 5928
+        "line_number": 6309
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a459817ca03ad504871b9dcd99023a9ab4982fa0",
+        "hashed_secret": "90d8737d7e4c8e52d424d1086a33c85830393cc5",
         "is_verified": false,
-        "line_number": 5929
+        "line_number": 6310
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3640bf2b5b4389f8bcacf4e7bc8ac963f0acef46",
+        "hashed_secret": "d79b06e9a677009dc6b10d543304f842b1b8420a",
         "is_verified": false,
-        "line_number": 5930
+        "line_number": 6311
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cb32a94a362c240e69fd34f8516c43c1b37c661b",
+        "hashed_secret": "7a217586c4132c344a3aeb4cf0445551ff4eacbc",
         "is_verified": false,
-        "line_number": 5931
+        "line_number": 6312
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "272282a806e8b35540e7a3b4e8c560dca552d610",
+        "hashed_secret": "feb4d08f41b8bfaa9c6dcc3801fe02e61246b742",
         "is_verified": false,
-        "line_number": 5932
+        "line_number": 6313
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c80a90bac2c8d6741f13b710429013c2073da5f8",
+        "hashed_secret": "d25bd27a679951b91356c793ad4b1154903cfb81",
         "is_verified": false,
-        "line_number": 5933
+        "line_number": 6314
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "172e64f74368df0b9bc5a88698984cd5c8b5e27e",
+        "hashed_secret": "b9dd549a17a0d38f2103109138e3cf5f9142232e",
         "is_verified": false,
-        "line_number": 5934
+        "line_number": 6315
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d85853bc686dace0f54db96a5dddaeb7dace12b2",
+        "hashed_secret": "b89042ecdf05d5a4fbba6243333a14c381693fa4",
         "is_verified": false,
-        "line_number": 5935
+        "line_number": 6316
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "07e9b81fc2a6047f7ee732586de4d281cf1a600a",
+        "hashed_secret": "24e41706a9aad6f8fec5840c770f0bc5d77c51f8",
         "is_verified": false,
-        "line_number": 5936
+        "line_number": 6317
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bfc163854bf911a8054f2b976dff5860c1748a98",
+        "hashed_secret": "251a660270de225cf708d6cc21627fba4b18d248",
         "is_verified": false,
-        "line_number": 5937
+        "line_number": 6318
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "857d2a2a2503b4c68581b2ecd3e04bac2016aa6c",
+        "hashed_secret": "44f228cc2df2ac234057d84a8434ec1bbe7cd269",
         "is_verified": false,
-        "line_number": 5938
+        "line_number": 6319
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "51fb99027e4bed20e77ad0ae85081c14c84e05c0",
+        "hashed_secret": "0339746bb411a70d351c38ee288ab6adfba0dee7",
         "is_verified": false,
-        "line_number": 5939
+        "line_number": 6320
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4d1064aac2b16991328e994c9b10f5f9487e7e68",
+        "hashed_secret": "bb8227d0c8e28dbffb6948a928de70106e8c4c90",
         "is_verified": false,
-        "line_number": 5940
+        "line_number": 6321
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d31242a926d82b8a9a6795ebeed2ba5591e70c21",
+        "hashed_secret": "b7fb8efefd8cbf530b3799ae8ca8e3e729f0091c",
         "is_verified": false,
-        "line_number": 5941
+        "line_number": 6322
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "56ecdd040f27cdb91c069052ab306f53f7cd6d41",
+        "hashed_secret": "9b64a441a7624f43729d0f397af42b006d6a2ab1",
         "is_verified": false,
-        "line_number": 5942
+        "line_number": 6323
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "77db889729eb7c5e9407061cbccceae9f8d4ecd8",
+        "hashed_secret": "2ccbfa9bfef69a2a7b838f5c97e6100e2794f25e",
         "is_verified": false,
-        "line_number": 5943
+        "line_number": 6324
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b708701d6a418b9d83623c7e7b11cd86cb09e32d",
+        "hashed_secret": "f9a511679fbf70dda2c9686f138b74280fb15d92",
         "is_verified": false,
-        "line_number": 5944
+        "line_number": 6325
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e890d4035b90c8a6f9f0faffea5917ba2e01cc9b",
+        "hashed_secret": "dda4d9d2fb5add14d1509766a379ebc2ac336420",
         "is_verified": false,
-        "line_number": 5945
+        "line_number": 6326
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fc5f6ea153f15199bc022d9081fbad3d14190d5f",
+        "hashed_secret": "a27044f771a48f341b6ac9cdf1d5efb69fa40a4d",
         "is_verified": false,
-        "line_number": 5946
+        "line_number": 6327
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7e4fdcef4e29d49bf2e74c09d58108628881747c",
+        "hashed_secret": "4bc5ceb285303185cbf72349708184e3b821fc40",
         "is_verified": false,
-        "line_number": 5947
+        "line_number": 6328
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ac84fbd10d92763f1a02838957132ccca7fc5fff",
+        "hashed_secret": "f05be26f32072b99b9b6faf9153c5c74aa295122",
         "is_verified": false,
-        "line_number": 5948
+        "line_number": 6329
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2d7b87a57054d90dca3ea568e4cdab069bf4facb",
+        "hashed_secret": "0804d319f0d53fcf2f731aa94b3b7729e1e88644",
         "is_verified": false,
-        "line_number": 5949
+        "line_number": 6330
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3a75b826cf84c0c1366caff16b7de6784cf3776a",
+        "hashed_secret": "ab484a0faa809b9c234febe8bcb54a09faa16167",
         "is_verified": false,
-        "line_number": 5950
+        "line_number": 6331
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6004350b55d1e51aa31f28138af49caa50d3ac8f",
+        "hashed_secret": "86adbdf7b5d61cb6e629b5362264fcd0e07911cd",
         "is_verified": false,
-        "line_number": 5951
+        "line_number": 6332
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1a227479e240496a14edc25fe045508a98e48d8c",
+        "hashed_secret": "2910780ab1eae047b56a9beb4eb66814e8554cd9",
         "is_verified": false,
-        "line_number": 5952
+        "line_number": 6333
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0d216feae3370482b993dd413bf916790a2ea430",
+        "hashed_secret": "4b226b8cf6abeeb9fbb978eca937948cfb8341ec",
         "is_verified": false,
-        "line_number": 5953
+        "line_number": 6334
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ceecbaf3e52d9202c3f5c57b0aabfa86e47b8515",
+        "hashed_secret": "816e0953fcfa52f47cb8397fc455eb6532e8dce9",
         "is_verified": false,
-        "line_number": 5954
+        "line_number": 6335
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f5d080c37b23dae4debc6384873aa21bbb06b22f",
+        "hashed_secret": "245088512818f70386f3b363290fa29c44dc4e6b",
         "is_verified": false,
-        "line_number": 5955
+        "line_number": 6336
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "51d6084f0e8e70d48aa44c807d41ddcc7d6b6a52",
+        "hashed_secret": "2643b6ace63c8fac578f3f029ba08865f3fe84e5",
         "is_verified": false,
-        "line_number": 5956
+        "line_number": 6337
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fd82ea93af61141bdd0f46272c9532d5d20e0c2c",
+        "hashed_secret": "a8a8f89d831a44a9249b4c6fb531a1b3467ce216",
         "is_verified": false,
-        "line_number": 5957
+        "line_number": 6338
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a3064b4c2ac448a979523259ecb340d6c3103a48",
+        "hashed_secret": "17a481faf88423f36f723fcbb1e5c42d71bc3a1f",
         "is_verified": false,
-        "line_number": 5958
+        "line_number": 6339
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9d61a03d6d2dab3d83b94e997b4d02090bd7faaa",
+        "hashed_secret": "4f8fbe72ddd0f0661460d983822d0077ab8a4597",
         "is_verified": false,
-        "line_number": 5959
+        "line_number": 6340
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0786e9c39cac921e956e20dc054f6db4496a3cc9",
+        "hashed_secret": "1d4adf2523a2cf8ed7b82b8f32b22a1b6e229bc4",
         "is_verified": false,
-        "line_number": 5960
+        "line_number": 6341
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ece9294f85f12f8d4ad89d727d1901b28e0e24e5",
+        "hashed_secret": "4e66e2d8939308074ed857e0548b7504573e21e5",
         "is_verified": false,
-        "line_number": 5961
+        "line_number": 6342
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "efbb99bcc6bf3b93a62a52a80e69595a8f09485d",
+        "hashed_secret": "61299f47ce91284601e4b904ebf807ce29319df4",
         "is_verified": false,
-        "line_number": 5962
+        "line_number": 6343
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e4e896816d85620f8b532d8a3bca6dcff97a4c66",
+        "hashed_secret": "8b5b75cafd31a6a924ffa51abbdc96bc8c379f69",
         "is_verified": false,
-        "line_number": 5963
+        "line_number": 6344
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e48cf53af0d4411166770656144942e00356327c",
+        "hashed_secret": "3dd6c3a08a46922d0a070228746174a3c9bf39ac",
         "is_verified": false,
-        "line_number": 5964
+        "line_number": 6345
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d86cee867ea9da08ebac50b7aefe905e5b723f82",
+        "hashed_secret": "8ba8c5f639e980a0df53442f9a997fbaf679c97e",
         "is_verified": false,
-        "line_number": 5965
+        "line_number": 6346
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "27556525cf6b7b68cd404386ac14b134983bfc79",
+        "hashed_secret": "d83da09e4052af592b4f520e168172eed94719d7",
         "is_verified": false,
-        "line_number": 5966
+        "line_number": 6347
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a1093894d17add3a36d0754f36d42add4ba634e1",
+        "hashed_secret": "9860849d239a84a971d48f3023ff28e2a3cd3e70",
         "is_verified": false,
-        "line_number": 5967
+        "line_number": 6348
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a2196d52688f418f8845a7062a8b719c43842f9",
+        "hashed_secret": "0b2aa2f6ab3dea1a184097b386035f9529a9efd6",
         "is_verified": false,
-        "line_number": 5968
+        "line_number": 6349
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "236babec4426817ddab8893dad242335f75da68d",
+        "hashed_secret": "76498865ea15b279c1b7d16281be1bf2d0d43f91",
         "is_verified": false,
-        "line_number": 5969
+        "line_number": 6350
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a10e90e58cacdf1347102c2b6145efc9dbb97b6",
+        "hashed_secret": "b00081591330bd05d0627ff77af072d25a8de08c",
         "is_verified": false,
-        "line_number": 5970
+        "line_number": 6351
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0102e490e74718c830e3abc87deba305de171527",
+        "hashed_secret": "5f65ba97022c1729ffafc68f00fe1efe078dff95",
         "is_verified": false,
-        "line_number": 5971
+        "line_number": 6352
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6fbb4916dfede94a7a1784212b33f2831feca558",
+        "hashed_secret": "a00a37e5f9ecc2867f1f6a63911c60b0c48069f8",
         "is_verified": false,
-        "line_number": 5972
+        "line_number": 6353
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3d496306a56564fc4715447849a0218a56b7af49",
+        "hashed_secret": "a0894f4b8604144935dbdfe729340289b1556a11",
         "is_verified": false,
-        "line_number": 5973
+        "line_number": 6354
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "382fba400e496de2f885aa4c0f3197d5dce0011d",
+        "hashed_secret": "ac91a8313ec4bc1df989f3e89c51d8a0ea0ac341",
         "is_verified": false,
-        "line_number": 5974
+        "line_number": 6355
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "609a33f3d41be6618d87c51a781924ade668f114",
+        "hashed_secret": "298a9329feb78930536d87595438612142d871b4",
         "is_verified": false,
-        "line_number": 5975
+        "line_number": 6356
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "13b2b3ac04fc006e3424821bfdaec820b6c2a808",
+        "hashed_secret": "1f48ba19fc8953ca24a720cf3e668fbb17cfdb56",
         "is_verified": false,
-        "line_number": 5976
+        "line_number": 6357
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9cd41e346a5c27b60e0e4498d707f6662cc3de61",
+        "hashed_secret": "17d1e20385bbd8289e688a9d8ec832cc95b0a0c0",
         "is_verified": false,
-        "line_number": 5977
+        "line_number": 6358
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "142fdd82e7c970bd2aba7271b8fe44686088fa9d",
+        "hashed_secret": "782ef8b31547e842086b1444133e0979ef6218e2",
         "is_verified": false,
-        "line_number": 5978
+        "line_number": 6359
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d4c15effcf4debab7cf3b89368f5a4a77dc63b6f",
+        "hashed_secret": "cbb7263401a0f40fb2f81e6d69a2eb54783371c8",
         "is_verified": false,
-        "line_number": 5979
+        "line_number": 6360
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5e82eaaded1d414b0a76a698d8b08cd3ae15850c",
+        "hashed_secret": "ae6b02d8a40075416bce197a3c0815abb106b391",
         "is_verified": false,
-        "line_number": 5980
+        "line_number": 6361
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a956f3e340e3060a3c1c6720872b3bf6d5b8f528",
+        "hashed_secret": "035784b804ff7188864091703a9122286b38b6e0",
         "is_verified": false,
-        "line_number": 5981
+        "line_number": 6362
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b021c2ffa2428de89884fde9329aaceb9971f470",
+        "hashed_secret": "9b9326f76232b13ab5c546726285f5eb6e88fbd9",
         "is_verified": false,
-        "line_number": 5982
+        "line_number": 6363
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a06b01da38cd5eb5da5235936e52602d9f6dc4a4",
+        "hashed_secret": "1e19857f3acaf50b6260ddf56e74e146f545c43f",
         "is_verified": false,
-        "line_number": 5983
+        "line_number": 6364
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cdf89be3c9b81768afe7dbca26411171d5e6b580",
+        "hashed_secret": "7a3a504964ce700d0dc5aeb33ce5bcfc894f0700",
         "is_verified": false,
-        "line_number": 5984
+        "line_number": 6365
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "75a33ac46087459c4e5efadb9a90c9d32037d535",
+        "hashed_secret": "39f780f09da9b3c0b7e96a09769fe9fe96fe38d6",
         "is_verified": false,
-        "line_number": 5985
+        "line_number": 6366
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fb5e797a8b28fbd740b208ea9f18b30ba8410dc3",
+        "hashed_secret": "da622634d738e6242e8d790ef90a0e5e28d2ecfc",
         "is_verified": false,
-        "line_number": 5986
+        "line_number": 6367
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c6fed8efe4d323c926385240f71a1282ad7f0226",
+        "hashed_secret": "a7cb8abdb6921b4ddb4eec1d22e60190fe495e92",
         "is_verified": false,
-        "line_number": 5987
+        "line_number": 6368
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "128e060ef6ba9f26796113ff3a531da6a0e0d7fb",
+        "hashed_secret": "b75812e33432001001e37d122bd814857bdd22f4",
         "is_verified": false,
-        "line_number": 5988
+        "line_number": 6369
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "256b561090b638790dbe3db64cd50e1090ceed5f",
+        "hashed_secret": "084f165aff3d54a41052adda8bb3c33d69f47eaa",
         "is_verified": false,
-        "line_number": 5989
+        "line_number": 6370
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "945d9436b59aa8b7e8f20371bede41b811e0781d",
+        "hashed_secret": "e025df3155b8791b6a02d51e6763c344086e1f7b",
         "is_verified": false,
-        "line_number": 5990
+        "line_number": 6371
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "eda5577b1ef2b5c7614c339827f674e8f4558d4d",
+        "hashed_secret": "82774b6e43ff7a018c960fe6b05262dff4ac0139",
         "is_verified": false,
-        "line_number": 5991
+        "line_number": 6372
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "430d45c5377bb2bd76d2060815baf376c9b67824",
+        "hashed_secret": "d95844bdaa54679c58caa76b64d908f04ab9d82e",
         "is_verified": false,
-        "line_number": 5992
+        "line_number": 6373
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0777e9094bab91096dc6978d8d59e9377f3214c1",
+        "hashed_secret": "0c74c8f28c24432b9500d4c96f370ddc4598e877",
         "is_verified": false,
-        "line_number": 5993
+        "line_number": 6374
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "86150eb3c5d40c4638f39253ffcc343fde60b5a6",
+        "hashed_secret": "1f87fe5a716d47258bcb7ca662ece7843b94a68f",
         "is_verified": false,
-        "line_number": 5994
+        "line_number": 6375
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "837ed969514860ce2fd82c83ae0e1daba580941d",
+        "hashed_secret": "a9212a876cd6ba7c60d21fb57fff4523464ef8a2",
         "is_verified": false,
-        "line_number": 5995
+        "line_number": 6376
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "09db3203f29b376fbae1a9a3e7110c507a4b9c61",
+        "hashed_secret": "873176e2fe660cbe7ee33c238ace07284917d067",
         "is_verified": false,
-        "line_number": 5996
+        "line_number": 6377
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0d1dcf41039292fd037dbea5bd80a4df06e0f5b4",
+        "hashed_secret": "1c9dc7a5015e25bf30eda4ab99485f74e75f9d5c",
         "is_verified": false,
-        "line_number": 5997
+        "line_number": 6378
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0d265f0d54d4445da6515d096671942325d96ccb",
+        "hashed_secret": "006bfcfdc7a35832329bdfd0b88092781d6f115c",
         "is_verified": false,
-        "line_number": 5998
+        "line_number": 6379
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3712e3e37d019d93e4bdb5a0fbdf9d7ae18b33c2",
+        "hashed_secret": "11dcfc26703a72d3ec94f152caf779107f926eeb",
         "is_verified": false,
-        "line_number": 5999
+        "line_number": 6380
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8d45db54919df891e0c35603e713d750810544f8",
+        "hashed_secret": "99ba2c00aaee0bf4c654806cd5651464565553bf",
         "is_verified": false,
-        "line_number": 6000
+        "line_number": 6381
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "78f828e9bc808bd54dcbed8d4c532898f977741a",
+        "hashed_secret": "a52eea667aefdbfeff8d52b8df5a12be5fe09614",
         "is_verified": false,
-        "line_number": 6001
+        "line_number": 6382
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9ddf3959b9852c64a47544fa3a5c2af2fa60848a",
+        "hashed_secret": "f57853221247752388cd15753ace1e10e11db258",
         "is_verified": false,
-        "line_number": 6002
+        "line_number": 6383
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "914fd7936058c3a937dda7fc48a92c58baea0b57",
+        "hashed_secret": "4dac408d80d7593d3c5c645d5a5cf3ffb4318e95",
         "is_verified": false,
-        "line_number": 6003
+        "line_number": 6384
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c1bce860272ffce2393dbce5322d5f79930f6b03",
+        "hashed_secret": "44ed6dc24808bff6a864c0039776df058d27c0a4",
         "is_verified": false,
-        "line_number": 6004
+        "line_number": 6385
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "82da7a7bfe8fe6cd9ff64749059736e9af5c2dae",
+        "hashed_secret": "ead74f4923c9cbece3e5e26e235e62741d480209",
         "is_verified": false,
-        "line_number": 6005
+        "line_number": 6386
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0439e1946bc21d5328dae59f073ce46143c5de61",
+        "hashed_secret": "775de92ad56ee9ef9cdf040a7f62e76f84f32992",
         "is_verified": false,
-        "line_number": 6006
+        "line_number": 6387
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5f24ef23c535a63953a0c7dda694807c4f958564",
+        "hashed_secret": "e70601ebd8dc2d6022ba4fb89556475a7ab2d2aa",
         "is_verified": false,
-        "line_number": 6007
+        "line_number": 6388
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "46642e5e19eba07acceda4171e591c7505a31037",
+        "hashed_secret": "093ef2914173aefbf9bb25e10a16f0c06990d9c1",
         "is_verified": false,
-        "line_number": 6008
+        "line_number": 6389
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5373cf7805841681fc39e5001b48014d7f2a703f",
+        "hashed_secret": "6c283e240e59aa01c58ce3f2acd06ea58eb1cd3f",
         "is_verified": false,
-        "line_number": 6009
+        "line_number": 6390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "da54d9a590a92728c5648aa3a14995a19fd6e48e",
+        "is_verified": false,
+        "line_number": 6391
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "23b23bb67b330d345570c2bf106107ea24b38b60",
+        "is_verified": false,
+        "line_number": 6392
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "a8ed39b90fec7e0fae43eca62d1b71da46882768",
+        "is_verified": false,
+        "line_number": 6393
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "72d7ed896e290da9ccbc4af8df46967f07049cc1",
+        "is_verified": false,
+        "line_number": 6394
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "64669eb37aceb6eb7cea4a2088329c4b29de38b7",
+        "is_verified": false,
+        "line_number": 6395
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "615746ba802f68f471e72a397cd510740bb973aa",
+        "is_verified": false,
+        "line_number": 6396
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "18940f3893bd1f8f60bcc3e00f70ba7b0c0567ef",
+        "is_verified": false,
+        "line_number": 6397
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "95c7781893f49cfd4d301544253b3f360900e6b5",
+        "is_verified": false,
+        "line_number": 6398
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "a6449c85ad02a89f471ba70aab0b4ab241fb3704",
+        "is_verified": false,
+        "line_number": 6399
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "574fe976609d3d1cb0d3dca4a5340be56a1d6a35",
+        "is_verified": false,
+        "line_number": 6400
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "2df01056c90a2447bd9a01e4c1ce35cd9d73ff71",
+        "is_verified": false,
+        "line_number": 6401
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "c9d3379c730b152a9dd0ab441d46fa03c7299d58",
+        "is_verified": false,
+        "line_number": 6402
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "a53f7e5d2ac6aa4a26918d8d7ca3f28df52587bf",
+        "is_verified": false,
+        "line_number": 6403
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "e113fe91150f620b7d12206ea6a749dc5a74f554",
+        "is_verified": false,
+        "line_number": 6404
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "b01e2b27f1db9d86c86a057407af54f71c162d3d",
+        "is_verified": false,
+        "line_number": 6405
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "internal/server/api/server.gen.go",
+        "hashed_secret": "2e8db5bf6f80ed46cc15c6129c0bad5072293f7b",
+        "is_verified": false,
+        "line_number": 6406
       }
     ],
     "internal/server/credentials_handlers.go": [
@@ -2559,5 +2671,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-13T00:23:34Z"
+  "generated_at": "2026-06-13T04:33:17Z"
 }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1406,6 +1406,226 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/hosts/{id}/exceptions:
+    get:
+      operationId: getHostExceptions
+      summary: List a host's compliance exceptions
+      description: |
+        Per-host exception list for the Compliance tab + Watchlist row.
+        By default returns open rows (requested + approved); ?history=true
+        returns every row. RBAC: exception:read. Spec
+        api-compliance-exceptions.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+        - name: history
+          in: query
+          required: false
+          schema: {type: boolean, default: false}
+      responses:
+        '200':
+          description: Exceptions, newest first
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ExceptionList'}
+        '404':
+          description: Unknown or deleted host
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks exception:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    post:
+      operationId: postHostException
+      summary: Request a compliance exception (rule waiver) on a host
+      description: |
+        Submits a requested exception for a host+rule. One open
+        (requested or approved) exception is allowed per host+rule; a
+        duplicate returns 409. The requester is the authenticated user.
+        RBAC: exception:request. Spec api-compliance-exceptions.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ExceptionRequest'}
+      responses:
+        '201':
+          description: The requested exception
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Exception'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '404':
+          description: Unknown or deleted host
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks exception:request permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: An open exception already exists for this host and rule
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/compliance/exceptions:
+    get:
+      operationId: getComplianceExceptions
+      summary: Fleet-wide compliance exception queue
+      description: |
+        Fleet exception list, optionally filtered by status (requested,
+        approved, rejected, revoked, expired). Newest first, capped at
+        500. RBAC: exception:read. Spec api-compliance-exceptions.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema: {type: string, enum: [requested, approved, rejected, revoked, expired]}
+        - name: limit
+          in: query
+          required: false
+          schema: {type: integer, default: 200}
+      responses:
+        '200':
+          description: Exceptions, newest first
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ExceptionList'}
+        '403':
+          description: Caller lacks exception:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/exceptions/{xid}:approve:
+    post:
+      operationId: postExceptionApprove
+      summary: Approve a requested exception
+      description: |
+        requested -> approved. The reviewer must differ from the
+        requester (separation of duties, 409). RBAC: exception:approve.
+        Spec api-compliance-exceptions.
+      parameters:
+        - name: xid
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ExceptionReview'}
+      responses:
+        '200':
+          description: The approved exception
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Exception'}
+        '403':
+          description: Caller lacks exception:approve permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Exception not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Not in the requested state, or reviewer is the requester
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/exceptions/{xid}:reject:
+    post:
+      operationId: postExceptionReject
+      summary: Reject a requested exception
+      description: |
+        requested -> rejected. The reviewer must differ from the
+        requester (409). RBAC: exception:approve. Spec
+        api-compliance-exceptions.
+      parameters:
+        - name: xid
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ExceptionReview'}
+      responses:
+        '200':
+          description: The rejected exception
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Exception'}
+        '403':
+          description: Caller lacks exception:approve permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Exception not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Not in the requested state, or reviewer is the requester
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/exceptions/{xid}:revoke:
+    post:
+      operationId: postExceptionRevoke
+      summary: Revoke an active exception before its expiry
+      description: |
+        approved -> revoked. RBAC: exception:revoke (dangerous). Spec
+        api-compliance-exceptions.
+      parameters:
+        - name: xid
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ExceptionReview'}
+      responses:
+        '200':
+          description: The revoked exception
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Exception'}
+        '403':
+          description: Caller lacks exception:revoke permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Exception not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Not in the approved state
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/system/connectivity/status:
     get:
       operationId: getSystemConnectivityStatus
@@ -3083,6 +3303,49 @@ components:
           type: object
           additionalProperties: {type: string}
           description: Variable name to override value. PUT replaces the full map
+
+    Exception:
+      type: object
+      required: [id, host_id, rule_id, reason, status, requested_by, requested_at]
+      properties:
+        id:           {type: string, format: uuid}
+        host_id:      {type: string, format: uuid}
+        rule_id:      {type: string}
+        reason:       {type: string}
+        status:
+          type: string
+          enum: [requested, approved, rejected, revoked, expired]
+        requested_by: {type: string, format: uuid}
+        reviewed_by:  {type: string, format: uuid, nullable: true}
+        review_note:  {type: string}
+        expires_at:   {type: string, format: date-time, nullable: true}
+        requested_at: {type: string, format: date-time}
+        reviewed_at:  {type: string, format: date-time, nullable: true}
+
+    ExceptionList:
+      type: object
+      required: [exceptions]
+      properties:
+        exceptions:
+          type: array
+          items: {$ref: '#/components/schemas/Exception'}
+
+    ExceptionRequest:
+      type: object
+      required: [rule_id, reason]
+      properties:
+        rule_id:    {type: string}
+        reason:     {type: string}
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Optional expiry; null means active until revoked
+
+    ExceptionReview:
+      type: object
+      properties:
+        note: {type: string, description: Optional reviewer note}
 
     HostComplianceSchedule:
       type: object

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
 	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/exception"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/intelligence/collector"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
@@ -519,6 +520,11 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	// a fresh boot has today's row. Spec system-posture-snapshots.
 	posture.Run(ctx, pool, 0)
 
+	// Compliance exception governance + its hourly expiry sweep.
+	// Spec api-compliance-exceptions.
+	exceptionSvc := exception.NewService(pool, audit.Emit)
+	exceptionSvc.Run(ctx, 0)
+
 	scanWorker := worker.NewScanWorker(worker.Config{
 		Pool:     pool,
 		Executor: scanExecutor,
@@ -538,7 +544,8 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		WithScanQueue(scanQueueKey).
 		WithScanWorker(scanWorker).
 		WithRuleCatalog(ruleCatalog).
-		WithVariableCatalog(varCatalog)
+		WithVariableCatalog(varCatalog).
+		WithExceptions(exceptionSvc)
 	runErr := srv.Run(ctx)
 
 	// Shutdown order REVERSE of boot (C-02). liveness.Run + alertrouter

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -997,6 +997,123 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/hosts/{id}/exceptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a host's compliance exceptions
+         * @description Per-host exception list for the Compliance tab + Watchlist row.
+         *     By default returns open rows (requested + approved); ?history=true
+         *     returns every row. RBAC: exception:read. Spec
+         *     api-compliance-exceptions.
+         */
+        get: operations["getHostExceptions"];
+        put?: never;
+        /**
+         * Request a compliance exception (rule waiver) on a host
+         * @description Submits a requested exception for a host+rule. One open
+         *     (requested or approved) exception is allowed per host+rule; a
+         *     duplicate returns 409. The requester is the authenticated user.
+         *     RBAC: exception:request. Spec api-compliance-exceptions.
+         */
+        post: operations["postHostException"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/compliance/exceptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fleet-wide compliance exception queue
+         * @description Fleet exception list, optionally filtered by status (requested,
+         *     approved, rejected, revoked, expired). Newest first, capped at
+         *     500. RBAC: exception:read. Spec api-compliance-exceptions.
+         */
+        get: operations["getComplianceExceptions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/exceptions/{xid}:approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve a requested exception
+         * @description requested -> approved. The reviewer must differ from the
+         *     requester (separation of duties, 409). RBAC: exception:approve.
+         *     Spec api-compliance-exceptions.
+         */
+        post: operations["postExceptionApprove"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/exceptions/{xid}:reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reject a requested exception
+         * @description requested -> rejected. The reviewer must differ from the
+         *     requester (409). RBAC: exception:approve. Spec
+         *     api-compliance-exceptions.
+         */
+        post: operations["postExceptionReject"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/exceptions/{xid}:revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke an active exception before its expiry
+         * @description approved -> revoked. RBAC: exception:revoke (dangerous). Spec
+         *     api-compliance-exceptions.
+         */
+        post: operations["postExceptionRevoke"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/system/connectivity/status": {
         parameters: {
             query?: never;
@@ -2148,6 +2265,43 @@ export interface components {
             overrides: {
                 [key: string]: string;
             };
+        };
+        Exception: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            host_id: string;
+            rule_id: string;
+            reason: string;
+            /** @enum {string} */
+            status: "requested" | "approved" | "rejected" | "revoked" | "expired";
+            /** Format: uuid */
+            requested_by: string;
+            /** Format: uuid */
+            reviewed_by?: string | null;
+            review_note?: string;
+            /** Format: date-time */
+            expires_at?: string | null;
+            /** Format: date-time */
+            requested_at: string;
+            /** Format: date-time */
+            reviewed_at?: string | null;
+        };
+        ExceptionList: {
+            exceptions: components["schemas"]["Exception"][];
+        };
+        ExceptionRequest: {
+            rule_id: string;
+            reason: string;
+            /**
+             * Format: date-time
+             * @description Optional expiry; null means active until revoked
+             */
+            expires_at?: string | null;
+        };
+        ExceptionReview: {
+            /** @description Optional reviewer note */
+            note?: string;
         };
         HostComplianceSchedule: {
             /** @description The scan config enabled flag */
@@ -4517,6 +4671,293 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             /** @description Caller lacks system:config:write permission */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getHostExceptions: {
+        parameters: {
+            query?: {
+                history?: boolean;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Exceptions, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExceptionList"];
+                };
+            };
+            /** @description Caller lacks exception:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unknown or deleted host */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postHostException: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExceptionRequest"];
+            };
+        };
+        responses: {
+            /** @description The requested exception */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Exception"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            /** @description Caller lacks exception:request permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unknown or deleted host */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description An open exception already exists for this host and rule */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getComplianceExceptions: {
+        parameters: {
+            query?: {
+                status?: "requested" | "approved" | "rejected" | "revoked" | "expired";
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Exceptions, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExceptionList"];
+                };
+            };
+            /** @description Caller lacks exception:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postExceptionApprove: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                xid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ExceptionReview"];
+            };
+        };
+        responses: {
+            /** @description The approved exception */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Exception"];
+                };
+            };
+            /** @description Caller lacks exception:approve permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Exception not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not in the requested state, or reviewer is the requester */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postExceptionReject: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                xid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ExceptionReview"];
+            };
+        };
+        responses: {
+            /** @description The rejected exception */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Exception"];
+                };
+            };
+            /** @description Caller lacks exception:approve permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Exception not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not in the requested state, or reviewer is the requester */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postExceptionRevoke: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                xid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ExceptionReview"];
+            };
+        };
+        responses: {
+            /** @description The revoked exception */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Exception"];
+                };
+            };
+            /** @description Caller lacks exception:revoke permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Exception not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not in the approved state */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/internal/db/migrations/0026_compliance_exceptions.sql
+++ b/internal/db/migrations/0026_compliance_exceptions.sql
@@ -1,0 +1,59 @@
+-- 0026_compliance_exceptions.sql
+--
+-- Operator-approved rule waivers (scan plan Phase 7, exception
+-- governance). DB-backed per scan plan decision 2026-06-13: an
+-- exception is approval-workflow data with a lifecycle, queries, and
+-- an audit trail - relational, not a signed static policy file.
+--
+-- OVERLAY MODEL: an exception NEVER mutates host_rule_state. A failing
+-- rule with an active exception stays 'fail' in the raw scan results
+-- (Kensa's verdict is authoritative); the exception is an OpenWatch
+-- governance annotation that the lens/UI reads to mark the failure as
+-- accepted risk. The raw compliance score stays honest.
+--
+-- Lifecycle: requested -> approved | rejected ; approved -> revoked |
+-- expired. Separation of duties (auth/permissions.yaml): exception:
+-- request (ops_lead) is distinct from exception:approve (auditor /
+-- security_admin); exception:revoke is dangerous (security_admin).
+--
+-- "Active" (suppressing) = status 'approved' AND not past expires_at.
+-- The expiry sweep flips approved->expired when expires_at passes and
+-- emits compliance.exception.expired; count queries also guard on
+-- expires_at so they stay correct between sweeps.
+--
+-- Spec: api-compliance-exceptions v1.0.0.
+
+-- +goose Up
+CREATE TABLE compliance_exceptions (
+    id            UUID PRIMARY KEY,
+    host_id       UUID NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    rule_id       TEXT NOT NULL,
+    reason        TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'requested'
+                  CHECK (status IN ('requested','approved','rejected','revoked','expired')),
+    requested_by  UUID NOT NULL REFERENCES users(id),
+    reviewed_by   UUID REFERENCES users(id),
+    review_note   TEXT,
+    expires_at    TIMESTAMPTZ,
+    requested_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reviewed_at   TIMESTAMPTZ,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- At most ONE open (requested or approved) exception per host+rule, so
+-- a duplicate request or a second approval cannot stack. Rejected /
+-- revoked / expired rows are historical and do not block a fresh
+-- request.
+CREATE UNIQUE INDEX compliance_exceptions_one_open
+    ON compliance_exceptions (host_id, rule_id)
+    WHERE status IN ('requested','approved');
+
+-- Per-host listing (Watchlist row, Compliance tab annotation).
+CREATE INDEX compliance_exceptions_host ON compliance_exceptions (host_id);
+
+-- Fleet queue + active-count scans by state.
+CREATE INDEX compliance_exceptions_status ON compliance_exceptions (status);
+
+-- +goose Down
+DROP TABLE IF EXISTS compliance_exceptions;

--- a/internal/exception/run.go
+++ b/internal/exception/run.go
@@ -1,0 +1,38 @@
+// Background expiry sweep, wired in serve. Mirrors posture.Run: an
+// immediate pass at boot plus an hourly tick.
+//
+// Spec: api-compliance-exceptions v1.0.0 (C-06).
+package exception
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/cron"
+)
+
+// Run starts the expiry sweep on a cron tick with one immediate pass.
+func (s *Service) Run(ctx context.Context, interval time.Duration) *cron.Scheduler {
+	if interval == 0 {
+		interval = ExpirySweepInterval
+	}
+	if n, err := s.ExpireSweep(ctx); err != nil {
+		slog.WarnContext(ctx, "exception boot expiry sweep failed", "err", err)
+	} else if n > 0 {
+		slog.InfoContext(ctx, "exception expiry sweep", "expired", n)
+	}
+	tick := cron.New(interval, func(ctx context.Context) error {
+		n, err := s.ExpireSweep(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "exception expiry sweep failed", "err", err)
+			return err
+		}
+		if n > 0 {
+			slog.InfoContext(ctx, "exception expiry sweep", "expired", n)
+		}
+		return nil
+	})
+	tick.Start(ctx)
+	return tick
+}

--- a/internal/exception/service.go
+++ b/internal/exception/service.go
@@ -1,0 +1,308 @@
+package exception
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+)
+
+// EmitFunc is the audit-emission shape (matches audit.Emit). Tests
+// pass a fake.
+type EmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
+
+// Service is the exception governance service.
+type Service struct {
+	pool *pgxpool.Pool
+	emit EmitFunc
+}
+
+// NewService wires the service. emit is audit.Emit in production.
+func NewService(pool *pgxpool.Pool, emit EmitFunc) *Service {
+	return &Service{pool: pool, emit: emit}
+}
+
+const selectCols = `id, host_id, rule_id, reason, status, requested_by,
+	reviewed_by, COALESCE(review_note, ''), expires_at, requested_at, reviewed_at`
+
+func scanException(row pgx.Row) (Exception, error) {
+	var e Exception
+	var status string
+	if err := row.Scan(&e.ID, &e.HostID, &e.RuleID, &e.Reason, &status,
+		&e.RequestedBy, &e.ReviewedBy, &e.ReviewNote, &e.ExpiresAt,
+		&e.RequestedAt, &e.ReviewedAt); err != nil {
+		return Exception{}, err
+	}
+	e.Status = Status(status)
+	return e, nil
+}
+
+// Request submits a new exception (status 'requested'). Returns
+// ErrDuplicateOpen when a requested/approved exception already exists
+// for the same host+rule. Emits compliance.exception.requested.
+func (s *Service) Request(ctx context.Context, hostID uuid.UUID, ruleID, reason string,
+	requestedBy uuid.UUID, expiresAt *time.Time) (Exception, error) {
+	ruleID = strings.TrimSpace(ruleID)
+	reason = strings.TrimSpace(reason)
+	if ruleID == "" || reason == "" {
+		return Exception{}, ErrInvalidInput
+	}
+
+	id := uuid.Must(uuid.NewV7())
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO compliance_exceptions
+			(id, host_id, rule_id, reason, status, requested_by, expires_at)
+		VALUES ($1, $2, $3, $4, 'requested', $5, $6)
+		RETURNING `+selectCols,
+		id, hostID, ruleID, reason, requestedBy, expiresAt)
+	e, err := scanException(row)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return Exception{}, ErrDuplicateOpen
+		}
+		return Exception{}, fmt.Errorf("exception: request: %w", err)
+	}
+
+	s.emitEvent(ctx, audit.ComplianceExceptionRequested, e, requestedBy, "requested")
+	return e, nil
+}
+
+// Approve transitions a 'requested' exception to 'approved'. The
+// reviewer must differ from the requester (separation of duties).
+// Emits compliance.exception.approved.
+func (s *Service) Approve(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
+	return s.review(ctx, id, reviewedBy, note, StatusRequested, StatusApproved,
+		audit.ComplianceExceptionApproved, true)
+}
+
+// Reject transitions a 'requested' exception to 'rejected'. Like
+// Approve, the reviewer must differ from the requester. Emits
+// compliance.exception.rejected.
+func (s *Service) Reject(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
+	return s.review(ctx, id, reviewedBy, note, StatusRequested, StatusRejected,
+		audit.ComplianceExceptionRejected, true)
+}
+
+// Revoke transitions an 'approved' exception to 'revoked' before its
+// expiry. The revoker may be anyone with the permission (revoking is
+// not a self-review concern). Emits compliance.exception.revoked.
+func (s *Service) Revoke(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
+	return s.review(ctx, id, reviewedBy, note, StatusApproved, StatusRevoked,
+		audit.ComplianceExceptionRevoked, false)
+}
+
+// review performs a guarded state transition fromState -> toState. The
+// CHECK is in SQL (WHERE status = fromState) so a concurrent reviewer
+// cannot double-transition; a zero-row update means the row was
+// missing or already moved.
+func (s *Service) review(ctx context.Context, id, reviewedBy uuid.UUID, note string,
+	fromState, toState Status, code audit.Code, blockSelfReview bool) (Exception, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return Exception{}, fmt.Errorf("exception: review begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Lock the row and read the requester for the self-review check.
+	var status string
+	var requestedBy uuid.UUID
+	err = tx.QueryRow(ctx, `
+		SELECT status, requested_by FROM compliance_exceptions
+		 WHERE id = $1 FOR UPDATE`, id).Scan(&status, &requestedBy)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Exception{}, ErrNotFound
+	}
+	if err != nil {
+		return Exception{}, fmt.Errorf("exception: review lock: %w", err)
+	}
+	if Status(status) != fromState {
+		return Exception{}, ErrWrongState
+	}
+	if blockSelfReview && requestedBy == reviewedBy {
+		return Exception{}, ErrSelfReview
+	}
+
+	row := tx.QueryRow(ctx, `
+		UPDATE compliance_exceptions
+		   SET status = $2, reviewed_by = $3, review_note = NULLIF($4, ''),
+		       reviewed_at = now(), updated_at = now()
+		 WHERE id = $1
+		RETURNING `+selectCols,
+		id, string(toState), reviewedBy, note)
+	e, err := scanException(row)
+	if err != nil {
+		return Exception{}, fmt.Errorf("exception: review update: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Exception{}, fmt.Errorf("exception: review commit: %w", err)
+	}
+
+	s.emitEvent(ctx, code, e, reviewedBy, string(toState))
+	return e, nil
+}
+
+// ListForHost returns a host's exceptions. When includeHistory is
+// false, only open rows (requested + approved) are returned; true
+// returns every row, newest first.
+func (s *Service) ListForHost(ctx context.Context, hostID uuid.UUID, includeHistory bool) ([]Exception, error) {
+	q := `SELECT ` + selectCols + ` FROM compliance_exceptions WHERE host_id = $1`
+	if !includeHistory {
+		q += ` AND status IN ('requested','approved')`
+	}
+	q += ` ORDER BY requested_at DESC`
+	return s.queryList(ctx, q, hostID)
+}
+
+// ListFleet returns fleet-wide exceptions, optionally filtered by
+// status. Empty status returns all. Newest first.
+func (s *Service) ListFleet(ctx context.Context, status Status, limit int) ([]Exception, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 200
+	}
+	if status == "" {
+		return s.queryList(ctx, `SELECT `+selectCols+`
+			FROM compliance_exceptions ORDER BY requested_at DESC LIMIT $1`, limit)
+	}
+	return s.queryList(ctx, `SELECT `+selectCols+`
+		FROM compliance_exceptions WHERE status = $1
+		ORDER BY requested_at DESC LIMIT $2`, string(status), limit)
+}
+
+func (s *Service) queryList(ctx context.Context, q string, args ...any) ([]Exception, error) {
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("exception: list: %w", err)
+	}
+	defer rows.Close()
+	out := []Exception{}
+	for rows.Next() {
+		e, err := scanException(rows)
+		if err != nil {
+			return nil, fmt.Errorf("exception: scan: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ActiveCountForHost counts the host's currently-suppressing
+// exceptions (approved, not past expiry). Backs the host-detail
+// Watchlist Exceptions row.
+func (s *Service) ActiveCountForHost(ctx context.Context, hostID uuid.UUID) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM compliance_exceptions
+		 WHERE host_id = $1 AND status = 'approved'
+		   AND (expires_at IS NULL OR expires_at > now())`, hostID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("exception: active count: %w", err)
+	}
+	return n, nil
+}
+
+// ActiveRuleIDsForHost returns the set of rule ids the host has an
+// active (suppressing) exception for. Backs the Compliance-tab
+// waived-rule annotation - read alongside host_rule_state, never
+// mutating it.
+func (s *Service) ActiveRuleIDsForHost(ctx context.Context, hostID uuid.UUID) (map[string]bool, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT rule_id FROM compliance_exceptions
+		 WHERE host_id = $1 AND status = 'approved'
+		   AND (expires_at IS NULL OR expires_at > now())`, hostID)
+	if err != nil {
+		return nil, fmt.Errorf("exception: active rule ids: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var ruleID string
+		if err := rows.Scan(&ruleID); err != nil {
+			return nil, fmt.Errorf("exception: scan rule id: %w", err)
+		}
+		out[ruleID] = true
+	}
+	return out, rows.Err()
+}
+
+// ExpireSweep flips approved exceptions whose expires_at has passed to
+// 'expired' and emits compliance.exception.expired for each. Returns
+// the count expired. Idempotent: a second run finds nothing.
+func (s *Service) ExpireSweep(ctx context.Context) (int, error) {
+	rows, err := s.pool.Query(ctx, `
+		UPDATE compliance_exceptions
+		   SET status = 'expired', updated_at = now()
+		 WHERE status = 'approved' AND expires_at IS NOT NULL AND expires_at <= now()
+		RETURNING `+selectCols)
+	if err != nil {
+		return 0, fmt.Errorf("exception: expire sweep: %w", err)
+	}
+	defer rows.Close()
+	var expired []Exception
+	for rows.Next() {
+		e, err := scanException(rows)
+		if err != nil {
+			return 0, fmt.Errorf("exception: sweep scan: %w", err)
+		}
+		expired = append(expired, e)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("exception: sweep iterate: %w", err)
+	}
+	for _, e := range expired {
+		// System-actor expiry: no reviewer.
+		s.emitEvent(ctx, audit.ComplianceExceptionExpired, e, uuid.Nil, "expired")
+	}
+	return len(expired), nil
+}
+
+// emitEvent records one compliance.exception.* audit row. actor is the
+// requester/reviewer; uuid.Nil actor marks a system event (expiry).
+func (s *Service) emitEvent(ctx context.Context, code audit.Code, e Exception, actor uuid.UUID, action string) {
+	if s.emit == nil {
+		return
+	}
+	actorType := "user"
+	actorID := actor.String()
+	if actor == uuid.Nil {
+		actorType, actorID = "system", "openwatch"
+	}
+	detail, _ := json.Marshal(map[string]any{
+		"exception_id": e.ID.String(),
+		"host_id":      e.HostID.String(),
+		"rule_id":      e.RuleID,
+		"action":       action,
+		"status":       string(e.Status),
+	})
+	s.emit(ctx, code, audit.Event{
+		ActorType:    actorType,
+		ActorID:      actorID,
+		ResourceType: "compliance_exception",
+		ResourceID:   e.ID.String(),
+		Detail:       detail,
+	})
+}
+
+// isUniqueViolation reports whether err is a Postgres unique-violation
+// (SQLSTATE 23505) - the partial-unique one-open-per-host+rule index.
+// Same errors.As idiom as internal/host (robust to wrapping).
+func isUniqueViolation(err error) bool {
+	var pgErr interface{ SQLState() string }
+	if errors.As(err, &pgErr) {
+		return pgErr.SQLState() == "23505"
+	}
+	return false
+}
+
+// ExpirySweepInterval is the production cadence of the expiry sweep.
+// Hourly is fine: an exception only needs to flip to expired soon
+// after its expires_at, and the count/annotation queries already guard
+// on expires_at so suppression stops at the deadline regardless.
+const ExpirySweepInterval = time.Hour

--- a/internal/exception/service_test.go
+++ b/internal/exception/service_test.go
@@ -1,0 +1,308 @@
+// @spec api-compliance-exceptions
+//
+// Service-level AC coverage (DSN-gated). Endpoint AC-06 lives in
+// internal/server.
+//
+//	AC-01  TestRequest_InsertDuplicateInvalidReopen
+//	AC-02  TestLifecycle_Transitions
+//	AC-03  TestSeparationOfDuties
+//	AC-04  TestActiveQueries_OverlayNeverMutatesRuleState
+//	AC-05  TestExpireSweep_FlipsAndIdempotent
+package exception
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+)
+
+type emitCall struct {
+	Code audit.Code
+}
+
+func fakeEmitter(calls *[]emitCall) EmitFunc {
+	return func(ctx context.Context, code audit.Code, ev audit.Event) {
+		*calls = append(*calls, emitCall{Code: code})
+	}
+}
+
+func freshPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run exception integration tests")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	pool, err := db.NewPool(ctx, dsn, 5)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := migrations.Apply(ctx, pool); err != nil {
+		t.Fatalf("migrations: %v", err)
+	}
+	for _, stmt := range []string{
+		"TRUNCATE TABLE compliance_exceptions CASCADE",
+		"TRUNCATE TABLE host_rule_state CASCADE",
+		"TRUNCATE TABLE hosts CASCADE",
+		"TRUNCATE TABLE users CASCADE",
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			t.Logf("truncate (ok if benign): %v", err)
+		}
+	}
+	return pool
+}
+
+func seedUser(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO users (id, username, email, password_hash)
+		 VALUES ($1, $2, $3, $4)`,
+		id, name+"-"+id.String(), name+"@example.com", "argon2id$dummy") // pragma: allowlist secret
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func seedHost(t *testing.T, pool *pgxpool.Pool, createdBy uuid.UUID) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, '192.0.2.30'::inet, $3)`,
+		id, "exc-"+id.String(), createdBy)
+	if err != nil {
+		t.Fatalf("seed host: %v", err)
+	}
+	return id
+}
+
+// @ac AC-01
+func TestRequest_InsertDuplicateInvalidReopen(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-01", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		user := seedUser(t, pool, "requester")
+		hostID := seedHost(t, pool, user)
+		var calls []emitCall
+		svc := NewService(pool, fakeEmitter(&calls))
+
+		e, err := svc.Request(ctx, hostID, "ssh-kex-fips", "accepted risk pending hardware refresh", user, nil)
+		if err != nil {
+			t.Fatalf("Request: %v", err)
+		}
+		if e.Status != StatusRequested || e.RuleID != "ssh-kex-fips" {
+			t.Errorf("requested exception = %+v", e)
+		}
+		if len(calls) != 1 || calls[0].Code != audit.ComplianceExceptionRequested {
+			t.Errorf("audit calls = %+v, want one requested", calls)
+		}
+
+		// Duplicate open: rejected.
+		if _, err := svc.Request(ctx, hostID, "ssh-kex-fips", "again", user, nil); !errors.Is(err, ErrDuplicateOpen) {
+			t.Errorf("duplicate Request err = %v, want ErrDuplicateOpen", err)
+		}
+
+		// Invalid input.
+		if _, err := svc.Request(ctx, hostID, "", "reason", user, nil); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("empty rule err = %v, want ErrInvalidInput", err)
+		}
+		if _, err := svc.Request(ctx, hostID, "r", "", user, nil); !errors.Is(err, ErrInvalidInput) {
+			t.Errorf("empty reason err = %v, want ErrInvalidInput", err)
+		}
+
+		// Reopen after the prior is rejected: a fresh request succeeds.
+		reviewer := seedUser(t, pool, "reviewer")
+		if _, err := svc.Reject(ctx, e.ID, reviewer, "denied"); err != nil {
+			t.Fatalf("Reject: %v", err)
+		}
+		if _, err := svc.Request(ctx, hostID, "ssh-kex-fips", "second attempt", user, nil); err != nil {
+			t.Errorf("reopen after reject failed: %v", err)
+		}
+	})
+}
+
+// @ac AC-02
+func TestLifecycle_Transitions(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-02", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		requester := seedUser(t, pool, "req")
+		reviewer := seedUser(t, pool, "rev")
+		hostID := seedHost(t, pool, requester)
+		var calls []emitCall
+		svc := NewService(pool, fakeEmitter(&calls))
+
+		// approve path
+		a, _ := svc.Request(ctx, hostID, "rule-a", "reason", requester, nil)
+		got, err := svc.Approve(ctx, a.ID, reviewer, "ok")
+		if err != nil || got.Status != StatusApproved || got.ReviewedBy == nil || *got.ReviewedBy != reviewer {
+			t.Fatalf("Approve = %+v, err %v", got, err)
+		}
+		// revoke the approved
+		got, err = svc.Revoke(ctx, a.ID, reviewer, "no longer needed")
+		if err != nil || got.Status != StatusRevoked {
+			t.Fatalf("Revoke = %+v, err %v", got, err)
+		}
+		// revoking a non-approved (now revoked) row: wrong state
+		if _, err := svc.Revoke(ctx, a.ID, reviewer, "again"); !errors.Is(err, ErrWrongState) {
+			t.Errorf("re-revoke err = %v, want ErrWrongState", err)
+		}
+
+		// reject path
+		b, _ := svc.Request(ctx, hostID, "rule-b", "reason", requester, nil)
+		if got, err := svc.Reject(ctx, b.ID, reviewer, "no"); err != nil || got.Status != StatusRejected {
+			t.Fatalf("Reject = %+v, err %v", got, err)
+		}
+		// approving a rejected row: wrong state
+		if _, err := svc.Approve(ctx, b.ID, reviewer, "x"); !errors.Is(err, ErrWrongState) {
+			t.Errorf("approve-rejected err = %v, want ErrWrongState", err)
+		}
+
+		// audit codes seen: requested x2, approved, revoked, rejected
+		seen := map[audit.Code]int{}
+		for _, c := range calls {
+			seen[c.Code]++
+		}
+		if seen[audit.ComplianceExceptionApproved] != 1 || seen[audit.ComplianceExceptionRevoked] != 1 ||
+			seen[audit.ComplianceExceptionRejected] != 1 {
+			t.Errorf("audit codes = %v", seen)
+		}
+	})
+}
+
+// @ac AC-03
+func TestSeparationOfDuties(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-03", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		user := seedUser(t, pool, "selfreq")
+		hostID := seedHost(t, pool, user)
+		svc := NewService(pool, fakeEmitter(&[]emitCall{}))
+
+		e, _ := svc.Request(ctx, hostID, "rule-s", "reason", user, nil)
+		// self-approve blocked
+		if _, err := svc.Approve(ctx, e.ID, user, "me"); !errors.Is(err, ErrSelfReview) {
+			t.Errorf("self-approve err = %v, want ErrSelfReview", err)
+		}
+		// self-reject blocked
+		if _, err := svc.Reject(ctx, e.ID, user, "me"); !errors.Is(err, ErrSelfReview) {
+			t.Errorf("self-reject err = %v, want ErrSelfReview", err)
+		}
+		// row unchanged (still requested)
+		got, _ := svc.ListForHost(ctx, hostID, false)
+		if len(got) != 1 || got[0].Status != StatusRequested {
+			t.Errorf("row mutated by blocked self-review: %+v", got)
+		}
+		// self-revoke allowed: approve with a different reviewer first,
+		// then the requester revokes their own (now-active) exception.
+		reviewer := seedUser(t, pool, "rev2")
+		if _, err := svc.Approve(ctx, e.ID, reviewer, "ok"); err != nil {
+			t.Fatalf("approve: %v", err)
+		}
+		if _, err := svc.Revoke(ctx, e.ID, user, "self revoke ok"); err != nil {
+			t.Errorf("self-revoke should be allowed: %v", err)
+		}
+	})
+}
+
+// @ac AC-04
+func TestActiveQueries_OverlayNeverMutatesRuleState(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-04", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		requester := seedUser(t, pool, "req")
+		reviewer := seedUser(t, pool, "rev")
+		hostID := seedHost(t, pool, requester)
+		svc := NewService(pool, fakeEmitter(&[]emitCall{}))
+
+		// A failing rule row in host_rule_state (the overlay target).
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO host_rule_state
+				(host_id, rule_id, current_status, severity, last_checked_at,
+				 check_count, last_scan_id, first_seen_at, last_changed_at)
+			VALUES ($1, 'rule-active', 'fail', 'high', now(), 1, $2, now(), now())`,
+			hostID, uuid.Must(uuid.NewV7())); err != nil {
+			t.Fatalf("seed rule state: %v", err)
+		}
+
+		// approved + active -> counted
+		active, _ := svc.Request(ctx, hostID, "rule-active", "reason", requester, nil)
+		_, _ = svc.Approve(ctx, active.ID, reviewer, "ok")
+		// approved but already expired -> NOT counted
+		past := time.Now().Add(-time.Hour)
+		expired, _ := svc.Request(ctx, hostID, "rule-expired", "reason", requester, &past)
+		_, _ = svc.Approve(ctx, expired.ID, reviewer, "ok")
+		// requested-only -> NOT counted
+		_, _ = svc.Request(ctx, hostID, "rule-pending", "reason", requester, nil)
+
+		n, err := svc.ActiveCountForHost(ctx, hostID)
+		if err != nil || n != 1 {
+			t.Errorf("ActiveCountForHost = %d (err %v), want 1 (active only)", n, err)
+		}
+		ids, err := svc.ActiveRuleIDsForHost(ctx, hostID)
+		if err != nil || !ids["rule-active"] || ids["rule-expired"] || ids["rule-pending"] || len(ids) != 1 {
+			t.Errorf("ActiveRuleIDsForHost = %v, want {rule-active}", ids)
+		}
+
+		// Overlay invariant: host_rule_state.current_status untouched.
+		var status string
+		_ = pool.QueryRow(ctx, `SELECT current_status FROM host_rule_state
+			WHERE host_id = $1 AND rule_id = 'rule-active'`, hostID).Scan(&status)
+		if status != "fail" {
+			t.Errorf("exception mutated host_rule_state: status = %q, want fail", status)
+		}
+	})
+}
+
+// @ac AC-05
+func TestExpireSweep_FlipsAndIdempotent(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-05", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		requester := seedUser(t, pool, "req")
+		reviewer := seedUser(t, pool, "rev")
+		hostID := seedHost(t, pool, requester)
+		var calls []emitCall
+		svc := NewService(pool, fakeEmitter(&calls))
+
+		past := time.Now().Add(-time.Hour)
+		future := time.Now().Add(time.Hour)
+		e1, _ := svc.Request(ctx, hostID, "rule-1", "reason", requester, &past)
+		_, _ = svc.Approve(ctx, e1.ID, reviewer, "ok")
+		e2, _ := svc.Request(ctx, hostID, "rule-2", "reason", requester, &future)
+		_, _ = svc.Approve(ctx, e2.ID, reviewer, "ok")
+		e3, _ := svc.Request(ctx, hostID, "rule-3", "reason", requester, nil) // no expiry
+		_, _ = svc.Approve(ctx, e3.ID, reviewer, "ok")
+
+		calls = nil
+		n, err := svc.ExpireSweep(ctx)
+		if err != nil || n != 1 {
+			t.Fatalf("ExpireSweep = %d (err %v), want 1 (only the past-expiry row)", n, err)
+		}
+		if len(calls) != 1 || calls[0].Code != audit.ComplianceExceptionExpired {
+			t.Errorf("sweep audit = %+v, want one expired", calls)
+		}
+		// future + null expiry untouched.
+		if c, _ := svc.ActiveCountForHost(ctx, hostID); c != 2 {
+			t.Errorf("active after sweep = %d, want 2", c)
+		}
+		// idempotent.
+		if n2, _ := svc.ExpireSweep(ctx); n2 != 0 {
+			t.Errorf("second sweep = %d, want 0", n2)
+		}
+	})
+}

--- a/internal/exception/types.go
+++ b/internal/exception/types.go
@@ -1,0 +1,77 @@
+// Package exception implements compliance exception governance:
+// operator-approved rule waivers with a request -> approve/reject ->
+// revoke/expire lifecycle.
+//
+// DB-backed (scan plan decision 2026-06-13): an exception is
+// approval-workflow data with a lifecycle, queries, and an audit
+// trail, not a signed static policy file.
+//
+// OVERLAY MODEL: an exception NEVER mutates host_rule_state. A failing
+// rule with an active exception stays 'fail' in the raw scan results
+// (Kensa's verdict is authoritative); the exception is a governance
+// annotation the lens/UI reads to mark a failure as accepted risk.
+//
+// Separation of duties: the requester cannot approve their own request
+// (enforced here, on top of the distinct exception:request vs
+// exception:approve RBAC permissions).
+//
+// Spec: api-compliance-exceptions v1.0.0.
+package exception
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Status is the exception lifecycle state.
+type Status string
+
+const (
+	StatusRequested Status = "requested"
+	StatusApproved  Status = "approved"
+	StatusRejected  Status = "rejected"
+	StatusRevoked   Status = "revoked"
+	StatusExpired   Status = "expired"
+)
+
+// Exception is one compliance_exceptions row.
+type Exception struct {
+	ID          uuid.UUID
+	HostID      uuid.UUID
+	RuleID      string
+	Reason      string
+	Status      Status
+	RequestedBy uuid.UUID
+	ReviewedBy  *uuid.UUID
+	ReviewNote  string
+	ExpiresAt   *time.Time
+	RequestedAt time.Time
+	ReviewedAt  *time.Time
+}
+
+// Active reports whether the exception is currently suppressing: an
+// approved row that has not passed its expiry.
+func (e Exception) Active(now time.Time) bool {
+	if e.Status != StatusApproved {
+		return false
+	}
+	return e.ExpiresAt == nil || e.ExpiresAt.After(now)
+}
+
+var (
+	// ErrNotFound is returned when an exception id does not exist.
+	ErrNotFound = errors.New("exception: not found")
+	// ErrDuplicateOpen is returned when a requested/approved exception
+	// already exists for the same host+rule (partial-unique violation).
+	ErrDuplicateOpen = errors.New("exception: an open exception already exists for this host and rule")
+	// ErrWrongState is returned when a transition does not apply to the
+	// current status (e.g. approving a rejected exception).
+	ErrWrongState = errors.New("exception: action not valid for the current state")
+	// ErrSelfReview is returned when the reviewer is the requester:
+	// separation of duties forbids approving your own request.
+	ErrSelfReview = errors.New("exception: requester cannot review their own request")
+	// ErrInvalidInput is returned for empty rule_id/reason etc.
+	ErrInvalidInput = errors.New("exception: invalid input")
+)

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -270,6 +270,33 @@ func (e ErrorEnvelopeErrorFault) Valid() bool {
 	}
 }
 
+// Defines values for ExceptionStatus.
+const (
+	ExceptionStatusApproved  ExceptionStatus = "approved"
+	ExceptionStatusExpired   ExceptionStatus = "expired"
+	ExceptionStatusRejected  ExceptionStatus = "rejected"
+	ExceptionStatusRequested ExceptionStatus = "requested"
+	ExceptionStatusRevoked   ExceptionStatus = "revoked"
+)
+
+// Valid indicates whether the value is a known member of the ExceptionStatus enum.
+func (e ExceptionStatus) Valid() bool {
+	switch e {
+	case ExceptionStatusApproved:
+		return true
+	case ExceptionStatusExpired:
+		return true
+	case ExceptionStatusRejected:
+		return true
+	case ExceptionStatusRequested:
+		return true
+	case ExceptionStatusRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FleetComplianceStatesStatesState.
 const (
 	FleetComplianceStatesStatesStateCompliant       FleetComplianceStatesStatesState = "compliant"
@@ -723,6 +750,33 @@ func (e GetAlertsParamsSeverity) Valid() bool {
 	}
 }
 
+// Defines values for GetComplianceExceptionsParamsStatus.
+const (
+	GetComplianceExceptionsParamsStatusApproved  GetComplianceExceptionsParamsStatus = "approved"
+	GetComplianceExceptionsParamsStatusExpired   GetComplianceExceptionsParamsStatus = "expired"
+	GetComplianceExceptionsParamsStatusRejected  GetComplianceExceptionsParamsStatus = "rejected"
+	GetComplianceExceptionsParamsStatusRequested GetComplianceExceptionsParamsStatus = "requested"
+	GetComplianceExceptionsParamsStatusRevoked   GetComplianceExceptionsParamsStatus = "revoked"
+)
+
+// Valid indicates whether the value is a known member of the GetComplianceExceptionsParamsStatus enum.
+func (e GetComplianceExceptionsParamsStatus) Valid() bool {
+	switch e {
+	case GetComplianceExceptionsParamsStatusApproved:
+		return true
+	case GetComplianceExceptionsParamsStatusExpired:
+		return true
+	case GetComplianceExceptionsParamsStatusRejected:
+		return true
+	case GetComplianceExceptionsParamsStatusRequested:
+		return true
+	case GetComplianceExceptionsParamsStatusRevoked:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for GetIntelligenceEventsParamsSeverity.
 const (
 	GetIntelligenceEventsParamsSeverityCritical GetIntelligenceEventsParamsSeverity = "critical"
@@ -1134,6 +1188,43 @@ type ErrorEnvelopeErrorFault string
 // EvaluateAlertRequest defines model for EvaluateAlertRequest.
 type EvaluateAlertRequest struct {
 	Score int `json:"score"`
+}
+
+// Exception defines model for Exception.
+type Exception struct {
+	ExpiresAt   *time.Time          `json:"expires_at,omitempty"`
+	HostId      openapi_types.UUID  `json:"host_id"`
+	Id          openapi_types.UUID  `json:"id"`
+	Reason      string              `json:"reason"`
+	RequestedAt time.Time           `json:"requested_at"`
+	RequestedBy openapi_types.UUID  `json:"requested_by"`
+	ReviewNote  *string             `json:"review_note,omitempty"`
+	ReviewedAt  *time.Time          `json:"reviewed_at,omitempty"`
+	ReviewedBy  *openapi_types.UUID `json:"reviewed_by,omitempty"`
+	RuleId      string              `json:"rule_id"`
+	Status      ExceptionStatus     `json:"status"`
+}
+
+// ExceptionStatus defines model for Exception.Status.
+type ExceptionStatus string
+
+// ExceptionList defines model for ExceptionList.
+type ExceptionList struct {
+	Exceptions []Exception `json:"exceptions"`
+}
+
+// ExceptionRequest defines model for ExceptionRequest.
+type ExceptionRequest struct {
+	// ExpiresAt Optional expiry; null means active until revoked
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Reason    string     `json:"reason"`
+	RuleId    string     `json:"rule_id"`
+}
+
+// ExceptionReview defines model for ExceptionReview.
+type ExceptionReview struct {
+	// Note Optional reviewer note
+	Note *string `json:"note,omitempty"`
 }
 
 // FleetComplianceStates defines model for FleetComplianceStates.
@@ -1920,6 +2011,15 @@ type GetAuditEventsParams struct {
 	Limit         *int       `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// GetComplianceExceptionsParams defines parameters for GetComplianceExceptions.
+type GetComplianceExceptionsParams struct {
+	Status *GetComplianceExceptionsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	Limit  *int                                 `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetComplianceExceptionsParamsStatus defines parameters for GetComplianceExceptions.
+type GetComplianceExceptionsParamsStatus string
+
 // PostDiagnosticsEchoParams defines parameters for PostDiagnosticsEcho.
 type PostDiagnosticsEchoParams struct {
 	IdempotencyKey string  `json:"Idempotency-Key"`
@@ -2030,6 +2130,11 @@ type PostHostDiscoveryRunParams struct {
 	IdempotencyKey string `json:"Idempotency-Key"`
 }
 
+// GetHostExceptionsParams defines parameters for GetHostExceptions.
+type GetHostExceptionsParams struct {
+	History *bool `form:"history,omitempty" json:"history,omitempty"`
+}
+
 // PostHostScanParams defines parameters for PostHostScan.
 type PostHostScanParams struct {
 	IdempotencyKey string `json:"Idempotency-Key"`
@@ -2100,6 +2205,15 @@ type PostDiagnosticsRequireHostWriteJSONRequestBody = EchoRequest
 // PostDiagnosticsRequireRemediationExecuteJSONRequestBody defines body for PostDiagnosticsRequireRemediationExecute for application/json ContentType.
 type PostDiagnosticsRequireRemediationExecuteJSONRequestBody = EchoRequest
 
+// PostExceptionApproveJSONRequestBody defines body for PostExceptionApprove for application/json ContentType.
+type PostExceptionApproveJSONRequestBody = ExceptionReview
+
+// PostExceptionRejectJSONRequestBody defines body for PostExceptionReject for application/json ContentType.
+type PostExceptionRejectJSONRequestBody = ExceptionReview
+
+// PostExceptionRevokeJSONRequestBody defines body for PostExceptionRevoke for application/json ContentType.
+type PostExceptionRevokeJSONRequestBody = ExceptionReview
+
 // PostHostsJSONRequestBody defines body for PostHosts for application/json ContentType.
 type PostHostsJSONRequestBody = HostCreateRequest
 
@@ -2108,6 +2222,9 @@ type PutHostMaintenanceJSONRequestBody = HostMaintenanceRequest
 
 // PatchHostByIDJSONRequestBody defines body for PatchHostByID for application/json ContentType.
 type PatchHostByIDJSONRequestBody = HostUpdateRequest
+
+// PostHostExceptionJSONRequestBody defines body for PostHostException for application/json ContentType.
+type PostHostExceptionJSONRequestBody = ExceptionRequest
 
 // PostRolesCreateJSONRequestBody defines body for PostRolesCreate for application/json ContentType.
 type PostRolesCreateJSONRequestBody = CustomRoleCreateRequest
@@ -2198,6 +2315,9 @@ type ServerInterface interface {
 	// Rotate the refresh cookie and mint a new session (browser flow)
 	// (POST /api/v1/auth/refresh-cookie)
 	PostAuthRefreshCookie(w http.ResponseWriter, r *http.Request)
+	// Fleet-wide compliance exception queue
+	// (GET /api/v1/compliance/exceptions)
+	GetComplianceExceptions(w http.ResponseWriter, r *http.Request, params GetComplianceExceptionsParams)
 	// List credentials (metadata only)
 	// (GET /api/v1/credentials)
 	GetCredentials(w http.ResponseWriter, r *http.Request)
@@ -2234,6 +2354,15 @@ type ServerInterface interface {
 	// Stage-0 RBAC+license demo; requires remediation:execute + remediation_execution feature
 	// (POST /api/v1/diagnostics:require-remediation-execute)
 	PostDiagnosticsRequireRemediationExecute(w http.ResponseWriter, r *http.Request, params PostDiagnosticsRequireRemediationExecuteParams)
+	// Approve a requested exception
+	// (POST /api/v1/exceptions/{xid}:approve)
+	PostExceptionApprove(w http.ResponseWriter, r *http.Request, xid openapi_types.UUID)
+	// Reject a requested exception
+	// (POST /api/v1/exceptions/{xid}:reject)
+	PostExceptionReject(w http.ResponseWriter, r *http.Request, xid openapi_types.UUID)
+	// Revoke an active exception before its expiry
+	// (POST /api/v1/exceptions/{xid}:revoke)
+	PostExceptionRevoke(w http.ResponseWriter, r *http.Request, xid openapi_types.UUID)
 	// Fleet host counts per compliance state
 	// (GET /api/v1/fleet/compliance/states)
 	GetFleetComplianceStates(w http.ResponseWriter, r *http.Request)
@@ -2309,6 +2438,12 @@ type ServerInterface interface {
 	// Synchronous on-demand OS fingerprint discovery for a single host
 	// (POST /api/v1/hosts/{id}/discovery:run)
 	PostHostDiscoveryRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params PostHostDiscoveryRunParams)
+	// List a host's compliance exceptions
+	// (GET /api/v1/hosts/{id}/exceptions)
+	GetHostExceptions(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params GetHostExceptionsParams)
+	// Request a compliance exception (rule waiver) on a host
+	// (POST /api/v1/hosts/{id}/exceptions)
+	PostHostException(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// Enqueue an on-demand compliance scan for a single host
 	// (POST /api/v1/hosts/{id}/scans)
 	PostHostScan(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params PostHostScanParams)
@@ -2516,6 +2651,12 @@ func (_ Unimplemented) PostAuthRefreshCookie(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Fleet-wide compliance exception queue
+// (GET /api/v1/compliance/exceptions)
+func (_ Unimplemented) GetComplianceExceptions(w http.ResponseWriter, r *http.Request, params GetComplianceExceptionsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // List credentials (metadata only)
 // (GET /api/v1/credentials)
 func (_ Unimplemented) GetCredentials(w http.ResponseWriter, r *http.Request) {
@@ -2585,6 +2726,24 @@ func (_ Unimplemented) PostDiagnosticsRequireHostWrite(w http.ResponseWriter, r 
 // Stage-0 RBAC+license demo; requires remediation:execute + remediation_execution feature
 // (POST /api/v1/diagnostics:require-remediation-execute)
 func (_ Unimplemented) PostDiagnosticsRequireRemediationExecute(w http.ResponseWriter, r *http.Request, params PostDiagnosticsRequireRemediationExecuteParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Approve a requested exception
+// (POST /api/v1/exceptions/{xid}:approve)
+func (_ Unimplemented) PostExceptionApprove(w http.ResponseWriter, r *http.Request, xid openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Reject a requested exception
+// (POST /api/v1/exceptions/{xid}:reject)
+func (_ Unimplemented) PostExceptionReject(w http.ResponseWriter, r *http.Request, xid openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Revoke an active exception before its expiry
+// (POST /api/v1/exceptions/{xid}:revoke)
+func (_ Unimplemented) PostExceptionRevoke(w http.ResponseWriter, r *http.Request, xid openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2735,6 +2894,18 @@ func (_ Unimplemented) PostHostConnectivityCheck(w http.ResponseWriter, r *http.
 // Synchronous on-demand OS fingerprint discovery for a single host
 // (POST /api/v1/hosts/{id}/discovery:run)
 func (_ Unimplemented) PostHostDiscoveryRun(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params PostHostDiscoveryRunParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List a host's compliance exceptions
+// (GET /api/v1/hosts/{id}/exceptions)
+func (_ Unimplemented) GetHostExceptions(w http.ResponseWriter, r *http.Request, id openapi_types.UUID, params GetHostExceptionsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Request a compliance exception (rule waiver) on a host
+// (POST /api/v1/hosts/{id}/exceptions)
+func (_ Unimplemented) PostHostException(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -3540,6 +3711,52 @@ func (siw *ServerInterfaceWrapper) PostAuthRefreshCookie(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
+// GetComplianceExceptions operation middleware
+func (siw *ServerInterfaceWrapper) GetComplianceExceptions(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetComplianceExceptionsParams
+
+	// ------------- Optional query parameter "status" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "status", r.URL.Query(), &params.Status, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "status"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetComplianceExceptions(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetCredentials operation middleware
 func (siw *ServerInterfaceWrapper) GetCredentials(w http.ResponseWriter, r *http.Request) {
 
@@ -3909,6 +4126,84 @@ func (siw *ServerInterfaceWrapper) PostDiagnosticsRequireRemediationExecute(w ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PostDiagnosticsRequireRemediationExecute(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostExceptionApprove operation middleware
+func (siw *ServerInterfaceWrapper) PostExceptionApprove(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "xid" -------------
+	var xid openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "xid", chi.URLParam(r, "xid"), &xid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "xid", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostExceptionApprove(w, r, xid)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostExceptionReject operation middleware
+func (siw *ServerInterfaceWrapper) PostExceptionReject(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "xid" -------------
+	var xid openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "xid", chi.URLParam(r, "xid"), &xid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "xid", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostExceptionReject(w, r, xid)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostExceptionRevoke operation middleware
+func (siw *ServerInterfaceWrapper) PostExceptionRevoke(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "xid" -------------
+	var xid openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "xid", chi.URLParam(r, "xid"), &xid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "xid", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostExceptionRevoke(w, r, xid)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4752,6 +5047,74 @@ func (siw *ServerInterfaceWrapper) PostHostDiscoveryRun(w http.ResponseWriter, r
 	handler.ServeHTTP(w, r)
 }
 
+// GetHostExceptions operation middleware
+func (siw *ServerInterfaceWrapper) GetHostExceptions(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetHostExceptionsParams
+
+	// ------------- Optional query parameter "history" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "history", r.URL.Query(), &params.History, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "history"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "history", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetHostExceptions(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostHostException operation middleware
+func (siw *ServerInterfaceWrapper) PostHostException(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostHostException(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // PostHostScan operation middleware
 func (siw *ServerInterfaceWrapper) PostHostScan(w http.ResponseWriter, r *http.Request) {
 
@@ -5513,6 +5876,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/api/v1/auth/refresh-cookie", wrapper.PostAuthRefreshCookie)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/compliance/exceptions", wrapper.GetComplianceExceptions)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/credentials", wrapper.GetCredentials)
 	})
 	r.Group(func(r chi.Router) {
@@ -5547,6 +5913,15 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/v1/diagnostics:require-remediation-execute", wrapper.PostDiagnosticsRequireRemediationExecute)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/exceptions/{xid}:approve", wrapper.PostExceptionApprove)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/exceptions/{xid}:reject", wrapper.PostExceptionReject)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/exceptions/{xid}:revoke", wrapper.PostExceptionRevoke)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/fleet/compliance/states", wrapper.GetFleetComplianceStates)
@@ -5622,6 +5997,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/v1/hosts/{id}/discovery:run", wrapper.PostHostDiscoveryRun)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/hosts/{id}/exceptions", wrapper.GetHostExceptions)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/hosts/{id}/exceptions", wrapper.PostHostException)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/v1/hosts/{id}/scans", wrapper.PostHostScan)
@@ -5713,301 +6094,316 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7L3rktu21iD6Kqs0UxX1saRW+3aSdrmmnLY99vfZsafbyT5zohxtiFySkKYAbgBsWXsnp+bX9wBfzRPu",
-	"J5nCAkiCEilRct+S7T8ppwXisrBuWNd/dCK5SKVAYXTn9B8dhTqVQiP9z/csPse/ZaiN/b9ICoOC/snS",
-	"NOERM1yK41+1FPZvOprjgtl//VeF085p578cl1Mfu1/18SulpHolrjCRKXZ+//33XidGHSme2sk6p52f",
-	"WMJjmrkHKZtx4f8tFfAYF6k0KKIVoJ2n83uv8x7NXMY/SPMiSeQS49vb6V+UFDN48+nTR1jQJjp2jP/c",
-	"zv4iMvyKm5X9d6pkispwB9i51GbMaa9TqRbMdE47WcbjTq8jsiRhkwQ7p0Zl2OuYVYqd0442iouZPXD9",
-	"ZxvDZBRlSmE8ZqYyPmYG+4YvsO4jjVeo/I5RZIvO6c8dLqay0+skctnpdRYY82zR6XXmfDbv9DqR4oZH",
-	"LOn8UjebzFSE4VwsQWXswooJzSICZK/DhcEk4TMUkd0Vy2JuBy2k4EbSZLWzZ4sFU7TVjd8MNwnW/PJ7",
-	"r6PwbxlXFk9+7hDk/C6Dw+ffV4FY7kFOfsXI2HXyG/7IZlhzyzyOUYwjmTlcXHDBFxYQw2Iqe/QZEiJz",
-	"gwv6rPjHNuwscOv3Yi6mFKP/F/jZjKNMaansNDswah0mtHqvuvnas8cLLs5lgvrc84xNCCj7c+sz2cle",
-	"CaNqDrW2STdv7a4IwzY2wqJLIZcJxrPtFLGT+ioTTVYHUTBRwdj9uQZ5JzKux+pIITN7UnSMcZaOL7F+",
-	"xpjrBdf6C2FSznIgQO4rO1SoZXL1hdApJjkQOCpL0APnpvk1TywLPninxfeZMDw5HGLaMFMVG5bZkWgI",
-	"qK9TLtgpodwJ0LH2kIbNHEeIY27lD0s+VjjF5gfrLKZJuPQ6WRrvSaB1Aqkk2QqrqBVQDlQtBJWd5x2f",
-	"YrSKEgyUuqpK8yF1IAHLg2AqFXz8cPEJkvxDQBGnkgujB+CBDyyKMDUamACZf04I8AxYkvifgYFCpqWg",
-	"Sc0cgaQ8xGgYTwad3rrgoMEkNNnndyhmZt45ffjkac2FfhGy/d4EK10v0vcU0iSMbkZC196yhemrK6/6",
-	"rktAd8f/qJNpRirPYloIQDu4UXhFUilMSN9uYlruzptpsLJwebibZfSRVPHeH8UOqFWEaGIgxeVbVmVV",
-	"zrYQL8bnQN/NQAOx0ILhrN1Zr1No5sFlt+AxBfZdD/GUyLybgtbZGPtbhuB+fgYp0xqYhv/m/vAcjIQp",
-	"mmhOjMjOZF+a7bhFnaoc7qUeMGb+Ts64CPhuFTLSpGu87mnPPheC/9u4ZHuqpVRxHZMMPj2pY5kalWAL",
-	"3PvTNQAU8wS72QGAppeCFRNaj428xHompXCqUM+3jLC72Y1UZv4ei22sH6iyi/U1/QpNB3z/+sUroWSS",
-	"NB8yVfKKay4FF7Nxpvhu+tz4YsvqP6Hi09U14tjaXuwEjcvjR1RW67LssBkAPEZhai0iDbKC6zETUqwW",
-	"MguZ60TKBJkgvJCtX/o0dG3OugOl5VH24ewbS/qzVidshmAz2HDhBeahr58GIFU5QQsIBgTv9uSnbjrU",
-	"R88VzuZMzLARNUmuCDOusLTtLEzgsv3wtaNsLLc2XdNpzh07aDzGLha1bsSoDK9b9IwZnEm1ckaRjfUq",
-	"Qq8ROVq9OMqJavchhUBvcPpeIbuM5VLUXGP+uNwQyJlQyKK5Fa3wACKL5VFm33TjKeNJplCPsuHwUfSo",
-	"0yuRmQvz9HGnzlQW40yx2Nl6qwu1Wgafn7Rcxx+zusaWeVvuX1j9bJwqOak7g5BABpGEX6FArUHJJeBn",
-	"ro1uN70UCRe4P3CeD9vMvy4V3GLBpQRWBg/CtRPvQrGzOUaX56izpIbIyPBfqMLVA5ooHVttXWamZ09I",
-	"M0oxVjjNNMY9mDAhUI0XXC+YiebkVbAf0aTPwKp/IAXojPSANrYKyzg8XHnCzWpsX+TZJnl2Pkpt+vOV",
-	"NqhQcw1uHHQ1WyBcsSRD0kZTVFzGPIJEyhSWMktiWCpu8MjyXG8PKS7SsmRR/b9LYSFeZ/lw0N/ziZNP",
-	"XS97vcQioI8XNaceWnB6/NqNS+FJNuYOD9AM9524JcWUz5p511hjVHN5dmWw21ZXLCEbRsjSLLlqmGAi",
-	"l3SJZm4Zu0xi6D4dDgbfPn08HB4N4CVOWZYYOHk4hO7Dhb3RBfvsXAI0ple6CJ4OtzG+1rtc3+OSm/lW",
-	"xli/40fDIXSfHLRjuRStd+v2yIwlSzaRV9gKmt/azT0aHrK7BbP/I5iIcDxL5KROdv1ljgKI+oEQ0FGm",
-	"4dGlhklm3B81eK6tSywPCCVcpx4YqDTXBmPLouI6qHABwSwN1/TUguLpcHE0gB+kgRUaYJmRffKCYvwM",
-	"jGLRJcaFFS5F1bfzV+bWCSeH2J7AdJLg+lHz+bD+tN/Zw54chJWKGRwnfMFrbKDv2We7Da8kwsXFm0CU",
-	"aIgzyxxhmiAa0EvEVEP3ZDB4OBxWNvKwso2Tul14UdWIEX2Hb5/OPvad4AL/hUUGjZEUsVv7UXXpRztX",
-	"DpjXuCCvzT2clbeRM3HL5qZSYXl9//yP/wx5od3PSXU/Jzv2U6tREFTWOF6vyqYD7rJJYlXwNh25ggq1",
-	"/KCdQGl+u0WFwNlml6gRUcTuCdP1IV+vv3ncn4M5dx3solBkqgdKmDZOk/OqxBr5WG6iMLK0Q6P62jBl",
-	"CHW9hkUWe2I/U660IV4aap57OYvCK/N+os09cavf6YKO7fHGDiKDmiuv4+DuwIUrv4UW7r7wZHPAl14J",
-	"3etLcgeNKbqCDOt7fLxpeCrOW7+j+hM27qH2pmpxUCFZTlhylkjRbDTgeuxxuY6Hq0swc64hsnMA04Ru",
-	"2qrfC/CfQVeKZGV1bx7D0kp5HckUn7tRR7VokNtKqst5iaTBSPjGvWSdyR7seKdaQZe2cvSNW0ouuDH0",
-	"WNrTdkt7DJ2jbrsd50Wv9+vaT7y3obrxc3/j4fFpmt6+3t819HG73HG9FM7QeL8sM/OxD6wKj6vn3jca",
-	"mG8m0sxrj75mIglgfTJ8+LhXa3AMsKoZAfa8tdBUVfMw41eWZpqiNILfyUiVzhXT9fa8L8SOvV3+1+VJ",
-	"cPv24K3YGUM02I5P77g2W+RwMa69C6qcu/QY7LD6hsts3+4WX8h1YP4hwUL5N/XxH7uI61DjNNeB4N6k",
-	"uLYUeee04O9nPOEmdBeE4tmPiORi4Z30jbNMuZihShXfMa7RE79/MMre7oB2VFu5wvC6a+kj00YuzmWC",
-	"O8RDM2dvw4/dFafMGFRWEP5/P7P+33+x/xn2vxv/8o+T3tNHv//XOhC1dg4tuHjrfjzZ6Slas8Hv9hiV",
-	"YGpmIwe5B+h+JhlPzJiLeoK7LvfYxqHDlXeD4CXXkbxC1WjSi9FgZMZSjOmZYRV+wyKz1cJD4U7HLOXH",
-	"VyfH3hyVGdlH8bcMM9TAyFoxiPPF4Vc5KawpApf0c/lGNpkSXMzg4fBkALTOlCUae8VQMgSvgBn3fwOp",
-	"x/ncRLvww4/v3gUvJiua4ixBBSlZoMwcF5ClZDETYI/PjFQQJfTrOfZVJqDYba1Om1tlmu0QdKaIxRTv",
-	"9c//9b89FL7R5cwwwUguUEOcIUg7Tshl9wj6TefCzxFirJ2WvmBilVs0BmTGGgyeDh9/OxyW5h6y7ED3",
-	"4eN5xbjghgUGBvv1Ndj6qsBes/kV6CCkRQANTMT0hT1s34lRmNn/THDOrpDCT/gUGlASuHZ4UXs/u4xV",
-	"mwip8w3GkKIKjmFPQBaaJxVL2sMnA/heZoKuIxMxWgruz1HFIAUwb+wyc4ul3GiHkxs3qvkiSwwTKDOd",
-	"rMI7ejLczwJUwcg1E00TVbc23qzxjS+13KyzoT3MNhufHmSzKWa5WCKmW4IIPErUmfkyYUBOazEpLS3T",
-	"K0esZPQcwP+LSlrEZf4FrQ2yeEV+LYQu0gzEOFii6JcSW8jv5pAKF6lZEUFvSY5Yg0txkjpwvIrmslFp",
-	"WKDWPjRt4ym4z3Mln6d5A826fczNGK9QNEW8HxJSidFcYgtvvx+3MWftORyUP6E2/yYn28hk5/Z+lZN2",
-	"h13brv+u3XYr6Vr1buO6zce3HcdaPGXyZ0mUcHSWM1RXqKzqIxMeWQ6Kn61+2hCuP88WTIwDlK5x3xq1",
-	"anLfbjCb2IqfXEsvP11faBP460hGoK69oyuWZMwgxUU3EqmOpMpJNHcgDPdiEG6Guh28tkznTC7ShFs5",
-	"cWGZVY2NWxd/XwssFQgojFqRXF2bB7iAhMUxKpAqRvUM/o5K9sn86diiBi6iJHNBEoXeXJMaWJhtG0y8",
-	"FfQpgy0EWVvdpshAy5Th9MtCapOsKj+G/24OG1iHrM83CHZZB+atmr8Hbovr+aRQxDWKPVvtvJuYrZxH",
-	"UQuW6rk0ugcyiVEb53RovgB2NRsTAo3TKLwDkS0m7goKJ5Rz+NZeU+xvqfLuruPuU8YT+8/aWRoXWAOp",
-	"n7y69fzzco2Nre99dwT6xpt7I7V57YM9NuDqNzGmfKZ9nBpbssO2I2v+Ya9u7cZDvPNhV5snWA/barH3",
-	"SgBNi/E5IbYdvd/8W8Jt6sOIWgRuEczOyd/nojz1lwb+04yfggzhnaaExoQYt7kswZ1YWWW7bW62MS1v",
-	"Hcp+YK9urcZNX0RM/A+rf21uuVTjW21TCM9e9kUPv045x5bNyjrYpkxre96pKpOP1owLbgRYGGk4hq7/",
-	"BB6AB9YRsEhJrSmXzJkSYDgYnAwqDmOZObzdYNVGGpaM0ekducVqy+vHcQj3hlFyqWE5R0WZJBQx7IP2",
-	"uHY5JfYV49PX9vavrsOmbq+NAP8k09cOPm9yCfHFFBcy7y+kuHJ7lvauZ3shFX/p9gLesvkiICY2vuSi",
-	"4nxxxgaNlAfiXNxuZBwkZhZ/+mW/JOfbTWpumU9cm5ab6RAoFok9X7NQuORpSvBYfwFs8yGUQrpklH6l",
-	"XuUydiegvUGWmPkWg/hk7CNAKm/lwNS2ecQ5zbkK45vrLvcKla63s9cov3S0ymbKCWrPJXWgFOdJATWo",
-	"G/xS5XH/jkIziJhhiZxBPu4ZZML/m/89DwIwcywGJsybmIlBD3aor20iWxzXazmaGOIhkqsARLliqAS7",
-	"eXdD+rViC1xKddmoNtREVFihsWCWEMBIZzCb5vP4GMeqMMklyOb5i++ayDUA55fuwk41aFZ0Cs2ous4P",
-	"JGgbhWfTDgbt8hgqr7Dqwv7kx+XmgGlg9ulnNVE2szvIROxWlwIhxogvWPIMhg7Pgy+5huEAPsolKl1E",
-	"xSYoNNAOQDqq+Injss80RHOe6soRpomkoPQ19WMNKyvXWYFrPZqWx98DVbck3xXrt5e8TfRQk5Arr1Cx",
-	"JDl4xiZgWV6Zz70bDu9wW/phzuzwUAgUvLcurTtLDp7XKjd1c+qICfJw4GfTZkb7ajjzw6slktrvxYLw",
-	"wn+4aVgL9lPO3wshm0Oi3WVdlFtsMNi2YBQ3KYRaMCGSJ/vyH/cRsZ52T5lcvbph2VnLidY0u3z6/XgU",
-	"IfkeSstZG3XFWyoG9Y4TYZRMxjyuffbRj8BjXfjvlTNJY1yKqmfOQwWZSFBr+G/FD8/t3c34FdLa7as/",
-	"rEVlVDf1muKhNQpDrnY5rahjwdh8W7tUNsiBaCkWpEhWPSCTDmgjFcYQzTG6BJmZNDO1QKRwbxp1Q++M",
-	"KgQu3LbyARvntBwI8nIdIKSoV0ubsvDWtB4PYLtVJ+W5dj5LMkT0SDfrgUf/nis6eFS7YFEUqB6H6edn",
-	"MGVJomHCokvLFjyEDtC7G01MeV2gamBNoA8HNYTKV1ZAJ5sXvpuwL3x8QZ17LR8zvmW/hX9YBjEBW0Jb",
-	"wuSnacJmucaXB05YbXZ76MyCi6zWY3Tm04isSqm9l8h9U0iCTGhE5xOqSxX+bMYkdlmt/p0kJfrQWeaM",
-	"olLCrcMKzcH5FUXwyBiFHVgTP/App0sXsAB+IIGyFmzlnCnLdO2UKsOQ6PMAlpjrlJloTqE3Zl5kYvWX",
-	"PEboxly7paUCFwIS3m1dSP+GgrN+2prd9jbxugYVajCwBSnde3Xo/mkhu6F6HX5EVngS2zoSr8cFGFzP",
-	"DuW03vjd3nsYeg73M5sc5jKkOzo0yLchfcPyh4Stxk05CZuRM+KKKynycOywOk7d/DMls/TQAHHLDw7M",
-	"H+HpmMWx8m7JtV3uyj2RylTCKZ4+efLoyc7kVF8nsUDuXaBZV3S3pYbs9tv6OPLg3E0o9JLCcLbFJ5W8",
-	"+pD3cPEW9nkDLT4Os0WSwJ3MkuTDtHP68+4ZCif077/0GmW+kFDUCHGpwlb4k3avMgFsxrjQptRqBxtI",
-	"Wgf5NfHmT98E/deMJxh/+dMuUPO3PumsXrotPOZevvn+mG+oe/akqX/EbH+7VBFmNw5vK2W9t3kvII0a",
-	"nHDe3kY/QuGVfvHuXe4Ld0b1HHH9O1Vq0y8QtD/liUHVg1RhnyKmjw5xTlf3tsug94630mCL0KPtvpMa",
-	"58Rz+wWF2OdzFLgN3Yhp7HOhkdKNr/CopXPhq0K9xay3cVfb7v6twUVNGJ2K5txgZHzYzU7tyFFqqrjM",
-	"uVrrAhK9BiG/j7ytFflbhO/6g7vWAdb1traICYHxUY0AvheJmuta8y4t+ebU4oNzSCv6cb0RM7CiHGYK",
-	"ud+qXDUBZlENbA+ML+t5O4fDQ+rxlC14smpF31KPgyiJncPThBm7rbGroznlqNp95187LV40u58wN59C",
-	"W//W8ceoEt42HtystxQhxK31loKn73rZN8cQV/C+LrFqo8hT/ZUR3VYr/u2m0vX6NAcSu52mKELnINfw",
-	"0fqGw/CwL9pD2QFn03zeru5iaH3cUR3QrtL+ZjaG++IwjeMVv+IJznCfNWq/2bFQQzHGLyudqPV8j32v",
-	"j9664/qY7J01DS2FvS8vt9GC1mi0tygHz4FM2r6G3TOXhArPQaHOFrjbXJ7P3rjDAoHfcG2aK9k63Y/I",
-	"ojWjdWwhSH/aSU57MpIpvd/GCVs50VNEPXrtWc87AY5aGHxJo5tdmk/zm+DWuYS83AK/Ss0svOIy09e+",
-	"rd1KQME52u61rpTpbnZvKb3dCttDXwP8r7nP1tS1LfnX7B321EC8NXrSNWTo5BtsOuuWjNq1h2aVzeFg",
-	"NoDP3z4dP33cA2bHEhXd8Gv065Puxp90d/rYWSv/xrVREt6+hKmSCzhGEx1L3VeYINMIXcJBNcekB9kk",
-	"EybrgZLR5aoHEQojdQ9YsmAJF9nnHsQ44Uz0QKYodKaxnyBLe6AT1EfPQMkkyVJwO4GunRR+89/Ab2A/",
-	"gN+AJSkX9A8VzeE3mNllJPwG0sxRHcGHH979T/fufPsSlvahuUjNyldnTBX2i5oCA7hIMfKF8yhYol/W",
-	"B7g6GTwaDOHFWf/hw0FLGF7DE7CGwPORp5h812Yj/3qPxDAydNPNmimX6e5LsNQURmFJ0o8SGV1CPjgP",
-	"nkqYQW2ALHBoMCaDRXfKBddzVxikD1QClP7nyGOZs3qE1jGqxc4XqA1bpBrYRKMwW9Bq49XVFCQTbqVp",
-	"z84lkonG3Q0ODqBxyfwh4q8Xhre/g/99G1QrjpyN3dVE7jBRW/WRx9cEh4NKQ1Yuq9zlBqAaMZl40Vsx",
-	"lXX1LHWW0C0zKHiYPc8A8hqwud127HjamIupBGO3PxKRTLKF6E+l6rt/bmN/g5HYaFvH0pSphazESu3W",
-	"Pfc3lcskocSh/VqBcn05nirE8WzSTr2lL5wzaK9PMo1x6y+mXOGSJclYo7ridXF6+YgYfoNsuoTfQEzp",
-	"xjT8Bjwt/knU0YYkyyUL+8Dub/4Wt5Na+7zxQj1p58SXqAQm433HezVkn0/2EdILXIzZFeM0arxoeen2",
-	"K4dYbb/4Av2rVvUaDAb1+tSx06aOrS517DSpY0uhx06LOvY6FNUO3tChrl1fatkjkEaOE36JbYe3RiOp",
-	"x6lCY1Z7fbIPCpXDx9PMpRDdmHtAI+nZjW1aXompVBEXM/gN8pZmV1aVfpmHlno+A3wKQhqrLmtXvmf3",
-	"2kuW7oX1ja/ligBoEpQ/kmJ6b2PrdkStfdH7808fLrdx4W+DHvpNBTH3LPRYjbxm8ZV9a2vqlzkOW/Zb",
-	"vXqyAjY1dljePGmaJXCeiTNqG9x9NGxsV3Iy39rA49HNV3PMt7mjicseTUPKGav1F7nQxrVv8R1DgjY2",
-	"w726h+xRMbFlXcRNDPrS0og1OLlHdcS6rw8qkBhO1NAc+eaqvblylXtq6q48YF6bbi0wLJEaYzDssxRy",
-	"sToFMoA4hWOQsuiSzXDgbRKde1yG4jpb1283rgfQrIQOhtuuXlQrLLqWJsebuHl73cLDtS9yD806XRzy",
-	"0NwHxfKkil2EtZYnqRDtM33hnvIVaUQ+k0E+L5UrXhT9X+g4Ug0u8mV3FTMs0UiXn+xUv97xCIV2UN3C",
-	"RamIN6rGqp6fU65Qf5HZeorM5J7q9jZNLsYzxSIcu3aEbYul+LruVnlj5LNzJyCVTY4TBxTKlaKSsbUe",
-	"RsOr3tapQmo+nqJYMhPNx2lCSYtoJV6quMbaaTKqrpQqvFprq9HkkaN1g6TIAnBb7ndHx2V/4PGvS7Pb",
-	"0BsObrFko6Pv1nCmYZoSh/TY3XIt8pi2D7YrOvBYFe1AN0YsGdVY/6LtrjPNfO/r69fdTNn5uim6IciD",
-	"2NQrmJihamxvfWAR/xybZsxg2y7AQYB9NX243OL24+tznHFttvmhD6jAUW2CXMOsmvoRbJt0/c7q6nnI",
-	"fQL+z2WCDVPVFydypTLCvedL1gJZJjziqM8xkSxuhq/MDJXhbxanzdy/QQIWUzbua/USI2pSv60XxUHa",
-	"8+4Sx3539eWRnEOhsUPKpmemrgGublPWK99GddGNJYoJ62BZotAfv5VHFa/DfdSd3Dsn6xvz5un+4wWv",
-	"K994jn1yWhW9Rbs+AfuoyJQppnDNVbuuqtN3Q0opoT6zRwM4S9giRWq9KuHnJz14+O23w1869eEdPjvi",
-	"oB0V7Vxpa3lCS7gz6sAAD4euqceqHDTlIuZitt9uGyMA3zNtUIFechPNC2CxmKXU8LOwWoSNS5zXsGo+",
-	"2czJH8AH0Y9xYc9kQaGB0bHYdJrXu9veI3enRWe7QaemSkA3KBNAMY/1/f3W600cjnTrM1Vu+P8egpHw",
-	"7Xf73WSlTMbhO6tMU9nWQ9rW4z235at1HL4hP0FlK09oK0/33EqbVim6RA/XHuXpUK+1SFlf86QHJ8OG",
-	"JX1Y4mGnJ9d6P0qY1nzKMc4r3LY+ckM87tq21llWLSqtXWQTLfQ6G384xNpYsvwvtTIGwmMP62L41UFW",
-	"RTvBeeZqNMdNRZr3s4g1xWvQDyoTesBjeP4caG5qPOX+35T1bPWgjKfYbXvZeMBv9FVpbNeYL1K8l8sD",
-	"N0ErLxP0UeEVx+UmzCZZdImmhooePgYfH9qjWmqWaucyU87fK+TyGbWdisJKzhqWc6kRfAEdt3RMgSc+",
-	"Z5kLbaWBa2skM7WlkkeG23LO7cdjOZ1qrGE7b2SmdLFR6A7hea6UWLlkvz3qtHD9lUv0gv3srsbhRgu5",
-	"rNvadjDNmS6a96RMa4ypwg7xTsr4TuTs6ICqRRdSCtSmdk1f7VtI0Q+rMtGNVoKSqiWONOBnrg+vcuSx",
-	"91c50Vvoz63knTzJCooK6Y111/edMS+1vhMh8kutbn1t3V5BUk00+RNT3ALmwxUqxeO6Wt0y/Kn1m7J6",
-	"3nwZ6odMFRH9pHDFkgwH8PHHT6AwTViELkRram96wdKdBtpye7vOuCW5/yofUpeIr9JM9zOL/cUw0FL5",
-	"llh5XGZDMxHSePW4qB7QkOUf0Sq+Dr7CKSoUFIVgYZEvW/8YIWmVKRzXdab+oGZM8L+TZ6uvU4z4lEdA",
-	"cJ7LxD4z8mbYdqGifaCeyyyJgSVLtrL7IX7dqzVPNXTgvqSK0/Tq63NRrMIFIIGE8vxlZqhrob/COhnV",
-	"GEXuP4qx4WnrC0jo+nJlIYip+h+Pdc/f6l6lPQh/a8JI6JD2GUUDoFsgvOu0jaYHmL+nPHCOdqZLeFwr",
-	"e6m61SvA6K3hXACJNWTZu5JTSSV1n/6oUe0o54QLbwTaUv3o0Y7u2Vs+/fYGG1QHvW3dKYJdNUFjazPq",
-	"vWPGC+Ad6qZ1ibF+0y3SU++io/AGmBthKxN8oTWfiUZsU7IonrPPTeefNa2st+db2xO0NxtX0GQX/bmp",
-	"6/b1k7MvNu/KMuK4SLCs8qq3Fx/63z4dnhC3jssY/PqSuovax/WLycRKCYseMOMUUe6eg5txXTVh2/9d",
-	"gpEyieaMiyIQ3nLGCRdMrSi8kkQJSY1ObeCq0KyGDS8mGMcYg2uAgGLGBcJCktqYL9R15+ZiKo9qwxty",
-	"12ONeE1R/IXUYY2LK1TQTeJpwma6z8WvZOrazdTL6fNjEJAKWPfCy6tpvkfu2rpg+AsqQz2EJUsuuZj1",
-	"9SUmaKQAnakp8518zVwhAoo4lVwY7V5D+BlVxJ10GompzETsUj60YdEldINwmR7wGBepNCiiVQ+ovaUv",
-	"lAvouzEeuVB5X08qAFrXb/EoaIBx2hkOTgbDPkvSORuc5BfAUt457TwaDAePiPWaOeF13qqZPM8+mmRW",
-	"9ww7p1bMZXl/LTMVIZx//+LMF03CGDLhMzAU9bMCihzRg5E4Y0mC6hsK58rt2lTRmwQ6t/dP82mgelR8",
-	"khl8BnOSyO6lNhIKU6mMhrlcun7HpPq7Gll+drsb0FmaKqTXlpb0+49vR8KV7CLD8KjzA1xxza0+fQzv",
-	"/TKjjo89Zinv5+BwgHdqHZfibWyJDc2LHFpk82ELNMSzfv5Hh1tY/S1zraId3+64o/lCqAtWcfgnSBlI",
-	"gQXCl0LNwzGoF3zsLENFPmmtgaFh8aBe8cbyh8cL1S8WBHsUa+1MaG3YNxdrMGsjL5tmo/7f1zabDyUK",
-	"p2v5ZW7kKz8sHgBPhnuFL/5SplwTIT8cDr3Jz/gIPZamCY8Ib49/9U64ct1tQjVHbwrQIga5Jqz875DS",
-	"gF7nsVu8bs5ik8ffszhXNeiTR9e232rr2roNCylWC5lpzypIhhR1rjo/Cmc8Ls41RYyh++MPbz/8QI8r",
-	"IDrV8KBiKoQHEFIqPHDcGx5ASalHtFTBZeMFF8c+tuDURUaQruHrYlYZzUepzQv7RSV0peOkH2rzvYxX",
-	"1wbD2oic36uy1pdJujG8qw/RqblPGuHXABdZAl0fN01pkKsUY/BFRo7WbvulWlFTfwpQYQaBwb/95RP4",
-	"Wyne1RRqnFDZQG5qbjH1EQWnikIKWlxjNQahc4OAbIh2qIHkR1R9Cy1wp4AiWOG2SdRpCL7MpfP655Ct",
-	"Xp87E9iXC8Z+JEx5gt5I7GzD/pkeQ8wVRSxauvncz3G5X+ohndPO5nLFVRPd71SKPHvwPmn/f5RWRzri",
-	"UnFjULgG8DgSPruJxvWVzAyqok28ZSRsgSJeWAWqe3VilbmjAZyRzBmJlM248PnDAoIQXHj56uJsQCrQ",
-	"qdvCqUIWO6VmJEiroY016TTuqO00GpNXvN5QaPIIRhZdCrlMMPYd/nhij+axXiZX9M+Ya3sLDR6Tm9cx",
-	"blM3+qrQ3KFCQ7jdqM44ev2jKDMVTlkSevC0WuOY77g2BX+Jc/bU9ZwE4x64B5zlV0c17O/4Hzz+vdXD",
-	"kMZTx4yua9ROFni7L8GSvIW75Yg5D4DjkSiYAAW5aMOTBAjLaD9NHA3aMbTvV29fNvA0+wYuEdm1lKuo",
-	"OvtwmBvH3kbEvZf4Z7f0+Bb1e8I7IQ2QrWUN/y+4mCU5ck5WwOMmJD8NpFao0FVXczIO+qNsOHyEEEq6",
-	"KrZauY+b6LqBrKQh2t9eBMvfFtJe/1OCjvKOTzFaRQkGb4nf74JIXBavZ3v3gVgIK+4Vtdj1v7u99d+6",
-	"7BX3liZvOMVy5bmfTrmsknBAGEBBDkSB/kobaNnLlWY6fiFWFCdRCiBXeTon7OLvX0jVL/1GvlL0V4r+",
-	"StG5FcYRBVEz7b6b64mNKuip1xp3SebfQon8W/7yLMg61z2/kKrP/Wa+UvVXqv5K1YVxjoiioOpGUvZU",
-	"uRcpFxSck/QAPqQumA4mMl4NyCgCPkoL9UiUHXvcF4AJSzXqZ0B3KmawQCY0cBHjlAviAB+ZNkAzjYTy",
-	"b9vHw2ErblHzEC34xYU/8Vd+cWP84g9nt/nKYvZnMZ6OSsXBUT0r426gK1VA0slqTaPIYm6OXWhCYNXa",
-	"tB/Zca5SRTureOG/39uKulY+5YAZWGTy0uwHfP3VNn2HtukSzZoM1PbvVJOT3Msecw/heJtm4XBK6DpY",
-	"9wPLsMBl0al1nYzM/DiRM5cau8X1mZn5Oxp2Q1Ipn/+OnNbB+s1uVhrgKnthjPEzMPISreKhdYae7Z7c",
-	"PtuNFFL1P5aQ2/z96xdQAI6QBaPM1Rj6+ZdKwISPMj3Oo2GBEMH1npO5Tvbpw6ePtSgjM9MKZ+y4jZt7",
-	"XBOohyQ9QeGVvMRNh7H9axEoZrU+jaWfpLI5F97ZLBHM/D12bhiZ3uM2THpLF2ZWt44zP0gXMZEDzyLM",
-	"BJnaiKZxDqEKvHmx6U2AH6/l0G8H/sdqvYebvYdKZY6tMRR+GCR8g82WmQxh7GORWr8bQlN2ikJJV9dz",
-	"O828f/3ilRt607DJF9oKFyWvqKyFPeCP52/BPacwLnPlMzO3544oaYal6TrsaI0KoDJNZQCJuViGVQ+w",
-	"VqFV7hw3GlVVWWMvAVXD5ix7poPxOxAZdnELcl96ylI/5ZutNvgtZQWrhVXQHd5iTJJFY6SQHHDuduxt",
-	"MpihsBeDMdRKi1zAnLp0i903+tF/cObG39y1Vhf60rvNZ4O88mCp3t0Se8clFNJcoQu+t5flgqNuHd/O",
-	"/BOw2NNSSR/8H6AawX6DP3yji89qMKrkwqfK11vaJXdqSjTdaPjelopQNaAqtlQFzussSVxEfH5M6Ja1",
-	"k3qhOOqViYZUQqlG01c4Vajnuwnw3A+8OcrzK9xnfd9SE6n4kDKu7krN94DyO/Gcuwe+qGDP8XBKzO1G",
-	"TEcsRq9Cg1F8NkOF8dHWd8C5JIepawMfrPUMFlwYYPb5CIzCch/kAyxAGtGrH0l5ybeYhc+RxS7W6I0x",
-	"6QeRrOCvZWlDP8tfwU3TAyVdzJH9gKoCJSR2Kpvt0Wa1363XbntU2+gCTf+MptIwkWbuTkpzxsUkbi1X",
-	"Cwncn4It+fn+OoAftWOolJel5NIqMi8+voUo4ZbRMbdLsoSljHifFP3HwxOrNqkVzKW8BC2Jwfku34x6",
-	"3hYbWXIRyyXEUnxjYGZFrczI82UkuJc6SEE9cVfARZ7iQnYzmZlG43VJcQ4Ud/v+ya/D38KzQnMutMs7",
-	"IzOPCN610NtGcAP43qKTRX3/mSvxFCX2RRUP9qW6AAcDystfat0c3aaJXFZ5e2AB2CYEz4JhN3j95TKV",
-	"HNE6NChGwgINi5lh/vF1l1b9EpoUEldncAtNLt1i61Ikq6MtEeobE/e2SOH1y7p+KVyuUE1YbyWKT25g",
-	"Gy1RxaeN37py/ZNLNXHpnv4BpSOZYs+1wC8cMMQi8hEXF2/gEle37pR5nyWGpwn6ouhQlHFaU74JmMAC",
-	"lG6HweT1auJCRbBxjAm6ktpVDH9Jfy8v9e4ifGuecW5zMXS5HjsP9nMq+3d06569AOsb42Ll1PQdmA+4",
-	"RX8/v/daCI0/QxT23swmZ+738epfo4nmlUv/Rpcb3kMObSHi0yiRYosqfyZT7lVzn0xe2Q2KSK1S6qnn",
-	"DEcLZlDZQ12hmjDDF666n1N1lFw6nZh0aKas+ksc9pj+O+bxmgKeJZfAF6lUhrQiqyMzY5iDylxqFMF2",
-	"wOAiTUjpkoB2kMBlsvIT+LKDReagwn6q5CI19qmRmzrXDtGkbQeSlaD3x40WWTvJ/VYR7A7vTDt4u1Mj",
-	"uCr0hzyp9daZysU6iZZbpDK7vsydLmXK7UeTcD32uspzqnEbySThMeavZeFq3JEDsKLZrCs2hA0hcww5",
-	"Dd0SdP0M//yP/3QX5gsTF384OlQXijmbCakNj/QpRnO53eL2shz9yg6u5xdzZDF1Z/Ac421ZcqT/77ja",
-	"yj4qRZ+e7Cz61LDi/9M/K2Nc+m+3x7jcEEeyALojo6FbupkB2d/L8ICDo9me7P7kPZq5jH+Q5kWSyOUd",
-	"EOka7uUWSCLRmE+prJyheM51Z6CFkTN60JHBl7V/VpTb0WEtnbwcQzNxCar82DeoTf9XOWlPaO7DT6jN",
-	"v8nJpj3k4fUBs7LSNgT6NzkhQ2tKNrGlVJeoYMmTBGLF+HpGKJUN6g99IdwYF/IZeHCQHVT2ZUr1cVMl",
-	"I1dKx+tNXPT93/wizeC9YknGDLrY2PbA9Z+98JVxboQRhGvcEUdoaPxQ50Z3JQ5iP7ThKtN8FN2lP2CQ",
-	"lTs2c4V6LpNYFy69hptLFS54tujvJX0+uo/uhRD615QfOS9/eHu83BdsgVi6TgHgsr4RPAqNA7QC3xVp",
-	"wyhKU/Sp0Q5YlHuWx6DprdNU1Kv8j6edmk8aEd1/7toM03u2Lbafuy/fSG3OkWq5fMX4u8B46LqCTuAY",
-	"m71IMkwc3a0foNhHA7Mmr7xj1QWuF9+E+QDNb4jqEjux270zDkDvv9CHX/H7/uA3XeV9QPDy7boHhm+k",
-	"vOxA8e0P5BzHFS4w5u5xiZ8xyvZH9vNyild+hq9Y/6+uxwR4NXZ4VWRp3RXpBVs6zVG9mQYf5GXt1mix",
-	"ZhZ4UH/cXRpXPYyaybrpADl9U6Op47xJToTHrm5QYwGiD4I6WFBTk7PiK2odC1xAwuIYFUhl/9vNC3f1",
-	"RqLSwqeXN1HqbTSe6kHwT98W6GgkCm9D0TWFgnHC1ilUqqw8SNGqYyTsfrkvGMd8ntsALlywEs38d1S+",
-	"l3pQFimhCk4j4evaXqAxXMw0aINpikpDUOWW2VknCYLmn/t2vYStXJhPkbXq69DpiIm+K5nXUErptb2S",
-	"NdjeaCBI/YIN9Qtd1Q7Xet/ehb4nyl9zRS46XrhjQt4SU4LEx0aqMPaeG4nCwiVmK6DPgM1mCmeEXFTO",
-	"1AeacYqY9WFj3bzFxKPhSMRspXsQ+S5aJ4PBd8OjU2BXqNgMwXUY851m8rbOuRtM90aiPFkPjDQsIbdF",
-	"3itCu+A6h9wRU4pi8nLKHAnfpU8P4KNcWqy226XR/dQu77fRD+AVY2JYiNrlb30CVDvE/kQw3RD7a+0v",
-	"1gDHBVhwPSvAVfQ8+45ajtWlJtoP6jMTHw1vOf+wFgQ1OP6S8STHJ1frvAcyiYvswHtPdOEBAtQx/sCb",
-	"pCYE+hjJ44lCdhnLpWgkuJeo+JVriLfJkAovcMGx//kf/wkXEaNeQzDKhsOHT0eiLBtMxQgH8D0Tsbab",
-	"RVfb9K+RRQErYa9w7D2B+q8jMbeMXKHm+hSkSLjA5wpZNLf8/4H75vmwBzHOFIsx3vjR1VV4ftIbiZwM",
-	"n2eidlT0qAcWEM8rXz7quVZ841TJCcbPhbQieTASZ+78OluQh90lQpWQCUoouP6SIdT7BdS3U2/5xffF",
-	"Nd1kIEjtgltl030QS07Y76CRx8WGyzNCcQ3Qdch1nCPScY4tx/bn4xAFjmpIyipIAvXWSFO603f5wJvm",
-	"e8VCtY8C9xsomSRZeuthxS/K5DiX3Jon5t57LHoTcL7JCjwf4YlFJt/vcBM5XMuIvsvz2o0i5zT8zI/e",
-	"IbJfU31Ty4Eq9dudlj61Hy6luhwrnLoGFIxTQVOu4RJXZRHmBmFeTLCrSEGrTdkPIpOsKPXeSg0m3FbO",
-	"X589evTou0p/mZsv5tC2iMLJ8E6rKNTgRG2kPrUlCeD9ZVV/v3KDFtxgE+gaul7MuKs6qtaZqGEO9EQl",
-	"/3SjAuY1DTmFteaQviq7a/NILw/f49EXJB6MxKe8RHGXFEM0GB9b9QrjI6CJ7BMcP5NNKB6Atxhq99BZ",
-	"L0pM9vZSwdymu1gNkBrg3rigK1equdP/UQOaiIk/ymv6okAOiDE1c9BpwinROMmLVTU+qOkpu1PYXNCo",
-	"1kKG7D7UNdChOaHhrQqbX24en6SqvTxn2nBg/coj2/LI12Vz/dAKRHaWbsoooeyYLCl1erWRad8bWIj7",
-	"7NaePsn0tfuAehj/kVD7T6CnrEO/TlNh4jKPK88f+l/VlJt+tOgyh2CRQ76wWkLXLoFkm9xFhUW74pZU",
-	"eO5bzX6lwrugQgf9ZiqkBsdfqfBWHgtEafVU6BwGjVQ4R5aY+Taie+NG3CBiuRW2ebgvUF3xCIFrcBum",
-	"/M4nt3krwRZyQx5IBZlgV4y7Nv/b0s8Lu9gDsHfJ6d9k9IMuyxvtrV3NLqWkQQupYzEorriSYmHhdACH",
-	"Mmx2Z5qzPeWuxHaynd19JntTBBvlsM/9bbWITduWp55f+k3EuLxxuXR3l5vuQkN33PPd56PnYg26E+bU",
-	"TUsnPeBpD1KpTA/QRIOjW88SeeN3UiSWUeoWGXNCBtCQkW7PsX9gGaH18T98g7nfw4TWutYD9QgdFF/Y",
-	"p0NA2dXuj5z9fJ639YruQRr0DzLcRiHbyBebp+xtzQPMi9lTkE+QCzxnxqXWTBAod8nOuBPptqVOr2Pe",
-	"glk9WLC8Qn5WY+/8JGczUouCweOFjNHnPrJMoyZJ8tHK5k+UE63t60Ff8rSIqShLAulsoi2vFAYMjy4H",
-	"8MkPGSelJ4zClhKcUtltmUVzjHugJTVhXaztBlJuRUmWlo05E6YNKIykivN2OwO4Ohk8GgxrM6Izoqn3",
-	"AThulZhuRi4Fx7mjMMxdwimvrU8ofdt0+6aS/7xGkx8tWh8TtiEUeEnap/Z0qF27t+uRAWVIxvGca+oj",
-	"u6sRYpZaIvsrPYX/Si+Yvm+HT7OWM479jO75bjcfhDYP4BWL5kRxEUuNfXkWvfcTtkJFJQ7JSwHThM3c",
-	"r4ssMTz/nVTynNi2kZlXwN8XO3vjj3pbxPaF1oQnd2pMqAXdVtUvvHbn+OoHIVT3hdQ+WdTKxcQ3Omhq",
-	"3q8gbpce6R7FfaH4ffNWPNm1Kv1jN30/i/74ugdjZkCjObpf11mt9tOGO+6u8HObV9EUPxHGV7vDXoeF",
-	"9CE13S5MHVxDJhhV8sb4/rrm7H28RMN4svPpGdOwvE8vaYqFWWcTpPcMl/PyRUXZnfrdAwrFo7k3FbWz",
-	"VjATzWted/bPt854bkb9dMrdPdU86drvqgb2T3dfZmcr2rubg0XmEjucc5BjEuuDFV2ycxQE05xOoOSv",
-	"GBkd6gPTLEk2+GwkVZrZYUpmszkwMRJFP5CCP0KCQg9cnA6B9bOhPIC8HFjCDGozEkUwTjWkp4imJgB0",
-	"RZYklrejcDHII2FHC4yPBpBLBB+M6B+6FIIIaZJp+1yIpMJxGpmRqHragdmfU1RWsWEz7IEUSGUYFizp",
-	"wdAt6YZyPRJWYJT1tWGmZJb68mZs4SXQZAWXKDSzA1kiZ/kHq5HoZiL/+u8Yu8nzbCP7xKY6Y7kr5OWr",
-	"izM7tRjlH63gxcXZwHsqE7KVvfrp1fn/dN3Yi7fCsX38pxgfo8XEo95IaAsUblZ9ypDCmKalecY8tpP2",
-	"HIe1F6VkMuYxvbdcgfiRyO/Ccyu7x+Kau7hIzQqkmaNaco1HzqZgdUf7qX3KkGstmmN0CTIzaWasqKVr",
-	"BPycSiqV+8k/e3zYOCGYBfjEkojVu/7/J4++cycnSDlJzjXdVyaKbkauq/xgJM43cq6bw7fAuUu3PJvK",
-	"3Im7VIOM3EvHYSLObxG40fntAo/1s4Jq7KAAo5lyz8lFmlloUj1tuvspbeF+q0XlLb3D7e1cypHEp6Dr",
-	"Y+Ecn3pQQOdBCJsHHv/uY7DcvbLflHS8BmVLrBbSPVgwsQq4yBXHZZ0/cV14+YjNjdiLeitN/QOBGJ3r",
-	"PDF2YuK5s7A4LucCPnuQs8rJCnL2WaaWgu9SOuezef7vBcY8W+T/l8il/+dIZMI+FR3TTZg2Y2KG7hFp",
-	"ufwAPnFjefoaMUZygSNRGFa56C9wYcWAky+Orzoh8wyKPqi52LHsM/D39sDYRWDKrCidsOiSwtItW7fz",
-	"cM+Ec0lu181vx9E+KHRx6z7mlr62jKiOHVnBXvAjXGdH2hnYi0++qTCnkaDsukAYDZwIHueikXs7mSSr",
-	"it1cD1KFfTIm2aUp7WgfEbCF978mlGuI3rkF5v+effYiP69+P4Azn4bokxBPhsNfnuUeDjgZNrHpLca2",
-	"k7qcxJsXRPdboARXv02avK4mvq5rW1/lxXZ54ZpU5k8Oz5qTVR5oF4oR5aO4doqJHH2ahcRLKhMamXX0",
-	"vcSVzvOeg5fQmiyh9P4giElkiwkqkFNPqguWevpEFs1DaRIyVst0X5H+XHBvEpxzlivIE0QB/q0zGInv",
-	"6Urp/WQFasqjS7tq8Gmo1XJc7pnIsI8m/LqE8R+87HfTubbSfDHKIYF9vJQX667fv3zubYbFvWMC9NAo",
-	"ARuQH0HSaXELZp/csgUXyGtxNPKAT8ECclm6sFnMUspizmdQpxuVG3ojIexjIR8Se80272ttpai6Yokr",
-	"hEDqCsustEzYTI9Et3jtht70B86WkK/qsgVQWP0tDiMGSL2a8tnRAF5UC5Oz4ms6Ut7d3oHO2xp8YRMG",
-	"IksSsKcYk/GFGeh7vsMEkPXgoFIiVXq6yG/hT8UlilPVBV/mN+CVnrzleY7PX3lB50eHiSAVeI+ah0yF",
-	"KXwQBX3mJEnoV+J490VmpPub4Qm2eUK2K6pi3xaZwqL0yZdVVSkMkD3w9sdebufz1VMG8JKttKNMT8d+",
-	"ZbLJsIkm12vBoZRiq2fgnbQjwaIoW2RkVC0HxVQNw6W2w0z6VgVLprwGMBJ7lFGpon9DFZVbeA79yUqz",
-	"1IG1sTLLH6Umy71kJg6EgRjPSZywnhi0FFh+WctFypIZp2TE2dL6hOwshWsgKKrtgnYWLJpzgWqVh/xw",
-	"GfMIEilTyLTV17tlOGF/qhDh09nH/sQ+BUjlp74mDx8eUZdPTd4AI52WX0TzOeUjVwKceoV6TqF8iRnA",
-	"Wl3DkcgJdfOJENRsoZM3dTdxCF2OPiMw3Q6nuM7ajScPv21Vu/EWKtAQCM/pyhp6cFMQmPv9wMylry+T",
-	"4GVyy4HwLzxLcDoid0ABrovAeC5gmvDZfJ2lXaxENFdSyEyDFP0YF47cg1os5czVqMkGDhdzHVlFZ3Wq",
-	"MtHM3D6kKJzv7eLiTdGDks0YF/4ZR0fINFlrjQYfWx+PRMnUeq7uAtmsE6kx7ms0fsMTZqI5dKXuK0yQ",
-	"aexBRlkLI7HABRdT2YN42guyGWZoUEylirAHjPWdZb9nZSQuWZIcUfVH4qt2QeeI1D3IUo3KePuOe+GM",
-	"7fTwAGIUluUk5KslGA2kHv9f9u2VZAtBiQoFUIPSFz1Is0nC9dwuhlcozCTTA4rb8dDF2DFmXPDA3z4o",
-	"gD8ovOIjQQ0ugKbxTNm/w4gvl59sYcf5sqvzTHzlxIdoaBcE8rdiKmuVsxy+ngnDP//X//auGIrqjcF9",
-	"/5pFRv8xOfRGSee7Z9FPbrN6sItZKsvl0RVb3hdzlljFM0ge8bwOnK/y1lM/S2zUPgnUgm1pySy3FNsf",
-	"fFuXXcLkwwVMuZihShUXBgp+016k2Me53qInU0KXi9JhwooE6DojWB4OlMjZRMpLUHJ55Nhm3saG3LVv",
-	"3r8462s+E94ER01t7Ay+Q46vP6zhijP4dxSaDSD3ED8cPgyq/NLXPC7I1/2/0ZhMSRrrEkLPwLNoLsVI",
-	"JFTDkYt1L8FxpSCS3bqdRgjfs9vdhpcRYIUEPB5+53wBjCDRqBH4SkdSjYQv57OhzEOpy59vlmcPDXsk",
-	"SexhtwmRi4j9ywiP62MsFmrnmSvLFNfbCj3S+zxRwhKLwR7J46/y4o+p0hPz2E2/eTWu9UZo7vaBiYAX",
-	"V8oG+dnbsWCnMVq9dmfQTFGSIUxoChXjMDpzxq9QOJvDAD7KlCyQLmamTkmFbsBCLT8eiY8fLj5B4wuE",
-	"2k7ab/LeZIVr5GgwEo+Hj71eLqQZuz6VfApddlQ+QSiqn8xDPehOjsoIH/tL2MmSmnB2o+BTn448yQwU",
-	"MnUkyDcrDdHsCp2u5zimdMXZ7Y/uEVPOguSzsQKIsAFFTKa8dStLcE9brLCBMvoncKlsV63fUZgwVAd+",
-	"dabUKqfOCPrhHISE4EkilxZPN/KeWRzEYQfjp/aR0mwN5cJgkvCZxehjUlx0K5biykC6d6z7y4cLeBtM",
-	"Rp1cMTKk0uTZw5a4XBtmmaJV8FKp7Ks9ZdElm6HPIqCYG1J1RyIv4eOKGsBZprRU4OODubTsFGI0FNlc",
-	"xt+5uKaRmKzA5zr23FbHkYyxDOnpAVVePc6E4UnoRJG6H0KmgXrD875ysGtVD6XMv/zifMvyVJ0Gjenp",
-	"47YNYNeL0nogVSZGkS06pz93uGNXiVx2eh0XKtnpdeZ8ZjlVHlbZ+aX9YtdaAZfu89pmiwjpbrK21sM7",
-	"zYbdROOPVGG3ptePI/cvKsB7j6uSUtDKBh8LOV0z73QPxCIL/TC9LJyxDHIuQ5lJP3PGRWjQlmo0JStD",
-	"+HQkhFw7GZVZtQpQWqh6FEDsRAx0Cz1oJLYoQrChBx19GSul1jF/ihIsm6eq1Ym0KaIDvqo/depPETux",
-	"qfkQ9CivrYLbxReNmo/vsrWtxJnvMXaT1ef8EoQc2+IT83ZnZVHkEgT/HZ2PJg9VS8Kx0DUcVS/vCKZ7",
-	"8LdMGmZ1LHKpVENslNxRBPNcJjfbRupFvOCCVtlatUgmeA9KrllwNZZcm2Q8MX0uQHmYNXZXq8xSuYpT",
-	"Z0baXsOKoOXsrjdUmu0s00Yu7Dp3WqCt3MbWZDAaRVC/s2ptH4v7zTnZrZusiER4DIZdomiquhaVsNqF",
-	"oJv5yM68Ue265AJJt3EQ9+6vxEO4b24r+oJW245Ajo+6s5DnmJR2DTqb9OXkV4zMH6KJg7cJVIJ9fEkY",
-	"UPaNtMDykBN2ibFlV/lpqbZCVh9T6eOT5mif834O+5ieCeajpIIAqaLQQ/GqNxLOMZGs4jd3hxr4UGSn",
-	"dscD+N5qti6T9col+5Mb3YclMBFbsFBeMVMrZ77LTF9O+4r09iuWZEWuFTweDmtCoEMANdQ024q1N8Bw",
-	"Nxe65aoPTTuorzrmsaiqxf6BHoeeoDbdHHXFHFrQ004+6Xsq7cUnL9w3t3TpF3nXpw3IvUejeKTvyZvl",
-	"GnhhwKsW/mwPKnkc04TVXmnh3NiUe82vfh/eiXFppXUEBl2p4KXjvqUBd0klI1x3Pu/DOIKP7368oMk2",
-	"uHYgo8D3nP3xLb3fyy6zI4tB9tEgi89GHWDTqVQxnbeMWleWsfaN4ulgJN5zezM6ZJ3h095nkcCVSzlb",
-	"57IFsLZnmzi8XwPNTSL92lL/SprBh4sgAqTwxd2AbgDdPH9qrDGCR0+Hw8Hg6fDxt8NhDxQzOPa53ieD",
-	"wZMh9b00GJmxFGOKiqeaMywyMJEyQVdxoCyhOkvkhCUj4X88GsCrZo0iby5FYdzE8EciiOtwafMBRyjB",
-	"UtRGzc/mdItCGTEyBTml+EhKJTM8unQuDwlzafqKVB6vJYFAjCkJ9BA6KTSSOjq5fnVkfZVb1kVql/9T",
-	"KyLuGC31kVZUvF186SViuiU+WGBfTqewYCJjCdBoV0fZ+/FHnfNMgJDLqhzJI6KKHrquR+6rPOCrGiYL",
-	"v8qJc1UKCpJwfnzq+t4PpfF6v3aK442LWNwxM/D2An748d27wUi4HjF5nEY5ih4UP3z4BAr7eWyOjxRz",
-	"lYgY1WmK5v0s7VGEAAMKR47tF0EMXRl9FnaWHwk6TDFzIYrBV6aZcuVTvxzbOZAPFI70gkYu6Cpvgxpp",
-	"pa2NMwhPYq6pRN89aWbSjrSKgJ0aHCUUdXXJymqGFt1gHQ/riK7iNTpIbQwN3ZuaY/jrSLgaa4crjyPh",
-	"UfYA5XEkAu0RapTHSsviBq2xRsHcqjhuAqdzSw6ef0n1sep0uUUN0iqQ3z59XKM/PrR/21QPYU07HImW",
-	"6iGsa4cjsY96CBXtcCQK9dC5X/fXD1tSRKEiNlDE9WuJNQvdsqLYtIOvumKgK7Yi2TrJpSMmDpNYFxET",
-	"m5KKYqUDATUSB5o3rIAaiS82b1ChS/6Zar8432nOcpz5ub6UyDcaDEc1EgmL7fqu9mCaMEGFR8kH9F8e",
-	"n/rbyk3lTqFMZcKjFUx5gkcHleZwFF6C9yZlXbnKv5KMKy58PVq7pJzrE3IDeOeQaMEF5bhYtDt79+L9",
-	"x1cvqRDCSPz8pAcPv/12+ItLBS9EX1kn4WQ4/MX+MM9b0SvMK792XdlXd3uA0VxinrDpii04kXX0zLlk",
-	"rl1EKqR89XxRB7cN64mvxPN0qH1Xmz3popB8a3Rx/RIvWOCWJd36yvUSruvv9ehfUtbtRb6NAi8f2E8V",
-	"XnFcbhF9LO5LkazCOkFy6iL7wvr8ebGbogKNRfeRePgY5jJTGro/fPgEDGK16qtMFO/no1NfUjlTEGd5",
-	"IbIyOLAwshQLaCvYeo5WpRSoTV4dyte4GrsaV/R5brnw5pXCYpJhWfIqcZKPCQh6t3+h4MqrK3304L1h",
-	"ollfrl29pz+AxHr4eJ6XA1pDQMdr69G/Ee2vmOJssq0s7weBgMKold0T5OO9818bewDfh9cXAGeRyViS",
-	"UFmSKSqrf2rouuK3es5TDQupsIybKjQHkmLuFHaikcg06meQCTJBWsQmQWl1qoQUziPfisltL6hTPxLr",
-	"szvyyCNdiSYVj9HppRr970QcI0Epn7G2QM07i+RVQnMScVifKRwvnN8QFkxdcjEbCalmTPC/E770dYoR",
-	"n/LIaooRzmVixX6hroqu0iudyNlY4UIaHLsU3x5QttVqLEw6TqVMeuAKyIwNfqaSxMyMRJm+pOcyS2Jg",
-	"yZKtNDiM31ucVqj1pwItbphOi4W21/22+NAnNCgQNi+8P1kBhQnff9ItiiVGwXnKotB9g4s0sRKtPCPZ",
-	"HAsCsciXY+4WpfPHT6CQ8M0pYK/JZplj/IKl0PWFySzgCGFQGV9XepN09NEA8lpNBfm7L7uWFgMHgdUH",
-	"c5bgDnnka9M71dSd5/FwaL/nYuaIcjp1TaNH4hJXz8oTAv4tY0le73p9WzRxrCRVbLX04FVUvsCtjkHf",
-	"6YBeb8zMwZljfIGRkI+Vra5RzSqY5/PxfSFJJvYXjRXdtUpsN6O+5mt8KNHn9jXZhk1sVvcMKrhU8NY1",
-	"+GS6tDn8uTXcc0fGVdlV0GDACgLpnmnKpGiOOPqRBtzgVdMCu7pp20H3ILTbQqsxtDvzkGoKmA0+3tZN",
-	"uwT49dO2nftOg7XtBnbe8z3opi1VYYYLG0jdKd6VsdY1Mdt2xC7c2wzWJpRt2a7RXs19bNd4+5UoLY62",
-	"687Y5lZ2d2e8W8gPb5X479dt5v0J29zjRq5OSVw+bYdpzWdie9oOwciOfuEG/3FbFOYncQfZS97UEDsl",
-	"rjgA3oFkyB80yqXPrGGJOyE5jhK0D5CdCEO5Mx4dtqJMJvZCmh/z4V/RJkAbhQt5hTF0eV5eyhxtqM52",
-	"SH6FVFz74Eu8sq8Nd+Qmjv6TH3KDzNYvsY3f+iGwQMNiZlhZySjGNJEr6rdKcMIoo6IPpz//EkLt+4wn",
-	"cX7ecpouE1KsFtLlkdL36ipHxLUMVhmxBGIk0vP9XTOVdE47c2NSfXp8nNgRlIL87ePHjzq///L7/wkA",
-	"AP//",
+	"7L1pkxu3liD6V05wJsKsJ5JFrc8uhaJD1jJWt2Spq2TfN8/04wUzD0m4kkBeAFkl3mu/mE/9AzrmF/Yv",
+	"mcABciWSTFK1yVdfHHIRieXg7DjLP3qRXKVSoDC6d/KPnkKdSqGR/ud7Fp/i3zLUxv5fJIVBQf9kaZrw",
+	"iBkuxfFvWgr7Nx0tccXsv/67wnnvpPffjsupj92v+viVUlK9EheYyBR7f/zxx6AXo44UT+1kvZPezyzh",
+	"Mc08gJQtuPD/lgp4jKtUGhTRGtDO0/tj0HuHZinjH6V5niTyEuOb2+lflBQL+OHjxw+wok307Bj/uZ39",
+	"eWT4BTdr++9UyRSV4Q6wS6nNlNNe51KtmOmd9LKMx71BT2RJwmYJ9k6MynDQM+sUeyc9bRQXC3vg8Gcb",
+	"w2QUZUphPGWmNj5mBoeGrzD0kcYLVH7HKLJV7+SXHhdz2Rv0EnnZG/RWGPNs1Rv0lnyx7A16keKGRyzp",
+	"/RqaTWYqwupcLEFl7MKKCc0iAuSgx4XBJOELFJHdFctibgetpOBG0mTB2bPViina6sZvhpsEA7/8Megp",
+	"/FvGlcWTX3oEOb/LyuHz7+tALPcgZ79hZOw6+Q1/YAsM3DKPYxTTSGYOF1dc8JUFxLiYyh59gYTI3OCK",
+	"Piv+sQ07C9z6o5iLKcXo/wV+MtMoU1oqO80OjGrChFYf1DcfPHu84uJUJqhPPc/YhICyP3c+k53slTAq",
+	"cKjGJt28wV0Rhm1shEXnQl4mGC+2U8RO6qtNNFsfRMFEBVP35wDyzmQcxupIITN7UnSMcZZOzzE8Y8z1",
+	"imv9mTApZzkQIHeVHSrUMrn4TOgUkxwIHJUl6IFz3fyaJ5YFH7zT4vtMGJ4cDjFtmKmLDcvsSDRUqK9X",
+	"LtgrodyroGPwkIYtHEeIY27lD0s+1DjF5gdNFtMmXAa9LI33JNCQQCpJtsYqggLKgaqDoLLzvOVzjNZR",
+	"ghWlrq7SvE8dSMDyIJhLBR/en32EJP8QUMSp5MLoEXjgA4siTI0GJkDmnxMCPAWWJP5nYKCQaSloUrNE",
+	"ICkPMRrGk1Fv0BQcNJiEJvv0FsXCLHsnDx4/CVzoZyHbH22w0mGRvqeQJmF0PRI6eMsWpq8uvOrblIDu",
+	"jv8RkmlGKs9iOghAO7hVeEVSKUxI325jWu7O22mwtnB5uOtl9JFU8d4fxQ6odYRoYyDF5VtWZVXOrhAv",
+	"xudA381AK2KhA8Np3NmgV2jmlcvuwGMK7Lsa4imReTcFNdkY+1uG4H5+CinTGpiGf3F/eAZGwhxNtCRG",
+	"ZGeylmY3bhFSlat7CQPGLN/KBRcVvluHjDRpg9c9GVhzofJ/G5dsT3UpVRxikpVP74dYpkYl2Ar3/rQB",
+	"gGKeym52AKDNUrBiQuupkecYZlIK5wr1cssIu5vdSGWW77DYRvNAtV001/QrtB3w3evnr4SSSdJ+yFTJ",
+	"C665FFwsppniu+lz44stq/+Mis/XV4hjjb3YCVqXxw+orNZl2WE7AHiMwgQ9Ii2yguspE1KsVzKrMteZ",
+	"lAkyQXghO1v6NLQxZ+hAaXmUfTj7xpL+rPUJ2yHYDjZceYF5qPXTAqQ6J+gAwQrBuz35qdsO9cFzhRdL",
+	"JhbYipokV4SZ1ljadhYm8LL78MZRNpZrTNd2mlPHDlqPsYtFNZ0YteGhRV8wgwup1s4psrFeTei1Ikcn",
+	"i6OcKLgPKQR6h9P3Ctl5LC9F4Bpz43JDIGdCIYuWVrTCPYgslkeZtemmc8aTTKGeZOPxw+hhb1AiMxfm",
+	"yaNeyFUW40Kx2Pl66wt1Wgaf3e+4jj9mfY0t83bcv7D62TRVchY6g5BADpGEX6BArUHJS8BPXBvdbXop",
+	"Ei5wf+A8G3eZvykV3GKVS6l4GTwIGyfehWIvlhidn6LOkgCRkeO/UIXrBzRROrXauszMwJ6QZpRiqnCe",
+	"aYwHMGNCoJquuF4xEy3pVcF+RJM+Bav+gRSgM9IDuvgqLOPwcOUJN+uptcizTfLsfZDaDJdrbVCh5hrc",
+	"OOhrtkK4YEmGpI2mqLiMeQSJlClcyiyJ4VJxg0eW53p/SHGRliWL+v+dCwvxkOfDQX9PEyefOix7vcQi",
+	"oE9XgVOPLTg9fu3GpepJNuauHqAd7jtxS4o5X7TzrqnGKHB5dmWw21YXLCEfRpWlWXLVMMNEXtIlmqVl",
+	"7DKJof9kPBp9++TReHw0gpc4Z1li4P6DMfQfrOyNrtgn9yRAYwblE8GT8TbG13mXzT1ecrPcyhjDO344",
+	"HkP/8UE7lpei827dHpmxZMlm8gI7QfNbu7mH40N2t2L2fwQTEU4XiZyFZNdfliiAqB8IAR1lGh6da5hl",
+	"xv1Rg+fausTyCqFU1wkDA5Xm2mBsWVQcggoXUJml5ZqeWFA8Ga+ORvCjNLBGAywzckivoBg/BaNYdI5x",
+	"4YVLUQ3t/LW5dcLpQWxPYDpJcPWo+WwcPu139rD3D8JKxQxOE77iAR/oO/bJbsMriXB29kNFlGiIM8sc",
+	"YZ4gGtCXiKmG/v3R6MF4XNvIg9o27od24UVVK0YMHb59fPFh6AQX+C8sMmiMpIjd2g/rSz/cuXKFeU0L",
+	"8trcw4vyNnImbtncXCosr++//uM/q7zQ7ud+fT/3d+wnqFEQVBocb1Bn0xXusklidfC2HbmGCkF+0E2g",
+	"tNtuUSFwtvklAiKK2D1huj7k66bN4/5cmXPXwc4KRaZ+oIRp4zQ5r0o0yMdyE4WRpR0aNdSGKUOo6zUs",
+	"8tgT+5lzpQ3x0qrmuddjUfXK/DvR5p641e90Qcf2eFMHkVHgykMc3B24eMrvoIW7LzzZHPClV0L3+pKe",
+	"g6YUXUGO9T0+3nQ8FecN7yh8wtY9BG8qiIMKyXPCkheJFO1OA66nHpdDPFydg1lyDZGdA5gmdNNW/V6B",
+	"/wz6UiRrq3vzGC6tlNeRTPGZG3UURIPcV1JfzkskDUbCN86SdS57sOOdagV92srRN24pueLGkLG0p++W",
+	"9lh9HHXb7blX9PC7rv3EvzbUN37qb7x6fJpmsO/rbwN93C53XC+FM7TeL8vMcuoDq6rH1Uv/Nlpx38yk",
+	"WQaP3nCRVGB9f/zg0SDocKxgVTsC7HlrVVdVwDDjF5Zm2qI0Kr+TkypdKqbD/rzPxI69n/yv6iXB7duD",
+	"t+ZnrKLBdnx6y7XZIoeLcd2foMq5yxeDHV7f6jLbt7vlLeQqMP+QYKH8m3D8xy7iOtQ5zXVFcG9SXFeK",
+	"vHVa8PcznXFTfS6oimc/IpKrlX+kb51lzsUCVar4jnGtL/H7B6Ps/RzQjWprV1i97iB9ZNrI1alMcId4",
+	"aOfsXfixu+KUGYPKCsL/7xc2/Puv9j/j4XfTX/9xf/Dk4R//PQSizo9DKy7euB/v73wpavjgd78YlWBq",
+	"ZyMHPQ/Q/cwynpgpF2GCu6rnsY1DV1feDYKXXEfyAlWrSy9Gg5GZSjElM8Mq/IZFZquHh8KdjlnKjy/u",
+	"H3t3VGbkEMXfMsxQAyNvxSjOF4ff5Kzwpgi8pJ9LG9lkSnCxgAfj+yOgdeYs0TgohpIjeA3MuP8bST3N",
+	"5ybahR9/evu2YjFZ0RRnCSpIyQNllriCLCWPmQB7fGakgiihX09xqDIBxW6DOm3ulWn3Q9CZIhZTvNd/",
+	"/a//7aHwjS5nhhlGcoUa4gxB2nFCXvaPYNh2LvwUIcbaaekrJta5R2NEbqzR6Mn40bfjcenuIc8O9B88",
+	"WtacC25YxcFgv74CX18d2A2fX4EOQloE0MBETF/Yww6dGIWF/c8Ml+wCKfyEz6EFJYFrhxfB+9nlrNpE",
+	"SJ1vMIYUVeUY9gTkoXlc86Q9eDyC72Um6DoyEaOl4OESVQxSAPPOLrO0WMqNdji5caOar7LEMIEy08m6",
+	"ekePx/t5gGoY2XDRtFF1Z+dNg298ruemyYb2cNtsfHqQz6aY5ewSMd0SROBRIuTmy4QBOQ9iUlp6pteO",
+	"WMnpOYL/F5W0iMu8Ba0NsnhN71oIfaQZiHGwRNEvJbbQu5tDKlylZk0EvSU5ogGX4iQhcLyKlrJVaVih",
+	"1j40bcMU3Mdcyedp30C7bh9zM8ULFG0R74eEVGK0lNjhtd+P25gzeA4H5Y+ozb/K2TYy2bm93+Ss22Eb",
+	"2/XfddtuLV0r/Gwc2nx803GshSmTmyVRwtF5zlBdoLKqj0x4ZDkofrL6aUu4/jJbMTGtoHTg+daoddvz",
+	"7Qazia34ybX08tPmQpvAbyIZgTp4RxcsyZhBiotuJVIdSZWTaP6AMN6LQbgZgjv4FGGhETcw5FPKFerP",
+	"yvXYkshycOhWEQkf+IkguPebfv5VRzNf4QXHy6mQpg3L7O+fnSXjJ7mOLJniJaMMoPAwsKZqmip54ZNI",
+	"LJ74f17Ic/qXw4tQMknIoskxoNxRcYXFRhp30LjIrWj7locoBvOfu7u2SkLYZahVJt+6tVZ6rhNWS8IJ",
+	"DVr7B6IVMqHBeQm87VPex6H41U5GrajTDE9p3ugOeFiM3gRHTkctgPCEoIDGdUpYeW01qRdylSbcKr9n",
+	"VgMLPNzp4u+NpQUCCqPWZCw05gEuIGFxjAqkilE9hb+jkkN603G6ngYuoiRzkV8F7gXynYu3qJZ3q5pM",
+	"LCPIBD0huU3RqxNThtMvK6lNsq79WP13eyxUU1z4JKrKLkM3u5VKPHB/3X09HxWKOOCtYOuddxOztQuT",
+	"0IKleimNHoBMYtTGvaS2XwC7WExJKk7TqHoHIlvN3BUUL+suiiV4TbG/pRoJhkTGnPHE/jM4S+sCDZD6",
+	"yetbzz8v19jY+t53R6BvvbkfpDavfQTbBlz9JqbEGvZ5qe2uKTQ2WwqYwNqth3jrY0kD7KgRi9ph77Wo",
+	"wA7jc0LsOnq/+bfEEIZjIztEoxLMTimIwYWu68/NZqIZP1bKHuz0j7Zm+bnNZQnuxMo62+1ys/uLwsBa",
+	"rZs+i5j4d2tUbm659E102qYQnr3six5+nXKOLZuVIdimTGt73rkqMyobHlM3AiyMNBxD338C98AD6whY",
+	"pKTWlCDr/KMwHo3uj2rqjcwc3m6waiMNS6bojKlc69vi0nEcwjlmlLzUcLlERelxlAbhI5G5dolyUtE2",
+	"RwfEgm/AJrTXVoB/lOlrB58fcgnx2RRXZd6fSXHl9iztXc32qlT8udur8JZNNwcxsek5F7UXZedB1Yii",
+	"iNtxI+NKtnnxp19vxuA9LIG3Y5GEDrahRWLP1ywUznmaOjuw4dbY1wosjL/qZezOqv0BWWKWW175ZlMf",
+	"1lZzAFbeDzaPuKQ519WkjdDlXqDS4cfDgPJLR6ttppwgeC6pK0pxnukUQN3KL3Ue928oNIOIGZbIBeTj",
+	"nkIm/L/53/PIJrPEYmDC/LsZMejRDvW1S7ie43odRxNDPERyFYAoV6wqwW7e3ZB+rdgKL6U6b1UbAmFi",
+	"VmismCUEMNK9AszzeXzgdl2Y5BJk8/zFd23kWgHn5+7CTjVqV3QKzai+zo8kaFuFZ9sORt2Ss2pWWH1h",
+	"f/LjcnPANDBr+llNlC3sDjIRu9WlQIgx4iuWPIWxw/PKl1zDeAQf5CUqXYT6Jyg00A5AOqr4mePlkGmI",
+	"ljzVtSPME0mZNg31o4GVteuswTWMpuXx90DVLRnFxfrdJW8bPQSqDMgLVCxJDp6xDViWV+Zz74bDW9yW",
+	"U50zOzwUAgXvDdWqyJKD57XKTWhOHTFBz7b4yXSZ0VoNL/zwet237nuxIDzzH26+FlT2U84/qEI2h0S3",
+	"yzort9jyCtWBUVynEOrAhEie7Mt/3EfEerqZMrl6dc2yM8iJGppdPv1+PIqQfA+l5UUXdcV7Kkbh12Bh",
+	"lEymPA6affQj8FgXQUnF40Ipqp66Z3fIRIJaw78UPzyzd7fgF0hrdy9p0wg1q2/qNSV5aBSG4ofkvKaO",
+	"Vcbm29qlskEOREuxIEWyHgC5dEAbqTCGaInROcjMpJkJApFyWGjUNdkZdQicuW3lAzbOaTkQ5DWIQEgR",
+	"VkvbUosbWo8HsN2qk/Jcu0AMckQMSDcbgEf/gaukehRcsKh0FsZh+vkpzFmSaJix6NyyBQ+hA/TuVhdT",
+	"XuysHi1Y0YcrhdFKK6tCJ5sXvpuwz3zQVChmIB8zveF3C29YVgKdtsTrVTM65wlb5BpfHg1mtdnt8YAr",
+	"LrLgi9ELnxtpVUrtX4ncN4UkyIRGdG9CofoHn8yUxC4L6t9JUqIPnWXJKNSuunVYozn4NbCIiJuisAMD",
+	"QVEfc7p0UVjgBxIog2Ar50xZpoNTqgyrRJ9H5cVcp8xES4onNMsivXR4yWOEfsy1W1oqcHFt1bsN5Slt",
+	"KDjN0wZ2O9jE6wAqBDCwAyndeXXo7mkhu6F6Fe+IrHhJ7PqQeDVPgJXr2aGchp3f3V8Pqy+H+7lNDnsy",
+	"pDs6NHOhJSfN8oeEradtiVab4YDigisp8hyTasmv0PwLJbP00KwXyw8OTIrj6ZTFsfLPko1d7kqok8rU",
+	"YsSePH788PHOjHtf/LVA7l2gaSq62/Lddr/b+uSYyrnbUOglxRZuC7osefUh9nBhC/tkqA4fV1Pgkspz",
+	"MkuS9/PeyS+7Zygeof/4ddAq84WEovCRq39ghT9p9yoTwBaMC21KrXa0gaQhyDfEmz99G/RfM55g/Pmm",
+	"XUXN32rSWb10W3jMnbT5vkwb6o6ZNGEjZrvtUkeY3Ti8rT7/3u69CmkEcMK99ra+IxSv0s/fvs3fwp1T",
+	"PUdcb6dKbYYFgg7nPDGoBpAqHFIayNEhj9P1ve1y6L3lnTTYIvRo+9tJ4HHimf2C8obyOQrchn7ENA65",
+	"0Eg1FC7wqOPjwleFeotbb+Outt39G4OrQBidipbcYGR82M1O7chRaqq4zLla56o4gxYhv4+8DYr8LcK3",
+	"aXAHH8D63tcWMSEwPgoI4DuRfd7UmndpydenFh+cGF/Tj8NOzIoX5TBXyN1W5epZfat6tk7F+dJMRjwc",
+	"HlJP52zFk3Un+pZ6WomS2Dk8TZix25q64sBzjqrbd97a6WDR7DZhrr8uQNjW8ceoE942HtyutxQhxJ31",
+	"loKn77Ls22OIa3gfyhbdqFwXvjKi23oZ091U2iy6dSCx22mKypoOci0fNTdcDQ/7rD2Ubb023efdislW",
+	"vY87Sp7aVbrfzMZwX/GqdbziFzzBBe6zRvCbHQu1VJj9vHqwWi/32Hdz9NYdh2OydxZqtRT2rrzc9oyi",
+	"Nqe9RTl4BuTS9oU5n7rMengGCnW2wt3u8nz21h0WCPwD16a9PLfT/YgsOjNaxxYqOZ07yWlPRjIn+22a",
+	"sLUTPUXUo9ee9bJXwVELg+tMemy3CW6cS8jzLfCrFQLECy4zfeXb2q0EFJyj615D9Zl3s3tL6d1W2B76",
+	"WsH/wH12pq5tFQ3M3mFPLcQb0JOuIEMn32DbWbeUCWgYmnU2h6PFCD59+2T65NEAmB1LVHTN1uhXk+7a",
+	"TbpbNXYaNS25NkrCm5cwV3IFx2iiY6mHChNkGqFPOKiWmAwgm2XCZANQMjpfDyBCYaQeAEtWLOEi+zSA",
+	"GGeciQHIFIXONA4TZOkAdIL66CkomSRZCm4n0LeTwu/+G/gd7AfwO7Ak5YL+oaIl/A4Lu4yE30GaJaoj",
+	"eP/j2//p7M43L+HSGpqr1OQZxanCYVEoZQRnKUa+GigFSwzLoicX90cPR2N4/mL44MGoIwyvwAQMEHg+",
+	"8gST77ps5J/PSKxGhm4+s2bKle/wdaUC1Z5YkgyjREbnkA/Og6cSZlAbIA8cGozJYdGfc8H10lU7GgLV",
+	"Nab/OfJY5rweVe8YNZjgK9SGrVINbKZRmC1otWF1tQXJVLfStmf3JJKJ1t2NDg6gcRVKqojf7HZhfwf/",
+	"+zao1h5yNnYXiNxhIljKlsdXBIeD6t3WLqvc5QagWjGZeNEbMZehIr06S+iWGRQ8zJ5nBHlh69xvO3U8",
+	"bcrFXIKx25+ISCbZSgznUg3dP7exv9FEbPTiZGnK1ErWYqV26577u8plklDi0H79jbk+n84V4nQx66be",
+	"0hfuMWivTzKNcecv5lzhJUuSqUZ1wUNxevmIGH6HbH4Jv4OY041p+B14WvyTqKMLSZZLFv6B3d/8Le4m",
+	"tfax8ap60s6Jz1EJTKb7jvdqyD6f7COkV7iasgvGadR01fHS7VcOsbp+8Rn6V1D1Go1GYX3q2GlTx1aX",
+	"Onaa1LGl0GOnRR17HYoKom/oUFeuL3VsfEojpwk/x67DO6OR1NNUoTHrvT7ZB4XK4dN55lKIru15QCPp",
+	"2a29p16JuVQRFwv4HfI+jRdWlX6Zh5Z6PgN8DkIaqy5rV5Ns99qXLN0L61ut5ZoAaBOUP5Fiemdj63ZE",
+	"rX2W/fmnD5fbuPA3wmCS8AWKCNuq/O5ZvbYeec3iC2tra2oCPOWV5axePVsDmxs7LO8IN88SOM3EC+qF",
+	"3n84bu3BdH+5tSvRw+svUZtvc0dnqj06IZUz1ovKcqGN60nl2yBVenON92qJtEcZ2I7FXjcx6HPrvQZw",
+	"co+Sr6GvD6r6Wp2opeP79ZWwdDV499TUXc3TvOBmIzAskRpjMOyTFHK1PgFygDiFY5Sy6JwtcOR9Er07",
+	"XIaiGr6YPwtYW6w36CWUbbPCmGfUgoAvltX3gX3rSlSgWQsdrG67flGdsOhKOrdv4ubuBu6HdF7fdaKz",
+	"/IWmSReHGJr7oFieVLGLsBp5kgrRmukrZ8rXpBG9mYzyeakG+6poakXHkWp0li+7q0JriUa6/GSn+vWW",
+	"Ryi0g+oWLkqdCVC1liq+gjKrc2Qmf6nu7tPkYrpQLMKp67HatViKb1ZhlTdGb3Z5QdBBT8hp4oBCuVJU",
+	"Bzv4wmh4/bV1rtB+IlMUl8xEy2maUNIiWomXKq4xOE1G1ZVShReNXkFtL3K0biUpsgDclvvd0UbeH3j6",
+	"26XZ7eitDu6wZOtD343hTMs0JQ7pqbvlIPKYrgbbBR14qooexxsjLhk1jvis7TaZZr735vqhmynb+bdF",
+	"N1TyIDb1CiYWqFp79h/YmSTHpgUz2LW1eSXAvp4+XG5x+/H1KS64NtveoQ+owFHv7B5gVm1NVrZN2ryz",
+	"UD0PuU/A/6lMsGWqcHEiVyqjuvd8ySCQZcIjjvoUE8nidvjKzFBvkXZx2s79WyRgMWXrvtYvMeKa6vi2",
+	"N9g5SHveXbfd7y5cHsk9KLS2fdp8meleCzkMpF590Y0ltpZDLlHoy+9PVMfr6j5CJ/ePk+Fu43m6/3TF",
+	"Q+UbT3FIj1ZFw+S+T8A+KjJliilcx+i+q+r03ZhSSqh59tEIXiRslSL1k5bwy+MBPPj22/GvvXB4h8+O",
+	"OGhHRY9q2lqe0FLdGbWVgQdj16loXQ6acxFzsdhvt60RgO+YNqhAX3ITLQtgsZilVEy88FpUuzG5V8O6",
+	"+2QzJ38E78UwxpU9kwWFBkbHYvN5Xu9ue+PvnR6d7Q6dQJWAfqVMAMU8hpuWNutNHI50zZlqN/x/j8FI",
+	"+Pa7/W6yVibj8J3Vpqlt6wFt69Ge2/LVOg7fkJ+gtpXHtJUne26lS/8nXaKH6/n0ZKwbfZ+aa94fwP1x",
+	"y5I+LPGw09PT+jBKmNZ8zjHOK9x2PnJLPG5jW02WFUSlxkW20cKgt/GHQ7yNJcv/XC9jRXjs4V2sfnWQ",
+	"V9FOcJq5Gs1xW5Hm/TxibfEa9IPKhB7xGJ49A5qbuum5/zdlPVs9KuMpdvteNgz4jWZRrT1o80UKe7k8",
+	"cBu08jJBH1RLu4dZFp2jCVDRg0fg40MHVEvNUu1SZsq99wp5+ZR66UXVSs4aLpdSI/gCOm7pmAJPfM4y",
+	"F9pKA9erTWZqSyWPDLflnNuPp3I+1xhgOz/ITOlio9Afw7NcKbFyyX571Ovw9FcuMajsZ3c1DjdayMvQ",
+	"1raDacl00ZEsZVpjTBV2iHdSxnciF0cHVC06k1KgNsE1fbVvIcWwWpWJbrQWlFQvcaQBP3F9eJUjj72/",
+	"yZneQn9uJf/Ik6yhqJDeWnd93xnzUus7ESK/1PrWG+sOCpJqo8mfmeIWMO8vUCkeh2p1y+pPnW3K+nnz",
+	"ZajJO1VE9JPCBUsyHMGHnz6CwjRhEboQrTk1t2HpTgdtub1dZ9yS3H+RDwkl4qs008PMYn8xDLRUvs9f",
+	"HpfZ0kyENF49LaoHtGT5R7SKr4OvcI4KBUUhWFjky4aNEZJWmcJpqN3+e7Vggv+dXraGOsWIz3kEBOel",
+	"TKyZkXf4twsVPVH1UmZJDCy5ZGvt++wE9eVKu+n6wudUcZqsviEXxSpcABJIKM9fZoZasforDMmo1ihy",
+	"/1GMLaatLyChw+XKqiCm6n881gN/q3uV9iD8DYSR0CGtGUUDoF8gPHEvjWYAmNtTHjhHO9MlPK6VDaLd",
+	"6jVgDBo4V4FEA1n2ruRUUkno0580qh3lnHDlnUBbqh89HITrXFMT9+2ffnuNXfcrDbvdKSq7aoPG1g77",
+	"e8eMF8A79JnWJcb6TXdIT72NNukbYG6FrUzwudZ80d5MTcmieM4+N51/1ray3p5vbU/Q3W1cQ5Nd9Oem",
+	"Du3rZ+dfbN+VZcRxkWBZ51Vvzt4Pv30yvk/cOi5j8MMldVdB4/r5bGalhEUPWHCKKHfm4GZcVyBs+39I",
+	"MFIm0ZJxUQTCW84444KpNYVXkighqdELBq4KzQJseDXDOMYYXAMEFAsuEFaS1MZ8ob47NxdzeRQMb8if",
+	"HkOt6FD8hdRhjasLVNBP4nnCFnrIheuPuJupl9PnxyAgFbAeVC8v0FGUnmtDwfBnVIZ6DJcsOediMdTn",
+	"mKCRAnSm5sy3JzdLhQgo4lRyYbSzhvATqog76TQRc5mJ2KV8aMOic+hXwmUGwGNcpdKgiNYDoJ69vlAu",
+	"oG8xe+RC5X09qQrQ+n6LR5UGGCe98ej+aDxkSbpko/v5BbCU9056D0fj0UNivWZJeJ33n6eXZx9NsgiZ",
+	"YafUX74s769lpiKE0++fv/BFkzCGTPgMDEX9rIAiR/RoIl6wJEH1DYVz5X5tquhNAp3b+6f5NFA9Kj7L",
+	"DD6FJUlkZ6lNhMJUKqNhKS9dE3dS/V2NLD+73Q3oLE0VkrWlJf3+05uJcCW7yDE86f0IF1xzq08fwzu/",
+	"zKTnY49Zyoc5OBzgnVrHpXgTW2JD8zyHFvl82AoN8axf/tHjFlZ/y1z/e8e3e+5ovhDqitUe/BOkDKSK",
+	"B8KXQs3DMaw+YnGiltcadDC0LF6pV7yx/OHxQuHFKsEexVo7E1pb9s1FA2Zd5GXbbNTY88pm86FE1ek6",
+	"fpk7+coPCwPg8Xiv8MVfy5RrIuQH47F3+RkfocfSNOER4e3xb/4Rrlx3m1DN0ZsCtIhBNoSV/x1SGjDo",
+	"PXKLh+YsNnn8PYtzVYM+eXhl+6334w5tWEixXslMe1ZBMqSoc9X7STjncXGuOWIM/Z9+fPP+RzKugOhU",
+	"w72aqxDuQZVS4Z7j3nAPSko9oqUKLhuvuDj2sQUnLjKCdA1fF7POaD5IbZ7bL2qhK2UP3+9lvL4yGAYj",
+	"cv6oy1pfJuna8C4cohO4Txrh1wAXWQJ9HzdNaZDrFGPwRUaOGrf9Uq2HKhNAASrMIDD41798BH8rhV1N",
+	"ocYJlQ3kJnCLqY8oOFEUUtDhGusxCL1rBGRLtEMAkh9QDS20wJ0CimCFmyZRpyH4Mpfu1T+HbP363JnA",
+	"Wi4Y+5Ew5wl6J7HzDXszPYaYK4pYtHTzaZjj8rDUQ3onvc3liqsmut+pFHn24N+k/f9RWh3piJeKG4MC",
+	"ZmunEPrsJho3VDIzqKxipLl2bSvYCkW8sgpU/+K+VeaORvCCZM5EpGzBhc8fFlAJwYWXr85ejEgFOnFb",
+	"OFHIYqfUTARpNbSxNp3GHbWbRmPyitcbCk0ewciicyEvE4x9hz+e2KN5rJeJa4Iec21voeXF5Pp1jJvU",
+	"jb4qNLeo0BBut6ozjl6/FGWmxilLQq+YVg2O+ZZrU/CXOGdPfc9JMB6AM+AsvzoKsL/jf/D4j06GIY2n",
+	"jhl916idPPB2X4IleQt3yxFzHgDHE1EwAQpy0YYnCRCW0X7aOBp0Y2jfr9+8bOFp1gYuEdn32q+qOvtw",
+	"mGvH3lbEvZP4Z7f06Ab1e8I7IQ2Qr6WB/2dcLJIcOWdr4HEbkp9UpFZVoauv5mQcDCfZePwQoSrp6thq",
+	"5T5uousGspKGaH97Xln+ppD26k0JOspbPsdoHSVYsSX+uA0icVm8nu3dBWIhrLhT1GLX/+7m1n/jslec",
+	"LU2v4RTLled+OuWyTsIVwgAKciAK9FfaQsterrTT8XOxpjiJUgC5ytM5YRd//0yqfuk38pWiv1L0V4rO",
+	"vTCOKIiaaff9XE9sVUFPvNa4SzL/XpXIv+eWZ0HWue75mVR96jfzlaq/UvVXqi6cc0QUBVW3krKnyr1I",
+	"uaDgnKRH8D51wXQwk/F6RE4R8FFaqCei7NjjvgBMWKpRPwW6U7GAFTKhgYsY51wQB/jAtAGaaSKUt20f",
+	"jceduEXAEC34xZk/8Vd+cW384ovz23xlMfuzGE9HpeLgqJ6VcTfQl6pC0sm6oVFkMTfHLjSh4tXa9B/Z",
+	"ca5SRTevePF+v7cXtVE+5YAZWGTy0uwHfP3VN32LvukSzdoc1PbvVJOTnpc95h7C8TbdwtUpoe9gPax4",
+	"hgVeFp1am2RklseJXLjU2C1Pn5lZvqVh1ySV8vlv6dG6sn77MysNcJW9MMb4KRh5jlbx0DpDz3bv3zzb",
+	"jRRS9T+W0LP5u9fPoQAcIQtGmasx9MuvtYAJH2V6nEfDAiGC6z0nc53s4/uPH4IoIzPTCWfsuI2bexQI",
+	"1EOSnqDwQp7j5oOx/WsRKGa1Po3lO0ltcy68s10imOU77F0zMr3DbZj0hi7MrG8cZ36ULmIiB55FmBky",
+	"tRFN4x6EavDmxaY3AX7cyKHfDvwP9XoP13sPtcocW2Mo/DBI+AabLTMZqrGPRWr9bgjN2QkKJV1dz+00",
+	"8+7181du6HXDJl9oK1yUvKCyFvaAP52+AWdOYVzmymdmac8dUdIMS9Mm7GiNGqAyTWUAiblYhhUGWKfQ",
+	"KneOa42qqq2xl4AKsDnLnulg/BZEhl3cgtyXnrLUT/lm6w1+S1nBamUVdIe3GJNk0RgppAc4dzv2Nhks",
+	"UNiLwRiC0iIXMCcu3WL3jX7wH7xw46/vWusLfe7d5rNBXnmwVO9uiL3jJRTSXKELvreX5YKjbhzfXngT",
+	"sNjTpZI++L+CagT7Df7wjS4+C2BUyYVPlK+3tEvuBEo0XWv43paKUAFQFVuqA+d1liQuIj4/JvTL2kmD",
+	"qjgalImGVEIpoOkrnCvUy90EeOoHXh/l+RXusr5vqYlUfEgZV7el5ntA+Z14zj0AX1Rw4Hg4Jeb2I6Yj",
+	"FqNXocEovligwvhoqx1wKunB1LWBr6z1FFZcGGDWfARGYbn38gEWIK3oNYykPOdb3MKnyGIXa/SDMel7",
+	"kazhr2VpQz/LX8FNMwAlXcyR/YCqAiUkdmqbHdBmtd+t124HVNvoDM3wBU2lYSbN0p2U5oyLSdxarhYS",
+	"uD9VtuTn++sIftKOoVJelpKXVpF5/uENRAm3jI65XZInLGXE+6QYPhrft2qTWsNSynPQkhic7/LNqOdt",
+	"sZFLLmJ5CbEU3xhYWFErM3r5MhKcpQ5SUE/cNXCRp7iQ30xmptV5XVKcA8Xt2j/5dfhbeFpozoV2eWtk",
+	"5hHBPy0MthHcCL636GRR33/mSjxFibWo4tG+VFfBwQrl5ZZaP0e3eSIv67y97Pt9jJ8ipCO1xzu/ThAN",
+	"FAPJ3BkUBn+yhiITbLYGV9kE+l4MYDyYCJamSl5YUOQqxiC32gswHY3gx4rXaQARS1OMgZmJeFw+xBS7",
+	"aAYFlkcalkdqiREsW5a/Kk/fOQSa6rZsRg4XB+4NevmBiWh+y4t35Y6KssBr9zjiLV7NB6FS79fqvCyg",
+	"9pbr4CtNCda6L/F2X1/quNMeOfu6rHlWYlUF/6l0SJ2eSo/aNqXyRWXYNV5PuUwt5zoEnmIkrNCwmBnm",
+	"nRm3eU8lNOmiQg7sqguzX2xdimR9tCXjY2PiwRattnlZV6/VlivUC0B0Um3vX8M2OqKKL8Nw48bqzy51",
+	"y6VPe4eEjmSKAyp0VD5oksjNR5yd/QDnuL7xR853WWJ4mqBvMgBFWbSGMUvABFZB6W4YTK/IbVyoCN6P",
+	"MUFXor6O4S/p7+Wl3l7EfMAt4jYXQ5/rqYsIeUZlNI9u/KW8gvWtceZyboYOzAfcor+fPwYdhMafIath",
+	"b2aTM/e7ePWv0UTL2qV/o8sN7yGHthDxSZRIscU0fiFT7k1dX5yhthsUkVqn1KPSOWJXzKCyh7pANWOG",
+	"r1y1TGc6KHnpbEyySZmy5iRx2GP675THDYM2S86Br1KpDFkZ1uZkxjAHlaXUKCrbAYOrNCEjRgLaQQIv",
+	"k7WfwJfxLDJxFQ5TJVepsaZ7/nTQOESb9VqRrAS9Lzf6qnGSu60i2B3emnbwZqdGcFHoD3mS+I0zlbMm",
+	"iZZbpLLVvmykLmXKzUdncT31usozqhkdySThMebeJ+FqRtKDek2zaSo2hA1V5ljlNHRL0Pcz/Nd//Ke7",
+	"MF/ou/jD0aG6UMzZQkhteKRPMFrK7R7sl+XoV3ZwmF8skcXU7cRzjDdlCZ/hv+F6K/uoFVF7vLOIWsuK",
+	"/8/wRRkzNnyzPWbsmjiSBdAtOeHd0u0MyP5ehtscHB36ePcn79AsZfyjNM+TRF7eApE2cC/36BOJxnxO",
+	"ZRoNxUc3H9ctjJwTkY4Mvk3E06J8la7WpsrLm7QTlyB3yNCgNsPf5Kw7obkPP6I2/ypnm/6QB1cHzNpK",
+	"2xDoX+WMHi5S8jFfSnWOCi55kkCsGG/6iagM13DsC0vHuJJPwYOD3hXkUKZUbzpVMnKlqbzexMXQ/80v",
+	"0g7eC5ZkzKCLNe8OXP/Zc19p6loYQXWNW+IILY1UQmEprmRI7Ie2XGWaj6K79AesZLlPzVKhXsok1sUT",
+	"ecvNpQpXPFsN95I+H9xHd0II/XPKj5yXP7g5Xu4LIEEsXecNcFUUEDwKTStoBb7L2IZTlKYYUuMqsCj3",
+	"NI/p1FunqalX+R9PeoFPWhHdf+7adpM92xXbT92XP0htTpFqI33F+NvAeOi7AmngGJu9SHJMHN3uO0Cx",
+	"jxZmTVEujlUXuF58U33eabch6kvsxG5nZxyA3n+hD7/i993Bb7rKu4Dgpe26B4ZvpJDtQPHtBnKO4wpX",
+	"GHNnXOInjLL9kf20nOKVn+Er1v+z6zEVvJo6vCqyHm+L9CpbOslRvZ0G7+VlIhu0GJgF7oWPu0vjCsOo",
+	"nazbDpDTdxkEc/yPT1TkyMWktL8kFAEsZY0jH8YyAtf84YLjJSpYZdp4J0NRfHEi8s8V9DVaije+KnSc",
+	"GYo8fTT+7mgzjMevMZqI/UN5LAsqQk2e+/N18fV/upvO/uIsp651yDUnWRfLhajF3nh+/+V13ZUAHr+z",
+	"20yiLqB3i4nUPxKTrbrz8nJGPurQUyzXtTHN3C1POsAqs1SufBtXceFt+zCVPCBuX6aynX1U6p0exj5O",
+	"3UG+co8r4x5FOslX7vGn5h6Ocg5jHhfyfFs1mFz+lLyDImhDwcCUwNAveq4fXQVHoN195QhXyBHo+u4e",
+	"Q/Do85UfFMXMc8oLl3siaJUVGcvQ6BnOpULgRru4/vrzCDWTriYfuNrArYkH7wV1qaTGpWXM/hnlQXAB",
+	"CYtjVCCV/W8/L849mIham95B3ih5sNFcegCVf/rWv0cTUURAFZ1RKeGm2h6VypGXBynacU6E3S/3ReGZ",
+	"r2UzgjOXkEQz/x2V9JOVpY8TqtI8Eb53zRkaw8VCgzaYpqg0VDrZMDvrLEHQ/NPQrpewtUvlKUwoX2te",
+	"R0wMXVn8llQIinVvwPZag9PDC7b0KHCVOSkihO5C3xGH9I7cgeqOCXkraQQlQbVShbH33EoUFi4xWwN9",
+	"BmyxULgg5KKWJT6ZjFNWrE8N6+dtJB+OJyJmaz2AyHfKvj8afTc+OgF2gYotEFwXcd9NVguW6qU0eWie",
+	"HkxEebIBGGlYQqFUeT9I7RLoHHJHTCnKu8spcyJ8J349gg/y0mK13S6NHqZ2eb+NisCGGBPDWrwDBKhu",
+	"iP2RYLohyxsyqgE4LsCC62kBrqKv+XfUVjyUqGM/COfpPLzpNJ0gCAI4/pLxJMcn189sADKJ70jWTgei",
+	"qx6ggjrGH3iT1IRAnwd5PFPIzmN5KVoJ7iUqfuGa3m8ypCIyteDY//Uf/wlnEaN+wmD11gdPJqJsDUQN",
+	"B0bwPROxtptFZ+3+NbIoEGVWnk59dKL+60QsLSNXqLk+ASkSLvCZQhYtLf+/5755Nh5AjAvFYow3fnSK",
+	"87P7g4nIyfBZJoKjoocDsIB4Vvvy4cC125+mSs4wfiakFcmjiXjhzq+zFUX9Ok2ghEwlNY+gPqxCfVhA",
+	"fTv1ll98X1zTdQanBxfcKpvuglhywn4HjTwqNlyeEYprgL5DruMckY5zbDm2Px9XUeAoQFJWQRKot2a/",
+	"0Z2+zQdeN98rFgo+VLjfQMkkydIbTx1+XhbAcQWs8uJbdx6LfqhwvtkaPB/hiUUmnxu7iRyuLeTQ1XLZ",
+	"jSKnNPyFH71DZL+m1GPLgWo92pyWPrcfXkp1PlU4d00mGaemJVzDOa7LRkstwryYYFchwk6bsh9EJllT",
+	"SqyVGky4rZy+fvHw4cPvaj1kr79gY9dCiffHt1opMYATwWx8aj1agffndfb5yg06cINNoGvoezHjruqo",
+	"mf+9wRzIRHUZ1W0KmNc05Bzs4KnKhHZdYL2zgr6OyfJQmdO7nGNhNBEf8zZEfVIM0WB8bNUrjI+AJrIm",
+	"OH6id+p4BD6KQTtDp1ljgGKASgVzm+5iNcB/p1NdN2mUKwXu9N8DoImY+FKs6bMCOSDG1CxBpwmnYmJJ",
+	"XpC61aAmU3ansDmjUZ2FDPl9rKU7dWhOaHijwubX68cnqYKX51wbDqxfeWRXHhkuJuH8LP2UUdGYY/Kk",
+	"hPRqI9Ohd7AQ99mtPX2U6Wv3wQ80/gtC7T+BntKEfkhTYeI8z3XNDf2vasp1Gy26zGte5ZAvvJbQt0sg",
+	"+SZ3USF9sAcVntL4r1R4O1TooN9OhRbSX6nwZowForQwFboHg1YqXCJLzHIb0f3gRlwjYrkVtkXdnqG6",
+	"4BEC1+A2TDVnHt/krVS2kDvyQCrIBLtgPGGzBLeWmCv8YvfA3iWnf5PTD/osb6bfuJpdSkmLFhJiMSgu",
+	"uJJiZeF0AIcybHFrmrM95a5iW+Q7u/3qWm1ZNVRXa+lvq0O+zLbaWfmlX0dQyw+uvsft1cty6Wo77vn2",
+	"a2TlYg36M+bUTUsnA+DpAFKpzADQRKOjG48y+cHvpCh2QeUkyJlTZQAtVbLsOfZPdiG0Pv6HbyL/R7XI",
+	"Tqi9YBihKwXh9ukCWHau/5IrMp3mrbujO1Ca6UdZ3UYh2+gtNi8jsrU2Sd6wjoJ8KvWJlsy4dP8ZAtVT",
+	"sDPuRLpt5ZyamLdiVg8WLO+ClwX8nR/lYkFqUWXwdCVj9PVYWKZRkyT5YGXzR6rTpK31oM95WsRUlGV/",
+	"dTbTllcKA4ZH5y7ymraUlC9hFLaU4Jxaa8ksWmI8AC1Boc5Wjd1Ayq0oydIiVBsSpg0ojKSK87CxEVzc",
+	"Hz0cjYORlhnR1LsKOG6UmK5HLlWOc0upYbuEU94/j1D6pun2h1pNpgZNfrBofUzYhlDgJWmf2tOhdi3d",
+	"r0YGlCEZx0uujaz1A2gyP9cQMkstkf2VTOG/kgUzdG+bjpjKGad+Rme+281X0i1H8IpFS6K4iKXGWp5E",
+	"QSmqYcLWqKiNAb1SwDxhC/frKksMz38nlTwntm1k5hXwd8XOfvBHvSli+0xvwuNbdSYEQbdV9ateu3v4",
+	"GlZCqO4KqX20qJWLiW80lIg7rCFun4x0j+K+Gdy+ufSe7DqVI7WbvpuFSH0ttikzoNEc3a3rrFcg7cId",
+	"d1cdvcmraIufqMZXu8NehYf0wWh8NILC1cE1ZIJRty6M7+7TnL2Pl2gYT3aanjENg77PvtalML0XAOkd",
+	"w+W8pGpRCjS8e0CheLT0rqJu3gpmomXAurN/vnHGcz3qp1Pu7qjmSdd+W32ufr790p9b0d7dHKwyl9jh",
+	"Hgc5JrE+WNElP0dBMO3pBEr+hpHRVX1gniXJBp+NpEozO0zJbLEEJiai6PlZ8EdIUOiRi9MhsH4ylAeQ",
+	"lyhOmEFtJqIIxqmH9BTR1ASAvsiSxPJ2FC4GeSLsaEHNQnKJ4IMRvaHrmo+kSaatuRBJhdM0MhNRf2kH",
+	"Zn9OUVnFhi1wAFIglYZbsWQAY7ekG8r1RFiBUfbQgoWSWepLLrOVl0CzNZyj0MwOZIlc5B+sJ6Kfifzr",
+	"v2PsJs+zjayJTbWP86eQl6/OXtipxST/aA3Pz16M/EtlQr6yVz+/Ov2fBLB+YSscW+M/xfgYLSYeDSZC",
+	"W6Bwsx5ShhTGNC3NM+WxnXTgOKy9KCWTKY/J3nJZuxOR30WZ1llecx9XqVmDNEtUl1zjkfMpWN3RfmpN",
+	"GXpai5YYnYPMTJoZK2rpGgE/pVLnGeB2rA8bJwSzAJ9ZErF61///+OF37uQEKSfJuab7ykTRsRhIXo8m",
+	"4nSjDlR7+Ba459ItZlOZO3GbapCRe+k4TMT5LVIenr9d4LF+WlCNHVTBaKacOblKMwtN6plFd+86+9xt",
+	"tai8pbe4vWVrOZL4FPR9LJzjU/cK6Nyrwuaex7+7GCx3p/w3JR03oGyJ1UJ6ACsm1hUucsHxMvSe2BRe",
+	"PmJzI/Yi7KUJGwjE6Fx3yakTE8+ch8VxORfwOYCcVc7WkLPPMrUUfBr6ki+W+b9XGPNslf9fIi/9Pyci",
+	"E9ZUdEw3YdpMiRk6I9Jy+RF85Mby9AYxRnKFE1E4VrkYrnBlxYCTL46vOiHz1EuqZfEXYp+V994BGLsI",
+	"zJkVpTMWnVNYumXrdh7umXAuye26+e042geFLm7dx9zS15YRhdiRFewFP8ImO9LOwV588k2NOU0EZddV",
+	"hNHIieBpLhp9HYJUklfFbm4AqcIhOZPs0pR2tI8I2ML7XxPKtUTv3ADzf8c+eZGfd7gbwQufhuiTEO+P",
+	"x78+zV844P64jU1vcbbdD+UkXr8gutsCpXL126TJ63ria1Pb+iovtssLijdgucnhWXOyzgPtqmJE+Siu",
+	"nWIiR592IfGSWhdEpom+57jWed5zxRJqyBJK768EMYlsNUMFcu5JdeV6Fvr2JlVpUmWslum+Iv254N4k",
+	"OJcsV5BniAK8rTOaiO/pSsl+sgI15dG5XbXyaVWr5Xi5ZyLDPprw6xLGX3grorZzbaX5YpRDAmu8lBfr",
+	"rt9bPnc2w+LOMQEyNErAVsiPIOm0uBWzJrfswAXyWhytPOBjZQF5WT5hs5illMWcz6BONio3DCZCWGMh",
+	"HxJ7zdbzL7BSVF2wxBVCIHWFZVZaJmyhJ6JfWLvV1/R7zpeQr+qyBVBY/S2uRgyQejXni6MRPK83S2LF",
+	"13Qk5VVhBzrva/CFTRiILEnAnmJKzhdmYOj5DhNA3oODSonU6eksv4U/FZcoThUKvsxvwCs95Gys+LO+",
+	"8oLeTw4TQSrwL2oeMjWm8F4U9JmTJKFfieP955mR7m+GJ9jFhOxWVMXaFpnCovTJ51VVKRyQA/D+x0Hu",
+	"5/PVU0bwkq21o0xPx35l8smwmaan14JDKcXWT8E/0k4Ei6JslZFTtRwUUzUMl9oOC+nbp10yFbfURNtW",
+	"RqWO/i1VVG7AHPqTlWYJgbW1MsuXUpPlTjITB8KKGM9JnLCeGLQUWH4Z5CJlyYwTcuJsacdIfpbiaaDS",
+	"6McF7axYtOQC1ToP+eEy5hEkUqaQaauv98twwuFcIcLHFx+GM2sKkMpPvRYfPDga2I81vQYY6bT8IprP",
+	"KR+5EuDUK9RLCuVLzAgatdZdmVVLqJsmQqVmC528rWqiQ+hy9AsC081wiqusJ3//wbed6snfQAUaAuEp",
+	"XVmwBo0PAnO/H5i59NUyub1yi889S3A6IndAAa6LwHguYJ7wxbLJ0s7WIloqKWSmQYphjCtH7pVaLOXM",
+	"9ajJFg4Xcx1ZRWd9ojLRztzepyjc29vZ2Q+gka4N2IJx4c04OkKmyVtrNPjY+ngiSqY2cHUXyGedSI3x",
+	"UKPxG54xEy2hL/VQYYJM4wAyylqYiBWuuJjLAcTzQSWbYYEGxVyqCAfA2NB59gdWRuIlS5Ijqv5IfNUu",
+	"6B4i9QCyVKMy3r/jLJypnR7uQYzCspyE3moJRiOpp/+Xtb2SbCUoUaEAaqX0xQDSbJZwvbSL4QUKM8v0",
+	"iOJ2PHQxdowZV7zy3j4qgD8qXsUngpruAU3jmbK3w4gvl59sYcf5suvTTHzlxIdoaGcE8jdiLoPKWQ5f",
+	"z4Thv/7X//ZPMRTVG4P7/jWLjP4yOfRGm5nbZ9GPb7KjiYtZKsvl0RVb3hdzlljFs5I84nkduLfKG0/9",
+	"LLFR+yRQC7ZLS2a5p9j+sFG9OyxM3p/BnIsFqlRxYaDgN91FSlloe6vRTQKjrB+ccGvgeKdJ5bnesBnc",
+	"g79Y8UBDXAnC79fF61eu7MoUhQ9eLuNW7hX1jI+ewr9465mSaazq6z50AUR23kBxcRYfVE7c28+vSlDc",
+	"IBtuGL/LIvA/YP/OWaKxmGomZYJMXDODLaDylmuztSS2bhaRuitFw78E+7fxzFaJoC2xspLL23BpZjPS",
+	"VYK1/SvJcfdUluAI3gskApyICvHZQTn1VT4mPZd6J1OF5GKWp8AmIs4c1LCg60fj7/KGIXlHEB8OwMqK",
+	"CBhbG1qNJmKThOmrin27V0+AGhV/wUHClYYAt5I63aFDQKCFxBemOW1g3Z1kEjdt7AonmksG0Ej/rlvB",
+	"rmBdstl5wAGUBRkZ9Om98JLxC1RHVuthW1UUHTGnnbS48ijn3AUSM2GtVui7d7o8YjmRi5mU51ZrOHKW",
+	"Xd79myLKfnj3/MVQ84Xwr4TUC9zO4BuL+7ZtGi44g39DodkI8iC2B+MHlUYE9DWPCwvD/b/RmMyJkepS",
+	"iXsK3orkUkxEQmWmuWgGMhzXajbardtphJCZiAqF0ZuxYO1Yy4BduAIjSLQ6LXwxRqkmwlcc3PA3Qulu",
+	"PN3sall9eyRj1x52G2M+i9g/jX17dbaPhdpp5ipHxuHnTI/0vpQFYYnFYI/k8VeT9sv0OhLz2E2/ecHQ",
+	"Bgt+5W4fmKiYi7XKhkx0txK9U4uLudwZ11tUjarmXFd9d9UEkgW/sHooOdjgg0zpkdSF9Yb8aNCvsFDL",
+	"jyfiw/uzj9DqJCW11n5jp6xFbxyNJuLR+JF3HQpppnTRwOfQZ0ell5QSD0k4D6A/OyqDkO0vukzpjKkZ",
+	"Vz+qfOpF5iwzUJj9E0HhY9IQza7RuaMcx5Suf4z90flZy1mQwkqsACJsQBHTa2PzIahyT1sM3Yq/7E8Q",
+	"9bHd+/eWMpmgPvBrvEfQf+ZU0PenICRUvKby0uLphorH4kqqWGX8nEVeTww+2HJhMEn4wmL0MSkuuhNL",
+	"cZWqnavd/eX9GbypTAaRTBKMDKk0eYETS1wCL5M1qbXWiJXK6AGkLDpnC/SJjhQWTN64icirDLq6S/Ai",
+	"U1oq8ClM1CpXQIyGkq/KFAEXej0RszX4cgwDt9VpJGMso44HQMXhjzNheFJ1Vkk9rEKmhXqr533lYNep",
+	"ZFtZIuKzHVTlqXotGtOTR7sUppapcyDVJkaRrXonv/S4Y1eJvOwNei6bozfoLfnCcqo886P3a/fFrrRI",
+	"P93nlc0WEdJdZ/nPB7dasGMTjT9QE4CAc9GR+2f1CLjDhdPJ67fBx6qcrp13OgOxKJRzmF5WnbHMwyqz",
+	"rUg/c++f0KItBTQlK0P4fCKEbJyMKsFbBSgtVD3KcXIiBvqFHjQRWxQh2NCDjj6PlVJ3uz9FlbjNUwV1",
+	"Im2KAMav6k9I/SnCOzc1H4Iepd7XcLv4olXzSXiEQm/tdfDWD7lGDPFLEHJsS6Hw44KdRf8HujCSPJo+",
+	"qY6FvuGoBjBHZpwi9bdMGmZ1LIr6qEcBK7mjTvepTK630+XzeMUFrbK1sKJM8A5UhbXgaq0KO8t4YoZc",
+	"gPIwa6tIUZ+ldhUnzo20vcwmQcv5Xa+peuyLTBu5suvcag3Zchtb89VpFEH91grKfijuN+dkN+6yIhLh",
+	"MRh2jqKtMGxUwmoXgm6WTHHujXpjSJfrso2DOLu/FrLpvrmpAFFabTsCOT7qzkLBbaS0a9DZbChnv2Fk",
+	"vog+U94nUItH9lXrQFkbaYXlIWfsHGPLrvLT0gN3Fo5A8SHUS7TmvJ/DGtMLwXwgdyWGu6hFVVj1RsIp",
+	"JpLVQvvcoUY+W8qp3fEIvrearSu2ceHqEVGkn4+cZCK2YKHSJ0ytnfsuM0M5HyrS2y9YkhXp4PBoPA5k",
+	"aVUB1FJ2dSvWXgPD3VzohgtTte0gXBjVY1Fdi/2CjENPUJvPHKF6Ux3oaSef9G0f9+KTZ+6bG7r0s7wx",
+	"5Qbk3qFRPNJ3xGa5Al5Y4VUrf7Z7tVTTecKCV1o8bmzKvXar32egYFx6aR2BQV8qeOm4b+nAvaSqVq6B",
+	"sH/DOIIPb386o8k2uHZFRoFvi//TG7Lfy0b4E4tB1miQxWeTHrD5XKqYzlsm1inLWIdG8XQ0Ee+4vRld",
+	"ZZ1V094nusKFy4pvctkCWNsTYh3eN0BznUjfWOqfSTN4f1YJUi3e4q5BN4B+nuI91RjBwyfj8Wj0ZPzo",
+	"2/F4AIoZnPpyNPdHo8djas1tMDJTKaYUvUhl8VhkwEdZDmpV3heJnLFkIvyPRyN41a5R5P0vKdOMGP5E",
+	"VOI6XLxchSOUYCnKt+dnc7pFoYwYmYKcUwoHZbsbHp27Jw8JS2mGilQeryWBQIypTsUhdFJoJCE6uXp1",
+	"pLnKDesiweX/1IqIO0ZHfaQTFW8XX/oSMd2SwiRwKOdzWDGRsQRotGv14N/xJ73TTICQl3U5kkdEFW3+",
+	"XRv/V3nAVz2TB36TM/dUKShIwr3jW9knhlVp7PpeuXpKRapRXKQLTZmBN2fw409v344mwrWxy+M0ylFk",
+	"UPz4/iMoHOaxOT5SzBVLZFRKMloOs3RAEQIMKGMqtl9UwvzL6DOnX2TCgJxPBB2mmLkQxeCL58258tnp",
+	"ju0cyAeKh/SCRs7oKm+CGmmlrb29CE9irqmK8B3pt9aNtIqAnQCOEoq6zIey4LJFN2jiYYjoaq9GB6mN",
+	"VUf3puZY/XUiXBnYw5XHifAoe4DyOBEV7RECymNVGW/TGgMK5lbFcRM4vRt64PmnVB/rjy43qEFaBfLb",
+	"J48C+uMD+7dN9RAa2uFEdFQPoakdTsQ+6iHUtMOJKNRD9/y6v37YkSIKFbGFIq5eSwwsdMOKYtsOvuqK",
+	"FV2xE8mGJJeOmDhMYp1FTGxKKoqVrgioiTjQvWEF1ER8tnuDanHzT1Sezr2d5izHuZ/D1c6+0WA4qolI",
+	"WGzXd+WR04QJqo1Ob0D/7dGJv63cVe4UylQmPFrDnCd4dFD1MEfhJXivU9aVq/wzybjiwpvR2iXlXJ2Q",
+	"G8Fbh0QrLijHxaLdi7fP33149ZJqNU3EL48H8ODbb8e/umyfQvSVpZzuj8e/2h+WVIKLVLe8OH3fVaZ3",
+	"twcYLSXmNSVcPSgnso6euieZKxeRCqmkTr6og9uG98QXC3wy1r7x3p50UUi+Bl1cvcSrLHDDkq65cljC",
+	"9f29Hv1Tyrq9yLdV4OUDh6nCC46XW0Qfi4dSJOtqKUM5d5F91RZCeT2+okieRfeJePAIljJTGvo/vv8I",
+	"DGK1HqpMFPbz0Ynv+pApiLO8VmoZHFg4WYoFtBVsA0erUgrUJi9g6ctwTl0ZTvo891x490rhMcmwrMqZ",
+	"OMnHhEt4gRhTs/xMwZUXgPzgwXvNRNNcrltJyi9AYj14tMwrFjYQ0PHaMPq3ov0FU5zNtnUOeC8QUBi1",
+	"plT0fLx//NfGHiD2dfddjxIWmYwlCVVOm6Oy+qeGvqvPr5c81bCSCsu4qUJzICnmTmEnmohMo34KmSAX",
+	"pEVsEpRWp0pI4Tzy3SLd9iqtdCaiObsjjzzSlWhS8RidXqrR/07EMRGU8hlrC9S8+VleyDwnEYf1mcLp",
+	"yr0bwoqpcy4WEyHVggn+d8KXoU4x4nMeWU0xwqVMrNgv1FXRV3qtE7mYKlxJg1NXhWQAlG21ngqTTlMp",
+	"kwG4GndTg5+oawIzE1GmL+mlzJIYWHLJ1hocxu8tTmvU+nOBFtdMp8VC21uTWHwYEhoUCJv3BpqtgcKE",
+	"7z7pFvWco8p5yr4VQ4OrNLESrTwj+RwLArHIl2PuFqXzp4+gkPDNKWCvyWeZY/yKpdD3tVMt4AhhUBnf",
+	"+mKTdPTRCPJM+YL83Zd9S4uVBwKrD+YswR3yyLfPcaqpO8+j8dh+z8XCEeV8jiIm0jnH9dPyhIB/y1iS",
+	"t+RobosmjpWkovKWHryKyle49WHQN2Mi642ZJTh3jK+BVuVjRYL5CtWihnm+ZJCvdc3E/qKxprvWie16",
+	"1Nd8jfcl+ty8Jtuyic1KF5UiczW8dT3ImS59Dn9uDffUkXFddhU0WGEFFemeacqkaI84+okGXONV0wKW",
+	"2W3tta0tSG49tNtCqzW0O/OQaguYrXw82BK4XQL86mnbzn2rwdp2Azvv+bbisyudLaUq3HDVHpe3indl",
+	"rHUgZtuO2IV7m8HahLIdO0rbq7mLHaVvvg6QxdFuDaS73MruBtK3C/nxjRL/3brNvIVyl3vcyNUpicun",
+	"7TCt+UJsT9shGNnRz93gL7dAWn4Sd5C95E2A2ClxxQHwFiRDbtAolz7TwBJ3Qno4StAaIDsRhnJnPDps",
+	"RZlM7IU0P+XDv6JNBW0UruQFxtDneXkpc7ShOtsh+RVS/4+DL/HCWhvuyG0c/Wc/5BqZrV9iG7/1Q2CF",
+	"hsXMsLKSUYxpItfUEp7ghFFGRR9Ofvm1CrXvM57E+XnLafpMSLFeSZdHSt+rixwRGxmsMmIJxEik51vQ",
+	"ZyrpnfSWxqT65Pg4sSMoBfnbR48e9v749Y//EwAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/server/api_compliance_exceptions_test.go
+++ b/internal/server/api_compliance_exceptions_test.go
@@ -1,0 +1,181 @@
+// @spec api-compliance-exceptions
+//
+// Endpoint AC (DSN-gated). Service-level AC-01..05 live in
+// internal/exception.
+//
+//	AC-06  TestAPI_Exceptions_LifecycleAndRBAC
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+)
+
+// @ac AC-06
+// AC-06: RBAC bars on all six endpoints + a full request->approve->
+// revoke happy path through HTTP; ops_lead (request, no approve) is
+// 403 on :approve; separation of duties holds at the HTTP layer.
+func TestAPI_Exceptions_LifecycleAndRBAC(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-06", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+
+		type exc struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+			RuleID string `json:"rule_id"`
+		}
+
+		// --- request: ops_lead can, viewer cannot, unknown host 404 ---
+		reqBody := map[string]any{"rule_id": "ssh-kex-fips", "reason": "accepted risk"}
+
+		viewerReq := asRole(t, "POST", url+"/api/v1/hosts/"+hostID.String()+"/exceptions",
+			auth.RoleViewer, reqBody)
+		vr := doReq(t, viewerReq)
+		vr.Body.Close()
+		if vr.StatusCode != http.StatusForbidden {
+			t.Fatalf("viewer request status = %d, want 403", vr.StatusCode)
+		}
+
+		ghost := uuid.Must(uuid.NewV7())
+		ghostReq := asRole(t, "POST", url+"/api/v1/hosts/"+ghost.String()+"/exceptions",
+			auth.RoleOpsLead, reqBody)
+		gr := doReq(t, ghostReq)
+		gr.Body.Close()
+		if gr.StatusCode != http.StatusNotFound {
+			t.Fatalf("unknown-host request status = %d, want 404", gr.StatusCode)
+		}
+
+		opsReq := asRole(t, "POST", url+"/api/v1/hosts/"+hostID.String()+"/exceptions",
+			auth.RoleOpsLead, reqBody)
+		or := doReq(t, opsReq)
+		defer or.Body.Close()
+		if or.StatusCode != http.StatusCreated {
+			t.Fatalf("ops_lead request status = %d, want 201", or.StatusCode)
+		}
+		var created exc
+		if err := json.NewDecoder(or.Body).Decode(&created); err != nil {
+			t.Fatalf("decode created: %v", err)
+		}
+		if created.Status != "requested" || created.RuleID != "ssh-kex-fips" {
+			t.Errorf("created = %+v", created)
+		}
+
+		// --- duplicate open -> 409 ---
+		dupReq := asRole(t, "POST", url+"/api/v1/hosts/"+hostID.String()+"/exceptions",
+			auth.RoleOpsLead, reqBody)
+		dr := doReq(t, dupReq)
+		dr.Body.Close()
+		if dr.StatusCode != http.StatusConflict {
+			t.Errorf("duplicate request status = %d, want 409", dr.StatusCode)
+		}
+
+		// --- list: exception:read; anonymous rejected ---
+		anon, _ := http.NewRequest("GET", url+"/api/v1/hosts/"+hostID.String()+"/exceptions", nil)
+		ar, _ := http.DefaultClient.Do(anon)
+		ar.Body.Close()
+		if ar.StatusCode != http.StatusUnauthorized && ar.StatusCode != http.StatusForbidden {
+			t.Errorf("anonymous list status = %d, want 401/403", ar.StatusCode)
+		}
+		listReq := asRole(t, "GET", url+"/api/v1/hosts/"+hostID.String()+"/exceptions",
+			auth.RoleViewer, nil)
+		lr := doReq(t, listReq)
+		defer lr.Body.Close()
+		var list struct {
+			Exceptions []exc `json:"exceptions"`
+		}
+		_ = json.NewDecoder(lr.Body).Decode(&list)
+		if len(list.Exceptions) != 1 {
+			t.Errorf("list len = %d, want 1", len(list.Exceptions))
+		}
+
+		// --- approve: ops_lead is 403 (no exception:approve) ---
+		opsApprove := asRole(t, "POST", url+"/api/v1/exceptions/"+created.ID+":approve",
+			auth.RoleOpsLead, map[string]any{})
+		oar := doReq(t, opsApprove)
+		oar.Body.Close()
+		if oar.StatusCode != http.StatusForbidden {
+			t.Fatalf("ops_lead approve status = %d, want 403", oar.StatusCode)
+		}
+
+		// --- approve: auditor (has approve, different user from the
+		// ops_lead requester) succeeds ---
+		audApprove := asRole(t, "POST", url+"/api/v1/exceptions/"+created.ID+":approve",
+			auth.RoleAuditor, map[string]any{"note": "risk accepted"})
+		aar := doReq(t, audApprove)
+		defer aar.Body.Close()
+		if aar.StatusCode != http.StatusOK {
+			t.Fatalf("auditor approve status = %d, want 200", aar.StatusCode)
+		}
+		var approved exc
+		_ = json.NewDecoder(aar.Body).Decode(&approved)
+		if approved.Status != "approved" {
+			t.Errorf("approved status = %q, want approved", approved.Status)
+		}
+
+		// --- re-approve -> 409 wrong state ---
+		reApprove := asRole(t, "POST", url+"/api/v1/exceptions/"+created.ID+":approve",
+			auth.RoleAuditor, map[string]any{})
+		rar := doReq(t, reApprove)
+		rar.Body.Close()
+		if rar.StatusCode != http.StatusConflict {
+			t.Errorf("re-approve status = %d, want 409", rar.StatusCode)
+		}
+
+		// --- revoke: auditor lacks exception:revoke -> 403; security_admin OK ---
+		audRevoke := asRole(t, "POST", url+"/api/v1/exceptions/"+created.ID+":revoke",
+			auth.RoleAuditor, map[string]any{})
+		avr := doReq(t, audRevoke)
+		avr.Body.Close()
+		if avr.StatusCode != http.StatusForbidden {
+			t.Fatalf("auditor revoke status = %d, want 403", avr.StatusCode)
+		}
+		secRevoke := asRole(t, "POST", url+"/api/v1/exceptions/"+created.ID+":revoke",
+			auth.RoleSecurityAdmin, map[string]any{"note": "no longer needed"})
+		svr := doReq(t, secRevoke)
+		defer svr.Body.Close()
+		if svr.StatusCode != http.StatusOK {
+			t.Fatalf("security_admin revoke status = %d, want 200", svr.StatusCode)
+		}
+		var revoked exc
+		_ = json.NewDecoder(svr.Body).Decode(&revoked)
+		if revoked.Status != "revoked" {
+			t.Errorf("revoked status = %q, want revoked", revoked.Status)
+		}
+
+		// --- separation of duties at the HTTP layer: a security_admin
+		// requests, then tries to approve their own -> 409 self_review ---
+		selfReqBody := map[string]any{"rule_id": "self-rule", "reason": "mine"}
+		selfReq := asRole(t, "POST", url+"/api/v1/hosts/"+hostID.String()+"/exceptions",
+			auth.RoleSecurityAdmin, selfReqBody)
+		sr := doReq(t, selfReq)
+		defer sr.Body.Close()
+		var selfExc exc
+		_ = json.NewDecoder(sr.Body).Decode(&selfExc)
+		selfApprove := asRole(t, "POST", url+"/api/v1/exceptions/"+selfExc.ID+":approve",
+			auth.RoleSecurityAdmin, map[string]any{})
+		sar := doReq(t, selfApprove)
+		sar.Body.Close()
+		if sar.StatusCode != http.StatusConflict {
+			t.Errorf("self-approve status = %d, want 409 (separation of duties)", sar.StatusCode)
+		}
+
+		// --- fleet queue: exception:read, status filter works ---
+		fleetReq := asRole(t, "GET", url+"/api/v1/compliance/exceptions?status=revoked",
+			auth.RoleViewer, nil)
+		fr := doReq(t, fleetReq)
+		defer fr.Body.Close()
+		var fleet struct {
+			Exceptions []exc `json:"exceptions"`
+		}
+		_ = json.NewDecoder(fr.Body).Decode(&fleet)
+		if len(fleet.Exceptions) != 1 || fleet.Exceptions[0].Status != "revoked" {
+			t.Errorf("fleet revoked filter = %+v, want 1 revoked", fleet.Exceptions)
+		}
+	})
+}

--- a/internal/server/api_helpers_test.go
+++ b/internal/server/api_helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/credential"
 	"github.com/Hanalyx/openwatch/internal/db"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/exception"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
 	"github.com/Hanalyx/openwatch/internal/kensa"
@@ -151,6 +152,7 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	// api-host-scan job-count assertions (caught by the DSN-gated CI
 	// run; scan_runs IS cascaded via its hosts FK).
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE posture_snapshots")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE compliance_exceptions")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE job_queue")
 	// TRUNCATE…CASCADE delegates child cleanup to the schema — the
 	// hosts row has 11 FK-referencing children and a hand-rolled
@@ -260,6 +262,7 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 		t.Fatalf("DeriveQueueKey: %v", err)
 	}
 	s.WithScanQueue(scanKey)
+	s.WithExceptions(exception.NewService(pool, audit.Emit))
 	// Variable catalog fixture: two corpus-style variables (one a
 	// configure-me placeholder) so the scan-variables endpoints are
 	// testable without the on-disk kensa corpus.

--- a/internal/server/exception_handlers.go
+++ b/internal/server/exception_handlers.go
@@ -1,0 +1,246 @@
+// Compliance exception governance HTTP surface: request / list /
+// approve / reject / revoke. Thin handlers over internal/exception -
+// RBAC + the host 404 pre-read + error-to-status mapping live here;
+// the lifecycle invariants (one-open, state guards, separation of
+// duties, overlay) live in the service.
+//
+// Spec: specs/api/compliance-exceptions.spec.yaml
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	openapitypes "github.com/oapi-codegen/runtime/types"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/exception"
+	"github.com/Hanalyx/openwatch/internal/host"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// toAPIException maps a service exception to the wire shape.
+func toAPIException(e exception.Exception) api.Exception {
+	out := api.Exception{
+		Id:          openapitypes.UUID(e.ID),
+		HostId:      openapitypes.UUID(e.HostID),
+		RuleId:      e.RuleID,
+		Reason:      e.Reason,
+		Status:      api.ExceptionStatus(e.Status),
+		RequestedBy: openapitypes.UUID(e.RequestedBy),
+		RequestedAt: e.RequestedAt,
+		ExpiresAt:   e.ExpiresAt,
+		ReviewedAt:  e.ReviewedAt,
+	}
+	if e.ReviewedBy != nil {
+		rb := openapitypes.UUID(*e.ReviewedBy)
+		out.ReviewedBy = &rb
+	}
+	if e.ReviewNote != "" {
+		n := e.ReviewNote
+		out.ReviewNote = &n
+	}
+	return out
+}
+
+func writeExceptionList(w http.ResponseWriter, items []exception.Exception) {
+	resp := api.ExceptionList{Exceptions: []api.Exception{}}
+	for _, e := range items {
+		resp.Exceptions = append(resp.Exceptions, toAPIException(e))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// exceptionSvcReady guards every handler: 503 when the service is not
+// wired (the generic builder guard, system-daemon-orchestration AC-11,
+// keeps this from happening in serve).
+func (h *handlers) exceptionSvcReady(w http.ResponseWriter) bool {
+	if h.exceptionSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "server.unavailable", "server",
+			"exception service not wired", true)
+		return false
+	}
+	return true
+}
+
+// reviewerID returns the authenticated user's UUID, or an error
+// response if it cannot be parsed (should not happen post-auth).
+func (h *handlers) reviewerID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	id, err := uuid.Parse(auth.FromContext(r.Context()).ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"actor id unavailable", true)
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// mapExceptionErr translates a service error to an HTTP response.
+// Returns true when it handled (wrote) the error.
+func mapExceptionErr(w http.ResponseWriter, err error) bool {
+	switch {
+	case err == nil:
+		return false
+	case errors.Is(err, exception.ErrNotFound):
+		writeError(w, http.StatusNotFound, "exceptions.not_found", "client",
+			"exception not found", false)
+	case errors.Is(err, exception.ErrDuplicateOpen):
+		writeError(w, http.StatusConflict, "exceptions.already_open", "client",
+			"an open exception already exists for this host and rule", false)
+	case errors.Is(err, exception.ErrWrongState):
+		writeError(w, http.StatusConflict, "exceptions.wrong_state", "client",
+			"action not valid for the exception's current state", false)
+	case errors.Is(err, exception.ErrSelfReview):
+		writeError(w, http.StatusConflict, "exceptions.self_review", "client",
+			"the requester cannot review their own exception", false)
+	case errors.Is(err, exception.ErrInvalidInput):
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"rule_id and reason are required", false)
+	default:
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"exception operation failed", true)
+	}
+	return true
+}
+
+// GetHostExceptions implements api.ServerInterface.
+// Spec api-compliance-exceptions AC-06.
+func (h *handlers) GetHostExceptions(
+	w http.ResponseWriter, r *http.Request, id openapitypes.UUID, params api.GetHostExceptionsParams,
+) {
+	if denied := auth.EnforcePermission(w, r, auth.ExceptionRead); denied {
+		return
+	}
+	if !h.exceptionSvcReady(w) {
+		return
+	}
+	ctx := r.Context()
+	hostID := uuid.UUID(id)
+	if _, err := h.hosts.GetByID(ctx, hostID); err != nil {
+		if errors.Is(err, host.ErrHostNotFound) {
+			writeError(w, http.StatusNotFound, "hosts.not_found", "client", "host not found", false)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server.error", "server", "lookup failed", true)
+		return
+	}
+	includeHistory := params.History != nil && *params.History
+	items, err := h.exceptionSvc.ListForHost(ctx, hostID, includeHistory)
+	if mapExceptionErr(w, err) {
+		return
+	}
+	writeExceptionList(w, items)
+}
+
+// PostHostException implements api.ServerInterface.
+// Spec api-compliance-exceptions AC-01, AC-06.
+func (h *handlers) PostHostException(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.ExceptionRequest); denied {
+		return
+	}
+	if !h.exceptionSvcReady(w) {
+		return
+	}
+	ctx := r.Context()
+	hostID := uuid.UUID(id)
+	if _, err := h.hosts.GetByID(ctx, hostID); err != nil {
+		if errors.Is(err, host.ErrHostNotFound) {
+			writeError(w, http.StatusNotFound, "hosts.not_found", "client", "host not found", false)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server.error", "server", "lookup failed", true)
+		return
+	}
+	var req api.ExceptionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"malformed request body", false)
+		return
+	}
+	requestedBy, ok := h.reviewerID(w, r)
+	if !ok {
+		return
+	}
+	e, err := h.exceptionSvc.Request(ctx, hostID, req.RuleId, req.Reason, requestedBy, req.ExpiresAt)
+	if mapExceptionErr(w, err) {
+		return
+	}
+	writeJSON(w, http.StatusCreated, toAPIException(e))
+}
+
+// GetComplianceExceptions implements api.ServerInterface.
+// Spec api-compliance-exceptions AC-06.
+func (h *handlers) GetComplianceExceptions(
+	w http.ResponseWriter, r *http.Request, params api.GetComplianceExceptionsParams,
+) {
+	if denied := auth.EnforcePermission(w, r, auth.ExceptionRead); denied {
+		return
+	}
+	if !h.exceptionSvcReady(w) {
+		return
+	}
+	var status exception.Status
+	if params.Status != nil {
+		status = exception.Status(*params.Status)
+	}
+	limit := 200
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	items, err := h.exceptionSvc.ListFleet(r.Context(), status, limit)
+	if mapExceptionErr(w, err) {
+		return
+	}
+	writeExceptionList(w, items)
+}
+
+// reviewException is the shared body for approve/reject/revoke: parse
+// xid + note, run the transition fn, map the result.
+func (h *handlers) reviewException(
+	w http.ResponseWriter, r *http.Request, xid openapitypes.UUID, perm auth.Permission,
+	fn func(ctx context.Context, id, reviewer uuid.UUID, note string) (exception.Exception, error),
+) {
+	if denied := auth.EnforcePermission(w, r, perm); denied {
+		return
+	}
+	if !h.exceptionSvcReady(w) {
+		return
+	}
+	var req api.ExceptionReview
+	_ = json.NewDecoder(r.Body).Decode(&req) // body optional
+	note := ""
+	if req.Note != nil {
+		note = *req.Note
+	}
+	reviewer, ok := h.reviewerID(w, r)
+	if !ok {
+		return
+	}
+	e, err := fn(r.Context(), uuid.UUID(xid), reviewer, note)
+	if mapExceptionErr(w, err) {
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPIException(e))
+}
+
+// PostExceptionApprove implements api.ServerInterface.
+// Spec api-compliance-exceptions AC-02, AC-03, AC-06.
+func (h *handlers) PostExceptionApprove(w http.ResponseWriter, r *http.Request, xid openapitypes.UUID) {
+	h.reviewException(w, r, xid, auth.ExceptionApprove, h.exceptionSvc.Approve)
+}
+
+// PostExceptionReject implements api.ServerInterface.
+// Spec api-compliance-exceptions AC-02, AC-03, AC-06.
+func (h *handlers) PostExceptionReject(w http.ResponseWriter, r *http.Request, xid openapitypes.UUID) {
+	h.reviewException(w, r, xid, auth.ExceptionApprove, h.exceptionSvc.Reject)
+}
+
+// PostExceptionRevoke implements api.ServerInterface.
+// Spec api-compliance-exceptions AC-02, AC-06.
+func (h *handlers) PostExceptionRevoke(w http.ResponseWriter, r *http.Request, xid openapitypes.UUID) {
+	h.reviewException(w, r, xid, auth.ExceptionRevoke, h.exceptionSvc.Revoke)
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/credential"
 	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/exception"
 	"github.com/Hanalyx/openwatch/internal/fleetrollup"
 	"github.com/Hanalyx/openwatch/internal/host"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
@@ -76,6 +77,10 @@ type handlers struct {
 	// exercise it. The key is scheduler.DeriveQueueKey output — the
 	// same HMAC key the worker verifies. Spec api-host-scan.
 	scanQueueKey []byte
+
+	// Compliance exception governance service. Set via
+	// (*Server).WithExceptions; nil makes the exception endpoints 503.
+	exceptionSvc *exception.Service
 
 	// Kensa variable catalog (corpus-used template variables). Set via
 	// (*Server).WithVariableCatalog; nil renders an empty variables

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/config"
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/exception"
 	"github.com/Hanalyx/openwatch/internal/idempotency"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/kensa"
@@ -112,6 +113,14 @@ func (s *Server) WithScanQueue(queueKey []byte) *Server {
 // falls back to rule ids. Spec api-host-compliance.
 func (s *Server) WithRuleCatalog(c *kensa.RuleCatalog) *Server {
 	s.handlers.ruleCatalog = c
+	return s
+}
+
+// WithExceptions threads the compliance exception governance service
+// into the API handlers. Nil makes the exception endpoints 503.
+// Spec api-compliance-exceptions.
+func (s *Server) WithExceptions(e *exception.Service) *Server {
+	s.handlers.exceptionSvc = e
 	return s
 }
 

--- a/specs/api/compliance-exceptions.spec.yaml
+++ b/specs/api/compliance-exceptions.spec.yaml
@@ -1,0 +1,124 @@
+spec:
+  id: api-compliance-exceptions
+  title: Compliance exception governance - operator rule waivers (request/approve/revoke lifecycle)
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Operator-approved rule waivers with a request -> approve/reject -> revoke/expire lifecycle, DB-backed, as a governance overlay that never mutates scan results
+    description: >
+      A compliance exception is an operator's documented acceptance of
+      a failing rule on a host ("we accept this risk: rule X on host Y,
+      because Z, until date D"). Scan plan Phase 7, exception
+      governance. DB-backed (decision 2026-06-13): an exception is
+      approval-workflow data with a lifecycle, queries, and an audit
+      trail - relational, not a signed static policy file.
+
+      OVERLAY MODEL (load-bearing): an exception NEVER mutates
+      host_rule_state. A failing rule with an active exception stays
+      'fail' in the raw scan results - Kensa's verdict is
+      authoritative. The exception is an OpenWatch governance
+      annotation the lens/UI reads to mark a failure as accepted risk;
+      the raw compliance score stays honest. host_rule_state.skip_reason
+      is for Kensa capability-gate skips and is unrelated.
+
+      Lifecycle: requested -> approved | rejected ; approved -> revoked
+      | expired. "Active" (suppressing) = approved AND not past
+      expires_at. The expiry sweep flips approved->expired on a cron
+      tick and emits compliance.exception.expired; count/annotation
+      queries also guard on expires_at so they are correct between
+      sweeps.
+
+      Separation of duties: the requester cannot review their own
+      request (enforced in the service, on top of the distinct
+      exception:request vs exception:approve RBAC permissions). Role
+      grants (auth/permissions.yaml): viewer reads; ops_lead requests;
+      auditor + security_admin approve; security_admin revokes
+      (dangerous).
+
+      Endpoints:
+        POST /hosts/{id}/exceptions          - request (exception:request)
+        GET  /hosts/{id}/exceptions          - per-host list (exception:read)
+        GET  /compliance/exceptions          - fleet queue (exception:read)
+        POST /exceptions/{xid}:approve       - approve (exception:approve)
+        POST /exceptions/{xid}:reject        - reject  (exception:approve)
+        POST /exceptions/{xid}:revoke        - revoke  (exception:revoke)
+
+      Each transition emits its compliance.exception.* audit code
+      (requested/approved/rejected/revoked/expired).
+
+    related_specs:
+      - api-host-compliance
+      - system-rbac
+      - system-audit-emission
+
+  objective:
+    summary: >
+      A correct, auditable waiver lifecycle with separation of duties,
+      one open exception per host+rule, and an overlay that leaves the
+      raw scan verdict untouched.
+    scope:
+      includes:
+        - compliance_exceptions table (migration 0026) + the lifecycle service
+        - Request / Approve / Reject / Revoke / ListForHost / ListFleet / ActiveCountForHost / ActiveRuleIDsForHost / ExpireSweep
+        - The six HTTP endpoints with their RBAC bars
+        - Expiry sweep on a cron tick, wired in serve
+      excludes:
+        - Fleet-wide / host-group exceptions (per-host + per-rule only in v1)
+        - Comment threads (exception:comment is reserved; not built in v1)
+        - Score recomputation under exceptions (overlay only; the raw score is unchanged)
+        - The remediation half of Phase 7
+
+  constraints:
+    - id: C-01
+      description: 'An exception NEVER mutates host_rule_state: the failing rule stays fail in the raw scan results. The service only reads host-scoped exception rows for annotation (ActiveRuleIDsForHost) and counts (ActiveCountForHost); no exception code path writes to host_rule_state or transactions'
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: 'At most ONE open (requested or approved) exception may exist per (host_id, rule_id), enforced by a partial-unique index; a duplicate Request returns ErrDuplicateOpen. Rejected/revoked/expired rows are historical and do not block a fresh request'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'Lifecycle transitions are guarded: Approve/Reject require status=requested, Revoke requires status=approved; a transition from any other state returns ErrWrongState. The transition locks the row (FOR UPDATE) so concurrent reviewers cannot double-transition. Each transition emits the matching compliance.exception.* audit code'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'Separation of duties: Approve and Reject reject a reviewer equal to the requester (ErrSelfReview), independent of RBAC. Revoke does not (revoking an active exception is not a self-review concern)'
+      type: security
+      enforcement: error
+    - id: C-05
+      description: 'RBAC: request requires exception:request, read endpoints require exception:read, approve+reject require exception:approve, revoke requires exception:revoke; anonymous callers are rejected on all. The host-scoped endpoints 404 hosts.not_found for unknown hosts before any exception read'
+      type: security
+      enforcement: error
+    - id: C-06
+      description: '"Active" (suppressing) is status=approved AND (expires_at IS NULL OR expires_at > now()). ActiveCountForHost and ActiveRuleIDsForHost apply this predicate so they are correct even before the expiry sweep runs. ExpireSweep flips approved+past-expiry to expired and emits compliance.exception.expired per row; it is idempotent'
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'Request inserts a requested row (host_id, rule_id, reason, requested_by, optional expires_at) and emits compliance.exception.requested; a second Request for the same host+rule while one is requested-or-approved returns ErrDuplicateOpen; an empty rule_id or reason returns ErrInvalidInput; a fresh Request after the prior one was rejected/revoked/expired succeeds'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-02
+      description: 'Approve (requester != reviewer) moves requested->approved, sets reviewed_by/reviewed_at, emits compliance.exception.approved; Reject moves requested->rejected and emits rejected; Revoke moves approved->revoked and emits revoked. Approving/Rejecting a non-requested row, or Revoking a non-approved row, returns ErrWrongState'
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-03
+      description: 'Approve and Reject with reviewer == requester return ErrSelfReview and leave the row unchanged; Revoke with reviewer == requester succeeds (no self-review guard)'
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-04
+      description: 'ActiveCountForHost and ActiveRuleIDsForHost count/return only approved, non-expired rows (requested, rejected, revoked, expired, and approved-but-past-expiry are excluded); host_rule_state is never written by any exception path (source inspection of internal/exception)'
+      priority: critical
+      references_constraints: [C-01, C-06]
+    - id: AC-05
+      description: 'ExpireSweep flips every approved row whose expires_at has passed to expired, emits compliance.exception.expired per flipped row, returns the count, and is idempotent (a second run flips zero); approved rows with a future or null expires_at are untouched'
+      priority: high
+      references_constraints: [C-06]
+    - id: AC-06
+      description: 'Endpoint RBAC + lifecycle: POST /hosts/{id}/exceptions requires exception:request and 404s an unknown host; GET endpoints require exception:read; POST :approve/:reject require exception:approve; POST :revoke requires exception:revoke; anonymous callers are rejected on all six; an ops_lead (request, no approve) is 403 on :approve. A full request->approve->revoke happy path round-trips through the HTTP layer'
+      priority: critical
+      references_constraints: [C-05, C-03]

--- a/specter.yaml
+++ b/specter.yaml
@@ -68,6 +68,7 @@ domains:
             - api-host-compliance
             - api-system-scan-config
             - api-compliance-trend
+            - api-compliance-exceptions
             - system-posture-snapshots
             - frontend-host-compliance-tab
 settings:


### PR DESCRIPTION
First half of scan plan Phase 7: compliance **exception governance** — operator-approved rule waivers. DB-backed per the ratified decision (2026-06-13): an exception is approval-workflow data with a lifecycle, queries, and an audit trail — relational, not a signed static policy file.

## Overlay model (load-bearing)

An exception **never mutates `host_rule_state`**. A failing rule with an active exception stays `fail` in the raw scan results — Kensa's verdict is authoritative. The exception is an OpenWatch governance annotation the lens/UI reads to mark a failure as accepted risk; the raw compliance score stays honest. (`skip_reason` is for Kensa capability-gate skips and is unrelated.)

## What's here

- **Migration 0026** `compliance_exceptions`: partial-unique one-open-per-(host, rule); lifecycle `requested → approved | rejected`, `approved → revoked | expired`
- **`internal/exception` service**: Request / Approve / Reject / Revoke / ListForHost / ListFleet / ActiveCountForHost / ActiveRuleIDsForHost / ExpireSweep. Row-locked transitions; **separation of duties** — the requester cannot review their own request, on top of the distinct `exception:request` vs `exception:approve` RBAC permissions. Each transition emits its `compliance.exception.*` audit code. Hourly expiry sweep wired in serve (mirrors `posture.Run`)
- **Six endpoints** (api-compliance-exceptions v1.0.0): `POST`/`GET /hosts/{id}/exceptions`, `GET /compliance/exceptions`, `POST /exceptions/{xid}:approve`/`:reject`/`:revoke`. RBAC bars: ops_lead requests, auditor + security_admin approve, security_admin revokes

The permissions, audit codes, and role grants were already defined in the registry — this builds to them.

## Testing
- 5 service ACs (request/duplicate/reopen, lifecycle transitions, separation of duties, overlay-never-mutates, expiry sweep idempotent) + the endpoint RBAC/lifecycle AC — all green under DSN
- Full server suite green under `-race`-free DSN run (274s); the generic builder-wiring guard (#519) covers `WithExceptions`
- Live: migration applied to dev, routes registered (403 unauth, not 404/503), boot expiry sweep ran

## Next
Frontend wiring (Watchlist Exceptions count, Compliance-tab waived-rule annotation, Settings exception-workflow, intel-tile count) is the follow-up PR.