### PR TITLE
fix(shell): disable unrouted sidebar links instead of 404ing

### DIFF
--- a/frontend/src/components/shell/Sidebar.tsx
+++ b/frontend/src/components/shell/Sidebar.tsx
@@ -20,16 +20,22 @@ interface NavItem {
   to: string;
   label: string;
   icon: React.ReactNode;
+  // enabled is false for destinations whose route is not yet in the
+  // route table (frontend/src/routes/router.tsx). Those entries render
+  // as disabled "coming soon" controls instead of Links, so the rail
+  // never points at a path that resolves to not-found.
+  // Spec: frontend-foundation C-12 / AC-18.
+  enabled: boolean;
 }
 
 const navItems: NavItem[] = [
-  { to: '/', label: 'Dashboard', icon: <LayoutDashboard size={18} /> },
-  { to: '/hosts', label: 'Hosts', icon: <Server size={18} /> },
-  { to: '/groups', label: 'Groups', icon: <Boxes size={18} /> },
-  { to: '/scans', label: 'Scans', icon: <Search size={18} /> },
-  { to: '/activity', label: 'Activity', icon: <Activity size={18} /> },
-  { to: '/reports', label: 'Reports', icon: <BarChart3 size={18} /> },
-  { to: '/terminal', label: 'Terminal', icon: <Terminal size={18} /> },
+  { to: '/', label: 'Dashboard', icon: <LayoutDashboard size={18} />, enabled: true },
+  { to: '/hosts', label: 'Hosts', icon: <Server size={18} />, enabled: true },
+  { to: '/groups', label: 'Groups', icon: <Boxes size={18} />, enabled: false },
+  { to: '/scans', label: 'Scans', icon: <Search size={18} />, enabled: false },
+  { to: '/activity', label: 'Activity', icon: <Activity size={18} />, enabled: false },
+  { to: '/reports', label: 'Reports', icon: <BarChart3 size={18} />, enabled: false },
+  { to: '/terminal', label: 'Terminal', icon: <Terminal size={18} />, enabled: false },
 ];
 
 export function Sidebar() {
@@ -72,6 +78,39 @@ export function Sidebar() {
       </Link>
 
       {navItems.map((item) => {
+        // Unbuilt destinations render as a disabled control with a
+        // "coming soon" affordance — never a Link to a missing route.
+        // A native disabled <button> is keyboard-correct and axe-clean;
+        // it is wrapped in a span so the Tooltip still fires on hover
+        // (disabled elements emit no pointer events of their own).
+        if (!item.enabled) {
+          return (
+            <Tooltip key={item.to} title={`${item.label} (coming soon)`} placement="right">
+              <span style={{ display: 'inline-flex' }}>
+                <button
+                  type="button"
+                  disabled
+                  aria-label={`${item.label} (coming soon)`}
+                  style={{
+                    width: 40,
+                    height: 40,
+                    display: 'grid',
+                    placeItems: 'center',
+                    borderRadius: 8,
+                    border: 'none',
+                    background: 'transparent',
+                    color: 'var(--ow-fg-3)',
+                    opacity: 0.45,
+                    cursor: 'default',
+                  }}
+                >
+                  {item.icon}
+                </button>
+              </span>
+            </Tooltip>
+          );
+        }
+
         const isActive = item.to === '/' ? currentPath === '/' : currentPath.startsWith(item.to);
         return (
           <Tooltip key={item.to} title={item.label} placement="right">

--- a/frontend/tests/foundation/runtime-and-shell.test.ts
+++ b/frontend/tests/foundation/runtime-and-shell.test.ts
@@ -11,6 +11,8 @@
 //   AC-13  axe-core light-mode scan of the shell shape
 //   AC-16  extendTheme called with cssVarPrefix:"ow" + dark + light colorSchemes
 //   AC-17  Route table includes /login + at least one guarded route via redirect
+//   AC-18  Sidebar renders unrouted destinations as disabled "coming soon"
+//          controls, never as Links to a not-found path
 
 import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync, existsSync } from 'node:fs';
@@ -152,6 +154,46 @@ describe('frontend-foundation — runtime + shell', () => {
     expect(ROUTER_SRC).toMatch(/return_to:/);
     // Multiple child routes hang off the protected subtree.
     expect(ROUTER_SRC).toMatch(/getParentRoute:\s*\(\)\s*=>\s*protectedRoute/);
+  });
+
+  // @ac AC-18
+  test('frontend-foundation/AC-18 — sidebar disables unrouted destinations instead of linking to a not-found path', () => {
+    // The NavItem contract carries an explicit enabled flag, and the
+    // disabled branch renders a non-navigating control (not a Link).
+    expect(SIDEBAR_SRC).toMatch(/enabled:\s*boolean/);
+    expect(SIDEBAR_SRC).toMatch(/if\s*\(\s*!item\.enabled\s*\)/);
+    // Disabled entries render a native disabled <button> with a label
+    // and a "coming soon" affordance (keyboard-correct + axe-clean).
+    expect(SIDEBAR_SRC).toMatch(/<button[\s\S]*?disabled/);
+    expect(SIDEBAR_SRC).toMatch(/coming soon/);
+    // User-facing copy (the nav labels) carries no em-dash. Scoped to
+    // the label literals, since code comments may legitimately use one.
+    const labels = (SIDEBAR_SRC.match(/label:\s*'[^']*'/g) ?? []).join(' ');
+    expect(labels).not.toContain('—');
+
+    // Core invariant — enabled item <=> its route exists in router.tsx.
+    // A disabled (coming-soon) item MUST NOT have a route yet; an
+    // enabled item MUST. Each navItems entry sits on one source line,
+    // so a per-line match tolerates the icon's own {…} braces.
+    const navRe = /to:\s*['"]([^'"]+)['"][^\n]*?enabled:\s*(true|false)/g;
+    const items = [...SIDEBAR_SRC.matchAll(navRe)].map((m) => ({
+      to: m[1] as string,
+      enabled: m[2] === 'true',
+    }));
+    expect(items.length).toBe(7); // all seven destinations present
+
+    const routeExists = (to: string): boolean => {
+      if (to === '/') return /path:\s*['"]\/['"]/.test(ROUTER_SRC);
+      const seg = to.replace(/^\//, '');
+      return new RegExp(`path:\\s*['"]${seg}['"]`).test(ROUTER_SRC);
+    };
+
+    for (const item of items) {
+      expect(
+        routeExists(item.to),
+        `${item.to}: enabled=${item.enabled} must match route-exists=${routeExists(item.to)}`,
+      ).toBe(item.enabled);
+    }
   });
 });
 

--- a/specs/frontend/foundation.spec.yaml
+++ b/specs/frontend/foundation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-foundation
   title: Frontend foundation — theme, color scheme, layout shell, route guards
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -102,6 +102,17 @@ spec:
       description: No PII or secret value MAY appear in client-side console.log / console.warn / console.error output. Error boundary error messages MUST be scrubbed of any field literally named "evidence", "token", "password", "secret", "private_key" before logging
       type: security
       enforcement: error
+    - id: C-12
+      description: >-
+        The sidebar MUST NOT render a navigation Link to a path that has
+        no matching route in the route table (such a Link resolves to
+        not-found when clicked). A nav destination whose route is not yet
+        implemented MUST instead render as a disabled, non-navigating
+        control carrying an aria-label and a "coming soon" affordance.
+        Only destinations whose route exists may render as active Links.
+        UI copy carries no em-dashes
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -172,3 +183,14 @@ spec:
       description: The route table includes /login (anonymous) and at least one guarded route; the guard component renders a redirect to /login?return_to=... on missing session, NOT a thrown exception.
       priority: high
       references_constraints: [C-06]
+    - id: AC-18
+      description: >-
+        Source-inspection — each Sidebar nav item carries an explicit
+        enabled flag; items with enabled:false render as a disabled
+        <button> (not a Link) with an aria-label and a "coming soon"
+        title, while enabled items render as Links. Every Link target in
+        the sidebar's nav list corresponds to a path present in
+        router.tsx (no Link points at an unrouted path). UI copy contains
+        no em-dash.
+      priority: high
+      references_constraints: [C-12]


### PR DESCRIPTION
## Summary

**Step 0 of the GA navigation work** (per `docs/engineering/navigation_mvp_plan.md`, kept local): stop the shell advertising sidebar destinations that resolve to a not-found page.

Five of the seven sidebar links — **Groups, Scans, Activity, Reports, Terminal** — have no entry in the route table (`frontend/src/routes/router.tsx`), so clicking them resolved to TanStack Router's not-found. They compiled only because the `Link` target was passed as a widened `string`.

## Change

- `Sidebar.tsx`: each nav item now carries an explicit `enabled` flag. Built destinations (**Dashboard**, **Hosts**) stay `<Link>`s; unbuilt ones render as a disabled native `<button>` with an `aria-label` and a `(coming soon)` tooltip — keyboard-correct and axe-clean, never pointing at a missing route. As each route lands, flip the flag.
- `frontend-foundation` spec → **v1.1.0**: adds **C-12** + **AC-18** encoding the invariant *enabled ⇔ route exists*, with a source-inspection test that fails if any enabled nav item lacks a route, or any disabled item gains one (guards against silently re-adding a dead link).

## Why disabled-in-place (not hidden, not stub pages)

Chosen by the maintainer: keeps the product's intended shape visible without making empty surfaces look navigable, and is the smallest possible change — no router changes, no backend, decoupled from every per-surface GA scoping decision.

## Verification

- `tsc --noEmit` clean
- Full frontend suite: **236 passed** (incl. new `frontend-foundation/AC-18`)
- `specter check`: 84 specs structural OK; `specter check --test`: **0 errors**
- Pre-commit: ESLint, Prettier, spec-coverage source-walk all pass
