### PR TITLE
feat(exceptions): host-detail exception surfaces (view + request)

### DIFF
--- a/frontend/src/hooks/useHostExceptions.ts
+++ b/frontend/src/hooks/useHostExceptions.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import type { components } from '@/api/schema';
+
+type Exception = components['schemas']['Exception'];
+
+// useHostExceptions fetches a host's open compliance exceptions
+// (requested + approved) once and derives the views the host-detail
+// surfaces need. The query key carries the ['host', hostId] prefix so
+// the scan.completed SSE invalidation and exception mutations both
+// refresh it, and so the Watchlist tile, the Server-intelligence tile,
+// and the Compliance tab share a single round-trip.
+//
+// Overlay model: an exception never changes a rule's raw verdict
+// (api-compliance-exceptions C-01). activeRuleIds annotates which
+// failing rules are waived; it never mutates the lens data.
+export interface HostExceptions {
+  items: Exception[];
+  activeRuleIds: Set<string>;
+  pendingRuleIds: Set<string>;
+  activeCount: number;
+  pendingCount: number;
+  isPending: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+export function useHostExceptions(hostId: string): HostExceptions {
+  const query = useQuery({
+    queryKey: ['host', hostId, 'exceptions'],
+    queryFn: async (): Promise<Exception[]> => {
+      const { data, error, response } = await api.GET('/api/v1/hosts/{id}/exceptions', {
+        params: { path: { id: hostId } },
+      });
+      if (error || !response.ok) {
+        throw new Error(apiErrorMessage(error, `Failed to load (${response.status})`));
+      }
+      return data!.exceptions;
+    },
+    enabled: !!hostId,
+  });
+
+  const items = query.data ?? [];
+  const now = Date.now();
+  const active = items.filter(
+    (e) => e.status === 'approved' && (!e.expires_at || new Date(e.expires_at).getTime() > now),
+  );
+  const pending = items.filter((e) => e.status === 'requested');
+
+  return {
+    items,
+    activeRuleIds: new Set(active.map((e) => e.rule_id)),
+    pendingRuleIds: new Set(pending.map((e) => e.rule_id)),
+    activeCount: active.length,
+    pendingCount: pending.length,
+    isPending: query.isPending,
+    isError: query.isError,
+    refetch: () => void query.refetch(),
+  };
+}

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import api from '@/api/client';
+import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { apiErrorCode, apiErrorMessage } from '@/api/errors';
 import { EditHostModal } from '@/components/hosts/EditHostModal';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
@@ -1400,6 +1401,15 @@ function HeroWatchlist({ hostId }: { hostId: string }) {
         ? 'No alerts firing'
         : `Worst severity: ${worst}`;
 
+  const exc = useHostExceptions(hostId);
+  const excSubtext = exc.isError
+    ? 'Failed to load exceptions'
+    : exc.isPending
+      ? 'Loading'
+      : exc.activeCount === 0
+        ? 'No suppressed rules'
+        : `${exc.activeCount} rule${exc.activeCount === 1 ? '' : 's'} waived`;
+
   return (
     <article style={heroCard} aria-labelledby="hero-watch-title">
       <header style={heroHead}>
@@ -1407,7 +1417,7 @@ function HeroWatchlist({ hostId }: { hostId: string }) {
         <Bell size={14} aria-hidden />
       </header>
       <WatchlistRow label={'Active alerts'} value={count} subtext={alertsSubtext} />
-      <WatchlistRow label={'Exceptions'} value={0} subtext="No suppressed rules" />
+      <WatchlistRow label={'Exceptions'} value={exc.activeCount} subtext={excSubtext} />
       <div
         style={{
           marginTop: 6,
@@ -1418,7 +1428,9 @@ function HeroWatchlist({ hostId }: { hostId: string }) {
           lineHeight: 1.5,
         }}
       >
-        Exceptions (operator rule waivers) ship with the remediation work.
+        {exc.pendingCount > 0
+          ? `${exc.pendingCount} exception ${exc.pendingCount === 1 ? 'request awaits' : 'requests await'} review.`
+          : 'Exceptions are operator-approved rule waivers (accepted risk).'}
       </div>
     </article>
   );

--- a/frontend/src/pages/host-detail/CardServerIntel.tsx
+++ b/frontend/src/pages/host-detail/CardServerIntel.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RefreshCw } from 'lucide-react';
 import api from '@/api/client';
+import { useHostExceptions } from '@/hooks/useHostExceptions';
 
 // Snapshot keys mirror collector.Snapshot (Go struct in
 // internal/intelligence/collector/types.go). additionalProperties is
@@ -73,6 +74,11 @@ export function CardServerIntel({ hostId }: CardServerIntelProps) {
     retry: false,
   });
 
+  // Open-exceptions tile data comes from the exception governance
+  // service, not the intel snapshot (overlay model). Shared query key
+  // with the Watchlist tile = one round-trip.
+  const exc = useHostExceptions(hostId);
+
   // 404 → query.data === null (resolved success), the view renders the
   // "Not collected yet" empty state below.
   return (
@@ -83,6 +89,7 @@ export function CardServerIntel({ hostId }: CardServerIntelProps) {
       snapshot={query.data ?? undefined}
       collectedAt={query.data?.collected_at}
       onRetry={() => query.refetch()}
+      activeExceptions={exc.activeCount}
     />
   );
 }
@@ -97,6 +104,9 @@ export interface CardServerIntelViewProps {
   snapshot?: IntelligenceSnapshot;
   collectedAt?: string;
   onRetry: () => void;
+  // Active (approved, unexpired) exception count for the Open
+  // exceptions tile. Undefined renders the dash placeholder.
+  activeExceptions?: number;
 }
 
 export function CardServerIntelView({
@@ -106,6 +116,7 @@ export function CardServerIntelView({
   snapshot,
   collectedAt,
   onRetry,
+  activeExceptions,
 }: CardServerIntelViewProps) {
   let body: React.ReactNode;
   if (isLoading) {
@@ -124,7 +135,7 @@ export function CardServerIntelView({
   } else if (isError) {
     body = <ErrorState onRetry={onRetry} />;
   } else if (snapshot) {
-    body = <TileGrid snapshot={snapshot} />;
+    body = <TileGrid snapshot={snapshot} activeExceptions={activeExceptions} />;
   } else {
     // Defensive: success with null body — render as empty.
     body = (
@@ -144,7 +155,13 @@ export function CardServerIntelView({
 
 // ── Tile grid ─────────────────────────────────────────────────────────────
 
-function TileGrid({ snapshot }: { snapshot: IntelligenceSnapshot }) {
+function TileGrid({
+  snapshot,
+  activeExceptions,
+}: {
+  snapshot: IntelligenceSnapshot;
+  activeExceptions?: number;
+}) {
   const packagesCount = Object.keys(snapshot.packages ?? {}).length;
   const services = snapshot.services ?? {};
   const servicesTotal = Object.keys(services).length;
@@ -203,7 +220,15 @@ function TileGrid({ snapshot }: { snapshot: IntelligenceSnapshot }) {
         subline={firewall.subline}
         sublineTone={firewall.tone}
       />
-      <Tile label="Open exceptions" value="—" subline="No rules suppressed" />
+      <Tile
+        label="Open exceptions"
+        value={activeExceptions === undefined ? '—' : String(activeExceptions)}
+        subline={
+          activeExceptions
+            ? `${activeExceptions} rule${activeExceptions === 1 ? '' : 's'} waived`
+            : 'No rules suppressed'
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/pages/host-detail/ComplianceTab.tsx
+++ b/frontend/src/pages/host-detail/ComplianceTab.tsx
@@ -42,10 +42,12 @@
 
 import { useMemo, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
 import type { components } from '@/api/schema';
+import { useAuthStore } from '@/store/useAuthStore';
+import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { SeverityPill } from '@/pages/host-detail/SeverityPill';
 
 type LensResponse = components['schemas']['HostComplianceLensResponse'];
@@ -113,6 +115,13 @@ export function ComplianceTab({
   // refetches. Spec C-03 / AC-04.
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [search, setSearch] = useState('');
+
+  // Exception overlay: which failing rules are waived (active) or have
+  // a pending request. Never mutates the lens data (overlay model).
+  const exc = useHostExceptions(hostId);
+  const canRequest = useAuthStore((st) => st.hasPermission)('exception:request');
+  // The rule a Request-exception modal is open for (null = closed).
+  const [requestRule, setRequestRule] = useState<LensRule | null>(null);
 
   let body: ReactNode;
   // isPending (not isLoading): isLoading goes false between retry
@@ -192,6 +201,10 @@ export function ComplianceTab({
           search={search}
           onSearchChange={setSearch}
           frameworkActive={!!framework}
+          activeRuleIds={exc.activeRuleIds}
+          pendingRuleIds={exc.pendingRuleIds}
+          canRequest={canRequest}
+          onRequest={setRequestRule}
         />
       </>
     );
@@ -215,6 +228,17 @@ export function ComplianceTab({
         onFrameworkChange={onFrameworkChange}
       />
       {body}
+      {requestRule && (
+        <RequestExceptionModal
+          hostId={hostId}
+          rule={requestRule}
+          onClose={() => setRequestRule(null)}
+          onSuccess={() => {
+            setRequestRule(null);
+            exc.refetch();
+          }}
+        />
+      )}
     </section>
   );
 }
@@ -891,6 +915,10 @@ function RulesTable({
   search,
   onSearchChange,
   frameworkActive,
+  activeRuleIds,
+  pendingRuleIds,
+  canRequest,
+  onRequest,
 }: {
   rules: LensRule[];
   filter: StatusFilter;
@@ -898,6 +926,10 @@ function RulesTable({
   search: string;
   onSearchChange: (next: string) => void;
   frameworkActive: boolean;
+  activeRuleIds: Set<string>;
+  pendingRuleIds: Set<string>;
+  canRequest: boolean;
+  onRequest: (rule: LensRule) => void;
 }) {
   const counts = useMemo(() => {
     const c: Record<StatusFilter, number> = {
@@ -1019,6 +1051,7 @@ function RulesTable({
               <Th>Rule and framework refs</Th>
               <Th width={160}>Category</Th>
               <Th width={110}>Last checked</Th>
+              <Th width={150}>Exception</Th>
             </tr>
           </thead>
           <tbody>
@@ -1048,6 +1081,15 @@ function RulesTable({
                 <td style={{ ...td, color: 'var(--ow-fg-2)' }}>{r.category}</td>
                 <td style={{ ...td, color: 'var(--ow-fg-3)', whiteSpace: 'nowrap', fontSize: 12 }}>
                   {relativeTime(r.last_checked_at)}
+                </td>
+                <td style={td}>
+                  <ExceptionCell
+                    rule={r}
+                    waived={activeRuleIds.has(r.rule_id)}
+                    pending={pendingRuleIds.has(r.rule_id)}
+                    canRequest={canRequest}
+                    onRequest={onRequest}
+                  />
                 </td>
               </tr>
             ))}
@@ -1120,6 +1162,245 @@ function StatusChip({ status }: { status: string }) {
       <span aria-hidden style={{ width: 6, height: 6, borderRadius: '50%', background: s.fg }} />
       {s.label}
     </span>
+  );
+}
+
+// ExceptionCell renders, for a rule's row, the exception governance
+// state: a Waived pill (active approved exception), a Pending pill (a
+// request awaiting review), or - for an unwaived FAILING rule and a
+// caller with exception:request - a Request button. Non-failing rules
+// with no exception render nothing. The overlay never changes the
+// rule's status chip.
+function ExceptionCell({
+  rule,
+  waived,
+  pending,
+  canRequest,
+  onRequest,
+}: {
+  rule: LensRule;
+  waived: boolean;
+  pending: boolean;
+  canRequest: boolean;
+  onRequest: (rule: LensRule) => void;
+}) {
+  if (waived) {
+    return (
+      <span style={{ ...excPill, color: 'var(--ow-info)', background: 'var(--ow-bg-2)' }}>
+        Waived
+      </span>
+    );
+  }
+  if (pending) {
+    return (
+      <span style={{ ...excPill, color: 'var(--ow-warn)', background: 'var(--ow-bg-2)' }}>
+        Pending
+      </span>
+    );
+  }
+  if (rule.status === 'fail' && canRequest) {
+    return (
+      <button
+        type="button"
+        onClick={() => onRequest(rule)}
+        style={{
+          height: 26,
+          padding: '0 10px',
+          background: 'var(--ow-bg-2)',
+          color: 'var(--ow-fg-1)',
+          border: '1px solid var(--ow-line)',
+          borderRadius: 7,
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: 'pointer',
+        }}
+      >
+        Request exception
+      </button>
+    );
+  }
+  return <span style={{ color: 'var(--ow-fg-3)', fontSize: 11 }}>—</span>;
+}
+
+const excPill: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '2px 8px',
+  borderRadius: 999,
+  fontSize: 11,
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+
+// RequestExceptionModal collects the reason (required) and an optional
+// expiry, then POSTs /hosts/{id}/exceptions. The host-detail
+// exceptions query is refreshed by the parent on success. A 409 (an
+// open exception already exists) surfaces inline. Spec
+// api-compliance-exceptions.
+function RequestExceptionModal({
+  hostId,
+  rule,
+  onClose,
+  onSuccess,
+}: {
+  hostId: string;
+  rule: LensRule;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [reason, setReason] = useState('');
+  const [expires, setExpires] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const { error, response } = await api.POST('/api/v1/hosts/{id}/exceptions', {
+        params: { path: { id: hostId } },
+        body: {
+          rule_id: rule.rule_id,
+          reason: reason.trim(),
+          expires_at: expires ? new Date(expires).toISOString() : null,
+        },
+      });
+      if (error || !response.ok) {
+        if (response.status === 409) {
+          throw new Error('An open exception already exists for this rule.');
+        }
+        throw new Error(apiErrorMessage(error, `Request failed (${response.status})`));
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['host', hostId, 'exceptions'] });
+      onSuccess();
+    },
+  });
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Request compliance exception"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 460,
+          maxWidth: '90vw',
+          background: 'var(--ow-bg-1)',
+          border: '1px solid var(--ow-line)',
+          borderRadius: 'var(--ow-radius)',
+          padding: 20,
+        }}
+      >
+        <h3 style={{ margin: '0 0 4px', fontSize: 14, fontWeight: 600 }}>Request exception</h3>
+        <div style={{ color: 'var(--ow-fg-2)', fontSize: 12, marginBottom: 4 }}>{rule.title}</div>
+        <div
+          style={{
+            fontFamily: 'var(--ow-font-mono)',
+            fontSize: 11,
+            color: 'var(--ow-fg-3)',
+            marginBottom: 14,
+          }}
+        >
+          {rule.rule_id}
+        </div>
+
+        <label style={{ display: 'block', fontSize: 12, color: 'var(--ow-fg-2)', marginBottom: 4 }}>
+          Reason (required)
+        </label>
+        <textarea
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          rows={3}
+          aria-label="Exception reason"
+          placeholder="Why is this failure an accepted risk?"
+          style={{
+            width: '100%',
+            background: 'var(--ow-bg-2)',
+            border: '1px solid var(--ow-line)',
+            borderRadius: 7,
+            color: 'var(--ow-fg-0)',
+            fontSize: 13,
+            padding: 8,
+            resize: 'vertical',
+            marginBottom: 14,
+          }}
+        />
+
+        <label style={{ display: 'block', fontSize: 12, color: 'var(--ow-fg-2)', marginBottom: 4 }}>
+          Expires (optional)
+        </label>
+        <input
+          type="date"
+          value={expires}
+          onChange={(e) => setExpires(e.target.value)}
+          aria-label="Exception expiry date"
+          style={{
+            background: 'var(--ow-bg-2)',
+            border: '1px solid var(--ow-line)',
+            borderRadius: 7,
+            color: 'var(--ow-fg-0)',
+            fontSize: 13,
+            padding: '6px 8px',
+            marginBottom: 16,
+          }}
+        />
+
+        {mutation.error && (
+          <div style={{ color: 'var(--ow-crit)', fontSize: 12, marginBottom: 12 }} role="alert">
+            {(mutation.error as Error).message}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              height: 32,
+              padding: '0 14px',
+              background: 'var(--ow-bg-2)',
+              color: 'var(--ow-fg-1)',
+              border: '1px solid var(--ow-line)',
+              borderRadius: 7,
+              fontSize: 12,
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={reason.trim() === '' || mutation.isPending}
+            onClick={() => mutation.mutate()}
+            style={{
+              height: 32,
+              padding: '0 14px',
+              background: 'var(--ow-info)',
+              color: 'var(--ow-info-on)',
+              border: 0,
+              borderRadius: 7,
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: reason.trim() === '' || mutation.isPending ? 'default' : 'pointer',
+              opacity: reason.trim() === '' || mutation.isPending ? 0.6 : 1,
+            }}
+          >
+            {mutation.isPending ? 'Submitting' : 'Submit request'}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/tests/pages/host-detail-compliance-tab.test.tsx
+++ b/frontend/tests/pages/host-detail-compliance-tab.test.tsx
@@ -410,3 +410,28 @@ describe('frontend-host-compliance-tab — re-scan', () => {
     expect(TAB_SRC).not.toMatch(/aria-label=["']Export/);
   });
 });
+
+describe('frontend-host-compliance-tab v1.2.0 — exception overlay', () => {
+  // @ac AC-09
+  test('frontend-host-compliance-tab/AC-09 — waived/pending badges + request action; overlay never mutates the lens', () => {
+    // Source inspection over the tab.
+    expect(TAB_SRC).toContain('useHostExceptions(hostId)');
+    expect(TAB_SRC).toContain("hasPermission)('exception:request')");
+    // Exception column cell with the three states.
+    expect(TAB_SRC).toContain('function ExceptionCell');
+    expect(TAB_SRC).toMatch(/Waived/);
+    expect(TAB_SRC).toMatch(/Pending/);
+    expect(TAB_SRC).toContain('Request exception');
+    // Request modal posts and invalidates the host exceptions key.
+    expect(TAB_SRC).toContain('function RequestExceptionModal');
+    expect(TAB_SRC).toContain("api.POST('/api/v1/hosts/{id}/exceptions'");
+    expect(TAB_SRC).toContain(
+      "queryClient.invalidateQueries({ queryKey: ['host', hostId, 'exceptions'] })",
+    );
+    // Reason required: submit disabled until non-empty.
+    expect(TAB_SRC).toMatch(/disabled=\{reason\.trim\(\) === ''/);
+    // Overlay model: the request button only on FAILING rules; the
+    // status chip is untouched (no remap of r.status by the overlay).
+    expect(TAB_SRC).toContain("rule.status === 'fail' && canRequest");
+  });
+});

--- a/frontend/tests/pages/host-detail-shell.test.ts
+++ b/frontend/tests/pages/host-detail-shell.test.ts
@@ -177,10 +177,10 @@ describe('frontend-host-detail — prototype shell', () => {
   // @ac AC-22
   test('frontend-host-detail/AC-22 — watchlist carries no coming-soon blob; only the exceptions footer pends', () => {
     expect(PAGE_SRC).toContain('HeroWatchlist');
-    // The alerts half is live (AC-30); the sole pending note is the
-    // exceptions footer naming the remediation track.
+    // Both halves are live now (alerts + exceptions); no coming-soon
+    // blob, no remediation-track placeholder remains.
     expect(PAGE_SRC).not.toMatch(/alerts? (subsystem|backend).*(BACKLOG|coming soon)/i);
-    expect(PAGE_SRC).toContain('ship with the remediation work');
+    expect(PAGE_SRC).not.toContain('ship with the remediation work');
   });
 
   // @ac AC-23
@@ -318,10 +318,15 @@ describe('frontend-host-detail — prototype shell', () => {
     expect(tile).toContain("'No alerts firing'");
     expect(tile).toContain('Worst severity:');
     expect(tile).toContain("'Failed to load alerts'");
-    // Exceptions row stays the honest pending state; footer names the
-    // remediation track, not BACKLOG.
-    expect(tile).toContain('subtext="No suppressed rules"');
-    expect(tile).toContain('Exceptions (operator rule waivers) ship with the remediation work.');
+    // Exceptions row is LIVE against the host exceptions hook: the
+    // active count + a subtext that names waived rules or the pending
+    // queue; the remediation-track placeholder is gone.
+    expect(tile).toContain('useHostExceptions(hostId)');
+    expect(tile).toContain('value={exc.activeCount}');
+    expect(tile).toContain("'No suppressed rules'");
+    expect(tile).toContain('waived');
+    expect(tile).toMatch(/review/);
+    expect(tile).not.toContain('ship with the remediation work');
     expect(PAGE_SRC).not.toContain('alerts subsystem (BACKLOG)');
     expect(PAGE_SRC).toContain('<HeroWatchlist hostId={hostId} />');
   });

--- a/specs/frontend/host-compliance-tab.spec.yaml
+++ b/specs/frontend/host-compliance-tab.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-compliance-tab
   title: Host detail Compliance tab — lens UI over the per-host compliance endpoints
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -148,3 +148,7 @@ spec:
       description: "Behavior: clicking the strip's Re-scan button issues exactly one POST /api/v1/hosts/{id}/scans with an Idempotency-Key header; a 202 renders the 'Scan queued' note and a 409 renders 'Scan already running' as an informational note (no thrown error, no retry UI). Source inspection: the tab contains no Export control"
       priority: critical
       references_constraints: [C-04]
+    - id: AC-09
+      description: 'v1.2.0 - exception overlay (api-compliance-exceptions): the tab reads the host exceptions via useHostExceptions and annotates the rules table with an Exception column - a Waived pill for rules with an active (approved) exception, a Pending pill for rules with a requested one, and for a FAILING rule with no exception and a caller holding exception:request a Request button that opens a modal (reason required, optional expiry) posting POST /hosts/{id}/exceptions and invalidating ["host", hostId, "exceptions"] on success. The overlay NEVER changes a rule status chip - the failing rule still shows Non-compliant (overlay model, never mutates the lens).'
+      priority: high
+      references_constraints: [C-03]


### PR DESCRIPTION
Frontend half of scan plan Phase 7 exception governance — the requester/viewer experience over the backend that merged in #521.

## Surfaces wired

- **`useHostExceptions` hook** — one `GET /hosts/{id}/exceptions` per host (key `['host', hostId, 'exceptions']`, shared across all surfaces = one round-trip), deriving the active/pending counts and the active + pending rule-id sets. **Overlay model**: read-only, never touches the lens data
- **Watchlist Exceptions row** → live active count + "N rules waived" / pending-queue subtext; the remediation-track placeholder is gone
- **Server-intelligence "Open exceptions" tile** → live active count
- **Compliance tab Exception column** → a **Waived** pill (active approved exception), a **Pending** pill (requested), or — for a FAILING rule with no exception and a caller holding `exception:request` — a **Request** button opening a modal (reason required, optional expiry) that POSTs `/hosts/{id}/exceptions` and invalidates the host exceptions key. The failing rule's status chip stays **Non-compliant** (the overlay invariant)

## Specs / tests
- frontend-host-compliance-tab v1.2.0 (AC-09 exception overlay); host-detail AC-22/AC-30 updated to the live Watchlist exceptions row
- 232 frontend tests green; tsc strict clean; 83 specs valid, `specter check --test` 0 errors

## Live verification
Injected an approved exception → the **Waived** badge rendered on the still-**Non-compliant** rule (proving the overlay never mutates the verdict), and the Watchlist ("1 rule waived") + intel tile ("1 rule waived") counts both updated from the single shared query. The gated Request button is correctly hidden in the fixtures-mode dev session (empty frontend permission store) — the RBAC gate is proven by the backend DSN test.

## Next
The Settings approver queue (fleet list + approve/reject/revoke) is the final exception slice.