### PR TITLE
fix(shell): set the topbar breadcrumb on every nav page

### DIFF
--- a/frontend/src/pages/activity/ActivityPage.tsx
+++ b/frontend/src/pages/activity/ActivityPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { Link, useSearch } from '@tanstack/react-router';
 import api from '@/api/client';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { apiErrorMessage } from '@/api/errors';
 import { useAuthStore } from '@/store/useAuthStore';
 import type { components } from '@/api/schema';
@@ -66,6 +67,12 @@ interface ActivitySearch {
 }
 
 export function ActivityPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  useEffect(() => {
+    setCrumbs([{ label: 'Infrastructure' }, { label: 'Activity' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
   const search = useSearch({ strict: false }) as ActivitySearch;
   const hostId = search.host_id;
   const hasPermission = useAuthStore((s) => s.hasPermission);

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import {
   KpiHostsOnline,
   KpiAvgCompliance,
@@ -19,6 +21,12 @@ import {
 // loading / empty / error states.
 
 export function DashboardPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  useEffect(() => {
+    setCrumbs([{ label: 'Dashboard' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
   const identity = useAuthStore((s) => s.identity);
 
   return (

--- a/frontend/src/pages/groups/GroupsPage.tsx
+++ b/frontend/src/pages/groups/GroupsPage.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { Plus, Boxes, Building2, MonitorCog, MoreVertical } from 'lucide-react';
 import api from '@/api/client';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { apiErrorMessage } from '@/api/errors';
 import type { components } from '@/api/schema';
 import { Modal, Btn, FormField, Select, Toggle, Callout } from '@/components/settings/primitives';
@@ -61,6 +62,12 @@ function statusDotColor(status: string): string {
 // ── page ───────────────────────────────────────────────────────────
 
 export function GroupsPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  useEffect(() => {
+    setCrumbs([{ label: 'Infrastructure' }, { label: 'Groups' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
   const canWrite = useAuthStore((s) => s.hasPermission('host:write'));
   const [createOpen, setCreateOpen] = useState(false);
 

--- a/frontend/src/pages/reports/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ReportsPage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/api/client';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { apiErrorMessage } from '@/api/errors';
 import { useAuthStore } from '@/store/useAuthStore';
 import type { components } from '@/api/schema';
@@ -57,6 +58,12 @@ function formatDate(iso: string): string {
 }
 
 export function ReportsPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  useEffect(() => {
+    setCrumbs([{ label: 'Compliance' }, { label: 'Reports' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
   const [tab, setTab] = useState<'library' | 'templates' | 'scheduled'>('library');
   const [selectedId, setSelectedId] = useState<string | null>(null);
 

--- a/frontend/src/pages/scans/ScansPage.tsx
+++ b/frontend/src/pages/scans/ScansPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import api from '@/api/client';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { apiErrorMessage } from '@/api/errors';
 
 // ScansPage — the fleet scan overview at /scans, composed entirely from
@@ -33,6 +34,12 @@ const TONE = {
 };
 
 export function ScansPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  useEffect(() => {
+    setCrumbs([{ label: 'Infrastructure' }, { label: 'Scans' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
   const [tab, setTab] = useState<'coverage' | 'history'>('coverage');
 
   const queueQ = useQuery({

--- a/frontend/tests/foundation/breadcrumbs.test.ts
+++ b/frontend/tests/foundation/breadcrumbs.test.ts
@@ -1,0 +1,37 @@
+// @spec frontend-foundation
+//
+// AC traceability (this file):
+//   AC-19  every top-level page sets + clears its topbar breadcrumb
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Each top-level navigation page and its expected crumb chain (matching
+// the openwatch-v1 prototypes: Reports lives under Compliance, the rest
+// under Infrastructure; Dashboard is a single crumb).
+const PAGES: { file: string; crumbs: string[] }[] = [
+  { file: 'src/pages/HostsListPage.tsx', crumbs: ['Infrastructure', 'Hosts'] },
+  { file: 'src/pages/dashboard/DashboardPage.tsx', crumbs: ['Dashboard'] },
+  { file: 'src/pages/activity/ActivityPage.tsx', crumbs: ['Infrastructure', 'Activity'] },
+  { file: 'src/pages/scans/ScansPage.tsx', crumbs: ['Infrastructure', 'Scans'] },
+  { file: 'src/pages/groups/GroupsPage.tsx', crumbs: ['Infrastructure', 'Groups'] },
+  { file: 'src/pages/reports/ReportsPage.tsx', crumbs: ['Compliance', 'Reports'] },
+];
+
+describe('frontend-foundation — page breadcrumbs', () => {
+  // @ac AC-19
+  test('frontend-foundation/AC-19 — every top-level page sets + clears its breadcrumb', () => {
+    for (const { file, crumbs } of PAGES) {
+      const src = readFileSync(resolve(process.cwd(), file), 'utf8');
+      // Sets its crumbs via the store, in a useEffect with a clearing cleanup.
+      expect(src, file).toMatch(/useBreadcrumbStore/);
+      expect(src, file).toMatch(/setCrumbs\(\[/);
+      expect(src, file).toMatch(/return \(\) => setCrumbs\(\[\]\)/);
+      // Carries the right crumb labels.
+      for (const label of crumbs) {
+        expect(src, file).toMatch(new RegExp(`label: '${label}'`));
+      }
+    }
+  });
+});

--- a/specs/frontend/foundation.spec.yaml
+++ b/specs/frontend/foundation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-foundation
   title: Frontend foundation — theme, color scheme, layout shell, route guards
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -113,6 +113,17 @@ spec:
         UI copy carries no em-dashes
       type: technical
       enforcement: error
+    - id: C-13
+      description: >-
+        Every top-level navigation page MUST set the topbar breadcrumb for
+        its route by calling useBreadcrumbStore.setCrumbs in a useEffect,
+        with a cleanup that clears it (returns setCrumbs([])), so the
+        topbar always reflects the current page and never shows a stale
+        crumb from the previously visited page. The crumb labels match the
+        page's place in the information architecture (e.g. Infrastructure /
+        Hosts, Compliance / Reports). UI copy carries no em-dashes
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -194,3 +205,13 @@ spec:
         no em-dash.
       priority: high
       references_constraints: [C-12]
+    - id: AC-19
+      description: >-
+        Source-inspection — every top-level page (HostsListPage,
+        DashboardPage, ActivityPage, ScansPage, GroupsPage, ReportsPage)
+        calls useBreadcrumbStore setCrumbs([...]) inside a useEffect whose
+        cleanup clears the crumbs (setCrumbs([])). Reports uses the
+        Compliance category; the others use Infrastructure (Dashboard a
+        single crumb). No page renders without setting its breadcrumb.
+      priority: high
+      references_constraints: [C-13]


### PR DESCRIPTION
## Summary

Every nav page now sets its **topbar breadcrumb**, matching the prototypes. Previously only `HostsListPage` called `useBreadcrumbStore.setCrumbs(...)`; Dashboard, Activity, Scans, Groups, and Reports left a **stale crumb** from the previously-visited page.

| Page | Breadcrumb |
|---|---|
| Dashboard | `Dashboard` |
| Activity | `Infrastructure / Activity` |
| Scans | `Infrastructure / Scans` |
| Groups | `Infrastructure / Groups` |
| Reports | `Compliance / Reports` |

Each sets its crumb in a `useEffect` with a clearing cleanup (the `HostsListPage` pattern). **Chrome-verified** the rendered crumb (`Compliance / Reports`).

The sidebar active-state was already correct (`startsWith(item.to)`), so this is breadcrumb-only.

## SDD
`frontend-foundation` → **v1.2.0**: adds **C-13** + **AC-19** (every top-level page sets + clears its breadcrumb) with a source-inspection test across all six pages.

## Verification
- `tsc` clean · **264** frontend tests (new breadcrumb test) · `specter check` **92** specs / 0 errors · eslint/prettier clean

Follow-up to the main-nav MVP (#533).
