### PR TITLE
feat(host-compliance): per-rule evidence/OSCAL drill-down on Compliance tab

### DIFF
--- a/frontend/src/pages/host-detail/ComplianceTab.tsx
+++ b/frontend/src/pages/host-detail/ComplianceTab.tsx
@@ -40,13 +40,14 @@
 //
 // Spec: frontend-host-compliance-tab v1.1.0.
 
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
 import type { components } from '@/api/schema';
 import { useAuthStore } from '@/store/useAuthStore';
+import { RuleDetailPanel } from '@/pages/scans/RuleDetailPanel';
 import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { SeverityPill } from '@/pages/host-detail/SeverityPill';
 
@@ -120,6 +121,9 @@ export function ComplianceTab({
   // a pending request. Never mutates the lens data (overlay model).
   const exc = useHostExceptions(hostId);
   const canRequest = useAuthStore((st) => st.hasPermission)('exception:request');
+  // Evidence drill-down is gated scan:read (it reaches the scan:read-only
+  // /scans evidence endpoints): the host lens itself stays evidence-free.
+  const canViewEvidence = useAuthStore((st) => st.hasPermission)('scan:read');
   // The rule a Request-exception modal is open for (null = closed).
   const [requestRule, setRequestRule] = useState<LensRule | null>(null);
 
@@ -205,6 +209,8 @@ export function ComplianceTab({
           pendingRuleIds={exc.pendingRuleIds}
           canRequest={canRequest}
           onRequest={setRequestRule}
+          scanId={lens.scan_context.scan_id ?? null}
+          canViewEvidence={canViewEvidence}
         />
       </>
     );
@@ -919,6 +925,8 @@ function RulesTable({
   pendingRuleIds,
   canRequest,
   onRequest,
+  scanId,
+  canViewEvidence,
 }: {
   rules: LensRule[];
   filter: StatusFilter;
@@ -930,7 +938,15 @@ function RulesTable({
   pendingRuleIds: Set<string>;
   canRequest: boolean;
   onRequest: (rule: LensRule) => void;
+  // scanId is the host's latest completed scan (scan_context.scan_id); the
+  // per-rule evidence drill-down reaches /scans/{scanId}/rules/{ruleId}.
+  // null when never scanned. canViewEvidence gates it on scan:read.
+  scanId: string | null;
+  canViewEvidence: boolean;
 }) {
+  // The rule whose evidence/OSCAL drill-down is expanded (one at a time).
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const canDrill = canViewEvidence && !!scanId;
   const counts = useMemo(() => {
     const c: Record<StatusFilter, number> = {
       all: rules.length,
@@ -1055,44 +1071,83 @@ function RulesTable({
             </tr>
           </thead>
           <tbody>
-            {visible.map((r) => (
-              <tr key={r.rule_id} style={{ borderTop: '1px solid var(--ow-line)' }}>
-                <td style={td}>
-                  <StatusChip status={r.status} />
-                </td>
-                <td style={td}>
-                  <SeverityPill severity={r.severity} />
-                </td>
-                <td style={td}>
-                  <div style={{ color: 'var(--ow-fg-0)', fontWeight: 500 }}>{r.title}</div>
-                  {r.description ? (
-                    <div style={{ color: 'var(--ow-fg-3)', fontSize: 11, marginTop: 2 }}>
-                      {r.description}
-                    </div>
+            {visible.map((r) => {
+              const open = expanded === r.rule_id;
+              return (
+                <Fragment key={r.rule_id}>
+                  <tr style={{ borderTop: '1px solid var(--ow-line)' }}>
+                    <td style={td}>
+                      <StatusChip status={r.status} />
+                    </td>
+                    <td style={td}>
+                      <SeverityPill severity={r.severity} />
+                    </td>
+                    <td style={td}>
+                      {canDrill ? (
+                        <button
+                          type="button"
+                          onClick={() => setExpanded(open ? null : r.rule_id)}
+                          aria-expanded={open}
+                          style={{
+                            background: 'transparent',
+                            border: 0,
+                            padding: 0,
+                            cursor: 'pointer',
+                            textAlign: 'left',
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 6,
+                            color: 'var(--ow-fg-0)',
+                            fontWeight: 500,
+                          }}
+                        >
+                          <span aria-hidden style={{ color: 'var(--ow-fg-3)', fontSize: 11 }}>
+                            {open ? '▾' : '▸'}
+                          </span>
+                          {r.title}
+                        </button>
+                      ) : (
+                        <div style={{ color: 'var(--ow-fg-0)', fontWeight: 500 }}>{r.title}</div>
+                      )}
+                      {r.description ? (
+                        <div style={{ color: 'var(--ow-fg-3)', fontSize: 11, marginTop: 2 }}>
+                          {r.description}
+                        </div>
+                      ) : null}
+                      <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 5 }}>
+                        {(r.control_ids.length > 0 ? r.control_ids : [r.rule_id]).map((cid) => (
+                          <span key={cid} style={refChip}>
+                            {cid}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td style={{ ...td, color: 'var(--ow-fg-2)' }}>{r.category}</td>
+                    <td
+                      style={{ ...td, color: 'var(--ow-fg-3)', whiteSpace: 'nowrap', fontSize: 12 }}
+                    >
+                      {relativeTime(r.last_checked_at)}
+                    </td>
+                    <td style={td}>
+                      <ExceptionCell
+                        rule={r}
+                        waived={activeRuleIds.has(r.rule_id)}
+                        pending={pendingRuleIds.has(r.rule_id)}
+                        canRequest={canRequest}
+                        onRequest={onRequest}
+                      />
+                    </td>
+                  </tr>
+                  {canDrill && open && scanId ? (
+                    <tr>
+                      <td colSpan={6} style={{ padding: '0 10px 12px 24px' }}>
+                        <RuleDetailPanel scanId={scanId} ruleId={r.rule_id} hasEvidence />
+                      </td>
+                    </tr>
                   ) : null}
-                  <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 5 }}>
-                    {(r.control_ids.length > 0 ? r.control_ids : [r.rule_id]).map((cid) => (
-                      <span key={cid} style={refChip}>
-                        {cid}
-                      </span>
-                    ))}
-                  </div>
-                </td>
-                <td style={{ ...td, color: 'var(--ow-fg-2)' }}>{r.category}</td>
-                <td style={{ ...td, color: 'var(--ow-fg-3)', whiteSpace: 'nowrap', fontSize: 12 }}>
-                  {relativeTime(r.last_checked_at)}
-                </td>
-                <td style={td}>
-                  <ExceptionCell
-                    rule={r}
-                    waived={activeRuleIds.has(r.rule_id)}
-                    pending={pendingRuleIds.has(r.rule_id)}
-                    canRequest={canRequest}
-                    onRequest={onRequest}
-                  />
-                </td>
-              </tr>
-            ))}
+                </Fragment>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/frontend/src/pages/scans/RuleDetailPanel.tsx
+++ b/frontend/src/pages/scans/RuleDetailPanel.tsx
@@ -32,9 +32,16 @@ export function RuleDetailPanel({
     queryKey: ['scan', scanId, 'rule', ruleId, 'evidence'],
     enabled: hasEvidence && view !== 'oscal',
     queryFn: async () => {
-      const { data, error } = await api.GET('/api/v1/scans/{id}/rules/{ruleId}/evidence', {
-        params: { path: { id: scanId, ruleId } },
-      });
+      const { data, error, response } = await api.GET(
+        '/api/v1/scans/{id}/rules/{ruleId}/evidence',
+        {
+          params: { path: { id: scanId, ruleId } },
+        },
+      );
+      // 404: this rule has no stored evidence in the linked scan (e.g. the
+      // host-tab drill-down points at the latest scan; a never-evaluated or
+      // pre-store rule simply has none). Treat as "no evidence", not an error.
+      if (response?.status === 404) return null;
       if (error || !data) throw new Error(apiErrorMessage(error, 'Failed to load evidence'));
       return data as Evidence;
     },
@@ -50,9 +57,21 @@ export function RuleDetailPanel({
         marginTop: 8,
       }}
     >
-      <div role="tablist" aria-label="Rule detail view" style={{ display: 'flex', gap: 4, marginBottom: 12 }}>
-        <SwitchTab label="Formatted" active={view === 'formatted'} onClick={() => setView('formatted')} />
-        <SwitchTab label="Evidence" active={view === 'evidence'} onClick={() => setView('evidence')} />
+      <div
+        role="tablist"
+        aria-label="Rule detail view"
+        style={{ display: 'flex', gap: 4, marginBottom: 12 }}
+      >
+        <SwitchTab
+          label="Formatted"
+          active={view === 'formatted'}
+          onClick={() => setView('formatted')}
+        />
+        <SwitchTab
+          label="Evidence"
+          active={view === 'evidence'}
+          onClick={() => setView('evidence')}
+        />
         <SwitchTab label="OSCAL" active={view === 'oscal'} onClick={() => setView('oscal')} />
       </div>
 
@@ -64,6 +83,8 @@ export function RuleDetailPanel({
         <Note>Loading evidence.</Note>
       ) : evidenceQ.isError ? (
         <Note tone="crit">{apiErrorMessage(evidenceQ.error, 'Failed to load evidence')}</Note>
+      ) : !evidenceQ.data ? (
+        <Note>No evidence was captured for this rule.</Note>
       ) : view === 'formatted' ? (
         <FormattedView ev={evidenceQ.data} />
       ) : (
@@ -93,12 +114,18 @@ function CheckSummary({ c }: { c: Check }) {
     <div style={{ marginBottom: 10 }}>
       <div style={{ fontSize: 12, color: 'var(--ow-fg-2)', marginBottom: 3 }}>{c.method}</div>
       {c.command ? (
-        <code style={{ fontFamily: 'var(--ow-font-mono)', fontSize: 12, color: 'var(--ow-fg-0)' }}>{c.command}</code>
+        <code style={{ fontFamily: 'var(--ow-font-mono)', fontSize: 12, color: 'var(--ow-fg-0)' }}>
+          {c.command}
+        </code>
       ) : null}
-      <div style={{ display: 'flex', gap: 16, marginTop: 4, fontSize: 12, color: 'var(--ow-fg-2)' }}>
+      <div
+        style={{ display: 'flex', gap: 16, marginTop: 4, fontSize: 12, color: 'var(--ow-fg-2)' }}
+      >
         {c.expected !== undefined && c.expected !== '' ? <span>expected: {c.expected}</span> : null}
         {c.actual !== undefined && c.actual !== '' ? <span>actual: {c.actual}</span> : null}
-        <span style={{ color: exitOk ? 'var(--ow-ok)' : 'var(--ow-warn)' }}>exit {c.exit_code}</span>
+        <span style={{ color: exitOk ? 'var(--ow-ok)' : 'var(--ow-warn)' }}>
+          exit {c.exit_code}
+        </span>
       </div>
     </div>
   );
@@ -185,7 +212,15 @@ function JsonBlock({ data, filename }: { data: unknown; filename: string }) {
   );
 }
 
-function SwitchTab({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+function SwitchTab({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
   return (
     <button
       role="tab"
@@ -210,7 +245,13 @@ function SwitchTab({ label, active, onClick }: { label: string; active: boolean;
 
 function Note({ children, tone }: { children: React.ReactNode; tone?: 'crit' }) {
   return (
-    <p style={{ margin: '8px 0 0', fontSize: 12, color: tone === 'crit' ? 'var(--ow-crit)' : 'var(--ow-fg-3)' }}>
+    <p
+      style={{
+        margin: '8px 0 0',
+        fontSize: 12,
+        color: tone === 'crit' ? 'var(--ow-crit)' : 'var(--ow-fg-3)',
+      }}
+    >
       {children}
     </p>
   );

--- a/frontend/tests/pages/host-detail-compliance-tab.test.tsx
+++ b/frontend/tests/pages/host-detail-compliance-tab.test.tsx
@@ -183,8 +183,15 @@ describe('frontend-host-compliance-tab — structural', () => {
   });
 
   // @ac AC-07
-  test('frontend-host-compliance-tab/AC-07 — no stored check-output reference anywhere in the tab code', () => {
-    expect(TAB_SRC.toLowerCase()).not.toContain('evidence');
+  test('frontend-host-compliance-tab/AC-07 — evidence drill-down via RuleDetailPanel, scan:read-gated, host lens stays evidence-free', () => {
+    // The drill-down reaches the scan:read-gated /scans evidence surface
+    // through the shared panel; it is NOT fetched from a /hosts endpoint.
+    expect(TAB_SRC).toContain('RuleDetailPanel');
+    expect(TAB_SRC).toMatch(/hasPermission\)\('scan:read'\)/);
+    expect(TAB_SRC).toContain('scan_context.scan_id');
+    // The host-compliance surface stays evidence-free: no evidence is
+    // fetched from any /hosts compliance endpoint (evidence lives at /scans).
+    expect(TAB_SRC).not.toMatch(/hosts\/\{id\}\/compliance[^']*evidence/i);
   });
 });
 

--- a/specs/frontend/host-compliance-tab.spec.yaml
+++ b/specs/frontend/host-compliance-tab.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-compliance-tab
   title: Host detail Compliance tab — lens UI over the per-host compliance endpoints
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -62,9 +62,14 @@ spec:
 
       Out of scope (deferred):
         - Export / report download
-        - Per-rule drill-down drawer
         - Remediate actions (Phase 7)
         - Pagination (the lens response is one bounded payload)
+
+      Added in v1.3.0: a per-rule evidence/OSCAL drill-down. Each rule row
+      expands the shared RuleDetailPanel (Formatted / Evidence / OSCAL),
+      reaching the scan:read-gated /scans endpoints for the host's latest
+      scan_context.scan_id. The drill-down shows only to callers holding
+      scan:read; the host-compliance API itself stays evidence-free.
 
     related_specs:
       - api-host-compliance
@@ -90,7 +95,7 @@ spec:
         - "In-strip Re-scan button reusing the page-head Run scan enqueue semantics"
       excludes:
         - "Export button — deferred, no dead controls"
-        - "Per-rule detail drawer and remediation actions"
+        - "Remediation actions (Phase 7)"
         - "Server-side pagination or filtering beyond ?framework="
 
   constraints:
@@ -111,7 +116,15 @@ spec:
       type: technical
       enforcement: error
     - id: C-05
-      description: 'The tab MUST never reference the host_rule_state stored per-rule check output (sensitive host configuration, api-host-compliance C-02): the string "evidence" (case-insensitive) MUST NOT appear anywhere in ComplianceTab.tsx'
+      description: >-
+        The tab MUST NOT render the host_rule_state stored per-rule check
+        output via the host-compliance API, which stays evidence-free
+        (api-host-compliance C-02 — the lens carries no evidence). Raw
+        evidence is reached ONLY through the per-rule drill-down to the
+        scan:read-gated /scans endpoints (the shared RuleDetailPanel),
+        linked to the host's latest scan_context.scan_id, and the
+        drill-down control is shown ONLY to callers holding scan:read. The
+        tab MUST fetch no evidence from any /hosts compliance endpoint.
       type: security
       enforcement: error
 
@@ -141,7 +154,7 @@ spec:
       priority: critical
       references_constraints: [C-04]
     - id: AC-07
-      description: "Source inspection: ComplianceTab.tsx never contains the string 'evidence' (case-insensitive), so the stored per-rule check output cannot be referenced or rendered"
+      description: "Source inspection: ComplianceTab renders the per-rule evidence/OSCAL drill-down via the shared RuleDetailPanel, gated on hasPermission('scan:read') and linked to scan_context.scan_id; it fetches no evidence from any /hosts compliance endpoint (the host-compliance surface stays evidence-free per api-host-compliance C-02; raw evidence comes only from the scan:read-gated /scans endpoints)."
       priority: critical
       references_constraints: [C-05]
     - id: AC-08


### PR DESCRIPTION
## Summary

Enhances the host detail **Compliance tab** so each rule row expands into the shared **RuleDetailPanel** (Formatted / Evidence / OSCAL), mirroring the `/scans/<id>` scan-detail drill-down. This answers "what command proved this rule passed/failed on this host" directly from the host page, without weakening the host-compliance security posture.

### How it stays secure (Option B)

- The host-compliance API **stays evidence-free** (`api-host-compliance` C-02 untouched): the host lens still carries no stored check output.
- The drill-down reaches the **`scan:read`-gated `/api/v1/scans` evidence endpoints** for the host's latest `scan_context.scan_id` (already present in the lens response, so this is a **frontend-only** change, no backend/OpenAPI change).
- The expand control renders **only** for callers holding `scan:read`; a `host:read`-only operator sees the tab exactly as before.

### Robustness

`RuleDetailPanel` now treats a `404` from the evidence endpoint as "no evidence captured for this rule" instead of an error, because the host-tab drill-down points at the latest scan where a given rule may legitimately have no stored evidence. This path is shared with scan-detail (no regression — `frontend-scan-detail` 7/7 ACs still green).

## Spec

`frontend-host-compliance-tab` -> **v1.3.0**: C-05 rewritten (evidence reached only via the scan:read-gated drill-down; lens stays evidence-free), **AC-07 added** (source-inspection: RuleDetailPanel present, `scan:read` gate, linked to `scan_context.scan_id`, no `/hosts` evidence fetch).

## Verification

- `tsc --noEmit`: clean
- Full vitest suite: **275/275** pass (44 files)
- `specter check`: 97 specs structural pass
- Coverage: `frontend-host-compliance-tab` **9/9** ACs, `frontend-scan-detail` **7/7** ACs (shared panel, no regression)
- Chrome (owas-tst01, latest scan = 539-result scan): drill-down renders Formatted (awk command + exit code) and Evidence (raw JSON: checks / detail / framework_refs / rule_id / severity / status + Download); `scan:read` admin sees the expand control.

## Files

- `frontend/src/pages/host-detail/ComplianceTab.tsx` — expandable rows, `scan:read` gate, `scan_context.scan_id` linkage
- `frontend/src/pages/scans/RuleDetailPanel.tsx` — 404-graceful evidence query
- `specs/frontend/host-compliance-tab.spec.yaml` — v1.3.0 (C-05, AC-07)
- `frontend/tests/pages/host-detail-compliance-tab.test.tsx` — AC-07 test