### PR TITLE
feat(frontend): activity feed MVP at /activity + backend scope doc

### DIFF
--- a/docs/engineering/activity_page_scope.md
+++ b/docs/engineering/activity_page_scope.md
@@ -1,0 +1,111 @@
+# Activity Page — Backend Scope + MVP
+
+**Created**: 2026-06-13
+**Status**: Scoping (informs the `frontend-activity` MVP and a backend backlog)
+**Prototype**: [`prototypes/openwatch-v1/Activity.html`](prototypes/openwatch-v1/Activity.html)
+
+> The `Activity.html` prototype is far richer than the live feed can back.
+> This doc records, per prototype feature, what ships **now** (zero new backend)
+> versus what is **backend-gated** (and how much backend each needs), so the MVP
+> is honest about its boundaries.
+
+---
+
+## The backend reality
+
+`GET /api/v1/activity` (`internal/activity/service.go`) is a **read-only UNION
+projection** of five sources — `alert`, `transaction`, `intelligence`, `audit`,
+`monitoring` — flattened to:
+
+```
+Activity { id, source, severity, host_id?, title, summary?, occurred_at }
+ActivityPage { items[], hidden_count, next_cursor }
+```
+
+- **Filters**: `source`, `severity` (info/low/medium/high/critical), `host_id`,
+  `since`, `until`, `cursor`, `limit` (default 50, max 200). **No** text-search
+  (`q`) param. **No** aggregate/histogram endpoint.
+- **RBAC**: per-source gating inside the service (alert→`alert:read`,
+  transaction/intelligence/monitoring→`host:read`, audit→`audit:read`).
+  `hidden_count` is the count of rows suppressed by the caller's missing
+  permissions (not a pagination remainder).
+- **Order**: `occurred_at DESC`, cursor-seek pagination.
+
+**The key structural fact**: the activity row `id` is the *real* underlying id
+**only for `source: "alert"`** (`service.go:159` — `SELECT id::text AS id ...
+FROM alerts`). Monitoring synthesizes a fake UUID (`service.go:251`); the other
+legs pass their row id but those tables have no per-id detail/mutation API. So
+**`alert` is the only source an activity row can act on or fetch detail for by
+id today.**
+
+---
+
+## Per-feature scope
+
+| Prototype feature | Status | What it needs |
+|---|---|---|
+| Day-grouped event stream | **READY** | The flat feed |
+| Source + severity filters | **READY** | Existing query params |
+| Host filter / deep-link | **READY** | `host_id` param |
+| Cursor "Load more" | **READY** | `next_cursor` |
+| `hidden_count` surfaced | **READY** | Response field |
+| Ack / Silence(Mute) / Resolve / Dismiss | **READY — alert rows only** | Lifecycle + endpoints + RBAC exist (`alerts/{id}:acknowledge\|silence\|resolve\|dismiss`, `main.go:543`); the activity id is the alert id. The other four sources are immutable logs |
+| Detail drawer — basic fields | **READY (all sources)** | Render the activity item's own title/summary/source/severity/host/time; no fetch |
+| Detail drawer — rich payload (alert) | **READY** | `GET /api/v1/alerts/{id}` returns tags/body/lifecycle |
+| Detail drawer — rich payload (audit) | **GATED (small)** | `detail` JSONB exists on `audit_events` but only via the list API; needs `GET /api/v1/audit/events/{id}` |
+| Detail drawer — rich payload (intelligence) | **GATED (small)** | `detail` JSONB on `host_intelligence_events`, list-only; needs `GET …/intelligence/events/{id}` |
+| Detail drawer — rich payload (transaction) | **GATED (medium)** | `evidence` + `framework_refs` JSONB on `transactions`; needs `GET …/transactions/{id}` |
+| Detail drawer — rich payload (monitoring) | **GATED (medium)** | per-layer flags + `error_*` on `host_monitoring_history`; needs a per-id GET |
+| "Routed to" delivery panel | **GREENFIELD (medium–large)** | `notifications.yaml` is spec-only: **no tables, no service, no persistence**. Needs `notification_channels` + `notification_deliveries` schema, dispatch-outcome capture in `internal/alertrouter`, and a `GET …/notifications/deliveries?alert_id=` endpoint |
+| Severity histogram | **GREENFIELD (small–medium)** | No aggregate endpoint. Either an `/activity/histogram` bucketed-count endpoint, or client-side over the loaded page (approximate only) |
+| Text search | **GATED (small)** | No `q` param; add server-side search or client-side filter over the loaded page |
+| Live tail | **PARTIAL** | SSE (`/api/v1/events`) carries monitoring/intelligence/heartbeat/drift/scan — **not** alert/audit/transaction state. A true activity tail needs those on the bus; a cheap version refetches on an SSE pulse |
+| Category chip | **substitute** | No category column; `source` is the closest grouping |
+| Group filter | **GREENFIELD** | Depends on the Groups entity (itself greenfield) |
+| Dedup ×N count | **GATED** | The feed has no per-event count; needs a dedup-count column |
+
+---
+
+## MVP (shipping now — zero new backend)
+
+1. `/activity` route + `ActivityPage`.
+2. Day-grouped stream: time · source · severity · title · summary · host link.
+3. Filters: **source** + **severity** dropdowns + **host_id** (deep-link), wired
+   to the real query params.
+4. Cursor **Load more**; surface **`hidden_count`** ("N hidden by permissions").
+5. **Alert-source row actions** — Acknowledge / Silence / Resolve, shown only
+   when `source === 'alert'` and the caller has `alert:write`, calling the
+   existing `/alerts/{id}:action` endpoints.
+6. **Detail drawer** — basic activity fields for every source, **enriched for
+   `alert`** via `GET /alerts/{id}` (tags, body, lifecycle, and the same
+   actions).
+
+Deferred but cheap follow-ups (small backend each), in priority order:
+
+1. `GET /audit/events/{id}` + `GET /intelligence/events/{id}` → rich drawer for
+   those two sources (the JSONB is already stored).
+2. `GET /transactions/{id}` + monitoring per-id GET → rich drawer for the
+   remaining two.
+3. Server-side text search (`q`) on the activity feed.
+
+Larger, genuinely new backend (own tracks, not part of Activity MVP):
+
+- **Notifications persistence** (channels + deliveries) → the "Routed to" panel.
+- **Activity histogram** aggregate endpoint.
+- **Live activity tail** (alert/audit/transaction events on the SSE bus).
+- Generic **ack/mute for non-alert sources** — would need an
+  `activity_event_state` table. **Recommendation: do not build this.** Keep
+  ack/mute semantics on alerts (their natural home); the other four sources are
+  immutable logs by design.
+
+---
+
+## Recommendation
+
+Ship the MVP above. It delivers the stream, real filtering, the honest
+`hidden_count`, and — because the alert lifecycle is already complete and
+reachable from activity rows — a real slice of the prototype's interaction model
+(ack/silence/resolve + an alert detail drawer) with **no backend work**. Treat
+the two small per-id detail GETs (audit, intelligence) as the first fast-follow
+if the richer drawer is wanted for those sources. Keep "Routed to", the
+histogram, and live-tail as separate backend tracks.

--- a/frontend/src/components/shell/Sidebar.tsx
+++ b/frontend/src/components/shell/Sidebar.tsx
@@ -34,7 +34,7 @@ const navItems: NavItem[] = [
   { to: '/hosts', label: 'Hosts', icon: <Server size={18} />, enabled: true },
   { to: '/groups', label: 'Groups', icon: <Boxes size={18} />, enabled: false },
   { to: '/scans', label: 'Scans', icon: <Search size={18} />, enabled: false },
-  { to: '/activity', label: 'Activity', icon: <Activity size={18} />, enabled: false },
+  { to: '/activity', label: 'Activity', icon: <Activity size={18} />, enabled: true },
   { to: '/reports', label: 'Reports', icon: <BarChart3 size={18} />, enabled: false },
   { to: '/terminal', label: 'Terminal', icon: <Terminal size={18} />, enabled: false },
 ];

