### PR TITLE
docs(engineering): remediation ships as beta in GA; ignore local nav plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -843,6 +843,7 @@ docs/guides/DEVELOPER_DOCUMENTATION_STYLE_GUIDE.md
 SESSION_LOG.md
 BACKLOG.md
 MONGODB_INDEX_MIGRATION_PLAN.md
+docs/engineering/navigation_mvp_plan.md
 
 # Dependency upgrade analysis documents (generated during updates)
 DEPENDENCY_UPGRADES_STATUS.md

--- a/docs/engineering/scan_remaining_work.md
+++ b/docs/engineering/scan_remaining_work.md
@@ -12,6 +12,16 @@
 > |------|------|---------------------|
 > | Phase 5 tail — bulk scan endpoint | small | no |
 > | Phase 7 — remediation | large (own track) | **yes** |
+>
+> **GA scope decision (2026-06-05): remediation ships as a BETA feature in the
+> GA release.** It is in-scope for GA but explicitly labelled *beta* — surfaced
+> behind a `Beta` badge, gated by the `remediation:*` RBAC perms, and limited to
+> the first-slice posture (per-rule manual, approval-gated, snapshot+rollback)
+> ratified in the decisions below. The beta label sets the expectation that the
+> auto/policy-driven and bulk-sequenced postures are *not* in GA and that the
+> blast-radius surface is still hardening. Everything else in this file (the
+> five decisions, the likely shape, the sequencing) stands — "beta in GA" is a
+> labelling + scope-boundary decision, not a change to the build order.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only change. Records a GA scope decision; no code.

- **`docs/engineering/scan_remaining_work.md`**: remediation is in scope for GA but ships as a **beta** feature — behind a `Beta` badge + `remediation:*` RBAC, limited to the first-slice posture (per-rule manual, approval-gated, snapshot+rollback). The auto/policy and bulk-sequenced postures stay out of GA.
- **`.gitignore`**: the GA navigation MVP plan (`docs/engineering/navigation_mvp_plan.md`) is kept as a **local-only working doc** (alongside `SESSION_LOG.md` / `BACKLOG.md`), so it is intentionally untracked.

> The navigation review itself (the per-surface MVP plan) lives in that local doc and is not part of this PR.
