### PR TITLE
feat(settings): activate Audit log + About/License (settings activation Phase 1a)

### DIFF
--- a/frontend/src/api/auth-bootstrap.ts
+++ b/frontend/src/api/auth-bootstrap.ts
@@ -26,6 +26,7 @@ function permissionsForRole(role: string): string[] {
       'credential:write',
       'credential:delete',
       'scan:read',
+      'audit:read',
       'admin',
     ];
   }
@@ -62,6 +63,7 @@ export async function bootstrapAuth(): Promise<void> {
         'credential:read',
         'credential:write',
         'scan:read',
+        'audit:read',
         'admin',
       ],
       mfaEnabled: false,

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -130,6 +130,7 @@ export function LoginPage() {
                     'credential:read',
                     'credential:write',
                     'scan:read',
+                    'audit:read',
                     'admin',
                   ]
                 : ['host:read', 'scan:read'],

--- a/frontend/src/pages/settings/AuditPage.tsx
+++ b/frontend/src/pages/settings/AuditPage.tsx
@@ -1,0 +1,404 @@
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
+import { useAuthStore } from '@/store/useAuthStore';
+import { SettingsLayout } from '@/components/settings/SettingsLayout';
+import {
+  PageHead,
+  Section,
+  SettingCard,
+  Field,
+  Btn,
+  StatusPill,
+} from '@/components/settings/primitives';
+import { ForbiddenPage } from '@/pages/ForbiddenPage';
+import type { components } from '@/api/schema';
+
+type AuditEvent = components['schemas']['AuditEvent'];
+
+// Settings -> Audit log.
+//
+// Filterable, cursor-paginated view of GET /api/v1/audit/events (newest
+// first). Gated on audit:read. Each row expands to its raw detail JSON +
+// any redactions. No write actions: the audit log is read-only by design.
+//
+// Spec: frontend-settings (AC-19), api-audit-events-query.
+
+// localDateToRFC3339 converts a yyyy-mm-dd date input into an RFC3339
+// instant. `end` pins to the end of the day so an inclusive "until" filter
+// captures events recorded that day.
+function localDateToRFC3339(value: string, end: boolean): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(`${value}T${end ? '23:59:59' : '00:00:00'}`);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toISOString();
+}
+
+function severityTier(severity?: string): 'ok' | 'warn' | 'crit' {
+  const s = (severity ?? '').toLowerCase();
+  if (s === 'critical' || s === 'error' || s === 'high') return 'crit';
+  if (s === 'warn' || s === 'warning' || s === 'medium') return 'warn';
+  return 'ok';
+}
+
+function relTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export function AuditPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  const canRead = useAuthStore((s) => s.hasPermission)('audit:read');
+  useEffect(() => {
+    setCrumbs([{ label: 'Settings' }, { label: 'Audit log' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
+  // Draft filter inputs vs. the applied filters that key the query. The
+  // query only re-runs when the operator clicks Apply (or Clear), so typing
+  // never issues a request per keystroke.
+  const [draftAction, setDraftAction] = useState('');
+  const [draftActor, setDraftActor] = useState('');
+  const [draftSince, setDraftSince] = useState('');
+  const [draftUntil, setDraftUntil] = useState('');
+  const [applied, setApplied] = useState<{
+    action: string;
+    actorType: string;
+    since: string;
+    until: string;
+  }>({ action: '', actorType: '', since: '', until: '' });
+
+  const sinceIso = useMemo(() => localDateToRFC3339(applied.since, false), [applied.since]);
+  const untilIso = useMemo(() => localDateToRFC3339(applied.until, true), [applied.until]);
+
+  const query = useInfiniteQuery({
+    queryKey: ['audit', applied.action, applied.actorType, applied.since, applied.until],
+    enabled: canRead,
+    initialPageParam: undefined as string | undefined,
+    queryFn: async ({ pageParam }) => {
+      const { data, error, response } = await api.GET('/api/v1/audit/events', {
+        params: {
+          query: {
+            limit: 50,
+            ...(applied.action ? { action: applied.action } : {}),
+            ...(applied.actorType ? { actor_type: applied.actorType } : {}),
+            ...(sinceIso ? { since: sinceIso } : {}),
+            ...(untilIso ? { until: untilIso } : {}),
+            ...(pageParam ? { cursor: pageParam } : {}),
+          },
+        },
+      });
+      if (error || !response.ok) {
+        throw new Error(apiErrorMessage(error, `Failed to load audit events (${response.status})`));
+      }
+      return data!;
+    },
+    getNextPageParam: (last) => last.next_cursor ?? undefined,
+  });
+
+  if (!canRead) {
+    // RBAC gate: the audit log requires audit:read. The backend is
+    // authoritative; this mirrors it so the UI never shows a surface the
+    // caller cannot load.
+    return <ForbiddenPage />;
+  }
+
+  const events: AuditEvent[] = query.data?.pages.flatMap((p) => p.items) ?? [];
+
+  function apply() {
+    setApplied({
+      action: draftAction.trim(),
+      actorType: draftActor.trim(),
+      since: draftSince,
+      until: draftUntil,
+    });
+  }
+  function clear() {
+    setDraftAction('');
+    setDraftActor('');
+    setDraftSince('');
+    setDraftUntil('');
+    setApplied({ action: '', actorType: '', since: '', until: '' });
+  }
+
+  return (
+    <SettingsLayout>
+      <PageHead
+        title="Audit log"
+        description="Every authentication, policy change, and remediation action OpenWatch has recorded. Read-only, newest first."
+      />
+
+      <Section title="Filters">
+        <SettingCard>
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              apply();
+            }}
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 12,
+              alignItems: 'flex-end',
+              padding: 16,
+            }}
+          >
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={labelStyle}>Action</span>
+              <Field
+                value={draftAction}
+                onChange={setDraftAction}
+                placeholder="e.g. auth.login"
+                ariaLabel="Filter by action"
+                width={200}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={labelStyle}>Actor type</span>
+              <Field
+                value={draftActor}
+                onChange={setDraftActor}
+                placeholder="e.g. user"
+                ariaLabel="Filter by actor type"
+                width={150}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={labelStyle}>From</span>
+              <input
+                type="date"
+                value={draftSince}
+                aria-label="Filter from date"
+                onChange={(e) => setDraftSince(e.target.value)}
+                style={dateInputStyle}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <span style={labelStyle}>To</span>
+              <input
+                type="date"
+                value={draftUntil}
+                aria-label="Filter to date"
+                onChange={(e) => setDraftUntil(e.target.value)}
+                style={dateInputStyle}
+              />
+            </label>
+            <Btn type="submit" variant="primary">
+              Apply
+            </Btn>
+            <Btn type="button" onClick={clear}>
+              Clear
+            </Btn>
+          </form>
+        </SettingCard>
+      </Section>
+
+      <Section title="Events">
+        <SettingCard>
+          {query.isPending ? (
+            <div style={emptyStyle}>Loading audit events.</div>
+          ) : query.isError ? (
+            <div role="alert" style={errorStyle}>
+              <strong>Failed to load audit events.</strong> {apiErrorMessage(query.error, '')}{' '}
+              <button type="button" onClick={() => query.refetch()} style={retryStyle}>
+                Retry
+              </button>
+            </div>
+          ) : events.length === 0 ? (
+            <div style={emptyStyle}>No audit events match these filters.</div>
+          ) : (
+            <>
+              <div role="table" aria-label="Audit events">
+                <div
+                  role="row"
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '150px 1fr 90px 150px 1fr',
+                    gap: 12,
+                    padding: '10px 20px',
+                    borderBottom: '1px solid var(--ow-line)',
+                    fontSize: 11,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.04em',
+                    color: 'var(--ow-fg-3)',
+                  }}
+                >
+                  <span role="columnheader">When</span>
+                  <span role="columnheader">Action</span>
+                  <span role="columnheader">Severity</span>
+                  <span role="columnheader">Actor</span>
+                  <span role="columnheader">Resource</span>
+                </div>
+                {events.map((ev) => (
+                  <AuditRow key={ev.id} ev={ev} />
+                ))}
+              </div>
+              {query.hasNextPage && (
+                <div style={{ display: 'flex', justifyContent: 'center', padding: 16 }}>
+                  <Btn
+                    type="button"
+                    onClick={() => query.fetchNextPage()}
+                    disabled={query.isFetchingNextPage}
+                  >
+                    {query.isFetchingNextPage ? 'Loading.' : 'Load more'}
+                  </Btn>
+                </div>
+              )}
+            </>
+          )}
+        </SettingCard>
+      </Section>
+    </SettingsLayout>
+  );
+}
+
+function AuditRow({ ev }: { ev: AuditEvent }) {
+  const [open, setOpen] = useState(false);
+  const hasDetail =
+    (ev.detail && Object.keys(ev.detail).length > 0) || (ev.redactions && ev.redactions.length > 0);
+  return (
+    <Fragment>
+      <div
+        role="row"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '150px 1fr 90px 150px 1fr',
+          gap: 12,
+          alignItems: 'center',
+          padding: '12px 20px',
+          borderTop: '1px solid var(--ow-line)',
+        }}
+      >
+        <span style={{ fontSize: 12, color: 'var(--ow-fg-2)' }} title={ev.occurred_at}>
+          {relTime(ev.occurred_at)}
+        </span>
+        <span style={{ minWidth: 0 }}>
+          {hasDetail ? (
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              aria-expanded={open}
+              style={{
+                background: 'transparent',
+                border: 0,
+                padding: 0,
+                color: 'var(--ow-fg-0)',
+                fontFamily: 'var(--ow-font-mono)',
+                fontSize: 12,
+                cursor: 'pointer',
+                textAlign: 'left',
+              }}
+            >
+              {open ? '▾' : '▸'} {ev.action}
+            </button>
+          ) : (
+            <span style={{ fontFamily: 'var(--ow-font-mono)', fontSize: 12 }}>{ev.action}</span>
+          )}
+        </span>
+        <span>
+          <StatusPill tier={severityTier(ev.severity)}>{ev.severity || 'info'}</StatusPill>
+        </span>
+        <span style={{ fontSize: 12, color: 'var(--ow-fg-1)', minWidth: 0 }}>
+          {ev.actor_type}
+          {ev.actor_id ? (
+            <span style={{ color: 'var(--ow-fg-3)', fontFamily: 'var(--ow-font-mono)' }}>
+              {' '}
+              {ev.actor_id}
+            </span>
+          ) : null}
+        </span>
+        <span style={{ fontSize: 12, color: 'var(--ow-fg-2)', minWidth: 0 }}>
+          {ev.resource_type ? (
+            <>
+              {ev.resource_type}
+              {ev.resource_id ? (
+                <span style={{ color: 'var(--ow-fg-3)', fontFamily: 'var(--ow-font-mono)' }}>
+                  {' '}
+                  {ev.resource_id}
+                </span>
+              ) : null}
+            </>
+          ) : (
+            <span style={{ color: 'var(--ow-fg-3)' }}>{'—'}</span>
+          )}
+        </span>
+      </div>
+      {open && hasDetail && (
+        <div
+          role="row"
+          style={{ padding: '0 20px 14px 20px', borderTop: '1px solid var(--ow-line)' }}
+        >
+          <div style={{ fontSize: 11, color: 'var(--ow-fg-3)', margin: '10px 0 4px' }}>
+            correlation:{' '}
+            <span style={{ fontFamily: 'var(--ow-font-mono)' }}>{ev.correlation_id}</span>
+          </div>
+          {ev.redactions && ev.redactions.length > 0 && (
+            <div style={{ fontSize: 11, color: 'var(--ow-warn)', marginBottom: 6 }}>
+              redacted fields: {ev.redactions.join(', ')}
+            </div>
+          )}
+          <pre
+            style={{
+              margin: 0,
+              padding: 12,
+              background: 'var(--ow-bg-1)',
+              border: '1px solid var(--ow-line)',
+              borderRadius: 'var(--ow-radius)',
+              fontFamily: 'var(--ow-font-mono)',
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: 'var(--ow-fg-1)',
+              whiteSpace: 'pre',
+              overflow: 'auto',
+              maxHeight: 320,
+            }}
+          >
+            {JSON.stringify(ev.detail ?? {}, null, 2)}
+          </pre>
+        </div>
+      )}
+    </Fragment>
+  );
+}
+
+const labelStyle = { fontSize: 11, color: 'var(--ow-fg-3)' } as const;
+const dateInputStyle = {
+  height: 32,
+  background: 'var(--ow-bg-2)',
+  border: '1px solid var(--ow-line)',
+  borderRadius: 6,
+  color: 'var(--ow-fg-0)',
+  fontFamily: 'inherit',
+  fontSize: 13,
+  padding: '0 10px',
+} as const;
+const emptyStyle = {
+  padding: 40,
+  textAlign: 'center',
+  color: 'var(--ow-fg-2)',
+  fontSize: 13,
+} as const;
+const errorStyle = {
+  padding: 20,
+  color: 'var(--ow-fg-1)',
+  background: 'var(--ow-crit-bg)',
+  borderLeft: '3px solid var(--ow-crit)',
+  fontSize: 13,
+} as const;
+const retryStyle = {
+  marginLeft: 12,
+  background: 'transparent',
+  border: 0,
+  color: 'var(--ow-info)',
+  cursor: 'pointer',
+  textDecoration: 'underline',
+} as const;