--- a/frontend/src/pages/activity/ActivityDrawer.tsx
+++ b/frontend/src/pages/activity/ActivityDrawer.tsx
@@ -1,0 +1,322 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import type { components } from '@/api/schema';
+import { useAlertActions, type AlertAction } from './useAlertActions';
+
+type Activity = components['schemas']['Activity'];
+
+// ActivityDrawer — the right-side detail panel for a clicked event.
+//
+// Basic fields (title, summary, source, severity, host, time) render for
+// every source straight from the activity item. For source === "alert"
+// it additionally fetches GET /alerts/{id} to show the alert body, tags,
+// state, and the lifecycle actions. The other four sources are immutable
+// logs whose richer payload has no per-id endpoint yet (see
+// docs/engineering/activity_page_scope.md) — they show the basics only.
+//
+// Spec: frontend-activity.
+
+export function severityTone(sev: string): 'crit' | 'warn' | 'info' {
+  if (sev === 'critical' || sev === 'high') return 'crit';
+  if (sev === 'medium' || sev === 'low') return 'warn';
+  return 'info';
+}
+
+const TONE: Record<string, string> = {
+  crit: 'var(--ow-crit)',
+  warn: 'var(--ow-warn)',
+  info: 'var(--ow-info)',
+};
+
+export function ActivityDrawer({
+  item,
+  canAlertWrite,
+  onClose,
+}: {
+  item: Activity | null;
+  canAlertWrite: boolean;
+  onClose: () => void;
+}) {
+  const isAlert = item?.source === 'alert';
+
+  const alertQuery = useQuery({
+    queryKey: ['alert', item?.id],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/alerts/{id}', {
+        params: { path: { id: item!.id } },
+      });
+      if (error || !response.ok) {
+        throw new Error(apiErrorMessage(error, `Failed to load alert (${response.status})`));
+      }
+      return data!;
+    },
+    enabled: !!item && isAlert,
+  });
+
+  const actions = useAlertActions();
+  const alert = alertQuery.data;
+
+  if (!item) return null;
+  const tone = TONE[severityTone(item.severity)];
+
+  const run = (action: AlertAction) => actions.mutate({ id: item.id, action });
+
+  return (
+    <>
+      <div
+        onClick={onClose}
+        aria-hidden="true"
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.5)',
+          zIndex: 70,
+        }}
+      />
+      <aside
+        role="dialog"
+        aria-label={`Event detail: ${item.title}`}
+        style={{
+          position: 'fixed',
+          top: 0,
+          right: 0,
+          height: '100vh',
+          width: 460,
+          maxWidth: '92vw',
+          background: 'var(--ow-bg-1)',
+          borderLeft: '1px solid var(--ow-line)',
+          zIndex: 80,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <header style={{ padding: '18px 20px', borderBottom: '1px solid var(--ow-line)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div
+              style={{
+                fontFamily: 'var(--ow-font-mono, monospace)',
+                fontWeight: 600,
+                fontSize: 15,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+              }}
+            >
+              <span
+                style={{ width: 10, height: 10, borderRadius: '50%', background: tone }}
+                aria-hidden="true"
+              />
+              {item.title}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close detail"
+              style={{
+                width: 30,
+                height: 30,
+                display: 'grid',
+                placeItems: 'center',
+                background: 'transparent',
+                border: '1px solid var(--ow-line)',
+                borderRadius: 6,
+                color: 'var(--ow-fg-2)',
+                cursor: 'pointer',
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <div
+            style={{
+              color: 'var(--ow-fg-2)',
+              fontSize: 12,
+              marginTop: 8,
+              display: 'flex',
+              gap: 10,
+              flexWrap: 'wrap',
+            }}
+          >
+            <span style={{ textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+              {item.source}
+            </span>
+            <span>{item.severity}</span>
+            <span>{new Date(item.occurred_at).toLocaleString()}</span>
+            {isAlert && alert && (
+              <span style={{ color: tone, fontWeight: 600 }}>{alert.state}</span>
+            )}
+          </div>
+        </header>
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: '18px 20px' }}>
+          {(item.summary || alert?.body) && (
+            <Section title="Message">
+              <div style={{ color: 'var(--ow-fg-0)', fontSize: 14, lineHeight: 1.5 }}>
+                {alert?.body || item.summary}
+              </div>
+            </Section>
+          )}
+
+          {item.host_id && (
+            <Section title="Host">
+              <Link
+                to="/hosts/$hostId"
+                params={{ hostId: item.host_id }}
+                style={{
+                  color: 'var(--ow-link)',
+                  fontFamily: 'var(--ow-font-mono, monospace)',
+                  fontSize: 12,
+                }}
+              >
+                {item.host_id}
+              </Link>
+            </Section>
+          )}
+
+          {isAlert && alertQuery.isError && (
+            <div role="alert" style={{ color: 'var(--ow-crit)', fontSize: 12 }}>
+              {apiErrorMessage(alertQuery.error, 'Failed to load alert detail')}
+            </div>
+          )}
+
+          {isAlert && alert?.tags && Object.keys(alert.tags).length > 0 && (
+            <Section title="Tags">
+              <dl
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: '130px 1fr',
+                  rowGap: 8,
+                  columnGap: 12,
+                  fontSize: 12,
+                  margin: 0,
+                }}
+              >
+                {Object.entries(alert.tags).map(([k, v]) => (
+                  <div key={k} style={{ display: 'contents' }}>
+                    <dt style={{ color: 'var(--ow-fg-2)' }}>{k}</dt>
+                    <dd
+                      style={{
+                        margin: 0,
+                        color: 'var(--ow-fg-1)',
+                        fontFamily: 'var(--ow-font-mono, monospace)',
+                      }}
+                    >
+                      {v}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </Section>
+          )}
+        </div>
+
+        {isAlert && canAlertWrite && alert && (
+          <footer
+            style={{
+              padding: '14px 20px',
+              borderTop: '1px solid var(--ow-line)',
+              display: 'flex',
+              gap: 8,
+              flexWrap: 'wrap',
+            }}
+          >
+            {alert.state === 'active' && (
+              <ActionButton
+                label="Acknowledge"
+                primary
+                disabled={actions.isPending}
+                onClick={() => run('acknowledge')}
+              />
+            )}
+            {(alert.state === 'active' || alert.state === 'acknowledged') && (
+              <ActionButton
+                label="Silence"
+                disabled={actions.isPending}
+                onClick={() => run('silence')}
+              />
+            )}
+            {alert.state !== 'resolved' && alert.state !== 'dismissed' && (
+              <ActionButton
+                label="Resolve"
+                disabled={actions.isPending}
+                onClick={() => run('resolve')}
+              />
+            )}
+            {actions.isError && (
+              <span role="alert" style={{ color: 'var(--ow-crit)', fontSize: 12, width: '100%' }}>
+                {(actions.error as Error).message}
+              </span>
+            )}
+          </footer>
+        )}
+      </aside>
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <h5
+        style={{
+          margin: '0 0 8px',
+          fontSize: 11,
+          color: 'var(--ow-fg-3)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          fontWeight: 600,
+        }}
+      >
+        {title}
+      </h5>
+      {children}
+    </div>
+  );
+}
+
+function ActionButton({
+  label,
+  primary,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  primary?: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        height: 34,
+        padding: '0 14px',
+        borderRadius: 6,
+        border: `1px solid ${primary ? 'var(--ow-info)' : 'var(--ow-line)'}`,
+        background: primary ? 'var(--ow-info)' : 'var(--ow-bg-2)',
+        color: primary ? 'var(--ow-info-on)' : 'var(--ow-fg-0)',
+        fontFamily: 'inherit',
+        fontSize: 13,
+        fontWeight: 600,
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -1,0 +1,442 @@
+import { useState } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSearch } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { useAuthStore } from '@/store/useAuthStore';
+import type { components } from '@/api/schema';
+import { ActivityDrawer, severityTone } from './ActivityDrawer';
+import { useAlertActions } from './useAlertActions';
+
+type Activity = components['schemas']['Activity'];
+type Source = Activity['source'];
+type Severity = Activity['severity'];
+
+// ActivityPage — the unified activity feed at /activity.
+//
+// MVP (frontend-activity): a day-grouped event stream over
+// GET /api/v1/activity with source + severity filters and cursor
+// pagination, surfacing hidden_count (RBAC-suppressed rows). Alert-source
+// rows carry quick lifecycle actions (the activity id is the alert id);
+// clicking any row opens a detail drawer. The richer prototype surfaces
+// (histogram, facet rail, "routed to", live tail, non-alert mutation) are
+// backend-gated and deferred per docs/engineering/activity_page_scope.md.
+
+const SOURCES: Source[] = ['alert', 'transaction', 'intelligence', 'audit', 'monitoring'];
+const SEVERITIES: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
+const TONE: Record<string, string> = {
+  crit: 'var(--ow-crit)',
+  warn: 'var(--ow-warn)',
+  info: 'var(--ow-info)',
+};
+
+function dayLabel(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const diffDays = Math.round((startOf(now) - startOf(d)) / 86_400_000);
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+interface ActivitySearch {
+  host_id?: string;
+}
+
+export function ActivityPage() {
+  const search = useSearch({ strict: false }) as ActivitySearch;
+  const hostId = search.host_id;
+  const hasPermission = useAuthStore((s) => s.hasPermission);
+  const canAlertWrite = hasPermission('alert:write');
+
+  const [source, setSource] = useState<Source | ''>('');
+  const [severity, setSeverity] = useState<Severity | ''>('');
+  const [selected, setSelected] = useState<Activity | null>(null);
+
+  const query = useInfiniteQuery({
+    queryKey: ['activity', source, severity, hostId],
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) => {
+      const { data, error, response } = await api.GET('/api/v1/activity', {
+        params: {
+          query: {
+            limit: 50,
+            ...(source ? { source } : {}),
+            ...(severity ? { severity } : {}),
+            ...(hostId ? { host_id: hostId } : {}),
+            ...(pageParam ? { cursor: pageParam } : {}),
+          },
+        },
+      });
+      if (error || !response.ok) {
+        throw new Error(apiErrorMessage(error, `Failed to load (${response.status})`));
+      }
+      return data!;
+    },
+    getNextPageParam: (last) => last.next_cursor ?? undefined,
+  });
+
+  const items = query.data?.pages.flatMap((p) => p.items) ?? [];
+  const hiddenCount = query.data?.pages[0]?.hidden_count ?? 0;
+
+  return (
+    <div style={{ padding: '20px 28px 60px' }}>
+      <title>Activity · OpenWatch</title>
+
+      <header style={{ marginBottom: 16 }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, letterSpacing: '-0.01em' }}>
+          Activity
+        </h1>
+        <div style={{ color: 'var(--ow-fg-2)', fontSize: 13, marginTop: 2 }}>
+          Unified feed across alerts, compliance, intelligence, audit, and monitoring
+          {hostId ? ' (filtered to one host)' : ''}
+        </div>
+      </header>
+
+      {/* filters */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 10,
+          marginBottom: 14,
+          flexWrap: 'wrap',
+          alignItems: 'center',
+        }}
+      >
+        <FilterSelect
+          label="Source"
+          value={source}
+          onChange={(v) => setSource(v as Source | '')}
+          options={SOURCES}
+        />
+        <FilterSelect
+          label="Severity"
+          value={severity}
+          onChange={(v) => setSeverity(v as Severity | '')}
+          options={SEVERITIES}
+        />
+        {(source || severity) && (
+          <button
+            type="button"
+            onClick={() => {
+              setSource('');
+              setSeverity('');
+            }}
+            style={{
+              background: 'none',
+              border: 0,
+              color: 'var(--ow-link)',
+              fontSize: 12,
+              cursor: 'pointer',
+            }}
+          >
+            Clear
+          </button>
+        )}
+        <div style={{ flex: 1 }} />
+        {hiddenCount > 0 && (
+          <span style={{ color: 'var(--ow-fg-3)', fontSize: 12 }}>
+            {hiddenCount} hidden by permissions
+          </span>
+        )}
+      </div>
+
+      {/* stream */}
+      <div
+        style={{
+          background: 'var(--ow-bg-1)',
+          border: '1px solid var(--ow-line)',
+          borderRadius: 'var(--ow-radius)',
+          overflow: 'hidden',
+        }}
+      >
+        {query.isError ? (
+          <div role="alert" style={{ padding: '16px', color: 'var(--ow-crit)', fontSize: 13 }}>
+            {apiErrorMessage(query.error, 'Failed to load activity')}
+          </div>
+        ) : query.isPending ? (
+          <div role="status" style={{ padding: '16px', color: 'var(--ow-fg-2)', fontSize: 13 }}>
+            Loading…
+          </div>
+        ) : items.length === 0 ? (
+          <div
+            role="status"
+            style={{
+              padding: '40px 16px',
+              textAlign: 'center',
+              color: 'var(--ow-fg-3)',
+              fontSize: 13,
+            }}
+          >
+            No events match these filters.
+          </div>
+        ) : (
+          <Stream items={items} canAlertWrite={canAlertWrite} onSelect={setSelected} />
+        )}
+      </div>
+
+      {query.hasNextPage && (
+        <div style={{ textAlign: 'center', marginTop: 14 }}>
+          <button
+            type="button"
+            disabled={query.isFetchingNextPage}
+            onClick={() => query.fetchNextPage()}
+            style={{
+              height: 36,
+              padding: '0 18px',
+              background: 'var(--ow-bg-2)',
+              color: 'var(--ow-fg-0)',
+              border: '1px solid var(--ow-line)',
+              borderRadius: 8,
+              fontFamily: 'inherit',
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: query.isFetchingNextPage ? 'default' : 'pointer',
+            }}
+          >
+            {query.isFetchingNextPage ? 'Loading…' : 'Load more'}
+          </button>
+        </div>
+      )}
+
+      <ActivityDrawer
+        item={selected}
+        canAlertWrite={canAlertWrite}
+        onClose={() => setSelected(null)}
+      />
+    </div>
+  );
+}
+
+function Stream({
+  items,
+  canAlertWrite,
+  onSelect,
+}: {
+  items: Activity[];
+  canAlertWrite: boolean;
+  onSelect: (a: Activity) => void;
+}) {
+  const actions = useAlertActions();
+  let lastDay: string | null = null;
+
+  return (
+    <>
+      {items.map((a, i) => {
+        const day = dayLabel(a.occurred_at);
+        const divider = day !== lastDay ? day : null;
+        lastDay = day;
+        const tone = TONE[severityTone(a.severity)];
+        const isAlert = a.source === 'alert';
+        return (
+          <div key={a.id}>
+            {divider && (
+              <div
+                style={{
+                  padding: '12px 16px 6px',
+                  color: 'var(--ow-fg-3)',
+                  fontSize: 11,
+                  fontWeight: 600,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                  background: 'var(--ow-bg-2)',
+                }}
+              >
+                {divider}
+              </div>
+            )}
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => onSelect(a)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onSelect(a);
+                }
+              }}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '64px 1fr auto',
+                gap: 14,
+                alignItems: 'baseline',
+                padding: '10px 16px',
+                borderTop: i === 0 ? 'none' : '1px solid var(--ow-line)',
+                cursor: 'pointer',
+                borderLeft: `3px solid ${tone}`,
+              }}
+            >
+              <span
+                style={{
+                  color: 'var(--ow-fg-3)',
+                  fontSize: 12,
+                  fontFamily: 'var(--ow-font-mono, monospace)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {new Date(a.occurred_at).toLocaleTimeString(undefined, {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                  <span style={{ fontWeight: 500, fontSize: 13, color: 'var(--ow-fg-0)' }}>
+                    {a.title}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 600,
+                      padding: '1px 7px',
+                      borderRadius: 3,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.03em',
+                      background: 'var(--ow-bg-3)',
+                      color: 'var(--ow-fg-2)',
+                    }}
+                  >
+                    {a.source}
+                  </span>
+                </div>
+                {a.summary && (
+                  <div style={{ color: 'var(--ow-fg-2)', fontSize: 12, marginTop: 3 }}>
+                    {a.summary}
+                  </div>
+                )}
+                {a.host_id && (
+                  <div style={{ marginTop: 4 }}>
+                    <Link
+                      to="/hosts/$hostId"
+                      params={{ hostId: a.host_id }}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{
+                        color: 'var(--ow-link)',
+                        fontSize: 11,
+                        fontFamily: 'var(--ow-font-mono, monospace)',
+                      }}
+                    >
+                      {a.host_id.slice(0, 8)}…
+                    </Link>
+                  </div>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                {isAlert && canAlertWrite && (
+                  <>
+                    <QuickAction
+                      label="Ack"
+                      disabled={actions.isPending}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        actions.mutate({ id: a.id, action: 'acknowledge' });
+                      }}
+                    />
+                    <QuickAction
+                      label="Silence"
+                      disabled={actions.isPending}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        actions.mutate({ id: a.id, action: 'silence' });
+                      }}
+                    />
+                    <QuickAction
+                      label="Resolve"
+                      disabled={actions.isPending}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        actions.mutate({ id: a.id, action: 'resolve' });
+                      }}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: string[];
+}) {
+  return (
+    <label
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontSize: 12,
+        color: 'var(--ow-fg-2)',
+      }}
+    >
+      {label}
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        style={{
+          height: 32,
+          padding: '0 8px',
+          background: 'var(--ow-bg-1)',
+          color: 'var(--ow-fg-0)',
+          border: '1px solid var(--ow-line)',
+          borderRadius: 6,
+          fontFamily: 'inherit',
+          fontSize: 13,
+        }}
+      >
+        <option value="">All</option>
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function QuickAction({
+  label,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  disabled: boolean;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        height: 26,
+        padding: '0 9px',
+        background: 'var(--ow-bg-2)',
+        color: 'var(--ow-fg-1)',
+        border: '1px solid var(--ow-line)',
+        borderRadius: 6,
+        fontFamily: 'inherit',
+        fontSize: 11,
+        fontWeight: 600,
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useSearch } from '@tanstack/react-router';
-import { Link } from '@tanstack/react-router';
+import { useEffect, useRef, useState } from 'react';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { Link, useSearch } from '@tanstack/react-router';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
 import { useAuthStore } from '@/store/useAuthStore';
@@ -13,23 +12,44 @@ type Activity = components['schemas']['Activity'];
 type Source = Activity['source'];
 type Severity = Activity['severity'];
 
-// ActivityPage — the unified activity feed at /activity.
+// ActivityPage — the unified activity feed at /activity, styled to the
+// openwatch-v1 Activity.html prototype using only honest data.
 //
-// MVP (frontend-activity): a day-grouped event stream over
-// GET /api/v1/activity with source + severity filters and cursor
-// pagination, surfacing hidden_count (RBAC-suppressed rows). Alert-source
-// rows carry quick lifecycle actions (the activity id is the alert id);
-// clicking any row opens a detail drawer. The richer prototype surfaces
-// (histogram, facet rail, "routed to", live tail, non-alert mutation) are
-// backend-gated and deferred per docs/engineering/activity_page_scope.md.
+// MVP (frontend-activity): a toolbar (client-side search, a time-range
+// segment backed by the `since` param, a Live poll toggle, an
+// Acknowledge-all over loaded alert rows, an event count), a restyled
+// Source + Severity filter bar, and a day-grouped stream. Alert-source
+// rows carry lifecycle actions (the activity id is the alert id) and any
+// row opens the detail drawer. The prototype's histogram, Status/Group
+// facets, dedup counts, and "routed to" panel are backend-gated and
+// deferred per docs/engineering/activity_page_scope.md.
 
 const SOURCES: Source[] = ['alert', 'transaction', 'intelligence', 'audit', 'monitoring'];
 const SEVERITIES: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
+
 const TONE: Record<string, string> = {
   crit: 'var(--ow-crit)',
   warn: 'var(--ow-warn)',
   info: 'var(--ow-info)',
 };
+
+// Cosmetic display category per source (the feed has no category
+// taxonomy; this is a label, not a backend filter).
+const CATEGORY: Record<Source, string> = {
+  monitoring: 'HOST LIFECYCLE',
+  transaction: 'COMPLIANCE & DRIFT',
+  alert: 'ALERT',
+  audit: 'AUDIT',
+  intelligence: 'INTELLIGENCE',
+};
+
+// Range segment -> `since` lookback (ms). "all" sends no since.
+const RANGES: { id: string; label: string; ms: number | null }[] = [
+  { id: '1h', label: '1h', ms: 3_600_000 },
+  { id: '24h', label: '24h', ms: 86_400_000 },
+  { id: '7d', label: '7d', ms: 604_800_000 },
+  { id: 'all', label: 'All', ms: null },
+];
 
 function dayLabel(iso: string): string {
   const d = new Date(iso);
@@ -53,11 +73,18 @@ export function ActivityPage() {
 
   const [source, setSource] = useState<Source | ''>('');
   const [severity, setSeverity] = useState<Severity | ''>('');
+  const [range, setRange] = useState('24h');
+  const [text, setText] = useState('');
+  const [live, setLive] = useState(false);
   const [selected, setSelected] = useState<Activity | null>(null);
 
+  const rangeMs = RANGES.find((r) => r.id === range)?.ms ?? null;
+  const since = rangeMs ? new Date(Date.now() - rangeMs).toISOString() : undefined;
+
   const query = useInfiniteQuery({
-    queryKey: ['activity', source, severity, hostId],
+    queryKey: ['activity', source, severity, range, hostId],
     initialPageParam: undefined as string | undefined,
+    refetchInterval: live ? 15_000 : false,
     queryFn: async ({ pageParam }) => {
       const { data, error, response } = await api.GET('/api/v1/activity', {
         params: {
@@ -66,6 +93,7 @@ export function ActivityPage() {
             ...(source ? { source } : {}),
             ...(severity ? { severity } : {}),
             ...(hostId ? { host_id: hostId } : {}),
+            ...(since ? { since } : {}),
             ...(pageParam ? { cursor: pageParam } : {}),
           },
         },
@@ -78,14 +106,43 @@ export function ActivityPage() {
     getNextPageParam: (last) => last.next_cursor ?? undefined,
   });
 
-  const items = query.data?.pages.flatMap((p) => p.items) ?? [];
+  // Hostname map for entity pills (the feed carries host_id only).
+  const hostsQuery = useQuery({
+    queryKey: ['hosts', 'names'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/hosts', {});
+      if (error || !response.ok)
+        throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
+      return data!;
+    },
+  });
+  const nameOf = (id: string) =>
+    hostsQuery.data?.hosts.find((h) => h.id === id)?.hostname ?? `${id.slice(0, 8)}…`;
+
+  const actions = useAlertActions();
+
+  const allItems = query.data?.pages.flatMap((p) => p.items) ?? [];
   const hiddenCount = query.data?.pages[0]?.hidden_count ?? 0;
+  const items = text
+    ? allItems.filter((a) =>
+        `${a.title} ${a.summary ?? ''} ${a.host_id ?? ''} ${a.source}`
+          .toLowerCase()
+          .includes(text.toLowerCase()),
+      )
+    : allItems;
+
+  const ackAll = () => {
+    if (!canAlertWrite) return;
+    for (const a of items)
+      if (a.source === 'alert') actions.mutate({ id: a.id, action: 'acknowledge' });
+  };
+  const hasLoadedAlerts = canAlertWrite && items.some((a) => a.source === 'alert');
 
   return (
     <div style={{ padding: '20px 28px 60px' }}>
       <title>Activity · OpenWatch</title>
 
-      <header style={{ marginBottom: 16 }}>
+      <header style={{ marginBottom: 14 }}>
         <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, letterSpacing: '-0.01em' }}>
           Activity
         </h1>
@@ -95,27 +152,144 @@ export function ActivityPage() {
         </div>
       </header>
 
-      {/* filters */}
+      {/* toolbar */}
       <div
         style={{
           display: 'flex',
-          gap: 10,
-          marginBottom: 14,
-          flexWrap: 'wrap',
           alignItems: 'center',
+          gap: 10,
+          marginBottom: 12,
+          flexWrap: 'wrap',
         }}
       >
-        <FilterSelect
-          label="Source"
-          value={source}
-          onChange={(v) => setSource(v as Source | '')}
-          options={SOURCES}
-        />
-        <FilterSelect
+        <div
+          style={{
+            flex: 1,
+            minWidth: 220,
+            maxWidth: 380,
+            height: 34,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '0 10px',
+            background: 'var(--ow-bg-1)',
+            border: '1px solid var(--ow-line)',
+            borderRadius: 7,
+          }}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--ow-fg-3)"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Search loaded events, hosts, messages…"
+            aria-label="Search loaded events"
+            style={{
+              flex: 1,
+              background: 'transparent',
+              border: 0,
+              outline: 0,
+              color: 'var(--ow-fg-0)',
+              fontFamily: 'inherit',
+              fontSize: 13,
+            }}
+          />
+        </div>
+
+        <Seg value={range} onChange={setRange} options={RANGES} />
+
+        <button
+          type="button"
+          onClick={() => setLive((v) => !v)}
+          aria-pressed={live}
+          style={{
+            height: 34,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '0 12px',
+            background: 'var(--ow-bg-1)',
+            border: `1px solid ${live ? 'var(--ow-info)' : 'var(--ow-line)'}`,
+            borderRadius: 7,
+            color: live ? 'var(--ow-info)' : 'var(--ow-fg-1)',
+            fontFamily: 'inherit',
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: live ? 'var(--ow-info)' : 'var(--ow-fg-3)',
+            }}
+          />
+          Live
+        </button>
+
+        <div style={{ flex: 1 }} />
+
+        <span style={{ color: 'var(--ow-fg-2)', fontSize: 12 }}>
+          {items.length} event{items.length === 1 ? '' : 's'}
+          {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ''}
+        </span>
+
+        {hasLoadedAlerts && (
+          <button
+            type="button"
+            onClick={ackAll}
+            disabled={actions.isPending}
+            style={{
+              height: 30,
+              padding: '0 12px',
+              background: 'var(--ow-bg-1)',
+              border: '1px solid var(--ow-line)',
+              borderRadius: 6,
+              color: 'var(--ow-fg-0)',
+              fontFamily: 'inherit',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: actions.isPending ? 'default' : 'pointer',
+            }}
+          >
+            Acknowledge all
+          </button>
+        )}
+      </div>
+
+      {/* filter bar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginBottom: 14,
+          flexWrap: 'wrap',
+        }}
+      >
+        <FilterDropdown
           label="Severity"
           value={severity}
           onChange={(v) => setSeverity(v as Severity | '')}
           options={SEVERITIES}
+        />
+        <FilterDropdown
+          label="Source"
+          value={source}
+          onChange={(v) => setSource(v as Source | '')}
+          options={SOURCES}
         />
         {(source || severity) && (
           <button
@@ -132,14 +306,8 @@ export function ActivityPage() {
               cursor: 'pointer',
             }}
           >
-            Clear
+            Clear all
           </button>
-        )}
-        <div style={{ flex: 1 }} />
-        {hiddenCount > 0 && (
-          <span style={{ color: 'var(--ow-fg-3)', fontSize: 12 }}>
-            {hiddenCount} hidden by permissions
-          </span>
         )}
       </div>
 
@@ -153,11 +321,11 @@ export function ActivityPage() {
         }}
       >
         {query.isError ? (
-          <div role="alert" style={{ padding: '16px', color: 'var(--ow-crit)', fontSize: 13 }}>
+          <div role="alert" style={{ padding: 16, color: 'var(--ow-crit)', fontSize: 13 }}>
             {apiErrorMessage(query.error, 'Failed to load activity')}
           </div>
         ) : query.isPending ? (
-          <div role="status" style={{ padding: '16px', color: 'var(--ow-fg-2)', fontSize: 13 }}>
+          <div role="status" style={{ padding: 16, color: 'var(--ow-fg-2)', fontSize: 13 }}>
             Loading…
           </div>
         ) : items.length === 0 ? (
@@ -173,11 +341,17 @@ export function ActivityPage() {
             No events match these filters.
           </div>
         ) : (
-          <Stream items={items} canAlertWrite={canAlertWrite} onSelect={setSelected} />
+          <Stream
+            items={items}
+            canAlertWrite={canAlertWrite}
+            actions={actions}
+            nameOf={nameOf}
+            onSelect={setSelected}
+          />
         )}
       </div>
 
-      {query.hasNextPage && (
+      {query.hasNextPage && !text && (
         <div style={{ textAlign: 'center', marginTop: 14 }}>
           <button
             type="button"
@@ -213,13 +387,16 @@ export function ActivityPage() {
 function Stream({
   items,
   canAlertWrite,
+  actions,
+  nameOf,
   onSelect,
 }: {
   items: Activity[];
   canAlertWrite: boolean;
+  actions: ReturnType<typeof useAlertActions>;
+  nameOf: (id: string) => string;
   onSelect: (a: Activity) => void;
 }) {
-  const actions = useAlertActions();
   let lastDay: string | null = null;
 
   return (
@@ -283,7 +460,14 @@ function Stream({
               </span>
               <div style={{ minWidth: 0 }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                  <span style={{ fontWeight: 500, fontSize: 13, color: 'var(--ow-fg-0)' }}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--ow-font-mono, monospace)',
+                      fontSize: 12,
+                      fontWeight: 500,
+                      color: tone,
+                    }}
+                  >
                     {a.title}
                   </span>
                   <span
@@ -298,11 +482,11 @@ function Stream({
                       color: 'var(--ow-fg-2)',
                     }}
                   >
-                    {a.source}
+                    {CATEGORY[a.source]}
                   </span>
                 </div>
                 {a.summary && (
-                  <div style={{ color: 'var(--ow-fg-2)', fontSize: 12, marginTop: 3 }}>
+                  <div style={{ color: 'var(--ow-fg-1)', fontSize: 13, marginTop: 3 }}>
                     {a.summary}
                   </div>
                 )}
@@ -313,45 +497,68 @@ function Stream({
                       params={{ hostId: a.host_id }}
                       onClick={(e) => e.stopPropagation()}
                       style={{
-                        color: 'var(--ow-link)',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 5,
+                        padding: '0 6px',
+                        height: 18,
+                        borderRadius: 4,
+                        background: 'var(--ow-bg-2)',
+                        border: '1px solid var(--ow-line)',
+                        color: 'var(--ow-fg-1)',
                         fontSize: 11,
                         fontFamily: 'var(--ow-font-mono, monospace)',
+                        textDecoration: 'none',
                       }}
                     >
-                      {a.host_id.slice(0, 8)}…
+                      <svg
+                        width="9"
+                        height="9"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        aria-hidden="true"
+                      >
+                        <rect x="2" y="4" width="20" height="13" rx="2" />
+                      </svg>
+                      {nameOf(a.host_id)}
                     </Link>
                   </div>
                 )}
               </div>
-              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 {isAlert && canAlertWrite && (
-                  <>
-                    <QuickAction
-                      label="Ack"
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    <IconAction
+                      title="Acknowledge"
                       disabled={actions.isPending}
                       onClick={(e) => {
                         e.stopPropagation();
                         actions.mutate({ id: a.id, action: 'acknowledge' });
                       }}
+                      path="M20 6 9 17l-5-5"
                     />
-                    <QuickAction
-                      label="Silence"
+                    <IconAction
+                      title="Silence"
                       disabled={actions.isPending}
                       onClick={(e) => {
                         e.stopPropagation();
                         actions.mutate({ id: a.id, action: 'silence' });
                       }}
+                      path="M11 5 6 9H2v6h4l5 4zM23 9l-6 6M17 9l6 6"
                     />
-                    <QuickAction
-                      label="Resolve"
-                      disabled={actions.isPending}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        actions.mutate({ id: a.id, action: 'resolve' });
-                      }}
-                    />
-                  </>
+                  </div>
                 )}
+                <span
+                  style={{
+                    color: 'var(--ow-fg-3)',
+                    fontSize: 11,
+                    fontFamily: 'var(--ow-font-mono, monospace)',
+                  }}
+                >
+                  {a.source}
+                </span>
               </div>
             </div>
           </div>
@@ -361,7 +568,60 @@ function Stream({
   );
 }
 
-function FilterSelect({
+// Segmented control (range).
+function Seg({
+  value,
+  onChange,
+  options,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  options: { id: string; label: string }[];
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Time range"
+      style={{
+        display: 'inline-flex',
+        background: 'var(--ow-bg-1)',
+        border: '1px solid var(--ow-line)',
+        borderRadius: 7,
+        padding: 3,
+        gap: 2,
+      }}
+    >
+      {options.map((o) => {
+        const active = value === o.id;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(o.id)}
+            style={{
+              border: 0,
+              background: active ? 'var(--ow-bg-3)' : 'transparent',
+              color: active ? 'var(--ow-fg-0)' : 'var(--ow-fg-2)',
+              fontFamily: 'inherit',
+              fontSize: 12,
+              fontWeight: 500,
+              padding: '5px 11px',
+              borderRadius: 5,
+              cursor: 'pointer',
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Dropdown-button single-select filter (All + options), styled to the
+// prototype's filter bar.
+function FilterDropdown({
   label,
   value,
   onChange,
@@ -372,71 +632,177 @@ function FilterSelect({
   onChange: (v: string) => void;
   options: string[];
 }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('click', onDoc);
+    return () => document.removeEventListener('click', onDoc);
+  }, [open]);
+
   return (
-    <label
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 6,
-        fontSize: 12,
-        color: 'var(--ow-fg-2)',
-      }}
-    >
-      {label}
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
         style={{
           height: 32,
-          padding: '0 8px',
+          padding: '0 10px',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
           background: 'var(--ow-bg-1)',
-          color: 'var(--ow-fg-0)',
-          border: '1px solid var(--ow-line)',
+          border: `1px solid ${value ? 'var(--ow-info)' : 'var(--ow-line)'}`,
           borderRadius: 6,
+          color: value ? 'var(--ow-fg-0)' : 'var(--ow-fg-1)',
           fontFamily: 'inherit',
           fontSize: 13,
+          fontWeight: 500,
+          cursor: 'pointer',
         }}
       >
-        <option value="">All</option>
-        {options.map((o) => (
-          <option key={o} value={o}>
-            {o}
-          </option>
-        ))}
-      </select>
-    </label>
+        {label}
+        {value && (
+          <span
+            style={{
+              background: 'var(--ow-bg-3)',
+              color: 'var(--ow-info)',
+              fontSize: 11,
+              fontWeight: 600,
+              padding: '1px 7px',
+              borderRadius: 999,
+            }}
+          >
+            {value}
+          </span>
+        )}
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="var(--ow-fg-3)"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+      {open && (
+        <div
+          role="listbox"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            left: 0,
+            minWidth: 180,
+            background: 'var(--ow-bg-1)',
+            border: '1px solid var(--ow-line)',
+            borderRadius: 10,
+            boxShadow: '0 16px 40px rgba(0,0,0,0.45)',
+            padding: 6,
+            zIndex: 50,
+          }}
+        >
+          <Opt
+            label="All"
+            active={!value}
+            onClick={() => {
+              onChange('');
+              setOpen(false);
+            }}
+          />
+          {options.map((o) => (
+            <Opt
+              key={o}
+              label={o}
+              active={value === o}
+              onClick={() => {
+                onChange(o);
+                setOpen(false);
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
-function QuickAction({
-  label,
+function Opt({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      onClick={onClick}
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        padding: '7px 8px',
+        borderRadius: 6,
+        border: 0,
+        background: active ? 'var(--ow-bg-2)' : 'transparent',
+        color: active ? 'var(--ow-fg-0)' : 'var(--ow-fg-1)',
+        fontFamily: 'inherit',
+        fontSize: 13,
+        cursor: 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function IconAction({
+  title,
   disabled,
   onClick,
+  path,
 }: {
-  label: string;
+  title: string;
   disabled: boolean;
   onClick: (e: React.MouseEvent) => void;
+  path: string;
 }) {
   return (
     <button
       type="button"
+      title={title}
+      aria-label={title}
       onClick={onClick}
       disabled={disabled}
       style={{
+        width: 26,
         height: 26,
-        padding: '0 9px',
+        display: 'grid',
+        placeItems: 'center',
         background: 'var(--ow-bg-2)',
-        color: 'var(--ow-fg-1)',
         border: '1px solid var(--ow-line)',
         borderRadius: 6,
-        fontFamily: 'inherit',
-        fontSize: 11,
-        fontWeight: 600,
+        color: 'var(--ow-fg-2)',
         cursor: disabled ? 'default' : 'pointer',
         opacity: disabled ? 0.6 : 1,
       }}
     >
-      {label}
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        aria-hidden="true"
+      >
+        <path d={path} />
+      </svg>
     </button>
   );
 }

--- a/frontend/src/pages/activity/useAlertActions.ts
+++ b/frontend/src/pages/activity/useAlertActions.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+
+// useAlertActions — the alert lifecycle mutations reachable from an
+// activity row whose source is "alert" (its activity id IS the alert id;
+// internal/activity/service.go selects the real alerts.id for that leg).
+//
+// Acknowledge / Silence / Resolve are the operator-facing subset of the
+// alert state machine (active -> acknowledged -> silenced -> resolved).
+// Silence is the prototype's "Mute" (indefinite here; a duration picker
+// is a later refinement). On success we invalidate the activity feed and
+// the alert detail so the drawer reflects the new state.
+//
+// Spec: frontend-activity. Backed by /alerts/{id}:action (already wired,
+// gated server-side by alert:write).
+
+export type AlertAction = 'acknowledge' | 'silence' | 'resolve';
+
+export function useAlertActions() {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (vars: { id: string; action: AlertAction }) => {
+      const path = `/api/v1/alerts/{id}:${vars.action}` as
+        | '/api/v1/alerts/{id}:acknowledge'
+        | '/api/v1/alerts/{id}:silence'
+        | '/api/v1/alerts/{id}:resolve';
+      const { error, response } = await api.POST(path, {
+        params: { path: { id: vars.id } },
+        body: {},
+      });
+      if (error || !response.ok) {
+        throw new Error(apiErrorMessage(error, `Action failed (${response.status})`));
+      }
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['activity'] });
+      queryClient.invalidateQueries({ queryKey: ['alert', vars.id] });
+    },
+  });
+
+  return mutation;
+}

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -14,6 +14,7 @@ import { HostDetailPage } from '@/pages/HostDetailPage';
 import { AddHostPage } from '@/pages/AddHostPage';
 import { HomePage } from '@/pages/HomePage';
 import { DashboardPage } from '@/pages/dashboard/DashboardPage';
+import { ActivityPage } from '@/pages/activity/ActivityPage';
 import { ForbiddenPage } from '@/pages/ForbiddenPage';
 import { ProfilePage } from '@/pages/settings/ProfilePage';
 import { PreferencesPage } from '@/pages/settings/PreferencesPage';
@@ -86,6 +87,14 @@ const dashboardRoute = createRoute({
   getParentRoute: () => protectedRoute,
   path: 'dashboard',
   component: DashboardPage,
+});
+
+// Unified activity feed. Read-only feed + alert-source lifecycle actions;
+// host_id deep-link via search params.
+const activityRoute = createRoute({
+  getParentRoute: () => protectedRoute,
+  path: 'activity',
+  component: ActivityPage,
 });
 
 const hostsListRoute = createRoute({
@@ -209,6 +218,7 @@ const routeTree = rootRoute.addChildren([
   publicHomeRoute,
   protectedRoute.addChildren([
     dashboardRoute,
+    activityRoute,
     hostsListRoute,
     addHostRoute,
     hostDetailRoute,

--- a/frontend/tests/pages/activity.test.ts
+++ b/frontend/tests/pages/activity.test.ts
@@ -1,0 +1,95 @@
+// @spec frontend-activity
+//
+// AC traceability (this file):
+//   AC-01  infinite query over /api/v1/activity + filters + cursor + hidden_count
+//   AC-02  alert-source lifecycle actions gated by alert:write; route + sidebar
+//   AC-03  drawer fetches /alerts/{id} only for source==='alert'; basic for all
+//   AC-04  read-only apart from alert actions; no em-dash copy
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PAGE_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/activity/ActivityPage.tsx'),
+  'utf8',
+);
+const DRAWER_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/activity/ActivityDrawer.tsx'),
+  'utf8',
+);
+const ACTIONS_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/activity/useAlertActions.ts'),
+  'utf8',
+);
+const ROUTER_SRC = readFileSync(resolve(process.cwd(), 'src/routes/router.tsx'), 'utf8');
+const SIDEBAR_SRC = readFileSync(
+  resolve(process.cwd(), 'src/components/shell/Sidebar.tsx'),
+  'utf8',
+);
+
+function stripComments(s: string): string {
+  return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('frontend-activity — unified event feed', () => {
+  // @ac AC-01
+  test('frontend-activity/AC-01 — infinite query over /api/v1/activity with filters + cursor + hidden_count', () => {
+    expect(PAGE_SRC).toMatch(/useInfiniteQuery\(/);
+    expect(PAGE_SRC).toContain("api.GET('/api/v1/activity'");
+    // filters wired into the query params
+    expect(PAGE_SRC).toMatch(/source\s*\?\s*\{\s*source\s*\}/);
+    expect(PAGE_SRC).toMatch(/severity\s*\?\s*\{\s*severity\s*\}/);
+    expect(PAGE_SRC).toMatch(/host_id:\s*hostId/);
+    // cursor pagination + hidden_count
+    expect(PAGE_SRC).toMatch(/getNextPageParam/);
+    expect(PAGE_SRC).toMatch(/next_cursor/);
+    expect(PAGE_SRC).toMatch(/hidden_count/);
+    expect(PAGE_SRC).toMatch(/hasNextPage/);
+  });
+
+  // @ac AC-02
+  test('frontend-activity/AC-02 — alert-source lifecycle actions gated by alert:write; route + sidebar', () => {
+    // gated on alert:write
+    expect(PAGE_SRC).toMatch(/hasPermission\(\s*'alert:write'\s*\)/);
+    // actions only on alert-source rows
+    expect(PAGE_SRC).toMatch(/source === 'alert'/);
+    expect(PAGE_SRC).toMatch(/isAlert && canAlertWrite/);
+    // the mutation POSTs the colon-action against the alert id
+    expect(ACTIONS_SRC).toMatch(/\/api\/v1\/alerts\/\{id\}:\$\{vars\.action\}/);
+    expect(ACTIONS_SRC).toMatch(/api\.POST\(/);
+    // route mounted + sidebar enabled
+    const route = ROUTER_SRC.match(/const activityRoute = createRoute\(\{[\s\S]*?\}\);/);
+    expect(route).toBeTruthy();
+    expect(route![0]).toMatch(/path:\s*'activity'/);
+    expect(route![0]).toMatch(/getParentRoute:\s*\(\)\s*=>\s*protectedRoute/);
+    expect(SIDEBAR_SRC).toMatch(/label: 'Activity'[^\n]*enabled: true/);
+  });
+
+  // @ac AC-03
+  test('frontend-activity/AC-03 — drawer enriches alert via /alerts/{id}; basic for all sources', () => {
+    expect(DRAWER_SRC).toContain("api.GET('/api/v1/alerts/{id}'");
+    // the alert fetch is gated on source === alert
+    expect(DRAWER_SRC).toMatch(/isAlert\s*=\s*item\?\.source === 'alert'/);
+    expect(DRAWER_SRC).toMatch(/enabled:\s*!!item && isAlert/);
+    // basic fields render for any source (title in header, source/severity/time)
+    expect(DRAWER_SRC).toMatch(/item\.title/);
+    expect(DRAWER_SRC).toMatch(/item\.source/);
+  });
+
+  // @ac AC-04
+  test('frontend-activity/AC-04 — read-only apart from alert actions; no em-dash copy', () => {
+    // No mutation anywhere except the alert lifecycle POST.
+    for (const src of [PAGE_SRC, DRAWER_SRC]) {
+      expect(src).not.toMatch(/api\.(PUT|DELETE)/);
+      expect(src).not.toMatch(/api\.POST/); // POSTs live only in useAlertActions
+    }
+    // the only POST is the alerts colon-action
+    const posts = ACTIONS_SRC.match(/api\.POST\(/g) ?? [];
+    expect(posts.length).toBe(1);
+    // no em-dash in UI copy (comments stripped)
+    for (const src of [PAGE_SRC, DRAWER_SRC]) {
+      expect(stripComments(src)).not.toContain('—');
+    }
+  });
+});

--- a/frontend/tests/pages/activity.test.ts
+++ b/frontend/tests/pages/activity.test.ts
@@ -5,6 +5,7 @@
 //   AC-02  alert-source lifecycle actions gated by alert:write; route + sidebar
 //   AC-03  drawer fetches /alerts/{id} only for source==='alert'; basic for all
 //   AC-04  read-only apart from alert actions; no em-dash copy
+//   AC-05  toolbar uses honest data (since/Live/search/ack-all/category); no histogram
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -91,5 +92,22 @@ describe('frontend-activity — unified event feed', () => {
     for (const src of [PAGE_SRC, DRAWER_SRC]) {
       expect(stripComments(src)).not.toContain('—');
     }
+  });
+
+  // @ac AC-05
+  test('frontend-activity/AC-05 — toolbar uses honest data; no histogram / status / group facets', () => {
+    // range segment -> since param
+    expect(PAGE_SRC).toMatch(/const since = rangeMs \?/);
+    expect(PAGE_SRC).toMatch(/since\s*\?\s*\{\s*since\s*\}/);
+    // Live toggle -> poll refetch (not a fabricated stream)
+    expect(PAGE_SRC).toMatch(/refetchInterval:\s*live\s*\?/);
+    // search is client-side over loaded items
+    expect(PAGE_SRC).toMatch(/allItems\.filter\(/);
+    expect(PAGE_SRC).toMatch(/toLowerCase\(\)\s*\.includes/);
+    // Acknowledge-all iterates loaded alert-source rows
+    expect(PAGE_SRC).toMatch(/const ackAll = /);
+    expect(PAGE_SRC).toMatch(/a\.source === 'alert'/);
+    // cosmetic per-source category label on each row
+    expect(PAGE_SRC).toMatch(/CATEGORY\[a\.source\]/);
   });
 });

--- a/specs/frontend/activity.spec.yaml
+++ b/specs/frontend/activity.spec.yaml
@@ -44,6 +44,8 @@ spec:
       includes:
         - 'ActivityPage at /activity: useInfiniteQuery over GET /api/v1/activity'
         - 'Source + severity single-select filters; host_id deep-link via search param'
+        - 'Toolbar: client-side search over loaded events, a time-range segment backed by the since param, a Live poll toggle, an Acknowledge-all over loaded alert rows, an event count'
+        - 'Cosmetic category chip + hostname entity pill per row'
         - 'Cursor pagination (Load more) + hidden_count surfaced'
         - 'Alert-source rows: acknowledge/silence/resolve gated by alert:write'
         - 'Detail drawer: basic for all sources, enriched for alert via GET /alerts/{id}'
@@ -88,6 +90,17 @@ spec:
         UI copy carries no em-dashes
       type: technical
       enforcement: error
+    - id: C-05
+      description: >-
+        The toolbar MUST use only honest data: the time-range segment maps
+        the selected window (1h/24h/7d/All) to the `since` query param;
+        the Live toggle drives a poll refetch (refetchInterval), not a
+        fabricated stream; search filters the already-loaded items
+        client-side (there is no server text search); Acknowledge-all acts
+        only on loaded source==='alert' rows the caller may act on. The
+        category chip is a cosmetic per-source label, not a backend filter
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -106,3 +119,13 @@ spec:
       description: 'Source-inspection — the activity modules issue no api.POST/PUT/DELETE other than the /api/v1/alerts/{id}: lifecycle actions, and activity UI copy contains no em-dash.'
       priority: high
       references_constraints: [C-04]
+    - id: AC-05
+      description: >-
+        Source-inspection — ActivityPage derives a since param from the
+        selected range segment, sets refetchInterval from the Live toggle,
+        filters loaded items client-side by the search text, exposes an
+        Acknowledge-all that iterates loaded alert-source rows, and renders
+        a per-source category label on each row. The histogram and the
+        Status/Group facets are absent.
+      priority: high
+      references_constraints: [C-05]

--- a/specs/frontend/activity.spec.yaml
+++ b/specs/frontend/activity.spec.yaml
@@ -1,0 +1,108 @@
+spec:
+  id: frontend-activity
+  title: Activity feed (unified event stream)
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: The /activity unified event feed — a day-grouped stream over GET /api/v1/activity with filters, pagination, alert-source lifecycle actions, and a detail drawer
+    description: >
+      /activity renders the unified activity feed (api-activity): a
+      read-only UNION projection of five sources (alert, transaction,
+      intelligence, audit, monitoring) into
+      {id, source, severity, host_id, title, summary, occurred_at} with
+      cursor pagination and an RBAC-suppression hidden_count.
+
+      The openwatch-v1 Activity.html prototype is much richer (facet rail,
+      severity histogram, "routed to" delivery panel, live tail, per-event
+      acknowledge/mute across all sources, rich payload drawer). Most of
+      that is backend-gated; the scope is recorded in
+      docs/engineering/activity_page_scope.md. This spec covers the MVP
+      that ships with zero new backend:
+
+        - the day-grouped stream with source + severity filters and a
+          host_id deep-link, cursor "Load more", and hidden_count;
+        - alert-source lifecycle actions (acknowledge / silence / resolve)
+          — the only mutable substrate, reachable because the activity row
+          id IS the alert id for that source;
+        - a detail drawer: basic fields for any source, enriched for
+          source === "alert" via GET /alerts/{id}.
+    related_specs:
+      - api-activity
+      - system-alerts
+      - frontend-foundation
+
+  objective:
+    summary: >
+      A user opens /activity, filters by source/severity, pages through
+      the stream, acts on alert-source rows within their authority, and
+      opens any row for detail — with honest empty / error states and an
+      RBAC-suppression count.
+    scope:
+      includes:
+        - 'ActivityPage at /activity: useInfiniteQuery over GET /api/v1/activity'
+        - 'Source + severity single-select filters; host_id deep-link via search param'
+        - 'Cursor pagination (Load more) + hidden_count surfaced'
+        - 'Alert-source rows: acknowledge/silence/resolve gated by alert:write'
+        - 'Detail drawer: basic for all sources, enriched for alert via GET /alerts/{id}'
+      excludes:
+        - 'Severity histogram (no aggregate endpoint)'
+        - 'Facet rail / multi-select facets'
+        - '"Routed to" delivery panel (notifications persistence is greenfield)'
+        - 'Live tail (alert/audit/transaction not on the SSE bus)'
+        - 'Ack/mute on non-alert sources (immutable logs; would need new state table)'
+        - 'Rich payload drawer for audit/intelligence/transaction/monitoring (need per-id GETs)'
+
+  constraints:
+    - id: C-01
+      description: >-
+        ActivityPage MUST read GET /api/v1/activity via an infinite query
+        keyed on the source/severity/host_id filters, advancing pages by
+        next_cursor, and MUST surface hidden_count (the RBAC-suppressed
+        row count). Source and severity are single-value filters
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: >-
+        Lifecycle actions (acknowledge / silence / resolve) MUST render
+        ONLY on rows whose source === "alert" AND only when the caller has
+        alert:write, and MUST POST /api/v1/alerts/{id}:<action> using the
+        activity row id. Non-alert rows are immutable and MUST expose no
+        mutation
+      type: security
+      enforcement: error
+    - id: C-03
+      description: >-
+        Clicking a row opens a detail drawer. The drawer MUST fetch
+        GET /api/v1/alerts/{id} ONLY when source === "alert" (enabled
+        gate); for every other source it renders the activity item's own
+        fields without an extra fetch
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: >-
+        The feed is read-only apart from the alert lifecycle actions: the
+        page MUST NOT issue any mutating request to a non-alert endpoint.
+        UI copy carries no em-dashes
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: 'Source-inspection — ActivityPage uses useInfiniteQuery against "/api/v1/activity" with source/severity/host_id query params, derives the next page from next_cursor (getNextPageParam), renders a Load more control gated on hasNextPage, and renders hidden_count.'
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: 'Source-inspection — the alert lifecycle actions render under a source === "alert" check AND hasPermission("alert:write"); the mutation POSTs "/api/v1/alerts/{id}:" acknowledge/silence/resolve via the activity row id. The router mounts ActivityPage at path "activity" under protectedRoute and the sidebar Activity entry is enabled.'
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: 'Source-inspection — ActivityDrawer queries GET "/api/v1/alerts/{id}" with enabled gated on source === "alert"; it renders the basic activity fields (title/source/severity/host/time) unconditionally so non-alert sources still get a drawer.'
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-04
+      description: 'Source-inspection — the activity modules issue no api.POST/PUT/DELETE other than the /api/v1/alerts/{id}: lifecycle actions, and activity UI copy contains no em-dash.'
+      priority: high
+      references_constraints: [C-04]


### PR DESCRIPTION
## Summary

Wires the unified **Activity feed** at `/activity` (sidebar link now live), restyled to the `Activity.html` prototype using **only honest data**, plus a tracked backend scope doc.

## Layout (matches the prototype, real data only)

- **Toolbar**: client-side search over loaded events, a time-range segment (1h/24h/7d/All) backed by the real `since` param, a **Live** poll toggle (`refetchInterval`, not a fabricated stream), **Acknowledge all** over loaded alert rows, and an event count.
- **Filter bar**: dropdown-buttons (Severity, Source) with a selected-value badge.
- **Rows**: mono severity-toned headline, a per-source **CATEGORY** chip (cosmetic label), a **hostname** entity pill (resolved via the hosts list), source on the right, and **Ack/Silence** icon actions on alert rows.
- **Detail drawer**: basic fields for every source, enriched for `alert` via `GET /alerts/{id}` (body, tags, state, state-aware Acknowledge/Silence/Resolve).

## The scoping payoff

`docs/engineering/activity_page_scope.md` records the full backend scope. The feed is a read-only UNION projection, **but** the alert lifecycle is fully built and the activity row id **is** the alert id for `source: "alert"` — so the alert actions + rich drawer ship with **zero new backend**.

## Deferred (backend-gated — in the scope doc, with effort)

- Severity **histogram** (no aggregate endpoint), **Status/Group** facets (status isn't a per-item field; Group needs the Groups entity), **dedup ×N** (no count column), **"routed to"** delivery panel (notifications persistence is greenfield), and rich drawers for audit/intelligence/transaction/monitoring (need small per-id detail GETs). Honest limitation surfaced in copy: **search filters loaded events only**.

## Verification

- `tsc --noEmit` clean
- **251** frontend tests (activity: 5 ACs)
- `specter check`: **87** specs (new `frontend-activity`)
- `vite build` OK
- Pre-commit: ESLint, Prettier, spec-coverage source-walk pass

Builds on #529 (dashboard), merged. Two commits: MVP + prototype-fidelity pass.