--- a/frontend/src/pages/settings/StubbedPages.tsx
+++ b/frontend/src/pages/settings/StubbedPages.tsx
@@ -10,6 +10,7 @@ import {
   SettingCard,
   BackendPendingBanner,
   Btn,
+  StatusPill,
 } from '@/components/settings/primitives';
 import { ForbiddenPage } from '@/pages/ForbiddenPage';
 
@@ -182,37 +183,20 @@ export function SecurityPage() {
   );
 }
 
-// ── Audit log ───────────────────────────────────────────────────────────
-export function AuditPage() {
-  const isAdmin = useAuthStore((s) => s.hasPermission('admin'));
-  if (!isAdmin) return <ForbiddenPage />;
-  return (
-    <StubShell
-      title="Audit log"
-      description="Every authentication, policy change, and remediation action OpenWatch has performed in this workspace."
-      slice="Slice B (audit query API)"
-      pendingText="GET /audit/events exists but the filterable UI is pending."
-      crumb="Audit log"
-    >
-      <Section title="Recent events">
-        <SettingCard>
-          <div
-            style={{
-              padding: 40,
-              textAlign: 'center',
-              color: 'var(--ow-fg-2)',
-              fontSize: 13,
-            }}
-          >
-            Audit table will render here.
-          </div>
-        </SettingCard>
-      </Section>
-    </StubShell>
-  );
-}
-
 // ── About ───────────────────────────────────────────────────────────────
+const LICENSE_TIER_LABEL: Record<string, string> = {
+  free: 'Free',
+  openwatch_plus: 'OpenWatch+',
+  enterprise: 'Enterprise',
+};
+const LICENSE_STATUS: Record<string, { label: string; tier: 'ok' | 'warn' | 'crit' }> = {
+  active: { label: 'Active', tier: 'ok' },
+  grace: { label: 'Grace period', tier: 'warn' },
+  expired: { label: 'Expired', tier: 'crit' },
+  no_license: { label: 'No license', tier: 'warn' },
+  invalid: { label: 'Invalid', tier: 'crit' },
+};
+
 export function AboutPage() {
   const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
   useEffect(() => {
@@ -233,6 +217,19 @@ export function AboutPage() {
     staleTime: 5 * 60 * 1000,
   });
   const v = versionQuery.data;
+
+  // License state from the live binary (GET /api/v1/license) — tier, status,
+  // and entitled features are read at request time, never hardcoded.
+  const licenseQuery = useQuery({
+    queryKey: ['license'],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/license');
+      if (error) throw error;
+      return data!;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+  const lic = licenseQuery.data;
 
   return (
     <SettingsLayout>
@@ -266,11 +263,84 @@ export function AboutPage() {
       </Section>
       <Section title="License">
         <SettingCard>
-          <div style={{ padding: 20, color: 'var(--ow-fg-2)', fontSize: 13 }}>
-            License view pending —{' '}
-            <code style={{ fontFamily: 'var(--ow-font-mono)' }}>GET /api/v1/license</code> exists;
-            UI rendering follows in a focused PR.
-          </div>
+          {licenseQuery.isError ? (
+            <div role="alert" style={{ padding: 20, color: 'var(--ow-fg-1)', fontSize: 13 }}>
+              Failed to load license state.
+            </div>
+          ) : (
+            <div
+              style={{
+                padding: 20,
+                display: 'grid',
+                gridTemplateColumns: '180px 1fr',
+                rowGap: 12,
+                alignItems: 'center',
+                fontSize: 13,
+              }}
+            >
+              <span style={{ color: 'var(--ow-fg-2)' }}>Tier</span>
+              <span>{lic ? (LICENSE_TIER_LABEL[lic.tier] ?? lic.tier) : '…'}</span>
+
+              <span style={{ color: 'var(--ow-fg-2)' }}>Status</span>
+              <span>
+                {lic ? (
+                  <StatusPill tier={LICENSE_STATUS[lic.status]?.tier ?? 'warn'}>
+                    {LICENSE_STATUS[lic.status]?.label ?? lic.status}
+                  </StatusPill>
+                ) : (
+                  '…'
+                )}
+              </span>
+
+              {lic?.customer_id ? (
+                <>
+                  <span style={{ color: 'var(--ow-fg-2)' }}>Customer</span>
+                  <span style={{ fontFamily: 'var(--ow-font-mono)' }}>{lic.customer_id}</span>
+                </>
+              ) : null}
+
+              {lic?.expires_at ? (
+                <>
+                  <span style={{ color: 'var(--ow-fg-2)' }}>Expires</span>
+                  <span>
+                    {new Date(lic.expires_at).toLocaleDateString()}
+                    {lic.in_grace_period ? (
+                      <span style={{ color: 'var(--ow-warn)', marginLeft: 8, fontSize: 12 }}>
+                        (in grace period)
+                      </span>
+                    ) : null}
+                  </span>
+                </>
+              ) : null}
+
+              <span style={{ color: 'var(--ow-fg-2)', alignSelf: 'start' }}>Features</span>
+              <span>
+                {lic && lic.features.length > 0 ? (
+                  <span style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {lic.features.map((f) => (
+                      <span
+                        key={f}
+                        style={{
+                          padding: '2px 8px',
+                          borderRadius: 'var(--ow-radius-sm)',
+                          background: 'var(--ow-bg-3)',
+                          color: 'var(--ow-fg-1)',
+                          fontSize: 12,
+                          fontFamily: 'var(--ow-font-mono)',
+                        }}
+                      >
+                        {f}
+                      </span>
+                    ))}
+                  </span>
+                ) : (
+                  <span style={{ color: 'var(--ow-fg-3)' }}>
+                    {lic ? 'No paid features entitled' : '…'}
+                  </span>
+                )}
+              </span>
+            </div>
+          )}
         </SettingCard>
       </Section>
     </SettingsLayout>

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -29,9 +29,9 @@ import {
   NotificationsPage,
   IntegrationsPage,
   SecurityPage,
-  AuditPage,
   AboutPage,
 } from '@/pages/settings/StubbedPages';
+import { AuditPage } from '@/pages/settings/AuditPage';
 import { PoliciesPage } from '@/pages/settings/PoliciesPage';
 
 // Top-level route table.

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -20,6 +20,8 @@
 //   AC-16  No var(--mui- or hardcoded HEX literals in settings code
 //   AC-17  Password handler doesn't console.log/warn/error secret values
 //   AC-18  axe-core dependency present (browser scan runs via Playwright)
+//   AC-19  Audit log: audit:read gate, infinite query, cursor, read-only
+//   AC-20  About: license state from GET /api/v1/license, not hardcoded
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -47,6 +49,7 @@ const STUBBED_SRC = readFileSync(
   resolve(process.cwd(), 'src/pages/settings/StubbedPages.tsx'),
   'utf8',
 );
+const AUDIT_SRC = readFileSync(resolve(process.cwd(), 'src/pages/settings/AuditPage.tsx'), 'utf8');
 const PREFS_STORE_SRC = readFileSync(
   resolve(process.cwd(), 'src/store/usePreferencesStore.ts'),
   'utf8',
@@ -188,21 +191,20 @@ describe('frontend-settings — structural', () => {
   });
 
   // @ac AC-15
-  test('frontend-settings/AC-15 — five stubbed pages each render BackendPendingBanner; PoliciesPage graduated', () => {
+  test('frontend-settings/AC-15 — three stubbed pages each render BackendPendingBanner; Audit/About/Policies graduated', () => {
     expect(STUBBED_SRC).toContain('BackendPendingBanner');
-    // The five remaining stub exports must be present.
-    const expected = [
-      'NotificationsPage',
-      'IntegrationsPage',
-      'SecurityPage',
-      'AuditPage',
-      'AboutPage',
-    ];
+    // The three remaining stub exports must be present and StubShell-based.
+    const expected = ['NotificationsPage', 'IntegrationsPage', 'SecurityPage'];
     for (const name of expected) {
       expect(STUBBED_SRC).toContain(`export function ${name}`);
     }
-    // Each renders the slice through a StubShell which mounts the banner.
     expect(STUBBED_SRC).toMatch(/<StubShell/);
+    // Audit log graduated to its own file (v1.3.0): no longer a stub here.
+    expect(STUBBED_SRC).not.toContain('export function AuditPage');
+    expect(ROUTER_SRC).toContain("from '@/pages/settings/AuditPage'");
+    // About graduated too: it renders live version + license, not a
+    // BackendPendingBanner. It still lives in this file but is not a stub.
+    expect(STUBBED_SRC).toContain('export function AboutPage');
     // PoliciesPage left the stub file: it lives in its own page with the
     // live scan-variables section and per-section banners on the
     // remaining stubs (frontend-settings-scan-config AC-06).
@@ -271,5 +273,35 @@ describe('frontend-settings — structural', () => {
     const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
     expect(deps['axe-core']).toBeTruthy();
     expect(deps['@axe-core/playwright']).toBeTruthy();
+  });
+
+  // @ac AC-19
+  test('frontend-settings/AC-19 — Audit log: audit:read gate, infinite query, cursor, read-only', () => {
+    // Gated on audit:read with a ForbiddenPage fallback.
+    expect(AUDIT_SRC).toMatch(/hasPermission\)\('audit:read'\)/);
+    expect(AUDIT_SRC).toContain('ForbiddenPage');
+    // Cursor-paginated infinite query over the audit events endpoint.
+    expect(AUDIT_SRC).toContain('useInfiniteQuery');
+    expect(AUDIT_SRC).toMatch(/api\.GET\(\s*['"]\/api\/v1\/audit\/events['"]/);
+    expect(AUDIT_SRC).toMatch(/getNextPageParam:\s*\(last\)\s*=>\s*last\.next_cursor/);
+    // Draft filters distinct from the applied filters that key the query,
+    // so typing issues no request per keystroke.
+    expect(AUDIT_SRC).toMatch(/queryKey:\s*\['audit',\s*applied\./);
+    expect(AUDIT_SRC).toMatch(/setApplied\(/);
+    // Read-only: no write verbs anywhere in the page.
+    expect(AUDIT_SRC).not.toMatch(/api\.(POST|PATCH|PUT|DELETE)\(/);
+  });
+
+  // @ac AC-20
+  test('frontend-settings/AC-20 — About renders license state from GET /api/v1/license, not hardcoded', () => {
+    expect(STUBBED_SRC).toMatch(/queryKey:\s*\['license'\]/);
+    expect(STUBBED_SRC).toMatch(/api\.GET\(\s*['"]\/api\/v1\/license['"]/);
+    // Tier + status rendered through the lookup maps (not hardcoded copy).
+    expect(STUBBED_SRC).toContain('LICENSE_TIER_LABEL');
+    expect(STUBBED_SRC).toContain('LICENSE_STATUS');
+    // Version still sourced live.
+    expect(STUBBED_SRC).toMatch(/api\.GET\(\s*['"]\/api\/v1\/version['"]/);
+    // The old "License view pending" stub copy is gone.
+    expect(STUBBED_SRC).not.toContain('License view pending');
   });
 });

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.2.0"
+  version: "1.3.0"
   status: draft
   tier: 2
 
@@ -60,7 +60,9 @@ spec:
         - "SSH & credentials — list from GET /api/v1/credentials with Add (POST), Replace (POST+DELETE) and Delete (DELETE) modals"
         - "SSH keys section is a derived view of key-bearing credentials; Add/Replace/Delete a key operates on the parent credential"
         - "Users & teams — list from GET /api/v1/users (admin-gated)"
-        - "Scanning, Policies, Notifications, Integrations, Security, Audit, About — structural shells with Backend Pending banner"
+        - "Audit log — filterable, cursor-paginated GET /api/v1/audit/events, audit:read gated, read-only (v1.3.0)"
+        - "About — version from GET /api/v1/version + license state from GET /api/v1/license (v1.3.0)"
+        - "Notifications, Integrations, Security — structural shells with Backend Pending banner"
         - "All control widgets themed via --ow-* tokens"
       excludes:
         - "PATCH /auth/me wiring (backend endpoint deferred)"
@@ -133,9 +135,10 @@ spec:
       enforcement: error
     - id: C-09
       description: >-
-        The 7 stubbed pages MUST each render a BackendPendingBanner
-        identifying the slice that unblocks them. Every interactive
-        control on these pages MUST be disabled
+        The remaining stubbed pages (Notifications, Integrations,
+        Security) MUST each render a BackendPendingBanner identifying
+        the slice that unblocks them. Every interactive control on
+        these pages MUST be disabled
       type: technical
       enforcement: error
     - id: C-10
@@ -157,6 +160,27 @@ spec:
         Every interactive element across all 11 pages MUST be
         reachable by keyboard alone. axe-core MUST report zero
         violations across wcag2a + wcag2aa in both color modes
+      type: technical
+      enforcement: error
+    - id: C-13
+      description: >-
+        v1.3.0 — Audit log (src/pages/settings/AuditPage.tsx) MUST be
+        gated on hasPermission('audit:read'): a caller without it
+        renders the 403 ForbiddenPage and issues no request. With it,
+        the page fetches GET /api/v1/audit/events via useInfiniteQuery
+        keyed on the applied filters (action, actor_type, since, until),
+        renders one row per event newest-first, and pages via the
+        response next_cursor (Load more). Filter inputs are draft state
+        applied on submit — typing MUST NOT issue a request per
+        keystroke. The page is read-only: it MUST contain no write
+        control (no POST/PATCH/PUT/DELETE).
+      type: technical
+      enforcement: error
+    - id: C-14
+      description: >-
+        v1.3.0 — About MUST render license state from GET
+        /api/v1/license (tier, status, entitled features, expiry) —
+        never hardcoded. Version stays sourced from GET /api/v1/version.
       type: technical
       enforcement: error
 
@@ -218,7 +242,7 @@ spec:
       priority: critical
       references_constraints: [C-08]
     - id: AC-15
-      description: v1.2.0 — Each remaining stubbed Settings page (Notifications, Integrations, Security, Audit, About — five now that Compliance policies hosts the live scan-variables section per frontend-settings-scan-config) renders a single BackendPendingBanner naming the slice. Visible controls render disabled. PoliciesPage lives in its own file with per-section banners on its remaining stub sections.
+      description: v1.3.0 — Each remaining stubbed Settings page (Notifications, Integrations, Security — three now that Audit log and About are wired and Compliance policies hosts the live scan-variables section) renders a single BackendPendingBanner naming the slice. Visible controls render disabled. PoliciesPage lives in its own file with per-section banners on its remaining stub sections.
       priority: high
       references_constraints: [C-09]
     - id: AC-16
@@ -230,6 +254,14 @@ spec:
       priority: critical
       references_constraints: [C-04]
     - id: AC-18
-      description: axe-core scan of /settings/profile, /settings/preferences, /settings/credentials, /settings/users, and /settings/notifications reports zero violations across wcag2a + wcag2aa in both color modes.
+      description: axe-core scan of /settings/profile, /settings/preferences, /settings/credentials, /settings/users, /settings/audit, and /settings/notifications reports zero violations across wcag2a + wcag2aa in both color modes.
       priority: critical
       references_constraints: [C-12]
+    - id: AC-19
+      description: "v1.3.0 source-inspection + behavior: AuditPage gates on hasPermission('audit:read') returning ForbiddenPage when absent; it calls useInfiniteQuery against '/api/v1/audit/events' with getNextPageParam reading next_cursor; the filter form applies on submit (draft state distinct from the applied queryKey) so keystrokes issue no request; and the page contains no api.POST/PATCH/PUT/DELETE call (read-only)."
+      priority: high
+      references_constraints: [C-13]
+    - id: AC-20
+      description: "v1.3.0 source-inspection: AboutPage fetches GET /api/v1/license via useQuery keyed ['license'] and renders the returned tier/status/features (mapped through LICENSE_TIER_LABEL / LICENSE_STATUS), with no hardcoded tier or feature list; version stays sourced from GET /api/v1/version."
+      priority: high
+      references_constraints: [C-14]


### PR DESCRIPTION
## Settings activation — Phase 1a

First slice of the [settings-navigation activation](review) initiative: two pages whose **backends already shipped** were rendering stubs. This wires them live (frontend-only — no backend change).

### Audit log (`/settings/audit`)
New `AuditPage` over `GET /api/v1/audit/events`:
- Filterable: action, actor_type, from/to date range (draft inputs applied on submit — no request per keystroke).
- Cursor-paginated, newest-first (`useInfiniteQuery` + `next_cursor` → Load more).
- Each row expands to its raw `detail` JSON + correlation id + any redactions.
- **`audit:read`-gated**, **read-only** (no write controls).
- Moved out of `StubbedPages` into its own file.

### About → License (`/settings/about`)
Renders `GET /api/v1/license` — tier, status (Active/Grace/Expired/No license/Invalid), entitled features, expiry — replacing the "License view pending" stub. Version still sourced from `GET /api/v1/version`.

### Permission baseline fix
The synthesized role→permission baseline omitted `audit:read` (same class as the earlier `scan:read` gap), which would 403 the audit route for everyone. Added `audit:read` to the admin baselines in `auth-bootstrap.ts` + `LoginPage.tsx`. The real fix remains wiring `/auth/me/permissions`.

## SDD
`frontend-settings` → **v1.3.0**: C-13 (audit gate + infinite query + read-only), C-14 (license from API), AC-19/AC-20; C-09/AC-15 stub set narrowed to Notifications/Integrations/Security.

## Verification
- `specter check`: 97 specs pass; `frontend-settings` **20/20 ACs, 100%**
- Full vitest: **277/277** (44 files); tsc + eslint clean
- Chrome (admin): audit table renders real events (`scheduler.tick.dispatched`) with working detail-expand + filters; License shows Tier Free / Status "No license" / Features `compliance_check`.

Part of the sequenced settings-activation plan; remaining pages (Notifications, Security/SSO, Integrations, Users invite/manage, Profile edit, framework-lenses) follow in later phases, several needing net-new backend.