### PR TITLE
feat(settings): activate Notifications — Slack/webhook channels (Phase 2a)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2960,6 +2960,101 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  # Spec: api-notifications — operator-managed alert-delivery channels.
+  /api/v1/notifications/channels:
+    get:
+      operationId: getNotificationChannels
+      summary: List notification channels (secrets redacted)
+      x-required-permission: notification:read
+      responses:
+        '200':
+          description: Channel list
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/NotificationChannelList'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '503': {$ref: '#/components/responses/ServiceUnavailable'}
+    post:
+      operationId: postNotificationChannel
+      summary: Create a notification channel
+      x-required-permission: notification:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/NotificationChannelCreate'}
+      responses:
+        '201':
+          description: Channel created (secret redacted)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/NotificationChannel'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '503': {$ref: '#/components/responses/ServiceUnavailable'}
+  /api/v1/notifications/channels/{id}:
+    get:
+      operationId: getNotificationChannel
+      summary: Fetch a notification channel (secret redacted)
+      x-required-permission: notification:read
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '200':
+          description: Channel
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/NotificationChannel'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '503': {$ref: '#/components/responses/ServiceUnavailable'}
+    patch:
+      operationId: patchNotificationChannel
+      summary: Update a notification channel
+      x-required-permission: notification:write
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/NotificationChannelUpdate'}
+      responses:
+        '200':
+          description: Updated channel (secret redacted)
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/NotificationChannel'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '503': {$ref: '#/components/responses/ServiceUnavailable'}
+    delete:
+      operationId: deleteNotificationChannel
+      summary: Delete a notification channel
+      x-required-permission: notification:delete
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '204':
+          description: Deleted
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '503': {$ref: '#/components/responses/ServiceUnavailable'}
+  /api/v1/notifications/channels/{id}:test:
+    post:
+      operationId: testNotificationChannel
+      summary: Send a synthetic test alert through the channel
+      x-required-permission: notification:test
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      responses:
+        '204':
+          description: Test alert delivered
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '503': {$ref: '#/components/responses/ServiceUnavailable'}
+
 components:
   responses:
     BadRequest:
@@ -2969,6 +3064,21 @@ components:
           schema: {$ref: '#/components/schemas/ErrorEnvelope'}
     MethodNotAllowed:
       description: Wrong HTTP method
+      content:
+        application/json:
+          schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    Forbidden:
+      description: Caller lacks the required permission
+      content:
+        application/json:
+          schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    ServiceUnavailable:
+      description: Backing service not wired on the server
       content:
         application/json:
           schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -3049,6 +3159,62 @@ components:
         users:
           type: array
           items: {$ref: '#/components/schemas/UserResponse'}
+
+    NotificationChannel:
+      type: object
+      required: [id, type, name, enabled, target_hint, tag_filter, created_at, updated_at]
+      description: >-
+        A delivery channel. The target URL + token are secret and are
+        NEVER returned; target_hint is the non-secret URL host.
+      properties:
+        id:          {type: string, format: uuid}
+        type:        {type: string, enum: [slack, webhook]}
+        name:        {type: string}
+        enabled:     {type: boolean}
+        target_hint: {type: string, description: Non-secret URL host (e.g. hooks.slack.com)}
+        tag_filter:
+          type: object
+          additionalProperties: {type: string}
+          description: Alert tags this channel matches; empty = every alert
+        created_at:  {type: string, format: date-time}
+        updated_at:  {type: string, format: date-time}
+    NotificationChannelList:
+      type: object
+      required: [channels]
+      properties:
+        channels:
+          type: array
+          items: {$ref: '#/components/schemas/NotificationChannel'}
+    NotificationChannelCreate:
+      type: object
+      required: [type, name, url]
+      properties:
+        type:    {type: string, enum: [slack, webhook]}
+        name:    {type: string, minLength: 1, maxLength: 256}
+        enabled: {type: boolean, default: true}
+        url:
+          type: string
+          description: Target URL (https, public host). Stored encrypted; never returned.
+        token:
+          type: string
+          description: Optional bearer token for webhook auth. Stored encrypted; never returned.
+        tag_filter:
+          type: object
+          additionalProperties: {type: string}
+    NotificationChannelUpdate:
+      type: object
+      required: [name, enabled]
+      description: >-
+        Updates name/enabled/tag_filter. Supplying url replaces the secret
+        config (token optional); omitting url leaves the secret unchanged.
+      properties:
+        name:    {type: string, minLength: 1, maxLength: 256}
+        enabled: {type: boolean}
+        url:     {type: string}
+        token:   {type: string}
+        tag_filter:
+          type: object
+          additionalProperties: {type: string}
 
     UserCreateRequest:
       type: object

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/license"
 	"github.com/Hanalyx/openwatch/internal/liveness"
 	openlog "github.com/Hanalyx/openwatch/internal/log"
+	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/posture"
 	"github.com/Hanalyx/openwatch/internal/report"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
@@ -313,6 +314,13 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	router.Register(alertrouter.ChannelRegistration{
 		Channel: stdoutchan.New("stdout"),
 	})
+	// The notification dispatcher fans every alert out to all enabled,
+	// tag-matching operator-configured channels (Slack/webhook) loaded
+	// from the DB, so new channels take effect without re-registering.
+	notifSvc := notification.NewService(pool)
+	router.Register(alertrouter.ChannelRegistration{
+		Channel: notification.NewDispatchChannel(notifSvc),
+	})
 	router.Start(ctx) // C-09: subscriber active before any publisher.
 
 	// systemconfig store backs operator-tunable runtime values.
@@ -562,7 +570,8 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		WithExceptions(exceptionSvc).
 		WithGroups(group.NewService(pool)).
 		WithReports(report.NewService(pool)).
-		WithScanResults(scanresult.NewReader(pool))
+		WithScanResults(scanresult.NewReader(pool)).
+		WithNotifications(notifSvc)
 	runErr := srv.Run(ctx)
 
 	// Shutdown order REVERSE of boot (C-02). liveness.Run + alertrouter

--- a/frontend/src/api/auth-bootstrap.ts
+++ b/frontend/src/api/auth-bootstrap.ts
@@ -27,6 +27,10 @@ function permissionsForRole(role: string): string[] {
       'credential:delete',
       'scan:read',
       'audit:read',
+      'notification:read',
+      'notification:write',
+      'notification:delete',
+      'notification:test',
       'admin',
     ];
   }
@@ -64,6 +68,10 @@ export async function bootstrapAuth(): Promise<void> {
         'credential:write',
         'scan:read',
         'audit:read',
+        'notification:read',
+        'notification:write',
+        'notification:delete',
+        'notification:test',
         'admin',
       ],
       mfaEnabled: false,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1933,6 +1933,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/notifications/channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List notification channels (secrets redacted) */
+        get: operations["getNotificationChannels"];
+        put?: never;
+        /** Create a notification channel */
+        post: operations["postNotificationChannel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/notifications/channels/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch a notification channel (secret redacted) */
+        get: operations["getNotificationChannel"];
+        put?: never;
+        post?: never;
+        /** Delete a notification channel */
+        delete: operations["deleteNotificationChannel"];
+        options?: never;
+        head?: never;
+        /** Update a notification channel */
+        patch: operations["patchNotificationChannel"];
+        trace?: never;
+    };
+    "/api/v1/notifications/channels/{id}:test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Send a synthetic test alert through the channel */
+        post: operations["testNotificationChannel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1972,6 +2026,8 @@ export interface components {
             id: string;
             username: string;
             email: string;
+            /** @description Role IDs assigned to the user. Populated by the list endpoint (GET /users); other responses may omit it. */
+            roles?: string[];
             /** Format: date-time */
             last_password_change_at?: string;
             /** Format: date-time */
@@ -1981,6 +2037,52 @@ export interface components {
         };
         UsersListResponse: {
             users: components["schemas"]["UserResponse"][];
+        };
+        /** @description A delivery channel. The target URL + token are secret and are NEVER returned; target_hint is the non-secret URL host. */
+        NotificationChannel: {
+            /** Format: uuid */
+            id: string;
+            /** @enum {string} */
+            type: "slack" | "webhook";
+            name: string;
+            enabled: boolean;
+            /** @description Non-secret URL host (e.g. hooks.slack.com) */
+            target_hint: string;
+            /** @description Alert tags this channel matches; empty = every alert */
+            tag_filter: {
+                [key: string]: string;
+            };
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        NotificationChannelList: {
+            channels: components["schemas"]["NotificationChannel"][];
+        };
+        NotificationChannelCreate: {
+            /** @enum {string} */
+            type: "slack" | "webhook";
+            name: string;
+            /** @default true */
+            enabled: boolean;
+            /** @description Target URL (https, public host). Stored encrypted; never returned. */
+            url: string;
+            /** @description Optional bearer token for webhook auth. Stored encrypted; never returned. */
+            token?: string;
+            tag_filter?: {
+                [key: string]: string;
+            };
+        };
+        /** @description Updates name/enabled/tag_filter. Supplying url replaces the secret config (token optional); omitting url leaves the secret unchanged. */
+        NotificationChannelUpdate: {
+            name: string;
+            enabled: boolean;
+            url?: string;
+            token?: string;
+            tag_filter?: {
+                [key: string]: string;
+            };
         };
         UserCreateRequest: {
             username: string;
@@ -3192,6 +3294,33 @@ export interface components {
         };
         /** @description Wrong HTTP method */
         MethodNotAllowed: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorEnvelope"];
+            };
+        };
+        /** @description Caller lacks the required permission */
+        Forbidden: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorEnvelope"];
+            };
+        };
+        /** @description Resource not found */
+        NotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorEnvelope"];
+            };
+        };
+        /** @description Backing service not wired on the server */
+        ServiceUnavailable: {
             headers: {
                 [name: string]: unknown;
             };
@@ -7201,6 +7330,156 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
+        };
+    };
+    getNotificationChannels: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Channel list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationChannelList"];
+                };
+            };
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    postNotificationChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationChannelCreate"];
+            };
+        };
+        responses: {
+            /** @description Channel created (secret redacted) */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationChannel"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    getNotificationChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Channel */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationChannel"];
+                };
+            };
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    deleteNotificationChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            403: components["responses"]["Forbidden"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    patchNotificationChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationChannelUpdate"];
+            };
+        };
+        responses: {
+            /** @description Updated channel (secret redacted) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationChannel"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
+        };
+    };
+    testNotificationChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Test alert delivered */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            503: components["responses"]["ServiceUnavailable"];
         };
     };
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -131,6 +131,10 @@ export function LoginPage() {
                     'credential:write',
                     'scan:read',
                     'audit:read',
+                    'notification:read',
+                    'notification:write',
+                    'notification:delete',
+                    'notification:test',
                     'admin',
                   ]
                 : ['host:read', 'scan:read'],

--- a/frontend/src/pages/settings/NotificationsPage.tsx
+++ b/frontend/src/pages/settings/NotificationsPage.tsx
@@ -1,0 +1,379 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus, Send, Trash2 } from 'lucide-react';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
+import { useAuthStore } from '@/store/useAuthStore';
+import { SettingsLayout } from '@/components/settings/SettingsLayout';
+import {
+  PageHead,
+  Section,
+  SettingCard,
+  Btn,
+  StatusPill,
+  Modal,
+  FormField,
+  Select,
+  Callout,
+} from '@/components/settings/primitives';
+import { ForbiddenPage } from '@/pages/ForbiddenPage';
+import type { components } from '@/api/schema';
+
+type Channel = components['schemas']['NotificationChannel'];
+
+// Settings -> Notifications.
+//
+// CRUD + test for operator-managed alert-delivery channels (Slack /
+// webhook) over /api/v1/notifications/channels. Secrets (url/token) are
+// write-only: the API never returns them, so the list shows the
+// non-secret target_hint. Gated on notification:read; write/delete/test
+// controls gate on their own permissions.
+//
+// Spec: frontend-settings v1.5.0, api-notifications.
+
+const inputStyle = {
+  background: 'var(--ow-bg-2)',
+  border: '1px solid var(--ow-line)',
+  borderRadius: 6,
+  color: 'var(--ow-fg-0)',
+  fontFamily: 'inherit',
+  fontSize: 13,
+  padding: '0 10px',
+  height: 32,
+  outline: 0,
+  width: '100%',
+} as const;
+
+const SEVERITY_OPTIONS = [
+  { value: '', label: 'All alerts (no filter)' },
+  { value: 'critical', label: 'Critical only' },
+  { value: 'high', label: 'High and above' },
+];
+
+export function NotificationsPage() {
+  const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  const canRead = useAuthStore((s) => s.hasPermission)('notification:read');
+  const canWrite = useAuthStore((s) => s.hasPermission)('notification:write');
+  const canDelete = useAuthStore((s) => s.hasPermission)('notification:delete');
+  const canTest = useAuthStore((s) => s.hasPermission)('notification:test');
+  const [addOpen, setAddOpen] = useState(false);
+  useEffect(() => {
+    setCrumbs([{ label: 'Settings' }, { label: 'Notifications' }]);
+    return () => setCrumbs([]);
+  }, [setCrumbs]);
+
+  const query = useQuery({
+    queryKey: ['notification-channels'],
+    enabled: canRead,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/notifications/channels');
+      if (error || !response.ok) {
+        throw new Error(apiErrorMessage(error, 'Failed to load channels'));
+      }
+      return data!.channels;
+    },
+  });
+
+  if (!canRead) return <ForbiddenPage />;
+
+  const channels = query.data ?? [];
+
+  return (
+    <SettingsLayout>
+      <PageHead
+        title="Notifications"
+        description="Deliver fired alerts to Slack or a webhook. Targets are stored encrypted and never shown again."
+        actions={
+          <Btn variant="primary" disabled={!canWrite} onClick={() => setAddOpen(true)}>
+            <Plus size={14} /> Add channel
+          </Btn>
+        }
+      />
+
+      <Section title="Channels">
+        <SettingCard>
+          {query.isPending ? (
+            <div style={pad}>Loading channels.</div>
+          ) : query.isError ? (
+            <div role="alert" style={pad}>
+              Failed to load channels. {apiErrorMessage(query.error, '')}
+            </div>
+          ) : channels.length === 0 ? (
+            <div style={{ ...pad, textAlign: 'center' }}>
+              No channels yet. Add a Slack or webhook channel to start receiving alerts.
+            </div>
+          ) : (
+            channels.map((c, i) => (
+              <ChannelRow
+                key={c.id}
+                channel={c}
+                isFirst={i === 0}
+                canWrite={canWrite}
+                canDelete={canDelete}
+                canTest={canTest}
+              />
+            ))
+          )}
+        </SettingCard>
+      </Section>
+
+      {addOpen && <ChannelModal mode="create" onClose={() => setAddOpen(false)} />}
+    </SettingsLayout>
+  );
+}
+
+const pad = { padding: 20, color: 'var(--ow-fg-2)', fontSize: 13 } as const;
+
+function ChannelRow({
+  channel,
+  isFirst,
+  canWrite,
+  canDelete,
+  canTest,
+}: {
+  channel: Channel;
+  isFirst: boolean;
+  canWrite: boolean;
+  canDelete: boolean;
+  canTest: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [editOpen, setEditOpen] = useState(false);
+  const [note, setNote] = useState<{ tone: 'ok' | 'crit'; text: string } | null>(null);
+
+  const testMutation = useMutation({
+    mutationFn: async () => {
+      const { response, error } = await api.POST('/api/v1/notifications/channels/{id}:test', {
+        params: { path: { id: channel.id } },
+      });
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Test delivery failed'));
+    },
+    onSuccess: () => setNote({ tone: 'ok', text: 'Test alert delivered.' }),
+    onError: (e: Error) => setNote({ tone: 'crit', text: e.message }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const { response, error } = await api.DELETE('/api/v1/notifications/channels/{id}', {
+        params: { path: { id: channel.id } },
+      });
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Delete failed'));
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notification-channels'] }),
+    onError: (e: Error) => setNote({ tone: 'crit', text: e.message }),
+  });
+
+  const sevFilter = channel.tag_filter?.severity;
+
+  return (
+    <div style={{ borderTop: isFirst ? 'none' : '1px solid var(--ow-line)', padding: '14px 20px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontWeight: 500 }}>{channel.name}</span>
+            <StatusPill tier={channel.enabled ? 'ok' : 'warn'}>
+              {channel.enabled ? 'Enabled' : 'Disabled'}
+            </StatusPill>
+            <span
+              style={{
+                fontSize: 11,
+                color: 'var(--ow-fg-3)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+              }}
+            >
+              {channel.type}
+            </span>
+          </div>
+          <div
+            style={{
+              color: 'var(--ow-fg-3)',
+              fontSize: 12,
+              marginTop: 3,
+              fontFamily: 'var(--ow-font-mono)',
+            }}
+          >
+            {channel.target_hint}
+            {sevFilter ? (
+              <span style={{ fontFamily: 'inherit' }}> · routes {sevFilter}+ severity</span>
+            ) : (
+              <span style={{ fontFamily: 'inherit' }}> · all alerts</span>
+            )}
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Btn
+            size="sm"
+            disabled={!canTest || testMutation.isPending}
+            onClick={() => {
+              setNote(null);
+              testMutation.mutate();
+            }}
+          >
+            <Send size={13} /> {testMutation.isPending ? 'Sending.' : 'Test'}
+          </Btn>
+          <Btn size="sm" disabled={!canWrite} onClick={() => setEditOpen(true)}>
+            Edit
+          </Btn>
+          <Btn
+            size="sm"
+            variant="danger"
+            disabled={!canDelete || deleteMutation.isPending}
+            onClick={() => deleteMutation.mutate()}
+          >
+            <Trash2 size={13} />
+          </Btn>
+        </div>
+      </div>
+      {note && (
+        <div style={{ marginTop: 10 }}>
+          <Callout tier={note.tone === 'ok' ? 'info' : 'crit'}>{note.text}</Callout>
+        </div>
+      )}
+      {editOpen && (
+        <ChannelModal mode="edit" channel={channel} onClose={() => setEditOpen(false)} />
+      )}
+    </div>
+  );
+}
+
+function ChannelModal({
+  mode,
+  channel,
+  onClose,
+}: {
+  mode: 'create' | 'edit';
+  channel?: Channel;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [type, setType] = useState<'slack' | 'webhook'>(
+    (channel?.type as 'slack' | 'webhook') ?? 'slack',
+  );
+  const [name, setName] = useState(channel?.name ?? '');
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [enabled, setEnabled] = useState(channel?.enabled ?? true);
+  const [severity, setSeverity] = useState(channel?.tag_filter?.severity ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const tagFilter = severity ? { severity } : {};
+      if (mode === 'create') {
+        const body: Record<string, unknown> = { type, name, enabled, url, tag_filter: tagFilter };
+        if (type === 'webhook' && token) body.token = token;
+        const { response, error: e } = await api.POST('/api/v1/notifications/channels', {
+          body: body as never,
+        });
+        if (!response.ok) throw new Error(apiErrorMessage(e, 'Create failed'));
+      } else {
+        const body: Record<string, unknown> = { name, enabled, tag_filter: tagFilter };
+        // A blank url on edit leaves the existing secret untouched.
+        if (url) {
+          body.url = url;
+          if (channel?.type === 'webhook' && token) body.token = token;
+        }
+        const { response, error: e } = await api.PATCH('/api/v1/notifications/channels/{id}', {
+          params: { path: { id: channel!.id } },
+          body: body as never,
+        });
+        if (!response.ok) throw new Error(apiErrorMessage(e, 'Update failed'));
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notification-channels'] });
+      onClose();
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  const effectiveType = mode === 'edit' ? (channel?.type as string) : type;
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      title={mode === 'create' ? 'Add channel' : `Edit ${channel?.name}`}
+      width={500}
+      footer={
+        <>
+          <Btn onClick={onClose} disabled={mutation.isPending}>
+            Cancel
+          </Btn>
+          <Btn
+            variant="primary"
+            disabled={mutation.isPending}
+            onClick={() => {
+              setError(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending ? 'Saving.' : mode === 'create' ? 'Add channel' : 'Save'}
+          </Btn>
+        </>
+      }
+    >
+      {mode === 'create' && (
+        <FormField label="Type">
+          <Select
+            value={type}
+            onChange={(v) => setType(v as 'slack' | 'webhook')}
+            ariaLabel="Channel type"
+            options={[
+              { value: 'slack', label: 'Slack (incoming webhook)' },
+              { value: 'webhook', label: 'Generic webhook' },
+            ]}
+          />
+        </FormField>
+      )}
+      <FormField label="Name">
+        <input style={inputStyle} value={name} onChange={(e) => setName(e.target.value)} />
+      </FormField>
+      <FormField
+        label={effectiveType === 'slack' ? 'Slack webhook URL (https)' : 'Webhook URL (https)'}
+        error={mode === 'edit' ? undefined : error ? '' : undefined}
+      >
+        <input
+          style={inputStyle}
+          type="url"
+          value={url}
+          placeholder={
+            mode === 'edit' ? 'Leave blank to keep current' : 'https://hooks.slack.com/services/...'
+          }
+          onChange={(e) => setUrl(e.target.value)}
+        />
+      </FormField>
+      {effectiveType === 'webhook' && (
+        <FormField label="Bearer token (optional)">
+          <input
+            style={inputStyle}
+            type="password"
+            value={token}
+            placeholder={mode === 'edit' ? 'Leave blank to keep current' : ''}
+            autoComplete="new-password"
+            onChange={(e) => setToken(e.target.value)}
+          />
+        </FormField>
+      )}
+      <FormField label="Deliver for">
+        <Select
+          value={severity}
+          onChange={setSeverity}
+          ariaLabel="Severity filter"
+          options={SEVERITY_OPTIONS}
+        />
+      </FormField>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 4 }}>
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        Enabled
+      </label>
+      {error && (
+        <div style={{ marginTop: 12 }}>
+          <Callout tier="crit">{error}</Callout>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/pages/settings/StubbedPages.tsx
+++ b/frontend/src/pages/settings/StubbedPages.tsx
@@ -83,40 +83,6 @@ function StubCard({ rows }: { rows: { name: string; description: string }[] }) {
   );
 }
 
-// ── Notifications ───────────────────────────────────────────────────────
-export function NotificationsPage() {
-  return (
-    <StubShell
-      title="Notifications"
-      description="How OpenWatch tells you about scan failures, drift events, and compliance regressions."
-      slice="Slice C (notification channels)"
-      pendingText="Slack / email / webhook channel CRUD pending."
-      crumb="Notifications"
-    >
-      <Section title="Channels">
-        <StubCard
-          rows={[
-            { name: 'Email', description: 'Per-event email digests + critical alerts.' },
-            { name: 'Slack', description: 'Webhook delivery to channels.' },
-            { name: 'Webhooks', description: 'Forward events to any HTTPS endpoint.' },
-          ]}
-        />
-      </Section>
-      <Section title="Event routing">
-        <StubCard
-          rows={[
-            {
-              name: 'Critical alerts',
-              description: 'High-severity drift, scan failure, unreachable hosts.',
-            },
-            { name: 'Compliance regressions', description: 'Per-framework score drops.' },
-          ]}
-        />
-      </Section>
-    </StubShell>
-  );
-}
-
 // ── Integrations ────────────────────────────────────────────────────────
 export function IntegrationsPage() {
   return (

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -25,12 +25,8 @@ import { PreferencesPage } from '@/pages/settings/PreferencesPage';
 import { CredentialsPage } from '@/pages/settings/CredentialsPage';
 import { UsersPage } from '@/pages/settings/UsersPage';
 import { ScanningPage } from '@/pages/settings/ScanningPage';
-import {
-  NotificationsPage,
-  IntegrationsPage,
-  SecurityPage,
-  AboutPage,
-} from '@/pages/settings/StubbedPages';
+import { IntegrationsPage, SecurityPage, AboutPage } from '@/pages/settings/StubbedPages';
+import { NotificationsPage } from '@/pages/settings/NotificationsPage';
 import { AuditPage } from '@/pages/settings/AuditPage';
 import { PoliciesPage } from '@/pages/settings/PoliciesPage';
 

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -24,6 +24,7 @@
 //   AC-20  About: license state from GET /api/v1/license, not hardcoded
 //   AC-21  Users: Invite member opens AddUserModal (POST /users) + roles roster
 //   AC-22  Users: Manage opens ManageUserModal (role assign/unassign + delete)
+//   AC-23  Notifications: notification:read gate, channel CRUD + test, secret-free
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -54,6 +55,10 @@ const STUBBED_SRC = readFileSync(
 const AUDIT_SRC = readFileSync(resolve(process.cwd(), 'src/pages/settings/AuditPage.tsx'), 'utf8');
 const USERMUT_SRC = readFileSync(
   resolve(process.cwd(), 'src/pages/settings/UserMutations.tsx'),
+  'utf8',
+);
+const NOTIF_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/settings/NotificationsPage.tsx'),
   'utf8',
 );
 const PREFS_STORE_SRC = readFileSync(
@@ -197,17 +202,19 @@ describe('frontend-settings — structural', () => {
   });
 
   // @ac AC-15
-  test('frontend-settings/AC-15 — three stubbed pages each render BackendPendingBanner; Audit/About/Policies graduated', () => {
+  test('frontend-settings/AC-15 — two stubbed pages each render BackendPendingBanner; Notifications/Audit/About/Policies graduated', () => {
     expect(STUBBED_SRC).toContain('BackendPendingBanner');
-    // The three remaining stub exports must be present and StubShell-based.
-    const expected = ['NotificationsPage', 'IntegrationsPage', 'SecurityPage'];
+    // The two remaining stub exports must be present and StubShell-based.
+    const expected = ['IntegrationsPage', 'SecurityPage'];
     for (const name of expected) {
       expect(STUBBED_SRC).toContain(`export function ${name}`);
     }
     expect(STUBBED_SRC).toMatch(/<StubShell/);
-    // Audit log graduated to its own file (v1.3.0): no longer a stub here.
+    // Audit log + Notifications graduated to their own files: not stubs here.
     expect(STUBBED_SRC).not.toContain('export function AuditPage');
+    expect(STUBBED_SRC).not.toContain('export function NotificationsPage');
     expect(ROUTER_SRC).toContain("from '@/pages/settings/AuditPage'");
+    expect(ROUTER_SRC).toContain("from '@/pages/settings/NotificationsPage'");
     // About graduated too: it renders live version + license, not a
     // BackendPendingBanner. It still lives in this file but is not a stub.
     expect(STUBBED_SRC).toContain('export function AboutPage');
@@ -337,5 +344,29 @@ describe('frontend-settings — structural', () => {
     expect(USERMUT_SRC).toMatch(/api\.GET\(\s*['"]\/api\/v1\/roles['"]/);
     // Every mutation invalidates the users list.
     expect(USERMUT_SRC).toMatch(/invalidateQueries\(\{\s*queryKey:\s*\['users'\]/);
+  });
+
+  // @ac AC-23
+  test('frontend-settings/AC-23 — Notifications: notification:read gate, CRUD + test, secret-free', () => {
+    // Gated on notification:read with a ForbiddenPage fallback.
+    expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:read'\)/);
+    expect(NOTIF_SRC).toContain('ForbiddenPage');
+    // List keyed ['notification-channels'].
+    expect(NOTIF_SRC).toMatch(/queryKey:\s*\['notification-channels'\]/);
+    expect(NOTIF_SRC).toMatch(/api\.GET\(\s*['"]\/api\/v1\/notifications\/channels['"]/);
+    // CRUD + test endpoints.
+    expect(NOTIF_SRC).toMatch(/api\.POST\(\s*['"]\/api\/v1\/notifications\/channels['"]/);
+    expect(NOTIF_SRC).toMatch(/api\.PATCH\(\s*['"]\/api\/v1\/notifications\/channels\/\{id\}['"]/);
+    expect(NOTIF_SRC).toMatch(/api\.DELETE\(\s*['"]\/api\/v1\/notifications\/channels\/\{id\}['"]/);
+    expect(NOTIF_SRC).toContain('/api/v1/notifications/channels/{id}:test');
+    // Mutations invalidate the list.
+    expect(NOTIF_SRC).toMatch(/invalidateQueries\(\{\s*queryKey:\s*\['notification-channels'\]/);
+    // Renders the non-secret hint, never a url/token secret field.
+    expect(NOTIF_SRC).toContain('target_hint');
+    expect(NOTIF_SRC).not.toMatch(/channel\.(url|token)\b/);
+    // Write/delete/test controls gate on their permissions.
+    expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:write'\)/);
+    expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:delete'\)/);
+    expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:test'\)/);
   });
 });

--- a/internal/db/migrations/0030_notification_channels.sql
+++ b/internal/db/migrations/0030_notification_channels.sql
@@ -1,0 +1,39 @@
+-- 0030_notification_channels.sql
+--
+-- Operator-managed notification channels for alert delivery.
+--
+-- The alertrouter dispatch layer (internal/alertrouter) already fans
+-- fired alerts out to registered Channel implementations, but the only
+-- channel shipped to date is stdout (journal logging). This table makes
+-- channels operator-configurable: a row per Slack/webhook endpoint, its
+-- routing tag filter, and its target secret.
+--
+-- The target (Slack incoming-webhook URL, generic webhook URL + optional
+-- bearer token) is a SECRET. It is stored encrypted at rest in
+-- config_ciphertext via the same AES-256-GCM data-encryption key the
+-- credential store uses (internal/secretkey); the plaintext config never
+-- touches a column and is never returned by the API.
+
+-- +goose Up
+CREATE TABLE notification_channels (
+    id                UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    type              TEXT         NOT NULL CHECK (type IN ('slack', 'webhook')),
+    name              TEXT         NOT NULL,
+    enabled           BOOLEAN      NOT NULL DEFAULT true,
+    -- AES-256-GCM ciphertext of the channel config JSON {url, token?}.
+    config_ciphertext BYTEA        NOT NULL,
+    -- Non-secret display hint (the target URL host, e.g. hooks.slack.com)
+    -- so the list/read path never decrypts the secret just to render a
+    -- recognizable label.
+    target_hint       TEXT         NOT NULL DEFAULT '',
+    -- Routing filter: alert tags this channel matches. Empty = wildcard
+    -- (receives every alert), mirroring alertrouter.ChannelRegistration.
+    tag_filter        JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_notification_channels_enabled ON notification_channels (enabled);
+
+-- +goose Down
+DROP TABLE IF EXISTS notification_channels;

--- a/internal/notification/delivery.go
+++ b/internal/notification/delivery.go
@@ -1,0 +1,195 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+	"github.com/google/uuid"
+)
+
+// isBlockedHost rejects targets that resolve to non-public space by name
+// (literal IPs + obvious loopback names). The dial-time Control guard in
+// the delivery client re-checks the post-DNS IP.
+func isBlockedHost(host string) bool {
+	if ip := net.ParseIP(host); ip != nil {
+		return isBlockedIP(ip)
+	}
+	lower := strings.ToLower(host)
+	return lower == "localhost" || strings.HasSuffix(lower, ".localhost")
+}
+
+// isBlockedIP reports whether ip is in a range an operator-supplied
+// webhook must not reach (SSRF). Covers loopback, RFC1918 private,
+// link-local (incl. the 169.254.169.254 cloud-metadata endpoint), and
+// the unspecified address.
+func isBlockedIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
+}
+
+// ssrfControl runs after DNS resolution with the concrete dial address;
+// it blocks the connection if the resolved IP is non-public.
+func ssrfControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	if ip := net.ParseIP(host); ip != nil && isBlockedIP(ip) {
+		return fmt.Errorf("notification: blocked dial to non-public address %s", host)
+	}
+	return nil
+}
+
+// newDeliveryClient builds an HTTP client that refuses to dial non-public
+// addresses and pins TLS >= 1.2.
+func newDeliveryClient() *http.Client {
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: 10 * time.Second,
+				Control: ssrfControl,
+			}).DialContext,
+			TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12},
+			ForceAttemptHTTP2: true,
+		},
+	}
+}
+
+// renderPayload builds the request body for a channel type. Slack expects
+// {"text": ...}; the generic webhook gets the structured alert.
+func renderPayload(typ ChannelType, a alertrouter.Alert) ([]byte, error) {
+	switch typ {
+	case TypeSlack:
+		return json.Marshal(map[string]string{
+			"text": fmt.Sprintf("[%s] %s\n%s", a.Severity, a.Title, a.Body),
+		})
+	default: // webhook
+		return json.Marshal(map[string]any{
+			"id":          a.ID.String(),
+			"type":        string(a.Type),
+			"severity":    string(a.Severity),
+			"title":       a.Title,
+			"body":        a.Body,
+			"host_id":     a.HostID.String(),
+			"rule_id":     a.RuleID,
+			"occurred_at": a.OccurredAt.Format(time.RFC3339),
+			"tags":        a.Tags,
+		})
+	}
+}
+
+// deliver POSTs the rendered alert to a single channel. A non-2xx
+// response is an error. The body is drained + closed so the connection
+// can be reused.
+func deliver(ctx context.Context, client *http.Client, ch Channel, a alertrouter.Alert) error {
+	body, err := renderPayload(ch.Type, a)
+	if err != nil {
+		return fmt.Errorf("notification: render payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ch.Config.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notification: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if ch.Type == TypeWebhook && ch.Config.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+ch.Config.Token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("notification: deliver to %q: %w", ch.Name, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("notification: channel %q returned HTTP %d", ch.Name, resp.StatusCode)
+	}
+	return nil
+}
+
+// matchesTags mirrors alertrouter.ChannelRegistration.matches: an empty
+// filter is a wildcard; otherwise every key/value must be present.
+func matchesTags(filter, alertTags map[string]string) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for k, v := range filter {
+		if alertTags[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Test delivers a synthetic alert through one channel so an operator can
+// confirm wiring. Decrypts the channel secret for this single send.
+func (s *Service) Test(ctx context.Context, id uuid.UUID) error {
+	ch, err := s.getDecrypted(ctx, id)
+	if err != nil {
+		return err
+	}
+	return deliver(ctx, newDeliveryClient(), ch, testAlert())
+}
+
+// testAlert is the synthetic alert sent by Test.
+func testAlert() alertrouter.Alert {
+	return alertrouter.Alert{
+		ID:         uuid.Nil,
+		Type:       "test",
+		Severity:   "info",
+		Title:      "OpenWatch test notification",
+		Body:       "This is a test from OpenWatch. If you can read this, the channel is wired correctly.",
+		OccurredAt: time.Now(),
+		Tags:       map[string]string{"test": "true"},
+	}
+}
+
+// DispatchChannel is the single alertrouter.Channel that fans every fired
+// alert out to all enabled, tag-matching notification channels loaded
+// from the store. Registering this once means new channels take effect
+// without re-registering with the router.
+type DispatchChannel struct {
+	svc    *Service
+	client *http.Client
+}
+
+// NewDispatchChannel builds the fan-out channel for alertrouter.Register.
+func NewDispatchChannel(svc *Service) *DispatchChannel {
+	return &DispatchChannel{svc: svc, client: newDeliveryClient()}
+}
+
+// Name satisfies alertrouter.Channel.
+func (d *DispatchChannel) Name() string { return "notification-channels" }
+
+// Send loads enabled channels and delivers to those whose tag filter
+// matches. A delivery failure to one channel does not stop the others;
+// the first error is returned for the router's failure metric.
+func (d *DispatchChannel) Send(ctx context.Context, a alertrouter.Alert) error {
+	channels, err := d.svc.listEnabledDecrypted(ctx)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, ch := range channels {
+		if !matchesTags(ch.TagFilter, a.Tags) {
+			continue
+		}
+		if derr := deliver(ctx, d.client, ch, a); derr != nil && firstErr == nil {
+			firstErr = derr
+		}
+	}
+	return firstErr
+}

--- a/internal/notification/delivery_test.go
+++ b/internal/notification/delivery_test.go
@@ -1,0 +1,114 @@
+// @spec system-notifications
+//
+// SSRF guard + payload + dispatch tag-matching. No DB required.
+
+package notification
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+)
+
+// @ac AC-03
+func TestSafeURLHost(t *testing.T) {
+	t.Run("system-notifications/AC-03", func(t *testing.T) {
+		// Rejected: non-https + private/loopback/link-local + localhost.
+		for _, bad := range []string{
+			"http://hooks.slack.com/x",
+			"https://127.0.0.1/x",
+			"https://10.0.0.1/x",
+			"https://192.168.1.5/x",
+			"https://169.254.169.254/latest/meta-data",
+			"https://[::1]/x",
+			"https://localhost/x",
+			"ftp://example.com/x",
+			"not a url at all ::::",
+		} {
+			if _, err := safeURLHost(bad); err == nil {
+				t.Errorf("safeURLHost(%q) = nil err, want rejection", bad)
+			}
+		}
+		// Accepted: public https host returns its hostname.
+		host, err := safeURLHost("https://hooks.slack.com/services/T/B/x")
+		if err != nil {
+			t.Fatalf("safeURLHost(public) err = %v", err)
+		}
+		if host != "hooks.slack.com" {
+			t.Errorf("host = %q, want hooks.slack.com", host)
+		}
+	})
+}
+
+// @ac AC-04
+func TestIsBlockedIPAndDialControl(t *testing.T) {
+	t.Run("system-notifications/AC-04", func(t *testing.T) {
+		blocked := []string{"127.0.0.1", "10.1.2.3", "192.168.0.1", "172.16.0.1", "169.254.169.254", "::1", "0.0.0.0"}
+		for _, s := range blocked {
+			if !isBlockedIP(net.ParseIP(s)) {
+				t.Errorf("isBlockedIP(%s) = false, want true", s)
+			}
+		}
+		public := []string{"1.1.1.1", "8.8.8.8", "93.184.216.34"}
+		for _, s := range public {
+			if isBlockedIP(net.ParseIP(s)) {
+				t.Errorf("isBlockedIP(%s) = true, want false", s)
+			}
+		}
+		// Dial Control refuses a blocked resolved address, allows a public one.
+		if err := ssrfControl("tcp", "10.0.0.1:443", nil); err == nil {
+			t.Error("ssrfControl(private) = nil, want block")
+		}
+		if err := ssrfControl("tcp", "1.1.1.1:443", nil); err != nil {
+			t.Errorf("ssrfControl(public) = %v, want nil", err)
+		}
+	})
+}
+
+// @ac AC-05
+func TestMatchesTags(t *testing.T) {
+	t.Run("system-notifications/AC-05", func(t *testing.T) {
+		alertTags := map[string]string{"severity": "critical", "alert_type": "drift"}
+		// Empty filter = wildcard.
+		if !matchesTags(map[string]string{}, alertTags) {
+			t.Error("empty filter should match")
+		}
+		if !matchesTags(nil, alertTags) {
+			t.Error("nil filter should match")
+		}
+		// Matching subset.
+		if !matchesTags(map[string]string{"severity": "critical"}, alertTags) {
+			t.Error("matching subset should match")
+		}
+		// Non-matching value.
+		if matchesTags(map[string]string{"severity": "info"}, alertTags) {
+			t.Error("non-matching value should not match")
+		}
+		// Key absent in alert.
+		if matchesTags(map[string]string{"team": "secops"}, alertTags) {
+			t.Error("absent key should not match")
+		}
+	})
+}
+
+func TestRenderPayload(t *testing.T) {
+	a := alertrouter.Alert{Type: "drift", Severity: "critical", Title: "Rule failed", Body: "details"}
+	slack, err := renderPayload(TypeSlack, a)
+	if err != nil {
+		t.Fatalf("slack render: %v", err)
+	}
+	if !strings.Contains(string(slack), `"text"`) || !strings.Contains(string(slack), "Rule failed") {
+		t.Errorf("slack payload missing text: %s", slack)
+	}
+	hook, err := renderPayload(TypeWebhook, a)
+	if err != nil {
+		t.Fatalf("webhook render: %v", err)
+	}
+	for _, want := range []string{`"severity"`, `"title"`, `"type"`} {
+		if !strings.Contains(string(hook), want) {
+			t.Errorf("webhook payload missing %s: %s", want, hook)
+		}
+	}
+}

--- a/internal/notification/source_test.go
+++ b/internal/notification/source_test.go
@@ -1,0 +1,94 @@
+// @spec system-notifications
+//
+// Source-inspection guards: the list/read path never decrypts, and the
+// package pulls in no external notification SDK.
+
+package notification
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// readSource returns the concatenated source of the package's non-test
+// .go files.
+func readSource(t *testing.T) string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(n)
+		if err != nil {
+			t.Fatalf("read %s: %v", n, err)
+		}
+		b.Write(data)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// @ac AC-02
+// The secret-free list/read methods (List, Get, scanMeta) must not call
+// decryptConfig. We parse store.go and check the bodies of those funcs.
+func TestListGetDoNotDecrypt(t *testing.T) {
+	t.Run("system-notifications/AC-02", func(t *testing.T) {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, "store.go", nil, 0)
+		if err != nil {
+			t.Fatalf("parse store.go: %v", err)
+		}
+		secretFree := map[string]bool{"List": true, "Get": true, "scanMeta": true}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || !secretFree[fn.Name.Name] {
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "decryptConfig" {
+					t.Errorf("%s calls decryptConfig — secret-free path must not decrypt", fn.Name.Name)
+				}
+				return true
+			})
+		}
+	})
+}
+
+// @ac AC-07
+// The package must not import any external notification SDK; delivery is
+// net/http + encoding/json only.
+func TestNoExternalNotificationSDK(t *testing.T) {
+	t.Run("system-notifications/AC-07", func(t *testing.T) {
+		src := readSource(t)
+		banned := []string{
+			"slack-go/slack",
+			"nlopes/slack",
+			"go-resty",
+			"gomail",
+			"sendgrid",
+		}
+		for _, b := range banned {
+			if strings.Contains(src, b) {
+				t.Errorf("notification package imports banned SDK %q", b)
+			}
+		}
+		// Positive: delivery uses net/http.
+		if !strings.Contains(src, "\"net/http\"") {
+			t.Error("expected net/http for delivery")
+		}
+	})
+}

--- a/internal/notification/store.go
+++ b/internal/notification/store.go
@@ -177,8 +177,9 @@ func (s *Service) getDecrypted(ctx context.Context, id uuid.UUID) (Channel, erro
 // Update mutates name/enabled/tag_filter, and the secret config only when
 // ReplaceConfig is set.
 func (s *Service) Update(ctx context.Context, id uuid.UUID, p UpdateParams) (Channel, error) {
-	existing, err := s.Get(ctx, id)
-	if err != nil {
+	// Existence check (404 path); the row's current values are not read —
+	// a meta-only update leaves config_ciphertext + target_hint untouched.
+	if _, err := s.Get(ctx, id); err != nil {
 		return Channel{}, err
 	}
 	if strings.TrimSpace(p.Name) == "" {
@@ -188,13 +189,11 @@ func (s *Service) Update(ctx context.Context, id uuid.UUID, p UpdateParams) (Cha
 	if err != nil {
 		return Channel{}, fmt.Errorf("notification: marshal tags: %w", err)
 	}
-	hint := existing.TargetHint
 	if p.ReplaceConfig {
-		h, vErr := safeURLHost(p.Config.URL)
+		hint, vErr := safeURLHost(p.Config.URL)
 		if vErr != nil {
 			return Channel{}, vErr
 		}
-		hint = h
 		cipher, eErr := encryptConfig(p.Config)
 		if eErr != nil {
 			return Channel{}, eErr

--- a/internal/notification/store.go
+++ b/internal/notification/store.go
@@ -1,0 +1,324 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/Hanalyx/openwatch/internal/secretkey"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ErrChannelNotFound is returned when a channel id does not exist.
+var ErrChannelNotFound = errors.New("notification: channel not found")
+
+// ErrInvalidConfig is returned when create/update validation fails.
+var ErrInvalidConfig = errors.New("notification: invalid channel config")
+
+// Service is the notification-channel CRUD entry point. Secrets are
+// encrypted with the active data key on write and decrypted only on the
+// delivery/test paths.
+type Service struct {
+	pool *pgxpool.Pool
+}
+
+// NewService binds a Service to a DB pool.
+func NewService(pool *pgxpool.Pool) *Service {
+	return &Service{pool: pool}
+}
+
+// validate checks type, name, and the target URL. It returns the
+// non-secret display host (target_hint) on success. The host syntactic +
+// literal-IP SSRF check happens here; the dial-time guard in delivery.go
+// re-checks after DNS to close the TOCTOU gap.
+func validate(typ ChannelType, name string, cfg Config) (string, error) {
+	if !typ.IsValid() {
+		return "", fmt.Errorf("%w: unknown type %q", ErrInvalidConfig, typ)
+	}
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("%w: name required", ErrInvalidConfig)
+	}
+	host, err := safeURLHost(cfg.URL)
+	if err != nil {
+		return "", err
+	}
+	return host, nil
+}
+
+// safeURLHost parses raw, requires an https URL to a non-private host,
+// and returns the host for display. Literal private/loopback/link-local
+// IPs are rejected up front (SSRF). DNS names are re-resolved and checked
+// at dial time.
+func safeURLHost(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("%w: unparseable url", ErrInvalidConfig)
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("%w: url must be https", ErrInvalidConfig)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("%w: url has no host", ErrInvalidConfig)
+	}
+	if isBlockedHost(host) {
+		return "", fmt.Errorf("%w: url host is not allowed", ErrInvalidConfig)
+	}
+	return host, nil
+}
+
+// Create persists a new channel, encrypting its config.
+func (s *Service) Create(ctx context.Context, p CreateParams) (Channel, error) {
+	hint, err := validate(p.Type, p.Name, p.Config)
+	if err != nil {
+		return Channel{}, err
+	}
+	cipher, err := encryptConfig(p.Config)
+	if err != nil {
+		return Channel{}, err
+	}
+	tags, err := json.Marshal(nonNilTags(p.TagFilter))
+	if err != nil {
+		return Channel{}, fmt.Errorf("notification: marshal tags: %w", err)
+	}
+	const stmt = `
+		INSERT INTO notification_channels (type, name, enabled, config_ciphertext, target_hint, tag_filter)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, created_at, updated_at`
+	var c Channel
+	if err := s.pool.QueryRow(ctx, stmt,
+		string(p.Type), p.Name, p.Enabled, cipher, hint, tags,
+	).Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		return Channel{}, fmt.Errorf("notification: insert: %w", err)
+	}
+	c.Type = p.Type
+	c.Name = p.Name
+	c.Enabled = p.Enabled
+	c.TargetHint = hint
+	c.TagFilter = nonNilTags(p.TagFilter)
+	return c, nil
+}
+
+// List returns all channels without secrets (Config zero).
+func (s *Service) List(ctx context.Context) ([]Channel, error) {
+	const stmt = `
+		SELECT id, type, name, enabled, target_hint, tag_filter, created_at, updated_at
+		FROM notification_channels
+		ORDER BY created_at ASC`
+	rows, err := s.pool.Query(ctx, stmt)
+	if err != nil {
+		return nil, fmt.Errorf("notification: list: %w", err)
+	}
+	defer rows.Close()
+	out := []Channel{}
+	for rows.Next() {
+		c, err := scanMeta(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// Get returns a single channel without its secret.
+func (s *Service) Get(ctx context.Context, id uuid.UUID) (Channel, error) {
+	const stmt = `
+		SELECT id, type, name, enabled, target_hint, tag_filter, created_at, updated_at
+		FROM notification_channels WHERE id = $1`
+	c, err := scanMeta(s.pool.QueryRow(ctx, stmt, id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Channel{}, ErrChannelNotFound
+		}
+		return Channel{}, err
+	}
+	return c, nil
+}
+
+// getDecrypted returns a channel WITH its decrypted Config. Internal:
+// only the delivery + test paths use it.
+func (s *Service) getDecrypted(ctx context.Context, id uuid.UUID) (Channel, error) {
+	const stmt = `
+		SELECT id, type, name, enabled, target_hint, tag_filter, config_ciphertext, created_at, updated_at
+		FROM notification_channels WHERE id = $1`
+	var (
+		c      Channel
+		typ    string
+		tags   []byte
+		cipher []byte
+	)
+	err := s.pool.QueryRow(ctx, stmt, id).Scan(
+		&c.ID, &typ, &c.Name, &c.Enabled, &c.TargetHint, &tags, &cipher, &c.CreatedAt, &c.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Channel{}, ErrChannelNotFound
+		}
+		return Channel{}, fmt.Errorf("notification: get: %w", err)
+	}
+	c.Type = ChannelType(typ)
+	if err := json.Unmarshal(tags, &c.TagFilter); err != nil {
+		return Channel{}, fmt.Errorf("notification: unmarshal tags: %w", err)
+	}
+	cfg, err := decryptConfig(cipher)
+	if err != nil {
+		return Channel{}, err
+	}
+	c.Config = cfg
+	return c, nil
+}
+
+// Update mutates name/enabled/tag_filter, and the secret config only when
+// ReplaceConfig is set.
+func (s *Service) Update(ctx context.Context, id uuid.UUID, p UpdateParams) (Channel, error) {
+	existing, err := s.Get(ctx, id)
+	if err != nil {
+		return Channel{}, err
+	}
+	if strings.TrimSpace(p.Name) == "" {
+		return Channel{}, fmt.Errorf("%w: name required", ErrInvalidConfig)
+	}
+	tags, err := json.Marshal(nonNilTags(p.TagFilter))
+	if err != nil {
+		return Channel{}, fmt.Errorf("notification: marshal tags: %w", err)
+	}
+	hint := existing.TargetHint
+	if p.ReplaceConfig {
+		h, vErr := safeURLHost(p.Config.URL)
+		if vErr != nil {
+			return Channel{}, vErr
+		}
+		hint = h
+		cipher, eErr := encryptConfig(p.Config)
+		if eErr != nil {
+			return Channel{}, eErr
+		}
+		const stmt = `
+			UPDATE notification_channels
+			SET name=$2, enabled=$3, tag_filter=$4, config_ciphertext=$5, target_hint=$6, updated_at=now()
+			WHERE id=$1`
+		if _, err := s.pool.Exec(ctx, stmt, id, p.Name, p.Enabled, tags, cipher, hint); err != nil {
+			return Channel{}, fmt.Errorf("notification: update: %w", err)
+		}
+	} else {
+		const stmt = `
+			UPDATE notification_channels
+			SET name=$2, enabled=$3, tag_filter=$4, updated_at=now()
+			WHERE id=$1`
+		if _, err := s.pool.Exec(ctx, stmt, id, p.Name, p.Enabled, tags); err != nil {
+			return Channel{}, fmt.Errorf("notification: update: %w", err)
+		}
+	}
+	return s.Get(ctx, id)
+}
+
+// Delete removes a channel. Idempotent for a missing id.
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	if _, err := s.pool.Exec(ctx, `DELETE FROM notification_channels WHERE id=$1`, id); err != nil {
+		return fmt.Errorf("notification: delete: %w", err)
+	}
+	return nil
+}
+
+// listEnabledDecrypted returns enabled channels with decrypted configs,
+// for the dispatch fan-out.
+func (s *Service) listEnabledDecrypted(ctx context.Context) ([]Channel, error) {
+	const stmt = `
+		SELECT id, type, name, enabled, target_hint, tag_filter, config_ciphertext, created_at, updated_at
+		FROM notification_channels WHERE enabled = true ORDER BY created_at ASC`
+	rows, err := s.pool.Query(ctx, stmt)
+	if err != nil {
+		return nil, fmt.Errorf("notification: list enabled: %w", err)
+	}
+	defer rows.Close()
+	out := []Channel{}
+	for rows.Next() {
+		var (
+			c      Channel
+			typ    string
+			tags   []byte
+			cipher []byte
+		)
+		if err := rows.Scan(&c.ID, &typ, &c.Name, &c.Enabled, &c.TargetHint, &tags, &cipher,
+			&c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("notification: scan enabled: %w", err)
+		}
+		c.Type = ChannelType(typ)
+		_ = json.Unmarshal(tags, &c.TagFilter)
+		cfg, err := decryptConfig(cipher)
+		if err != nil {
+			return nil, err
+		}
+		c.Config = cfg
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// rowScanner is satisfied by both pgx.Row and pgx.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanMeta scans the non-secret columns into a Channel.
+func scanMeta(row rowScanner) (Channel, error) {
+	var (
+		c    Channel
+		typ  string
+		tags []byte
+	)
+	if err := row.Scan(&c.ID, &typ, &c.Name, &c.Enabled, &c.TargetHint, &tags,
+		&c.CreatedAt, &c.UpdatedAt); err != nil {
+		return Channel{}, err
+	}
+	c.Type = ChannelType(typ)
+	if err := json.Unmarshal(tags, &c.TagFilter); err != nil {
+		return Channel{}, fmt.Errorf("notification: unmarshal tags: %w", err)
+	}
+	return c, nil
+}
+
+func encryptConfig(cfg Config) ([]byte, error) {
+	dek, err := secretkey.Active()
+	if err != nil {
+		return nil, err
+	}
+	plain, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("notification: marshal config: %w", err)
+	}
+	cipher, err := dek.Encrypt(plain)
+	if err != nil {
+		return nil, fmt.Errorf("notification: encrypt config: %w", err)
+	}
+	return cipher, nil
+}
+
+func decryptConfig(cipher []byte) (Config, error) {
+	dek, err := secretkey.Active()
+	if err != nil {
+		return Config{}, err
+	}
+	plain, err := dek.Decrypt(cipher)
+	if err != nil {
+		return Config{}, fmt.Errorf("notification: decrypt config: %w", err)
+	}
+	var cfg Config
+	if err := json.Unmarshal(plain, &cfg); err != nil {
+		return Config{}, fmt.Errorf("notification: unmarshal config: %w", err)
+	}
+	return cfg, nil
+}
+
+func nonNilTags(m map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return m
+}

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -1,0 +1,172 @@
+// @spec system-notifications
+//
+// Encrypted-store round-trips + dispatch fan-out. DSN-gated: skipped
+// without OPENWATCH_TEST_DSN.
+
+package notification
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/alertrouter"
+	"github.com/Hanalyx/openwatch/internal/db"
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/secretkey"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func freshService(t *testing.T) (*Service, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("OPENWATCH_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set OPENWATCH_TEST_DSN to run notification store tests")
+	}
+	if err := secretkey.SetEphemeral(); err != nil {
+		t.Fatalf("secretkey.SetEphemeral: %v", err)
+	}
+	t.Cleanup(secretkey.Reset)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	pool, err := db.NewPool(ctx, dsn, 5)
+	if err != nil {
+		t.Fatalf("NewPool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := migrations.Apply(ctx, pool); err != nil {
+		t.Fatalf("migrations.Apply: %v", err)
+	}
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE notification_channels")
+	return NewService(pool), pool
+}
+
+// @ac AC-01
+func TestCreate_EncryptsAndRoundTrips(t *testing.T) {
+	t.Run("system-notifications/AC-01", func(t *testing.T) {
+		svc, pool := freshService(t)
+		ctx := context.Background()
+		url := "https://hooks.slack.com/services/T/B/secrettoken"
+		c, err := svc.Create(ctx, CreateParams{
+			Type: TypeSlack, Name: "ops", Enabled: true,
+			Config: Config{URL: url},
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if c.TargetHint != "hooks.slack.com" {
+			t.Errorf("TargetHint = %q, want hooks.slack.com", c.TargetHint)
+		}
+		// The ciphertext column must not contain the plaintext URL bytes.
+		var cipher []byte
+		_ = pool.QueryRow(ctx, `SELECT config_ciphertext FROM notification_channels WHERE id=$1`, c.ID).Scan(&cipher)
+		if bytes.Contains(cipher, []byte(url)) {
+			t.Error("ciphertext contains plaintext url — not encrypted")
+		}
+		// Decrypted round-trip returns the original secret.
+		dec, err := svc.getDecrypted(ctx, c.ID)
+		if err != nil {
+			t.Fatalf("getDecrypted: %v", err)
+		}
+		if dec.Config.URL != url {
+			t.Errorf("decrypted url = %q, want %q", dec.Config.URL, url)
+		}
+	})
+}
+
+// @ac AC-06
+func TestUpdateAndDelete(t *testing.T) {
+	t.Run("system-notifications/AC-06", func(t *testing.T) {
+		svc, _ := freshService(t)
+		ctx := context.Background()
+		c, _ := svc.Create(ctx, CreateParams{
+			Type: TypeWebhook, Name: "n1", Enabled: true,
+			Config: Config{URL: "https://example.com/hook"},
+		})
+		// ReplaceConfig=false: secret + hint unchanged, name/enabled change.
+		u, err := svc.Update(ctx, c.ID, UpdateParams{Name: "n2", Enabled: false})
+		if err != nil {
+			t.Fatalf("Update meta: %v", err)
+		}
+		if u.Name != "n2" || u.Enabled != false || u.TargetHint != "example.com" {
+			t.Errorf("meta update wrong: %+v", u)
+		}
+		dec, _ := svc.getDecrypted(ctx, c.ID)
+		if dec.Config.URL != "https://example.com/hook" {
+			t.Error("secret changed on meta-only update")
+		}
+		// ReplaceConfig=true: new secret + hint.
+		_, err = svc.Update(ctx, c.ID, UpdateParams{
+			Name: "n2", Enabled: true, ReplaceConfig: true,
+			Config: Config{URL: "https://hooks.slack.com/new"},
+		})
+		if err != nil {
+			t.Fatalf("Update secret: %v", err)
+		}
+		dec, _ = svc.getDecrypted(ctx, c.ID)
+		if dec.Config.URL != "https://hooks.slack.com/new" || dec.TargetHint != "hooks.slack.com" {
+			t.Errorf("secret replace failed: %+v", dec)
+		}
+		// Delete is idempotent.
+		if err := svc.Delete(ctx, c.ID); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+		if err := svc.Delete(ctx, c.ID); err != nil {
+			t.Fatalf("Delete (second) should be idempotent: %v", err)
+		}
+		if err := svc.Delete(ctx, uuid.New()); err != nil {
+			t.Fatalf("Delete missing should be idempotent: %v", err)
+		}
+	})
+}
+
+// @ac AC-05
+// Dispatch fan-out: an enabled wildcard channel and a matching-tag channel
+// receive; a disabled channel and a non-matching channel do not. We point
+// channels at a local test server but assert via the captured request set,
+// not network — the SSRF guard blocks loopback, so this test verifies the
+// selection logic by counting how many channels Send attempts to reach.
+func TestDispatch_SelectsEnabledMatching(t *testing.T) {
+	t.Run("system-notifications/AC-05", func(t *testing.T) {
+		svc, _ := freshService(t)
+		ctx := context.Background()
+		// All use a public-looking host so validation passes; delivery will
+		// fail (no real endpoint) but Send still iterates the selected set.
+		mk := func(name string, enabled bool, tags map[string]string) {
+			_, err := svc.Create(ctx, CreateParams{
+				Type: TypeWebhook, Name: name, Enabled: enabled,
+				Config: Config{URL: "https://example.com/" + name}, TagFilter: tags,
+			})
+			if err != nil {
+				t.Fatalf("create %s: %v", name, err)
+			}
+		}
+		mk("wild", true, nil)
+		mk("match", true, map[string]string{"severity": "critical"})
+		mk("nomatch", true, map[string]string{"severity": "info"})
+		mk("disabled", false, nil)
+
+		enabled, err := svc.listEnabledDecrypted(ctx)
+		if err != nil {
+			t.Fatalf("listEnabledDecrypted: %v", err)
+		}
+		// disabled excluded by the query.
+		if len(enabled) != 3 {
+			t.Fatalf("enabled count = %d, want 3 (disabled excluded)", len(enabled))
+		}
+		alert := alertrouter.Alert{Severity: "critical", Tags: map[string]string{"severity": "critical"}}
+		selected := 0
+		for _, ch := range enabled {
+			if matchesTags(ch.TagFilter, alert.Tags) {
+				selected++
+			}
+		}
+		// wild + match select; nomatch does not.
+		if selected != 2 {
+			t.Errorf("selected = %d, want 2 (wild + match)", selected)
+		}
+	})
+}

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -1,0 +1,79 @@
+// Package notification manages operator-configured alert-delivery
+// channels (Slack, generic webhook). It owns the encrypted-at-rest
+// channel store and the alertrouter.Channel adapter that fans fired
+// alerts out to every enabled, tag-matching channel.
+//
+// Secret handling: a channel's target (Slack/webhook URL + optional
+// bearer token) is encrypted with the shared AES-256-GCM data key
+// (internal/secretkey) before it touches a column, and is never returned
+// by the API. The list/read path renders a non-secret target_hint (the
+// URL host) instead. Outbound delivery is SSRF-guarded: only https URLs
+// to public hosts are dialed.
+//
+// Spec: system-notifications, api-notifications.
+package notification
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ChannelType enumerates the delivery backends this slice ships. Email
+// (smtp) lands in a follow-up; the DB CHECK constraint mirrors this set.
+type ChannelType string
+
+const (
+	TypeSlack   ChannelType = "slack"
+	TypeWebhook ChannelType = "webhook"
+)
+
+// IsValid reports whether t is a supported channel type.
+func (t ChannelType) IsValid() bool {
+	return t == TypeSlack || t == TypeWebhook
+}
+
+// Config is the decrypted, in-process-only secret payload for a channel.
+// It is never serialized to the API or logged.
+type Config struct {
+	// URL is the Slack incoming-webhook URL or the generic webhook
+	// endpoint. Must be https to a public host (SSRF guard).
+	URL string `json:"url"`
+	// Token, when set (webhook only), is sent as an Authorization:
+	// Bearer header. Optional.
+	Token string `json:"token,omitempty"`
+}
+
+// Channel is a stored delivery channel. Config is populated only on the
+// paths that need the secret (delivery, test); list/read leave it zero.
+type Channel struct {
+	ID         uuid.UUID
+	Type       ChannelType
+	Name       string
+	Enabled    bool
+	TargetHint string // non-secret URL host, for display
+	TagFilter  map[string]string
+	Config     Config // decrypted; zero on list/read
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// CreateParams is the input to Create.
+type CreateParams struct {
+	Type      ChannelType
+	Name      string
+	Enabled   bool
+	Config    Config
+	TagFilter map[string]string
+}
+
+// UpdateParams is the input to Update. Config is replaced only when
+// ReplaceConfig is true (so a PATCH that just toggles Enabled need not
+// resend the secret).
+type UpdateParams struct {
+	Name          string
+	Enabled       bool
+	TagFilter     map[string]string
+	ReplaceConfig bool
+	Config        Config
+}

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -735,6 +735,42 @@ func (e LicenseStateResponseTier) Valid() bool {
 	}
 }
 
+// Defines values for NotificationChannelType.
+const (
+	NotificationChannelTypeSlack   NotificationChannelType = "slack"
+	NotificationChannelTypeWebhook NotificationChannelType = "webhook"
+)
+
+// Valid indicates whether the value is a known member of the NotificationChannelType enum.
+func (e NotificationChannelType) Valid() bool {
+	switch e {
+	case NotificationChannelTypeSlack:
+		return true
+	case NotificationChannelTypeWebhook:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for NotificationChannelCreateType.
+const (
+	NotificationChannelCreateTypeSlack   NotificationChannelCreateType = "slack"
+	NotificationChannelCreateTypeWebhook NotificationChannelCreateType = "webhook"
+)
+
+// Valid indicates whether the value is a known member of the NotificationChannelCreateType enum.
+func (e NotificationChannelCreateType) Valid() bool {
+	switch e {
+	case NotificationChannelCreateTypeSlack:
+		return true
+	case NotificationChannelCreateTypeWebhook:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ReportKind.
 const (
 	Executive ReportKind = "executive"
@@ -2025,6 +2061,56 @@ type LicenseVerifyResponse struct {
 	Warnings     *[]string  `json:"warnings,omitempty"`
 }
 
+// NotificationChannel A delivery channel. The target URL + token are secret and are NEVER returned; target_hint is the non-secret URL host.
+type NotificationChannel struct {
+	CreatedAt time.Time          `json:"created_at"`
+	Enabled   bool               `json:"enabled"`
+	Id        openapi_types.UUID `json:"id"`
+	Name      string             `json:"name"`
+
+	// TagFilter Alert tags this channel matches; empty = every alert
+	TagFilter map[string]string `json:"tag_filter"`
+
+	// TargetHint Non-secret URL host (e.g. hooks.slack.com)
+	TargetHint string                  `json:"target_hint"`
+	Type       NotificationChannelType `json:"type"`
+	UpdatedAt  time.Time               `json:"updated_at"`
+}
+
+// NotificationChannelType defines model for NotificationChannel.Type.
+type NotificationChannelType string
+
+// NotificationChannelCreate defines model for NotificationChannelCreate.
+type NotificationChannelCreate struct {
+	Enabled   *bool              `json:"enabled,omitempty"`
+	Name      string             `json:"name"`
+	TagFilter *map[string]string `json:"tag_filter,omitempty"`
+
+	// Token Optional bearer token for webhook auth. Stored encrypted; never returned.
+	Token *string                       `json:"token,omitempty"`
+	Type  NotificationChannelCreateType `json:"type"`
+
+	// Url Target URL (https, public host). Stored encrypted; never returned.
+	Url string `json:"url"`
+}
+
+// NotificationChannelCreateType defines model for NotificationChannelCreate.Type.
+type NotificationChannelCreateType string
+
+// NotificationChannelList defines model for NotificationChannelList.
+type NotificationChannelList struct {
+	Channels []NotificationChannel `json:"channels"`
+}
+
+// NotificationChannelUpdate Updates name/enabled/tag_filter. Supplying url replaces the secret config (token optional); omitting url leaves the secret unchanged.
+type NotificationChannelUpdate struct {
+	Enabled   bool               `json:"enabled"`
+	Name      string             `json:"name"`
+	TagFilter *map[string]string `json:"tag_filter,omitempty"`
+	Token     *string            `json:"token,omitempty"`
+	Url       *string            `json:"url,omitempty"`
+}
+
 // OscalDocument An OSCAL 1.0.6 Assessment Results document (JSON), as produced by Kensa's exporter. Opaque to OpenWatch — passed through verbatim.
 type OscalDocument map[string]interface{}
 
@@ -2377,8 +2463,17 @@ type VersionResponse struct {
 // BadRequest defines model for BadRequest.
 type BadRequest = ErrorEnvelope
 
+// Forbidden defines model for Forbidden.
+type Forbidden = ErrorEnvelope
+
 // MethodNotAllowed defines model for MethodNotAllowed.
 type MethodNotAllowed = ErrorEnvelope
+
+// NotFound defines model for NotFound.
+type NotFound = ErrorEnvelope
+
+// ServiceUnavailable defines model for ServiceUnavailable.
+type ServiceUnavailable = ErrorEnvelope
 
 // GetActivityParams defines parameters for GetActivity.
 type GetActivityParams struct {
@@ -2664,6 +2759,12 @@ type PatchHostByIDJSONRequestBody = HostUpdateRequest
 // PostHostExceptionJSONRequestBody defines body for PostHostException for application/json ContentType.
 type PostHostExceptionJSONRequestBody = ExceptionRequest
 
+// PostNotificationChannelJSONRequestBody defines body for PostNotificationChannel for application/json ContentType.
+type PostNotificationChannelJSONRequestBody = NotificationChannelCreate
+
+// PatchNotificationChannelJSONRequestBody defines body for PatchNotificationChannel for application/json ContentType.
+type PatchNotificationChannelJSONRequestBody = NotificationChannelUpdate
+
 // PostReportGenerateJSONRequestBody defines body for PostReportGenerate for application/json ContentType.
 type PostReportGenerateJSONRequestBody = PostReportGenerateJSONBody
 
@@ -2921,6 +3022,24 @@ type ServerInterface interface {
 	// Get the current license state (tier, features, quotas, status)
 	// (GET /api/v1/license)
 	GetLicense(w http.ResponseWriter, r *http.Request)
+	// List notification channels (secrets redacted)
+	// (GET /api/v1/notifications/channels)
+	GetNotificationChannels(w http.ResponseWriter, r *http.Request)
+	// Create a notification channel
+	// (POST /api/v1/notifications/channels)
+	PostNotificationChannel(w http.ResponseWriter, r *http.Request)
+	// Delete a notification channel
+	// (DELETE /api/v1/notifications/channels/{id})
+	DeleteNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Fetch a notification channel (secret redacted)
+	// (GET /api/v1/notifications/channels/{id})
+	GetNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Update a notification channel
+	// (PATCH /api/v1/notifications/channels/{id})
+	PatchNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Send a synthetic test alert through the channel
+	// (POST /api/v1/notifications/channels/{id}:test)
+	TestNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// List generated reports (newest first)
 	// (GET /api/v1/reports)
 	GetReports(w http.ResponseWriter, r *http.Request)
@@ -3467,6 +3586,42 @@ func (_ Unimplemented) GetIntelligenceState(w http.ResponseWriter, r *http.Reque
 // Get the current license state (tier, features, quotas, status)
 // (GET /api/v1/license)
 func (_ Unimplemented) GetLicense(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List notification channels (secrets redacted)
+// (GET /api/v1/notifications/channels)
+func (_ Unimplemented) GetNotificationChannels(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create a notification channel
+// (POST /api/v1/notifications/channels)
+func (_ Unimplemented) PostNotificationChannel(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete a notification channel
+// (DELETE /api/v1/notifications/channels/{id})
+func (_ Unimplemented) DeleteNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Fetch a notification channel (secret redacted)
+// (GET /api/v1/notifications/channels/{id})
+func (_ Unimplemented) GetNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update a notification channel
+// (PATCH /api/v1/notifications/channels/{id})
+func (_ Unimplemented) PatchNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Send a synthetic test alert through the channel
+// (POST /api/v1/notifications/channels/{id}:test)
+func (_ Unimplemented) TestNotificationChannel(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -6098,6 +6253,138 @@ func (siw *ServerInterfaceWrapper) GetLicense(w http.ResponseWriter, r *http.Req
 	handler.ServeHTTP(w, r)
 }
 
+// GetNotificationChannels operation middleware
+func (siw *ServerInterfaceWrapper) GetNotificationChannels(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetNotificationChannels(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostNotificationChannel operation middleware
+func (siw *ServerInterfaceWrapper) PostNotificationChannel(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostNotificationChannel(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteNotificationChannel operation middleware
+func (siw *ServerInterfaceWrapper) DeleteNotificationChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteNotificationChannel(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetNotificationChannel operation middleware
+func (siw *ServerInterfaceWrapper) GetNotificationChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetNotificationChannel(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PatchNotificationChannel operation middleware
+func (siw *ServerInterfaceWrapper) PatchNotificationChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PatchNotificationChannel(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// TestNotificationChannel operation middleware
+func (siw *ServerInterfaceWrapper) TestNotificationChannel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.TestNotificationChannel(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetReports operation middleware
 func (siw *ServerInterfaceWrapper) GetReports(w http.ResponseWriter, r *http.Request) {
 
@@ -7042,6 +7329,24 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/license", wrapper.GetLicense)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/notifications/channels", wrapper.GetNotificationChannels)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/notifications/channels", wrapper.PostNotificationChannel)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/api/v1/notifications/channels/{id}", wrapper.DeleteNotificationChannel)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/notifications/channels/{id}", wrapper.GetNotificationChannel)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/api/v1/notifications/channels/{id}", wrapper.PatchNotificationChannel)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/notifications/channels/{id}:test", wrapper.TestNotificationChannel)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/reports", wrapper.GetReports)
 	})
 	r.Group(func(r chi.Router) {
@@ -7143,382 +7448,395 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7P3rkhs3tiAKv8oKzkSY9YlklS7WZ0vh2CFLclvdsqWpkt1nTtOHDWaCJFxJIBtAFsVu+8T8mgfYMU+4",
-	"n+QEFoBMZBKZTJbqJnf96ZaLSFwW1h3r8q9BIta54JRrNXj2r4GkKhdcUfyPb0l6Sv9RUKXNfyWCa8rx",
-	"nyTPM5YQzQQ//lUJbv6mkhVdE/Ov/y7pYvBs8N+Oq6mP7a/q+LWUQr7mFzQTOR38/vvvo0FKVSJZbiYb",
-	"PBv8TDKW4swjyMmScfdvIYGldJ0LTXmyBWrmGfw+GvxA9UqkPwr9IsvEhqY3t9O/SsGX8P2HD+9hjZsY",
-	"mDHuczP7i0SzC6a35t+5FDmVmlnAroTSM4Z7XQi5JnrwbFAULB2MBrzIMjLP6OCZlgUdDfQ2p4NnA6Ul",
-	"40tz4PhnO8NEkhRS0nRGdG18SjQda7amsY8UvaDS7ZjyYj149rcB4wsxGA0ysRmMBmuasmI9GA1WbLka",
-	"jAaJZJolJBv8EptNFDKh4Vwko1KbhSXhiiQIyNGAcU2zjC0pT8yuSJEyM2gtONMCJ4vOXqzXROJWd37T",
-	"TGc08svvo4Gk/yiYNHjytwFCzu0yOLz/vg7Eag9i/itNtFnH3/B7sqSRW2ZpSvksEYXFxTXjbG0AcVJO",
-	"ZY6+pIjITNM1flb+ows7S9z6vZyLSEnwvzn9qGdJIZWQZpo9GNWECa4+qm8+evZ0zfipyKg6dTxjFwLS",
-	"/Nz7TGay11zLyKEam7TzRneFGLazEZKcc7HJaLrspoi91FebaL69FAUjFczsnyPIOxdpHKsTSYk+kKJT",
-	"mhb57JzGZ0yZWjOlPhEm1SyXBMhdZYeSKpFdfCJ0ykkuCRxZZNQB57r5NcsMC770TsvvC65ZdnmIKU10",
-	"XWwYZoeiIaC+QbXgoILyIEDH6CE1WVqOkKbMyB+Sva9xit0PmiymTbiMBkWeHkigMYFUkWyNVUQFlAVV",
-	"D0Fl5nnLFjTZJhkNlLq6SvMutyABw4NgISS8f3f2ATL/IVCe5oJxrSbggA8kSWiuFRAOwn+OCPAcSJa5",
-	"n4GApEQJjpPqFQWU8pBSTVg2GYyaggMHo9AkH99SvtSrwbNHXz6NXOgnIdvvbbBScZF+oJBGYXQ9Ejp6",
-	"ywamry+c6tuUgPaO/xWTaVpIx2J6CEAzuFV4JUJKmqG+3ca07J2302Bt4epw18voEyHTgz9KLVDrCNHG",
-	"QMrLN6zKqJx9IV6O90Dfz0ADsdCD4TTubDQoNfPgsnvwmBL7roZ4KmTeT0FNNkb+UVCwPz+HnCgFRMF/",
-	"2D98A1rAgupkhYzIzGQszX7cIqYqh3uJA0av3ool4wHfrUNG6LzB656OjLkQ/NfOJZtTbYRMY0wy+PRh",
-	"jGUqKjlZ04M/bQCgnCfYzR4AtFkKRkwoNdPinMaZlKQLSdWqY4TZzX6k0qsfaLmN5oFqu2iu6VZoO+AP",
-	"3714zaXIsvZD5lJcMMUEZ3w5KyTbT587X3Ss/jOVbLG9Qhxr7MVM0Lo8fU+l0boMO2wHAEsp11GPSIus",
-	"YGpGuODbtShC5joXIqOEI16I3pY+Dm3MGTtQXh3lEM6+s6Q7a33Cdgi2g42uncC8rPXTAqQ6J+gBwYDg",
-	"7Z7c1G2Heu+4wssV4UvaipooV7ie1VhaNwvjdNN/eOMoO8s1pms7zallB63H2Meimk6M2vDYoi+Jpksh",
-	"t9YpsrNeTei1Ikcvi6OaKLoPwTl1DqdvJSXnqdjwyDV643JHIBdcUpKsjGiFB5AYLE8KY9PNFoRlhaRq",
-	"WpycPE4eD0YVMjOunz4ZxFxlKV1Kklpfb32hXsvQbx72XMcds75Gx7w998+NfjbLpZjHzsAFoEMkYxeU",
-	"U6VAig3Qj0xp1W96wTPG6eHA+eakz/xNqWAXCy4l8DI4EDZOvA/FXq5ocn5KVZFFiAwd/6UqXD+gTvKZ",
-	"0dZFoUfmhDij4DNJF4Wi6QjmhHMqZ2um1kQnK3xVMB/hpM/BqH8gOKgC9YA+vgrDOBxcWcb0dmYs8mKX",
-	"PAfvhdLj1VZpKqliCuw4GCqypnBBsoKiNppTyUTKEsiEyGEjiiyFjWSaHhme6/wh5UUalszr/3XODcRj",
-	"ng8L/QNNHD91XPY6iYVAn60jpz4x4HT4tR+XwpPszB0eoB3ue3FL8AVbtvOumaJJ5PLMymC2LS9Ihj6M",
-	"kKUZclUwp5nY4CXqlWHsIkth+PRkMvnq6ZOTk6MJvKILUmQaHj46geGjtbnRNflonwRwzKh6Inh60sX4",
-	"eu+yuccN06tOxhjf8eOTExh+eakdiw3vvVu7R6INWZK5uKC9oPmV2dzjk8vsbk3Mf3DCEzpbZmIek11/",
-	"XVEOSP2ACGgpU7PkXMG80PaPChzXVhWWB4QSrhMHBpWKKU1Tw6LSGFQYh2CWlmt6akDx9GR9NIEfhYYt",
-	"1UAKLcb4CkrT56AlSc5pWnrhcirHZv7a3Cpj+CB2IDCtJLh61PzmJH7ar81hH14KKyXRdJaxNYv4QH8g",
-	"H802nJIIZ2ffB6JEQVoY5giLjFINakNprmD4cDJ5dHJS28ij2jYexnbhRFUrRowtvn14+X5sBRe4Lwwy",
-	"KJoIntq1H9eXfrx35YB5zUry2t3Dy+o2PBM3bG4hJK2u77/+93+GvNDs52F9Pw/37CeqUSBUGhxvVGfT",
-	"AXfZJbE6eNuOXEOFKD/oJ1DabbekFDhdfomIiEJ2j5iuLvN10+axfw7m3Hews1KRqR8oI0pbTc6pEg3y",
-	"MdxE0sTQDo4aK02kRtR1GhZ67JH9LJhUGnlpqHke9FgUXpl7J9rdEzP6nSrp2BxvZiEyiVx5jIPbA5dP",
-	"+T20cPuFI5tLfOmU0IO+xOegGUZXoGP9gI93HU/leeM7ip+wdQ/Rm4rioKToOSHZy0zwdqcBUzOHyzEe",
-	"Ls9Br5iCxMwBRCG6KaN+r8F9BkPBs63RvVkKGyPlVSJy+o0ddRRFA+8rqS/nJJICLeALa8lalz2Y8Va1",
-	"giFu5egLu5RYM63RWDrQd4t7DB9H7XYH9hU9/q5rPnGvDfWNn7obD4+P04wOff1toI/d5Z7rxXCG1vsl",
-	"hV7NXGBVeFy1cm+jgftmLvQqevSGiySA9cOTR09GUYdjgFXtCHDgrYWuqohhxi4MzbRFaQS/o5MqX0mi",
-	"4v68T8SOg5/8r+olwe7bgbfmZwzRoBuf3jKlO+RwOa7/E1Q1d/VisMfrGy7Tvd2Ot5CrwPzLBAv5b+Lx",
-	"H/uI67LOaaYCwb1LcX0p8tZpwd3PbM50+FwQimc3IhHrtXukb51lwfiSylyyPeNaX+IPD0Y5+DmgH9XW",
-	"rjC87ih9FEqL9anI6B7x0M7Z+/Bje8U50ZpKIwj/n7+R8T9/Mf9zMv569su/Ho6ePv79v8dA1PtxaM34",
-	"G/vjw70vRQ0f/P4XowpM7WzkUs8DeD/zgmV6xnic4K7qeWzn0OHK+0HwiqlEXFDZ6tJLqaaJngk+QzPD",
-	"KPyaJLrTw4PhTsckZ8cXD4+dO6rQYkz5PwpaUAUEvRWT1C8Ov4p56U3hdIM/VzayLiRnfAmPTh5OANdZ",
-	"kEzRUTkUHcFbINr+10SomZ8baRd+/Ont28BiMqIpLTIqIUcPlF7RNRQ5esw4mOMTLSQkGf56Ssey4FDu",
-	"NqrTeq9Mux8Cz5SQFOO9/ut//R8HhS9UNTPMaSLWVEFaUBBmHBeb4RGM285FPyaUpspq6WvCt96jMUE3",
-	"1mTy9OTJVycnlbsHPTswfPRkVXMu2GGBg8F8fQW+vjqwGz6/Eh24MAiggPAUvzCHHVsxCkvzP3O6IhcU",
-	"w0/YAlpQEpiyeBG9n33Oql2EVH6DKeRUBscwJ0APzZc1T9qjLyfwrSg4XkfBU2ooeLyiMgXBgThnl14Z",
-	"LGVaWZzcuVHF1kWmCaeiUNk2vKMvTw7zANUwsuGiaaPq3s6bBt/4VM9Nkw0d4LbZ+fRSPptylrMNpXlH",
-	"EIFDiZibr+AaxCKKSXnlmd5aYkWn5wT+byqFQVziLGilKUm3+K5FYUhxBmQcJJP4S4Ut+O5mkYquc71F",
-	"gu5IjmjApTxJDByvk5VoVRrWVCkXmrZjCh5irvh52jfQrtunTM/oBeVtEe+XCamkyUrQHq/9btzOnNFz",
-	"WCh/oEr/Wcy7yGTv9n4V836HbWzXfddvu7V0rfizcWzz6U3HsZamjDdLkoxR6zmj8oJKo/qIjCWGg9KP",
-	"Rj9tCddfFWvCZwFKR55vtdy2Pd/uMJvUiB+vpVefNhfaBX4TyRDU0Tu6IFlBNMW46FYiVYmQnkT9A8LJ",
-	"QQzCzhDdwceElhpxA0M+5kxS9Um5Hh2JLPGxcX/i90Jp88sIcpEXmTHjjCDOGLrWXYImDJF3YrwC48uM",
-	"jqXYBKH6EgMo1NHg8kkzVRR+5Ce8vYPjCfxXPV0Mkl4wuplxodsw3Pz+yRk6bpLryNApX1Gq4A0HA2Mm",
-	"57kUFy6BxeCo++eFOMd/WZyMJbLErCmPfdWOyissN9K4g8ZFdpLMWxajVup/7u9Wq4hwn5EYTN65tVZe",
-	"UifqlmQXHLR1j1NrSrgC66Fwdld1H5fFr3YyakWdZmhM80b3wMNg9C44PB21AMIRggQc1ytZ5jujxb0U",
-	"6zxjRvE+M9pf5NFQlX9vLM0pUK7lFg2VxjzAOGQkTakEIVMqn8M/qRRjfE+yeqYCxpOssFFnJe5Fcq3L",
-	"d7CWN7OaPK6i1zg+X9lN4YsXkZrhL2uhdLat/Rj+uz0OqymqXAJXsMvYzXZSiQPuL/uv54OkPI14Ssh2",
-	"792kZGtDNBQnuVoJrUYgspQqbV9x2y+AXCxnKJFneRLeAS/Wc3sF5au+jaCJXlPqbqlGgjGRsSAsM/+M",
-	"ztK6QAOkbvL61v3n1Ro7Wz/47hD0rTdnFIHvXPTcDlzdJmbIGg55Je6vpTQ2WwmYyNqth3jr4lgj7KgR",
-	"B9tj77WIxB7jPSH2HX3Y/B3xi/G4zB6RsAizUwygsGHz6lMzqXDGD0HJhb2+2dYMQ7u5IqN7sbLOdvvc",
-	"7OGiMLJW66bPEsL/hzFod7dc+UV6bZNzx14ORQ+3TjVHx2ZFDLY5UUbVny1klc3Z8NbaEWBgpOAYhu4T",
-	"eAAOWEdAEimUwuRc65uFk8nk4aSm3ojC4u0Oq9ZCk2xGrSHntb4Od5LlENYpJMVGwWZFJabmYQqGi4Jm",
-	"yibpCYnbnFwiDn0HNrG9tgL8g8i/s/D53kuIT6a4kHl/IsVV2zO0dzXbC6n4U7cX8JZdFwsysdk547XX",
-	"bOu9VZTyMmbIjkyDTPfyT798orF9rcnDPQs09LANDRI7vmagcM7y3NqBDZfKoVZgafyFl7E/o/dPUhR5",
-	"zGmWxbJuX1HFlnyM6UyAY+CcbmFIJ8sJML4QR4MrilPoeZtNlFPM1kpQs8QlVkXxKnhHiD+AYu7IbEHW",
-	"LNtG1OYzsD8B4fh4CEsDRsCvqALBvedmISSsCS9IZofEfTVranivWrE8PIv9zr60i+gx2uMiink8feY7",
-	"SenYQBVUMR8nmeGoC0YlDNdkC3NaOeuvqfKFCx5w2On3OXIIVwNF/ZpqaFTbTSta2/CCDuS+OnTqwpYy",
-	"As8gA2JLdcjnsC7wMRma+HLTeNJ9d/VrC/bRCvzuUC1LDL2lGc74V6ZXpyLLijxWLSCoFbZ3pjM3dsfK",
-	"dn8f+f21nu6HCjPbs7F5D598i5vHLoJgPqi0XFSCtl9/SyLb95guUtZmswkrQxu0P4JUbPgInLkzgslk",
-	"cnSAWVluqFx+z/lb4fvJNm7rwg7Lom6OpPS0eF9H47meEiMa/SCviquEcE5TT/rOE4kxuVxw6n9v9zUG",
-	"9kkvX4qziA/wj5R0fRhZOiyNkGSVpLpHsfc+lyrR1BrSjYNWG2y9ubOKCxx+dajoonc4uMD6TemVoYdD",
-	"LqvidC1XMYsrI2HWVSl+6gWsQg8n020/FRy3UHs7brsIt1k/X3Pp2I7DBVqv5ac8PVASX5HIat1RIEwM",
-	"dmTZu8Xg2d96oPvg91GkBKKbZ+/XXn7tFjs0f97d7S+/jwbfU5LpVUcQ4Hzmsl5qdxxos7tWyArn3IY5",
-	"3THF4YJKFY8tjPin0fqobaaaIHYPRspUfmtfCCGCJMEvdYL9C+WKQEI0ycQS/LjnUHCPtP/0iQ96RcuB",
-	"GXFhdehDmezxMPfJ5rGOiZ6j0WdxGedSCYhqxdBPbefdD+nvJFnTjZDnrZ69iA4rNgrWxNiqoIUNElr4",
-	"eVxeZ93f4508u+cvv2uzqANwfuouzFSTdl9k6bysr/Mj+sJa/VttO5j0q91QeyipL+xOflxtDogCAjmV",
-	"CeWaLM0OCp7a1Y3ekNKErUn2HE4sngdfMgUnE3gvNlSqMhM4o9woI0JSY6Wav/7M6GZMFCQrlqvaERaZ",
-	"QFur4SFsYGXtOmtwjaNpdfwDULWj4FC5fn+9pY0eYjrMBZUkyy49YxuwULi6uffD4S3tKrlUVw4uAYGS",
-	"98ZK2RXZpec9LTIatdUSwjGqk37UfWY8Swh/6Yb3N/V2Qdhq94X7GQVmYE33sZDod1mtemgZpNaDUVyn",
-	"EOrBhFCeHMp/7EfIevq9NngP6DXLzignajhf/fSH8ShE8gOUlpd91BVnXU/iwaJcS5HNWBp9mcEfgaWq",
-	"zFko438qUfXc+ZsKnlGl4D/KH74xd7dkFxTX7l/xspGJ0jCsMAdcUWM0JNTI1VAdC8b6be1T2cAD0VAs",
-	"CJ5tR4CvrqC0kDSFZEWTcxCFzgsdBSKmuOOoa3oKqEPgzG7LD9g5p+FA4EuUokcguus2h01D63EANlu1",
-	"Up4pG6eNb4Uj1M1G4NB/ZBstHEUXLAshx3EYf34OC5JlCuYkOTdswUHoEnp36yuwr4VcTyYK9OGgbnL1",
-	"EBLQye6F7yfsM5dTETNbS0fCDYcWubefhsugJZ0nLPiyyMjSa3w+WcRos93pQmvGi2hQ10tXOsWolMoF",
-	"ctlvSklQcEWpDduKlUf7qGcodklU//YeF59wAyuCmTjh1mFL9aUD9sqEmRnlZmAkZ+KDp0ubpAFuIIIy",
-	"CrZqzpwUKjqlLGhI9D5pJ2Uqd29H3seEuRPjDUspDFOm7NJCgk17Ce82VsZgR8Fpnjay29EuXkdQIYKB",
-	"PUjpzqtDd08L2Q/Vqwj1I2WwX99Yv6uJ0guuZ49yGo9P6R/gFwb3HeY2uVxUH97RZRObW0pWGP6Qke2s",
-	"rQ7DbrYQv2BScJ+CHlYEjs2PDtzLJsWHT0yH5mjnM5Km0kUONna5r96GkLqWQvL0yy8ff7m3IJfrDVEi",
-	"9z7QNBXdrnIY+5+d3MtXcO42FHqFqUddOVkVr76MPVzawq5WQo+PwwoZWRDx2c97bmYo40R//2XUKvO5",
-	"gLIuqi2PZoQ/avey4ECWhHGlK612soOkMcg3xJs7fRv0vyMso+mnm3aBmt9p0hm9tCuC/U7afJ+nDXXH",
-	"TJq4EdNtu9QRZj8Od7XvOti9F5BGBCdsQGbrO0IZOPri7Vsfrmqd6h5xnZ0qlB6XCDpesExTOYJc0jFm",
-	"iR9dJn60vrd9Dr23rJcGW75Rd7+dRB4nvjFfYFkBP0eJ2zBMiKJjxhXFEmsX9Kjn48K9Qt3h1tu5q667",
-	"f6PpOhJHIJMV0zTRLjJ+r3ZkKTWXTHiu1rto5qhFyB8ib6Miv0P4Ng3u6APY0PnabBjEUUQA34niVE2t",
-	"eZ+WfH1q8aXrZtX047gTM/CiXM4VcrdVuXrRj3U9mT9wvjRrlVweHkIFoZx9RgdREnuH5xnRZlsz2ztk",
-	"wajs952zdnpYNPtNmOsvGxa3ddwx6oTXxYPb9ZYyiq233lLy9H2WfXuaXw3vY8Vkdgpbx68M6bbe5WA/",
-	"lTZr8l6S2M00ZeF9C7n9QWyW0QQZHJ+0hyqydNd93q/XRDMAraMjglml/83sDHcFcVvHS3bBMrqkh6wR",
-	"/WbPQi0NKD6tXYRSqwP23RzdueN42uTePg6GwvrEVrc67Q3KwTeALm1Xt/+5LbwF32C9jDXd7y73s7fu",
-	"sETg75nS7d17rO6HZNGb0Vq2EJR82UtOBzKSBdpvs4xsregpE5Oc9qxWgwBHDQyutCYK62sT3DiXEOcd",
-	"8KvVCacXTBTqyre1XwkoOUffvcbat+xn94bS+63QnZ0W4H/kPntTV1fBM31w2FML8Ub0pCtIovcbbDtr",
-	"RxWxhqFZZ3OYcPfxq6ezp09GQMxYpKJrtkbvTbprN+lu1dhpJHsypaWAN69gIcUajqlOjoUaS5pRoqhL",
-	"+pQrmo2gmBdcFyOQIjnfjiChXAs1ApKtScZ48XEEKZ0zwkcgcspVoeg4oyQfgcqoOnoONv7dJ1UOzaTw",
-	"m/sGfgPzAfwGJMsZx3/IZAW/wdIsI+A3EHpF5RG8+/Ht/7R255tXsDGG5jrXvuhPLum4rKM4gbOcJq5Z",
-	"AAZLjKuaiBcPJ48nJ/Di5fjRo0lPGF6BCRghcD/yGc2+7rORfz8jMYwM3X1mLaSt7ufKzkaKwZIsGyeZ",
-	"SM7BD/bBUxnRVGmbCEQ1TdFhMVwwztTKFkMdA7Y9wf84qqUJhd4x7D/H1lRpss4VkLmiXE96pQ413Tv1",
-	"vYdbaduzfRIpeOvuJpcOoLEFDEPEbzbDM7+D+70LqrWHnJ3dRSJ3CI92umDpFcHhUu0wapdV7XIHUK2Y",
-	"jLzoDV+IWAaxKjK8ZQIlDzPnmYDve+P9tjPL02aMLwRos/0pT0RWrPl4IeTY/rOL/U2mfKdVP8lzItei",
-	"Fiu1X/c83FUusgwThw5iOilT57OFpHS2nPdTb/EL+xh00CeFomnvLxZM0g3Jspmi8oLF4vT8iBR+g2Kx",
-	"gd+AL/DGFPwGLC//idTRhySrJUv/wP5v/pH2k1qXTTreO/E5lZxms0PHOzXkkE8OEdJrup6RC8Jw1Gzd",
-	"89LNVxax+n7xCfpXVPWaTCZxferYalPHRpc6tprUsaHQY6tFHTsdCvsl7ehQV64vsbSvc52ls4yd077D",
-	"e6ORULNcUq23B31yCApVw2eLwqYQXdvzgKKoZ7e2pn3NF0ImjC/hN/Bt3C+MKv3Kh5Y6PgNsAVxooy4r",
-	"W7J4/9obkh+E9a3Wck0AtAlKm0t8Z2Pr9kStfZL9+YcPl9u58Ddc0yxjS8oT2tYE5MDmFvXIa5JeGFtb",
-	"AUaks2A5o1fPt0AW2gzzDaMXRQanBX+J9ZeHj09aW7Q+XHU2LX18/R0s/Db3NK49oFFqNWO95wTjStuW",
-	"ta5LatC69+SgjqkHdIno2QtiF4M+tR1EBCcP6AgR+/pSTSHCiV5fOGZ0cN3+S1a4ty06DtTUbUsEX4+/",
-	"ERiWCUVT0OSj4GK9fQboALEKxyQnyTlZ0onzSQzucKW4MHzRPwsYW2wwGmSYbbOmKSuwQxlbrsL3gUNL",
-	"vwXQrIUOhtuuX1QvLFLv3bvTp1Qf3MXNiGhAjpsUUok+Ok7vcoXh2me6rezIJQzNQ1DMJ1XsI6y26mx2",
-	"rVAa4ZvJxM+LLZrWZc9bPI6QkzO/7L4GDhUaqeqTverXW5ZQrixUO7goNi6jsrWTyRV0YVhQov1LdX+f",
-	"JuOzpSQJneVUMtG7WIrrZWeUN4Jvdr5m/2jAxSyzQMFcKWyTE31h1Kz+2rqQFCvL5ZRvsHpcnmHSIjUS",
-	"L5dM0eg0BRZAzSW9aLQSbXuRw3WDpMgScB33+zOVbLFt1bDdgWe/bvR+R284uMeSrQ99N4YzLdNUOKRm",
-	"9pajyKP7GmwXeOCZ7eAR3ciGYF+5T9puk2n6vTfXj93MO5WQ7JVICm/o9OdjLzi8O3v54i08nJxMnsIL",
-	"pahSa9QgbccSSN28MPzz2bsfj0ZAMEAwLRLbhQor+3yhgH40dguVE3iXk38UFLSAdznlfzU0g0wwJwoV",
-	"h5UUxXIFF1TOiWbrySBypPdlv8G2gI0gtWNXVSJ8SaUoVPzqL9mL0RPIkug+7Z2snVzlDNQzoqst/tJ5",
-	"fHVKl0zprqf1SxQV8WVEWh/U29pKdk3avLNYiRJxSA7Dqchoy1Txeku2+ke4d79kFMgiYwmj6pRmgqTt",
-	"8BWFxm6K7ZTVLtBahHo5Zeu+tq9owhR2D2lvKXopg2B/pyq3u3jFJ/tG0trodvexqX8HljiQBvVFd5bo",
-	"bMJySr03Zcd+1Aczyw+YrcVTKmkKhhtCLpQRVCWTnMB3tvcn/ehi78BlAzyb8npRwxFUhfJH4AumY6LL",
-	"CMKODmo05WU6BFOqMAO0yGe1QfYxaOf8lwkESYkmM6JmYtH/Gz8qFsdBOZVBZMlVFZAuQdzRPDojc5rF",
-	"6dPnlvVg4j4BzJdCDqauQatx1hIqoxLdahfSjq/dAdUSxxzARi0N7OOhftrotkpO/Pk3Nq6Lh3Af0ZMX",
-	"GY332josH8/PE49rD/KqGkGyWKTJNpBgNucnY3NJwu7BrZG8uMGutPnapqJ1CLjB4AyrHdkSjlipxmcA",
-	"uq3AXIqNonKy8xzdraXtwZyqXJ2ki07pe8niR7WCeDCeFicnjykkQY7uUJE1BbUiOTV6r8tbbbbyqwDa",
-	"guySrmnKiD/pPjw5DYZ35tmW2Yi/wYotV/AbWJ8V/AZZWDAmgMfB0UVtjHI00FWjiSjqulTbLxSQPM+2",
-	"kBO9sj1qE5LrQhpjCIgWa5ZAMBcMzZfTgf1lOgDFlpxkPWqndBQgChN2K5UcobGDaM2T1e+vjY5O63e8",
-	"W6Z7zHhKc6M+cA3BjF5DsG/H5uznltIoSWEtUprBcEESrfDF9zlIps4hoxcUi7eVTcatVjQCseHWMCuN",
-	"r6Nduizfy1vC8vFZ2XVMWGPHyyEXfGzr1x/Vdk8/srb3ijVNVoQztY48c6ZMacaTOiSqD3wxbrbOM2o0",
-	"K9szxoUyWrf7TFE9Ahe04QNejg7Ki5d0LoSeYV9wFmuj4a/CDHOI+Aym5pB6nBNJ1tMBDJUmSwNzM8Ym",
-	"3YzAXDRmTOOnRyAkTAdccGo+4EIbKnBBT+BwWI3dOoSrDZVH8RacGMmmfKxKBLL+F1dcoIKuRDsH+/r4",
-	"aQ4AVoPWKgyq3XNsh7tgjtEQxgeuaHL++oLh819cICVivSY8/UKBpNYNwQwboe4jGHpXq7252owxQkh0",
-	"QbKWpsO4UotjlFXPI5HU7o95s8ZzGK+iV6KtP2lKpWz7SRS6hQ/bsoRpDyejWzw8QetltDziluXPZmsW",
-	"6zh1SscoJ/2LoLkSLEh1VOoN5RSuX4Gtcvv1CabYk7m4oEcTeJmRdU5TM4+Av305gkdffXXyy6CzzP6l",
-	"doQPrl67KkVquDPswg+PTgCNu201aMGQyg/bbWtG1A9EaSpBbZhOViWwSEpya0n6V9wJ4MOyzZVCPaz+",
-	"nLxbo2wC7/g4pQafUYlRQPBYZLHw9b9jnXUOeOHufuCOVE0bBmXTMAfsKL6JRv29yyNdc6baDf//T0AL",
-	"+Orrw26yVjbw8jurTVPb1iPc1pMDt+WqF15+Q26C2la+xK08PXAr+0IWLO2V6JFiuMLTExWgksGi5poP",
-	"R/DwpGVJl6Z1udNjqHHVbSn1Tfl6H7klP7GxrSbLiqJS4yLbaGE02PnDZaIvKpb/qVEXgfA4INoi/OpS",
-	"URZmglelS7TpMlF+D72sdTOXVerx0aWlMHafWboKWVttqfNAcddD4z1+t+ukMVb/ww74xpDtghqJgryG",
-	"ftSQkyV97hIcrK5PP65I4fqg9wyfMGLkIIAGdcy6OyjjzG0QMdfSrSI6o3NRZBmkkmXZOBUbDjnZGv0X",
-	"n6JQWNkiVaXmWPCNtO0C8qxQsKaapESTiFPD6JSHHb2u2Eb9Eh5x6+dBZ/3YmIJoLV9QmbJEQ1UBPZ5j",
-	"HCkVbqNEg6jhqttnWXznJjwwO5d6+Y6N5yyfdbRzb4uwxeamv6GPHX7ztZXhtzYwtNYFK1/qA+eCu8eR",
-	"R5IdGHah9Wn5xNyK1Klzm3hEwEZ1qNJN4EcBDNOad2pq962K1+zPAsN6cbXpoFYAfTo46pEZWl9CcDq2",
-	"e9ytKQ5iAZsV0VVJbAvFRnE+92URDy+7fa9hzDG4ImpGW7mWDooNM2WPviIqViLdXAMyNVRF4mGil6rZ",
-	"1+1LhN9gOpgOqnrRUd5zQxTZWhkQuaUFH46oXGoe24bRaoFHn1gNMMIIdnyKNQxo5wK2LXba1hf7sAjH",
-	"tvw7/EEWXE1YCt98Azg3/CrmYP878H+qSZUftz+Wbicgy3XZ3hsxWS1SArM6cBu0fNn395JeMLrZhdm8",
-	"SM6pjiDcoyfg8v1H2BvDWB0rUUiLMFxsnkNaGKIOmmcr2KyEshrUzJsnKSYSuhqUjCtjzWrDwsxsHZWZ",
-	"C9pVQ9R8PBOLhSGziC+5kKrcKAxP4BvvVDF2tfn2aNAjlaNaYhTsZ391ZTuai03czd0FJsPTSGa0ma2P",
-	"Bhp62w9pMhPLo0tUoT8TglOlo2s6R7J1X1dV9vFG6x0DayXrlXVsXzrp1mHvr2KuOujPruSC9rMtlE3p",
-	"W1vdHzqj726/FyH8pda33lh3VJJUK01WxQ93lZjaLlERt7rLF5W6jS5AF/lh6U/tajBBQvXlgwwPCRLu",
-	"EdVyCf6MD7SzUmGPdz5TGOfR9Tv2Ke/4PSjwGSvgXsqIPuxd6k+EepsKYMEHv3mEhd+CpHCrGsT1PS3Z",
-	"cknlTIlCxnQrwWfO8flbSeD768JU8iiIv/aSqbFkePex6KTqkmo32ryeOj600dfPRDID4HcXVEqW0ohw",
-	"EeFPvQPW6lDzywAnawzl9JPCBckKOoH3P30ASfOM+JcmNLfXJN8b0F5tb98ZO4ohX/ghscLFMi/UuDDS",
-	"pRwGShjUhfkWfB2LuGS2HnE1K6M7WqoiJ7iKi8yQdEEl5Zi1aWDhl40/VqA3q5B0to45MOSScPZPfLEb",
-	"q5wmbMESQDivRJZSCc4JhguVr79qJYosBZJtyNbsB/WhUTT2Fb9ue+nEWJgx4+UqjANFkGBdZFFoILxE",
-	"hsEhHczdRyltCfhxKraKt3cJQYwKPkvVyN3qQU++iL+RtFs8JLtwCA7DEuGts4TqEVD/3uKAs99scLjm",
-	"ge5XrwFj1MC5ABINZDm480VFJbFPf1JU7ml/QddO9nR0i3g8ivcF3QiZ7vn0qz2VaQ7qUdE4eznPyJ0i",
-	"2FUbNDo835eIoyyBd9mIR1tI1G26RznPXQVDRJnYqcgovHmlgCjFltw3SKVgYDaB9yIvMuK4pQ3zUhoo",
-	"T3PBuIbhn15/gGMzVB09twWdwBevU7AmWxBrpoHpw1oU3EAVox2UaMUDkdEXCJtWyjCgdXrTIVjpP2tb",
-	"WXWHfiLUe3ueayi9j1fYqWP7+tmqMu27MkIjLYtn1nHtzdm78VdPTx6iZEmr+krxdonr6EPhi/ncSDRE",
-	"ySXDakH2aWs31jhSkudPArQQWbIijJdFjgxazxkncoulM1DsoYSLRh4b0RgRGes5TdMyMpLyJeMU1gJN",
-	"SL/Q0J6b8YWIOkvLtLKIKlBmzyi6vqAShlm6yMhSjRn/FZ/t9wuganp/DARSCetReHm7l/87puLFCh2d",
-	"YYvRE9iQ7Jzx5Vid04xqjGaTC5JQ98wiKS05h7KeEfqRyoRZSTrlC1Hw1MXBaZKcwzBIhR4BS+k6F5ry",
-	"ZDsCUqRMuyaIQPkFzUROj1zku/UIBkAbui0eBc3Nnw1OJg8nJ2OS5SsyeegvgORs8GzweHIyeYxiQq8Q",
-	"r49Jzo4vHh5jVqFzmi5jLplTqgvJq9bN1jCA029fvHQNMWgKBXcubkkTyjVgVrCaTPlLkmVUfoGp+j4y",
-	"Gbu1ovLBzP3jfMo6mdm80PQ5rFB7sF6bKXfB27ASG1gTvrVuAOv5dLOb3YAq8lxS9Lwoy/N/ejPlNqwV",
-	"g1ymgx/hgikMqjqGH9wy04GrK0NyNvbgsIC3KigT/E1qiI3qFx5a+H5N1lQjz/rbvwbMGXroNLV8e1Da",
-	"UJZp1ZI5M4rV5QJvpGtz51Ntje5kcKJWszTqbGxZPOhFubP85XPB44sFhmS51t5ipS37ZrwBsz7ysm22",
-	"gmuWXdls7lk6nK7nlz5gofqwNFa+PDmoNMUvVTldJORHJyfNpJ88z1iCeHv8q3uuqNbtEqoevTH5Hhlk",
-	"Q1i53/GR3TCYJ3bx2JzlJo+/JalXNfCTx1e239eGW752zDK6YS74di0K5VgFypCyh8ngJ24DYcpzLShN",
-	"YfjTj2/e/YiGICCdKnhQezaABxBSKjyw3BseQEWpR7hUyWXTNePHLsnymc16RV3D9TyrM5r3QukX5ota",
-	"WvLASj+q9Lci3V4ZDKPZ1r/XZa1rgXFteBdPv47cJ45wa7hkBRi6mjhY4nKb0xRcAfmjxm2/ktuxLDhg",
-	"8jHRFAj8+a8fwN1K6QPAMjIZtoRiOnKLuUutfGZjjntcYz0Zc3CNgGxJ+4xA8j2VYwMtFzkNZdbmTZOo",
-	"1RBcCzPrYPSQrV+fPRM4q86OhAXLqAqeQr1LIYWUSaxGYejm49jj8rjSQwbPBrvLlVeNdL9XKXLswcXX",
-	"uv/CkomoI24k05pyZ2tOuatch+PGUhSaSqMYKaZsS3Kypjy1CekXD40ydzSBlyhzpjwnS8ZdbVgOQXkV",
-	"ePX67OUEVaBndgvPJCWpVWqmHLUa3FibTmOP2k+j0b6b6Y5C46tTkOSci01G06Xt78syczSH9SK7wH+m",
-	"TJlbaHk9vX4d4yZ1o3uF5hYVGsTtVnXG0uvnoszUOGVF6IFp1eCYb5nSJX9JPXsaOk5C0xFYA87wq6MI",
-	"+zv+F0t/72UY4nh8+BwynmQFpgdpsy9OMozGowo5oucBcDzlJRPAgH2lWZYBYhnup42jQT+G9u32zasW",
-	"nmZs4AqRWTpoqjqHcJhrx95WxL2T+Ge29OQG9XvEOy40oK+lgf9njC8zj5zzLbC0DcmfBVIrVOjqq1kZ",
-	"V4bFhZKujq1G7tNddN1BVtQQzW8vguVvCmmv3pTAo7xlC5psk4wGtsTvt0EktkKrY3t3gVgQK+4UtZj1",
-	"v7659d/YymTWlsaXe4zx9XU9rXJZJ+GAMDBn11Kgu9IWWnZypZ2OX/AtxkxVAsh2FfWEXf79E6n6ldvI",
-	"PUXfU/Q9RXsvjCUKpGbc/dDria0q6DOnNe6TzL+FEvk3b3mWZO11z0+k6lO3mXuqvqfqe6ounXNIFCVV",
-	"t5Kyo8qDSLmkYE/SE3iX28A/mIt0O0GnCLiIMqqmvGwi7r4AmpFcUfUc8E75EtaUcAWMp3TBOHKA90Rp",
-	"wJmmXDrb9snJSS9uETFES35x5k58zy+ujV98dn6bexZzOItxdFQpDpbqSRV3A0MhA5LOtg2NokiZPrah",
-	"CYFXa9d/ZMbZKuT9vOLl+/3BXtRGafxLzEAS7dvuXuLre9/0LfqmKzRrc1Cbv2O/NXxedph7GY636xYO",
-	"p4ShhfU48AxzuqFKw4JJpZtkpFfHmVja4oYdT5+FXr3FYdcklfz8t/RoHazf/syKA2zXFprS9DlocU6N",
-	"4qFUQR3bfXjzbDeRFDs7kQyfzX/47gWUgENkoUlhU2n/9kstYMJFmR77yF1ARMC3cxBeJ/vw7sP7KMq4",
-	"Kk97ccaM27m5J5FAPYrSEyS9EOd098HY/LUMFDNan6LVO0ltcza8s10i6NUPdHDNyPQD7cKkN3hhenvj",
-	"OPOjsBETHngGYeaUyJ1oGvsgVIM3Kze9C/DjRhXUbuC/rxe+vt57qJUo74yhcMMwjLwBjirrIox9LMuE",
-	"7YfQgjyjXArbs62bZn747sVrO/S6YeMX6oSLFBdY39sc8KfTN2DNKZpWdb8KvTLnTjDBh+R5E3a4Rg1Q",
-	"hcIWT8hcDMOKA6xXaJU9x7VGVdXWOEhARdicYc94MHYLIsMsbkDu2orYCot5RrY7/BYrHMk1lgjH+6Mp",
-	"ShZFE0nxAc7ejrlNAmU5aYhKCy9gntnUkP03+t598NKOv75rrS/0qXfrZwPfVapS726IvdMNlNJcUht8",
-	"by7LBkfdOL69dCZguaeNFC74P0A1hP0Of/hClZ9FMKriws+kazyxT+5EelVca/heR2uMCKjKLdWB812R",
-	"ZTYi3h8ThlUTiVEojkZVUiTmU0U0fUkXkqrVfgI8dQOvj/LcCndZ3zfUhCo+5ITJ21LzHaDcThznHoFr",
-	"GDWyPByTiIcJUQlJqVOhwaV/0/So0w44FfhgaqvwBms9hzXjGogxH4FgWO4DP8AApBW9xokQ56zDLXxK",
-	"SWpjjb7XOn/Hsy38vWpb5Wb5O9hpRiCFjTnCzD+eUpltbcXiYLMj3Kxyu3Xa7QiLNJxRPX6JUymYC23L",
-	"y9k503ISu5at6wr2T8GW3Hx/n8BPqko3dNXk4cX7N5BkzDA6YneJnrCcSFvIbPzk5KFRm+QWVkKcgxLI",
-	"4JS1tAhkRq/0G9kwnooNpIJ/oWFpRK0o8OVLC7CWOghubH25BcZ9igv6zUShW53XFcVZUNyu/eOvw93C",
-	"81JzLrXLWyMzhwjuaWHURXAT+Nagk0F995ktV5tkxqJKJ4dSXYCDAeV5S23o0W2RiU2dt1cNW47px4Ti",
-	"kdrjnb/LKNVQDkRzZ1Qa/NkWykyw+dYX3xs6MUDT0ZSTPJfiwoDCqxgjb7WXYDqawI+B12kEiS1ZSPSU",
-	"f1k9xJS7aAYFVkcaV0dqiRF8WY59XZ2+dwi0LYi1EzlcHngwGvgDI9H86gsRe0dF1byvfxxxh1fzUayN",
-	"77U6L0uovWUq+kpTgbXuS7zd15c67rRHzn5X1W+usCrAfyyKUqenyqPWpVS+DIZd4/VUy9RyrmPgKUdW",
-	"ZYqsM+M276mCJl5UzIEdujCH5dYFz7ZHHRkfOxOPOrTa5mVdvVZbrVAvVtFLtX14DdvoiSquZMSNG6s/",
-	"29Qtmz7tHBLYssp2HKseNFHk+hFnZ9/DOd3e+CPnD0WmWZ5R10AayhLPDWMWgQkkQOl+GIyvyG1cqAze",
-	"T2lGbfvhOoa/wr9Xl3p7EfMRt4jdXApDpmY2IuQbbAlwdOMv5QHWt8aZi4UeWzBf4hbd/WA3uX1C44+Q",
-	"1XAws/HM/S5e/XdYfDy89KDe3yFyqIOInyWZ4B2m8UuRM2fquuIMtd1QnshtbojJOWLXRFNpDuW71NrK",
-	"/9Z0kGJjbUy0SYk05iRy2GPbGpClDYO2yM6BrXMhNVoZxuYkWhMLlZVQlAfbAU3XeYZGjABqBnG6ybZu",
-	"AteSoMzElXScS7HOtTHd/dNB4xBt1msgWRF6n2/0VeMkd1tFMDu8Ne3gzV6N4KLUH3yS+I0zlbMmiVZb",
-	"xBY8roSsqmTKzUdnMTVzuso3WL47EVnGUuq9T64xGj6o1zSbpmKD2BAyx5DT4C3B0M3wX//7P+2FuaZF",
-	"5R+OLqsLpYwsuVCaJeoZTVai24P9qhr92gyO84sVJSl2sncc401Vwmf8F7rtZB+1gm9f7i341rLi/zV+",
-	"WcWMjd90x4xdE0cyALolJ7xdup0Bmd+rcJtLR4d+uf+TH7Db2I9Cv8gysbkFIm3gnvfoI4mmbIElJTXG",
-	"Rzcf1w2MrBMRjwyuX/bzsnyVCmtT+fIm7cTF0R0y1lTp8a9i3p/Q7IcfqNJ/FvNdf8ijqwNmbaUuBPqz",
-	"mOPDRY4+5o2Q51TChmG7FcKafiIswzU+cUXmU7oWz8GBA98VxFjkWHs+lyKxpamc3sT42P3NLdIO3guS",
-	"FURTG2veH7jusxeu0tS1MIJwjVviCC0d5WNhKbZkSOqGtlxl7kfhXboDBlnuM72SVK1Elqryibzl5nJJ",
-	"16xYjw+SPu/tR3dCCP17yg/Pyx/dHC93BZAgFbaLINgqChQcCs0CtIIFJRo114ZTFKcYL/GN0qDc87L5",
-	"auc0NfXK/xGbKjU/aUV09/nY6GvY0Kk3tp/aL78XSp9SrI10j/G3gfEwtAXSwDI2c5HomDi63XeAch8t",
-	"zBqjXCyrLnG9/CZ83mm3IepL7MVua2dcAr3/ih/e4/fdwW+8yruA4JXtegCG76SQ7UHxbgPZ43jQU3tM",
-	"P9KkOBzZg2bxr90M91j/767HBHg1s3hVZj3eFukFW3rmUb2dBh/4MpENWozMAg/ix92nccVh1E7WbQfw",
-	"9F0FwRz/6yMWObIxKe0vCWUAS1XjyIWxTMA2qrhgdEMlrAulnZOhLL445f5zCUNFDcX7xodpoTHy9MnJ",
-	"10e7YTxujcmUHx7KY1hQGWrywp2vj6//49109pdnObVtTq45ybpcLkYt5sb9/VfXdVcCeNzObjOJuoTe",
-	"LSZS/4hMNnTn+XJGLurQUSxTtTHN3C1HOkCCWYIr7+IqNrztEKbiA+IOZSrd7COod3o59nFqD3LPPa6M",
-	"e5TpJPfc4w/NPSzlXI55XIjzrmowXv5UvAMjaGPBwJjAMEwJX1IpCnV0FRwBd3fPEa6QI+D13T2G4NDn",
-	"nh+Uxcw95cXLPSG0qoqMVWj0nC6EpMC0snH99eeRRUapDpMPbG3g1sQDbA8vNtjEuIrZP8M8CMYhI2lK",
-	"JQhp/nfoi3OPppwLPvOr6BHkRGpGshGshdLZNvwp+GfBz7nY8KMpLyOgyi7JmHATtkrGcuTVQcrWvFNu",
-	"9stcUXjiatlM4MwmJOHM/6RSuMmq0scZVmmecte75oxqzfhSgdI0z6lUEHSyIWbWeUZBsY9js15GtjaV",
-	"pzShXK15lRA+tmXxW1IhMNa9AdtrDU6PL9jSo8BW5sSIENsx9444pPfkDoQ7RuQN0ggqgmqlCm3uuZUo",
-	"DFxSsgX8DMhyKekSkQtblrhkMoZZsS41bOhbXj4+mfKUbNUIkoysc5rCw8nk65OjZ0AuqCRLCiox5Os6",
-	"SytOcrUS2ofmqdGUVycbgRaaZBhK5XtXKptAZ5E7IVJi3p2nzClfMJ4atJ7Ae7ExWG22i6PHuVnebSMQ",
-	"2JDSTJMW7wACqh9if0CY7sjyhoxqAI5xMOB6XoILA5j+9nAEX5/8gh2bdhN1zAfxPJ3HN52mEwVBBMdf",
-	"EZZ5fLL9zEYgsvSOZO30ILrwAAHqaHfgXVLjnLo8yOO5pOQ8FRveSnCvqGRGFOYxhlRGppYc+7/+93/C",
-	"WUJsr2ejtz56OuVVayBsODCBbwlPFWAvcLR2/54YFEgKI09nLjpR/X3KV4aRS6qYegaCZ4zTbyQlycrw",
-	"/wf2m29ORpDSpSQpTXd+tIrzNw9HU+7J8JuCR0clj0dgAPFN7cvHI+D0gspZLsWcpt9wYUTyZMpf2vOr",
-	"Yo1Rv1YTqCATpOYh1Mch1Mcl1Lupt/ri2/KarjM4Pbpgp2y6C2LJCvs9NPKk3HB1RiivAYYWuY49Ih17",
-	"bDk2Px+HKHAUISmjIHGqOrPf8E7f+oHXzffKhaIPFfY3kCLLivzGU4dfVAVwbAErX3zrzmPR9wHnm2/B",
-	"8RGWGWRyubG7yGHbQo5tLZf9KHKKw1+60XtE9neYeoxtfsMebVZLX5gPN0KezyRd2CaThGHTEqbgnG6r",
-	"RkstwrycYF8hwl6bMh8kOttiSqyRGoTbrZx+9/Lx48df13rIXn/Bxr6FEh+e3GqlxAhORLPxsfVoAO9P",
-	"6+xzzw16cINdoCsYOjFjr+qomf+9wxzQRLUZ1W0KmNM0xALM4JksuLJdYJ2zAr9O0fKQhdW7rGNhMuUf",
-	"fBuiISqGVNP02KhXND0CnMiY4PQjvlOnE3BRDMoaOs0aAxgDVCmYXbqL0QD/B57qukmjWilyp/8jApqE",
-	"8M/Fmj4rkQNSmusVqDxjWEws8wWpWw1qNGX3CpszHNVbyKDfx1i6M4vmiIY3Kmx+uX58EjJ6eda1YcF6",
-	"zyP78sh4MQnrZxnmBIvGHKMnJaZXa5GPnYMFuc9+7emDyL+zH3yP4z8j1P4D6ClN6Mc0FcLPfa6rN/Tv",
-	"1ZTrNlpUlde89pAvvZYwNEtQ9E3uo0L84AAqPMXx91R4O1Rood9OhQbS91R4M8YCUlqcCu2DQSsVLqUo",
-	"ctWrF+mfcKh9TfjL+zfg1kcN2Py+KNxjmzEn7LxTPlRMU+ULjxkAw7szqKpmHo1suQLcPNPot80LTVNY",
-	"0/Wcyim3jiQflxCzHexaLSaD3fV1mgq4wr5yUGcOWHlWKAcce2Z7PHXz5WAtljEbThzUjb5tjO/9EohQ",
-	"LLHwgavDaP9aolPlhmyp8eFrBBk8heGa8AIroxjcUyuWH2HtgBBpt37UlBuGj73T7aJmZKGF+69zuqUp",
-	"thRXswVZs2zrY+ycBdxsedSOxu+Fsnh8TemmOLeFxE2Xv7DHaglqcfUuLEBvreqFvU7X/KYMYLkn1bZ8",
-	"mZuOrXnBQ7LzdT6wkoZ/QyTaELClwrYiYQ7JdmRjpN5XU0auxYXLZLZ7GDr+Aa4I8FFNegV0b2Po2gnf",
-	"VuvypH+nKojdU0EPKrjBKDdEktZyWq98EbWSleZEJ6tY2XydrMCg0whUMTcYYgNPEpEJOYG/MG59npWI",
-	"BCLplLP1usDQqTZc3yfjzMI3i+nXJEhtH72bTlzrFKSuB8ItC9LCAeaecXw+jMMis2ccXyhImcozsoUF",
-	"o1mq2uTlsWMPHb3ClWJLroBYdx1Wr3LatxOilVBXkGKgkBGxTE65F6/49mJD5NFTg1r/k5OTS8vbUtH+",
-	"AVf43DmRPcUnd8nBWYCk6S2UnntJOFJtmhr8sDsxuBLqfPcc5XPiKC/wKuNEv4+dHP8Lnbg9FXK3CgYB",
-	"1te5An385jjEKDqpA8T16/uO/CUC9V7t30drjSiOtU3+bEPENoR/tibMnIh0tvQ+o9qancFoWGRkCbab",
-	"oFgsPl0SBhv53MVhdZRbqi5xqJJ+T2efh0z7IJbLLNSSmwRZo/MVJZledT10fm9HXCMm2hU6XyyovGAJ",
-	"NRhhN4x1/r+8STwItuCDpw1bKzi5ICwj84x2tvUpY5EfgKQkZfhvDLSGIeGCb9eiaHRm2xsI0hL5EXvW",
-	"pfyCScHXBk6XeBXWZHlr0UrmlPtetDBe+fY7mrRVMsNeJit3Wz1qlHX1K/GXfh2S6XtbU/32epTYEoF7",
-	"7vn2+5L4UAIYzokN8bFOSpaPIBdSj4DqZHJ0468P37udNB8eGIeQAbQ8OphzHF5gDNG6soXCxgbPJFUi",
-	"u9hTXOz7ehOeU/dNH/3ueuyOm+6C4U4cNmy/vXYYP4pwG6Vsw7crX7q9sx68O41NrA56QqyItiWW5xSw",
-	"hrWZcS/SdbXQaGJe00wpIlYKKkeML0OlaLYWKXU18EmhqEJJ8t7I5g/YG0OBFqDOWV7msVatFlUxV4ZX",
-	"cg2aJee22g1uKauyjzBVPKMLDQXXokhWNB2BEiCpKtaN3UDOjCgp8rI8DmREaZA0ETL1qfoTuHg4eTw5",
-	"iZpLBdLUocbSlRHT9cil2zeY9gmnn5zNhCh903T7fa0PRoMm3xu0PkZso1DiJWqfytGhYtxYDVcjA6o0",
-	"2OMVU1rUejDHg7qK3BDZ3zH88O8YNTa2+WSWmKoZZ25GGzJpNh+UuJzAa5KskOISkutCuqfwnMpxRrZU",
-	"YutozAxBU8h5LIpMM/87quSe2LrIzCngP5Q7+94d9aaI7RMjOL+81QDOKOg6Vb/w2m2y0ThIW78rpPbB",
-	"oJYXE8b4Ls84riHuEAMjHYrjOY4Orl/syK5XCziz6bvZ/M31v5kRDYrqo7t1nfWub3244/5Obzd5FW05",
-	"q2FNGxe0eAVR6Y8mJ0cTKF0dTEHByWJh6wDe2XQocx+vqCYs22t6pjgMhq7iraqE6YMISO8YLvs2dmX7",
-	"tfjugXLJkpVzFfXzVvj4nUgYzY0znutRP61yd0c1T7x257K/A26Ru4X2LmrERYS51y8bMHJZRRf9HCXB",
-	"tJdwkuJXmmgV6gOYmNDks4mQeWGGSVEsV0D4lPu26xXjhYxyNbG50QjWjxprL/m2kBnRVOkpLxOg62nU",
-	"ZQUbBMCQF1lmeDvltu7LlJvRHBu0e4ngCkA4Q9c2fMecAWITG2d5oqe8nt0IxPycU2kUG7KkIxCcYjue",
-	"NclGcGKXtEOZmnIjMKoMDB9igz0gydpJoPkWzilXxAwkmViW0e9TPiy4//qfNLWT+wpvxsTGfpM+/eTV",
-	"67OXmPYx5WX8/IuzlxOXHZahr+z1z69P/ycCbFjaCsfG+M9pekwNJh6NplwZoDC9HWNVOprabBK8Upaa",
-	"SUeWw5qLkiKbsRTtLVspdcr9XVSlNKtrHtJ1rrcg9IrKDVP0yPoUjO5oPjWmDKYzJSuanIModF5ofCoz",
-	"WwL6MRfKV901Y12pHkQwA/C5IRGjd/2/Xz7+2p4cIWUlOVN4XwXPyZJxNGdRXk+m/HSn90Z7yjzYFLUO",
-	"s6mqV3WbapAWB+k4hKf+Fl1+EN4usFQ9r6UgBRhNpDUnXSZRgaX9MEUJt3C31aLqlt5SrjqbglZ3b/gU",
-	"DF39AcunHgSpMQFsHjj8u4tJPnfKf1PRcQPKhlgNpEewJnwbcJELRjex98Sm8HJVMnbyXeNemriBgIyu",
-	"kJJyPbNi4hvrYbFczqYYjcCzyvkWPPusynmCK/27YsuV//eapqxY+//KxMb9c8oLbkxFy3QzovQMmaE1",
-	"Ig2Xn8AHpg1PbxBjItZ0ykvHKuPjNV0bMWDli+WrVsg8d5JqVf4F2Wfw3jsCbRaBBTGidE6ScywFZNi6",
-	"mYc5JuwluVnX346lfZDU1gpydU7wa8OIYuzICPaSH9EmO1LWwV5+8kWNOU05VjQMhNHEiuCZF42u9nMu",
-	"0KtiNjeCXNIxOpPM0ljq7RAR0MH7v0OUa8mYvgHm/wP56ES+RLw24vKlK/3oCj8+PDn55bl/4YCHJ21s",
-	"usPZ9jBWB/L6BdHdFijB1XdJk+/qxUab2ta9vOiWFxhvQLzJ4VhztvXFDUIxIl3m/F4x4dGnXUi8wnbR",
-	"iW6i7zndKl9rNrCEGrIESyoHieO8wFBPsXCkuia5o09KklUoTULGapjua9SfS+6NgnNFvII8p5SDs3Um",
-	"U/4tXinaT0ag5iw5N6sGn4ZaLaObA4tHHaIJf1fB+Fa8tNelO1bn6qT5cpRFAmO8VBdrr99ZPne2qtWd",
-	"YwJoaFSADcgPIWm1uDUxJrfowQV8/fNWHvAhWEBsqidskpIcK8f6GeSznWrZoynnxljwQ1Kn2Tr+BUaK",
-	"yguSjcoqDzkplI1pVFM+LK3d8DX9gfUl+FVthSbKjf6WhhEDqF4t2PJoAi8qD6koNDo77Nd4JOlUYQs6",
-	"52twxeQJ8CLLwJxihs4XomHs+A7hgN6DS5Vvr9PTmb+FPxSXKE8VC770N+CUHnQ2Bv6se14w+MliIggJ",
-	"7kXNQabGFN7xkj49SSL6VTg+fFFoYf+mWUb7mJD9Ctkb26KQtCw3/2mV7EsH5Aic/3Hk/XyuYv0EXpGt",
-	"spTp6NitjD4ZMlf49FpyKCnJ9jm4R9opJ0lSrAt0qlaDUqxAbut4wFKYLS+E3BCZtvSh6SpdX0f/lsr1",
-	"N2AO/cHK4cfA2loN/3Opg38nmYkFYSDGPYkj1iODFpxWX0a5SFWm/Bk6cdozjF6in6V8GmB8nEuRVHH0",
-	"a5KsGKdy60N+mEhZApkQORTK6OvDKpxwvJCUwoeX78dzYwqgyp8LqeHRo6OR+Vjha4AWVssvo/lGLtG3",
-	"KkW1kFStMJQv0xNo9Le1re0Moe6aCEGdfDx5W+qTRehq9EsE0w0m+11RD9+Hj77q1cP3Bqr+IwhP8cqi",
-	"df9dEJj9/ZLV4u4tk9trcfXCsQSrIzILFGCqDIxnHBYZW66aLO1sy5OVFFwUCgQfp3RtyT2of1/NXI+a",
-	"bOFwKVOJUXS2z2TB25nbu5xy+/Z2dvY9KIrXBmRJGHdmHB6hUOit1QpcbH065RVTG9la1+izzoSi6VhR",
-	"7TY8x2IqQ6HGkmaUKDqCArMWsIQB4wsxgnQxCrIZllRTvhAyoSMgZGw9+yMjI+mGZNkRdtxCvmoWtA+R",
-	"agRFrqjUzr9jLZyZmR4eQEq5YTkZvtUijCZCzf5/xvbKijXHRIUSqEG58RHkxTxjamUWoxeU63mhJhi3",
-	"46BLU8uY6ZoF7+2TEviT8lV8ykmRMg04jWPKzg5Dvlx90sGO/bLb04Lfc+LLaGhnCPI3fCGiypmHr2PC",
-	"8F//6/+4pxiM6k3Bfv8dSbT6PDn0rWeR7rLoL2+yi7yNWapaFOEVG96XMpIZxTNIHnG8Duxb5Y2nflbY",
-	"qFwSqAHbxpCZ9xSbH3Y6psaFybszWDC+pDKXjGso+U1/kVI1N+00ulFgVD0bsRqqd5oEz/WazOEB/NWI",
-	"Bxxi2z59uy1fv7yyK3LKXfByFbfyoOwhefQc/sNZz5hMY1Rf+6ENIDLzRhq6kvRSLVyd/fy6AsUNsuGG",
-	"8bsqA/8j9u+CZIqWU82FyCjh18xgS6i8ZUp3tiFVzcYdd6VR6+dg/zae2YII2gorW4u9nhVz1FWi/ZSD",
-	"5LgHssjoBN5xigQ45QHxmUGe+oKPUc/NxMY2s6tmeQ5kytPCQo2WdP3k5GvfpN13YXfhALXKC8aGlpMp",
-	"3yVh/Cqwbw/qw1yj4s84SDhownwrqdM9ujJH2nZ/ZprTDtbdSSZx8zVnUTRXDCBad9ZbwbZJULbb7dkC",
-	"lEQZGQzxvXBD2AWVR0brIZ0qikoI7yi4Z3PObSAx4cZqhaF9p/MRy5lYzoU4N1rDkbXsODYIUjai7Psf",
-	"XrwcK7bk7pUQfhVzZFkbIc8xDJYmhVnhghH4C+WKTMAHsT06eRQ0f8avWVpaGPa/taLZAhmpqpS45+Cs",
-	"SCb4lGfY2pPxZiDDca1Pltm6mYZzUfCkVBidGQvGjjUM2IYrEIREq9PCNcAScspdl6cdfyNU7sZ6sJYt",
-	"txS8PaKxaw7bxZjPEvJvY99ene1joHZa2G5dafw50yG9LypusMRgsEPy9N6k/Ty9jsg89tOvb9LWYMGv",
-	"7e0D4YG5WOsmRXh/K9E5tRhfiF4tNcKE1B3fXZhAsmQXRg9FBxu8Fzk+ktqw3pgfDYYBCzX8eMrfvzv7",
-	"AK1OUlRrzTdmylr0xtFkyp+cPHGuQy70DC8a2AKG5KjykmLiIQrnEQznR1UQsvlFVSmd6cisNUyCT53I",
-	"nBcaSrN/yjF8TGik2S217ijLMYXt2W9+tH7WahaKYSVGACE2UJ7ia2PzISi4pw5DN/CX/QGiPrq9f28x",
-	"kwnqA+/jPaL+M6uCvjsFLiDwmoqNwdMdFY+kQapYMH5BEqcnRh9sGdc0y9jSYPQxKi79uvTY7qDW1W7/",
-	"8u4M3gSTQSKyjCYaVRpf4MQQF6ebbItqrTFihdRqBDlJzsnS1ybEsGD0xk257+xk6y7By0IqIcGlMBnt",
-	"VXBIqcbkqypFwIZeT/l8C64cw8hudZaIlFZRxyPAhrzHBdcsC51VQo1DyLRQb3je1xZ2vUq2VSUiPtlB",
-	"VZ1q0KIxPX2yT2FqmdoDqTYx5cV68OxvA2bZVSY2g9HAZnMMRoMVWxpO5TM/Br/0X+xKGyPjfV7ZbAki",
-	"3XW2XHt0qwU7dtH4PTZejjgXLbl/Ul/mO9zwCb1+O3ws5HTtvNMaiLXC0YfrZeGMVR5WlW2F+pl9/4QW",
-	"bSmiKRkZwhZTzkXjZNh91yhAeanqYY6TFTEwLPWgKe9QhGBHDzr6NFZ6hv2A/whV4nZPFdWJlC4DGO/V",
-	"n5j6U4Z37mo+CD1Mva/hdvlFq+aTsYRy1dlf+q0bco0Y4pZA5OhKoXDjgl7ZFQj+RG0YiY+mz8KxMNSM",
-	"yhEsKNFWkfpHITQxOhZGfdSjgCVFjawX9zq1YyFjc0nk9pnvjEe5ASNNwU7mn6GmHN+hujosutVbWIRb",
-	"7zpvwy6xryStdbnXDn9fR/tQMdtEEwXD8LkyipZlQaxO3CxdKPYrmG/B6P+2sA/jS+t4wJoL8Oezdz/a",
-	"9FsMGfo01Ly9IlxXTQHdWH+P7HdKXtor21MbyohARw/DsmtpQAQ+wDtKd888sXY8+9gqGFghxqiAY8bR",
-	"ytrJDbEZF15UpUSTKR82iw9UpRxdoZoH4G3KkU/dLLgegRa59RGUKcX2SQlPpoBpLFrDoWwb54BgX8V/",
-	"+Pn9lPuzKRA8s15J+8SEOW2utgW6Zl15H9XdX7WDU7zHYk/m5z95gF7+xdpxBTH/lSZIsNf5BN3NFpq8",
-	"/J5BHNK9xeMCELAdh4MIrtclJrrOznXyFHs62Z8KW4jh2sTFi3TNOK7SWQZbZPQO1PA34Gqt4T8vWGa4",
-	"FkgHs7b6YfVZalfxzD76dRdFR2i5LsjXE6/yslBarM06t1rxv9pGZ3UhHIVQv7Xy/+/L+/V2540/MCKJ",
-	"sBQ0Oae8rYx/UsFqH4LuFrjrVwbI2nB/qWrmlMpCEN9f5e5LuqDSGNxqyo3cJSDpmqbM+ubdEUblA4+Z",
-	"cexMJphLsVE2PcsGlWAlMjcfagY2cqSscIYWK0uORq7IDk0hyRjleqxYSkupbObaUd/N4duU9+KamaRZ",
-	"oC1c84OvKXRvSDa4dXmNewxJgyIBvnrsQtRBv1BY+qmrEnO5YI1synCnvf6QKsLJl4MOfU/1aNwRFpVi",
-	"fGkzbLBMgP8qlSzLxqnYcCDakQYM6cfcEphvaagoNXRp8V0dTfxLl7nKKlRo98Fs7qMVZkSXMZ8xmvE0",
-	"GaOZM4TKgY9dN1kP/VH4vPJw7/PKTuZ0CSIQi6BTg9iUIR+KUg7D0+9ePn78+Ouj5yDWzN6LJlKbm8NS",
-	"N3jnLZnVkXelXs9U12n/m4vt4lUuIhrjVTzCftJz0D2ra2N1d7jsVD1wacd1dyke29u5lxDuMNByW99Q",
-	"xxawdRkpRUa/UJAW0hj9U35BZcoSnyRDtEXgoU98rOIBaqqNGmF80IxesNQoJa5eqySbnRKtP777AIxn",
-	"jNMUVlTS57BAvwvTWNfVCiH7UEbBzxcEDkXZsH1A28eH/whuR3MOW6i9jfHghaVuyD3juEOMA0Ne2xjH",
-	"O1fF9IuATh9AWenY5oAaBiIc+ZTE8Sls5FiohGQdzISntrE7mIuUDrtI8Hbw7uzli7fwcHIyeQovlKJK",
-	"rSnXYAsLqClPRVLgX7BO64JxfFl4AGKuqLywmpan+6MRlgnmSssisRWhxdoqfo5B2fXRaVmFtX+hsOSz",
-	"1FSWIeyY4Dy21VymnEjNFqTJ1lqYSS+dDo/9uTOTd+byX7kLimFs9+WiP/yex3w+POYFbFYiC4iY7yFf",
-	"8NT7KSwGXQrH/zL/9yb9/dizrb0aDL7E1NSTSh9wEeBmaSR3p7ZMuRV8I/d0adgIpsobPpqItY0mNxqJ",
-	"gqH771GZUD/lVk0ZAf3INNgISPoxx5jJY5LogmRHtsZCXfsx2g6zpeWx7I4UYgFzumKuRp/b3chXprcP",
-	"KLYMeg1gZu4pX5ax5CVGDX200ti1X2kkLyuNdb48fLCyz9EB7Oy0yOhrfzG31kPfokjfDJdHXz69zQoO",
-	"O2DrcFoZCVUOu+eXd41fCmd2dOlm7hrRURZhQ5ZCA49UTraZIOnRFXLOfrpawDbds7UodCLW1KltmvCU",
-	"ZGZUwPunvIP5d6huRyMbtF5X2eAAje2TPGuG/m5ME/sD8Kx7he/fnoGFzOAa1T/MWaqVNjy21X27XuFt",
-	"plOtSJ395qZK4uFq3Y+wNhzHngXLeaEfXYEq5mMfYnKrSIkw3PMeVGZB1Sowuj6dIAuOEUnlIefknKZj",
-	"xsvTYkmPIl5zxxWNtD59N8cIFFty4kpXBlUry+57ZR6TFnBKjeQMi5nZQ01cfWibaJBO4FuD6ra90IXt",
-	"wIa1zVytOMJTAxZs9kTk1iYsFnosFmOJmQoXJCvKBhjw5OQkUpc6BFBLo+lOrL2GoIXdhW64FV/bDuKt",
-	"oB0W1eP2P6N0GEdQe2KTXIe9HvS0l09aX/thfPLMfnNDl+5Wi0DuB6olS9QdydK4Al4Y8Kq1O9uDWnH9",
-	"RUaiV1qmc+/KvfaXcVdzl6ZVXqolMBgKCa8s961SVjfYx4/b1HSbtX0E79/+dIaT7XDtQEbZZncUfnqD",
-	"GUsg0XgAAlODQRTfZ/1n0wGQxULIFM9blRKXhrGOtWT5ZMp/YOZmVMg6w2QmV9ofLmwfkCaXLYHV3QLA",
-	"4n0DNNeJ9I2l/p00g3dnQVm+svrANegGMPRNLWaKJvD46cnJZPL05MlXJycjkETTmWvA9XAy+dL8zWYx",
-	"zwSf4SsqNgIliQZXV24UkudsmYk5yabc/Xg0gdftGgUwXtXWRoY/5UElG/uoGXCECiw5MxAu8vJsVrco",
-	"lREtchALGx5GP2rQLDm3Sd4CVkKPJao8TksCTmmKnXkuQyelRhKjk6tXR5qr3LAuEl3+D62I2GP01Ed6",
-	"UXG3+FIbSvOOos2cjsViAWvCC5IBjoZCWQe2Qf3p4LTgwMWmLkd8DagzqjXjS5srPYHXvsRVvXYx/Crm",
-	"tjgDx7IwtnKJkX18HEpjTDtwHeTK4sppWSB5RjS8OYMff3r7djLl3+NgH6ZUjUKD4sd3H0DSsa9G5B4W",
-	"bXtYgs1zk9W4yEfWKQFYIzo1XwSFTat6W1a/KLgGsZhyPEw5cymKwbULXTDp+nFYtnNJPlCWDilp5Ayv",
-	"8iaoEVfqEpc4wMAc+6bfuifnENIqSxRFcBRR1EbWVC3mDbpBEw9jRFfLk7+U2him9u5qjuGvU24bX19e",
-	"eZxyh7KXUB6nPNAeIaI8hsp4m9YYUTA7Fcdd4AxuKKX931J9rKeZ36AGaRTIr54+ieiPj8zfdtVDaGiH",
-	"U95TPYSmdjjlh6iHUNMOp7xUD23BicP1w54UUaqILRRx9VpiZKEbVhTbdnCvKwa6Yi+SjUkulRB+OYl1",
-	"lhC+K6nwVSMQUFN+SfeGEVBT/snuDQysZB8xjsRm3nqWY93P8f6OXyjQjMopz0hq1rcN4fMMAzQThnlU",
-	"/+3JM3db3lVuFcpcZCzZwoJl9OhS/RIthVfgHVxzLMS/n4wrL7xZn7KinKsTchN4a5FozbjNH5cUXr59",
-	"8cP716+wO92U/+3LETz66quTX2x941L0Vc3rHp6c/GJ+WGHTQVTdfsXopinH+AWPIECTlaC+i47tgGdF",
-	"1tFz+yRz5SJSUmwi5he1cNvxnrj2qE9PFLpQwlCBXnRRSr4GXVy9xAsWuGFJ11w5LuGG7l6P/i1l3UHk",
-	"2yrw/MBxLukFo5sO0UfSMQb9Bc1bxcJmolXLz8oOpGVbUIPuU/7oCaxEIRUMf3z3AQikcjuWBS/t56Nn",
-	"YDv/FhLSwneHrsqhlU6WcgFlBJsLkxSCU6V9y17XeHhmGw/j595z4dwrpcekoFUf4sxKPsJt0hykNNer",
-	"TxRcvuXtewfeayaa5nL9mvB+BhLr0ZOV79HaQEDLa+Po34r2F0QyMu9Kkn7HKVCu5RZD+/149/ivtDlA",
-	"6tJNbc6yDa7NsFekT5SG4Tlmq6oVyxWshaRV7YFSc0ApViU/T3mhqHoOBS9snK0TlEanylDhNDYeSVZu",
-	"ewmRkvmC+s3ZLXn42n5Ik5Kl1OqlirrfkThsUjdLlQEqWSxQqNo6KxWJWKwvJJ2t7bshrIm0ua1CLgln",
-	"/0R8GaucJmzBEqMpJnQlMiP2S3WVD6XaqkwsZ5KuhaYz23dpBFhfejvjOp/lQmQjsF09Z5p+1EeY9TDl",
-	"VcFmtRJFlgLJNmSrwGL8weK0Rq0/l2hxzXRaLtSpbCI+jBENSoQFJaSLrcbwvbtPumXmdhKc57zM4h5r",
-	"us4zI9GqM6LPsSQQg3weczuUzp8+gKSIb1YB+w59lh7j1ySHoesWbQCHCEMl2lFR0lFHE/C9QUryt18O",
-	"DS0GDwRGH/QswR7yCEnWq6b2PE9OTsz3viqZWCwohqNO+TndPq9OCPQfBcncvnb4BU6cSpEbhdbQg1NR",
-	"2Zp2Pgzalz9rvRG9AuuOceH+IR8rW2qsqVzWMM81SXPd/Qk/XDTWdNc6sV2P+urXeFehz81rsi2b2I2z",
-	"D8pu1PAW0702RFU+hz+2hntqybguu0oaDFhBIN0LhWHT7RFHP+GAa7xqXGBfPUkz6A6URzLQai2PVDhI",
-	"tcXLBh+POoofVQC/eto2c99qwSOzgb33fFs1jn62kaSoIMvSDWer698BvKvqFUXqHpkR+3Bvt+ARomxZ",
-	"VcA+ru9i5Sv8u7ma28ujf7KrudhtpTff+czgaFu8/VnVX6XnrTio/z7qZMF/hAoGfYj/bt2mLQza7x53",
-	"MiEq4nKl74hSbMm7S98hjMzoF3bw59sS0p/EHuQgeRMhdiz+ZgF4C5LBGzTSlqBrJlfjtvDhKKPGANmL",
-	"MFh/zqFDJ8oU/CCk+ckPv0ebAG0kXYsLmsKQ+YZ6rnZ2qDqbIf4KMZPx0pd4YawNe+Q2jv6zG3KNzNYt",
-	"0cVv3ZCq6kjZuy2leSa2LlVwNFA0KbDNzbO//RJC7duCZak/bzXNkHDBt2thK+fj9/LCI2KjZr9ISAYp",
-	"RdJz+WaFzAbPBiutc/Xs+DgzI7BG7FdPnjwe/P7L7/9fAAAA//8=",
+	"7P35khs31iCKv8oJzkSY/IlklRbrZ0uh+ELW0la3LOmrkt13btOXDWaCJFxJIBtAkmK3fWP+mgeYmCf8",
+	"nuQGDoDciEwmWavd9U+3XERiOTg7zvKvXiRWqeCUa9V79q+epCoVXFH8j+9IfEb/kVGlzX9FgmvK8Z8k",
+	"TRMWEc0EP/lFCW7+pqIlXRHzr/8u6bz3rPffToqpT+yv6uSNlEK+4WuaiJT2fvvtt2EvpiqSLDWT9Z71",
+	"fiIJi3HmIaRkwbj7t5DAYrpKhaY82gI18/R+G/beCjljcUz5zW3xFUkSKiEh0YUCvaQg6T8yJmkMKZUr",
+	"ppQZ9tuw9wPVSxF/EPplkogNjW9uh3+Vgi/g+8+fP8EKN2G280HotyLjN7iNM6pEJiMKXGiY49q/DXvn",
+	"VK5ZRH/kZE1YQmYJvbkdfUeiC8YXoOwecGMbvDrB8SrND1T2zJduUrPmy0izNdNb8+9UipRKzSyJLIXS",
+	"U4YwnQu5Irr3rJdlLO4NezxL3Om0zOiwp7cp7T3rKS0ZXxhAhD/bGSaiKJOSxlOiK+NjoulIsxUNfaTo",
+	"mkq3Y8qzVe/Z33qMz0Vv2EvEpjfsrWjMslVv2FuyxbI37EWSaRaRpPdzaDa8xvJcJKFSm4Ul4YpECN5h",
+	"j3FNk4QtKI/MrkgWMzNoJTjTAicLzp6tVkTiVnd+00xb/Kj98tuw56kOj2Yg53ZZOrz/vgrEYg9i9guN",
+	"tFnH3/AnsqCBW0YOM41EZjF0xThbGUCc5lOZoy8osiSm6Qo/y//RhrM5bv2Wz0WkJPjfnH7R0yiTSkgz",
+	"zR6MqsMEVx9WNx88e7xi/EwkVJ057r8LAWl+7nwmM9kbrmXgULVN2nmDu0IM29kIiS642CQ0XrRTxF7q",
+	"q0w02x5FwUgFU/vnAPLORBzG6khSog+k6JjGWTq9oOEZY6aM5LkkTIpZjgTIXWWHkiqRrC8JnXySI4Ej",
+	"s4Q64Fw3v2aJYcFH7zT/PuOaJcdDTGmiq2LDMDsUDSXq6xUL9goo90roGDykJgvLEeKYGflDkk8VTrH7",
+	"QZ3FNAmXYS9L4wMJNCSQCpKtsIqggLKg6iCozDzv2ZxG2yihJfW8quh8TC1IwPAgmAsJnz6ef4bEfwiU",
+	"x6lgXKsxOOADiSKaagWEg/CfIwI8B5Ik7mcgIClRguOkRmVCKQ8x1YQl496wLjhwMApN8uU95Qu97D17",
+	"9PXTwIVeCtl+a4KVCov0A4U0CqPrkdDBWzYwfbN2CnFdAto7/ldIpmkhHYvpIADN4EbhFQkpaYJaeBPT",
+	"snfeTIOVhYvDXS+jj4SMD/4otkCtIkQTA8kvXzr7pivE8/Ee6PsZaEksdGA4tTsb9nLNvHTZHXhMjn1X",
+	"QzwFMu+noDobI//IKNifn0NKlAKi4D/sH16AFjCnOloiIzIzQWo2PDxSVS7vJQwYvXwvFoyX+G4VMkKn",
+	"NV73dGjMhdJ/7VyyOdVGyDjEJEufPgyxTEUlJyt68Kc1AOTzlHazBwBNloIRE0pNtbigYSYl6VxStWwZ",
+	"YXazH6n08geab6N+oMou6mu6FZoO+MPbl2+4FEnSfMhUijVTTHDGF9NMsv30ufNFy+o/Ucnm2yvEsdpe",
+	"zASNy9NPuROrxR5kMeU66BFpkBVMTQkXfLsSWZm5zoRIKEF3mTEFO/I5HFqbM3Sgwh93EGffWdKdtTph",
+	"MwSbwUZXTmAea/00AKnKCTpAsETwdk9u6qZDfXJc4dWS8AVtRE2UK1xPKyytnYVxuuk+vHaUneVq0zWd",
+	"5syyg8Zj7GNRdSdGZXho0VdE04WQW+sU2VmvIvQakaOTxVFMFNyH4Jw6h9N3kpKLWGx44Bq9cbkjkDMu",
+	"KYmWRrTCA4gMlkeZsemmc8KSTFI1yU5PH0ePe8MCmRnXT5/0Qq6ymC4kia1rvLpQp2Xoi4cd13HHrK7R",
+	"Mm/H/XOjn01TKWahM3AB6BBJ2JpyqhRIsQH6hSmtuk0veMI4PRw4L067zF+XCnax0qWUvAwOhLUT70Ox",
+	"V0saXZxRlSUBIsMnnFwVrh5QR+nUaOsi00NzQpxR8Kmk80zReAgzwjmV0xVTK6KjJb4PmY9w0udg1D8Q",
+	"HFSGekAXX4VhHA6uLGF6OzUWebZLnr1PQunRcqs0lVQxBXYc9BVZUViTJKOojaZUMhGzCBIhUtiILIlh",
+	"I5mmA8NznT8kv0jDknn1vy64gXjI82Ghf6CJ46cOy14nsRDo01Xg1KcGnA6/9uNS+SQ7c5cP0Az3vbgl",
+	"+JwtmnnXVNEocHlmZTDblmuSoA+jzNIMuSqY0URs8BL10jB2kcTQf3o6Hn/z9Mnp6WAMr+mcZImGh49O",
+	"of9oZW50Rb7YJwEcMyyeCJ6etjG+zrus73HD9LKVMYZ3/Pj0FPpfH7VjseGdd2v3SLQhSzITa9oJmt+Y",
+	"zT0+PWZ3K2L+gxMe0ekiEbOQ7PrrknJA6gdEQEuZmkUXCmaZtn9U4Li2KrC8RCjldcLAoFIxpWlsWFQc",
+	"ggrjUJql4ZqeGlA8PV0NxvBBaNhSDSTTYoRvozR+DlqS6ILGuRcupXJk5q/MrRKGD2IHAtNKgqtHzRen",
+	"4dN+aw778CislETTacJWLOAD/YF8MdtwSiKcn39fEiUK4swwR5gnlGpQG0pTBf2H4/Gj09PKRh5VtvEw",
+	"tAsnqhoxYmTx7fOrTyMruMB9YZBB0Ujw2K79uLr0470rl5jXNCev3T28Km7DM3HD5uZC0uL6/ut//e8y",
+	"LzT7eVjdz8M9+wlqFAiVGscbVtl0ibvsklgVvE1HrqBCkB90EyjNtluUC5w2v0RARCG7R0xXx3xdt3ns",
+	"n0tz7jvYea7IVA+UEKWtJudUiRr5GG4iaWRoB0eNlCZSI+o6DQs99sh+5kwqjby0rHke9FhUvjL3TrS7",
+	"J2b0O5XTsTne1EJkHLjyEAe3B86f8jto4fYLRzZHfOmU0IO+xOegKUZXoGP9gI93HU/5ecM7Cp+wcQ/B",
+	"mwrioKToOSHJq0TwZqcBU1OHyyEeLi9AL5mCyMwBxEZcKaN+r8B9Bn3Bk63RvVkMGyPlVSRS+sKOGgTR",
+	"wPtKqss5iaRAC/jKWrI+hImsqFWtoI9bGXxllxIrpjUaSwf6bnGP5cdRu92efUUPv+uaT9xrQz3UyoWg",
+	"lY6P0wwPff2toY/d5Z7rxXCGxvslmV5OXRxa+bhq6d5GS+6bmdDL4NFrLpISrB+ePnoyDDocS1jVjAAH",
+	"3lrZVRUwzNja0ExTlEbpd3RSpUtJVNifd0nsOPjJ/6peEuy+HXgrfsYyGrTj03umdIsczsd1f4Iq5i5e",
+	"DPZ4fcvLtG+35S3kKjD/mGAh/004/mMfcR3rnGaqJLh3Ka4rRd46Lbj7mc6YLj8XlMWzGxGJ1co90jfO",
+	"Mmd8QWUq2Z5xjS/xhwejHPwc0I1qK1dYvu4gfWRKi9WZSOge8dDM2bvwY3vFKdGaSiMI/5+/kdE/fzb/",
+	"czr6dvrzvx4Onz7+7b+HQNT5cWjF+Dv748O9L0U1H/z+F6MCTM1s5KjnAbyfWcYSPWU8THBX9Ty2c+jy",
+	"yvtB8JqpSKypbHTpxVTTSE8Fn6KZYRR+TSLd6uHBcKcTkrKT9cMT547KtBhR/o+MZlQBQW/FOPaLwy9i",
+	"lntTON3gz4WNrDPJGV/Ao9OHY8B15iRRdJgPRUfwFoi2/zUWaurnRtqFDz++f1+ymIxoirOESkiZSyRY",
+	"QZaix4yDOT7RQkKU4K9ndCQzDvlugzqt98o0+yHwTBGJMd7rv/7n/3FQ+EoVM8OMRmJFFcQZBcExSH7T",
+	"H8Co6Vz0S0RprKyWviJ86z0aY3RjjcdPT598c3pauHvQswP9R0+WFeeCHVZyMJivr8DXVwV2zeeXowMX",
+	"BgEUEB7jF+awIytGYWH+Z0aXZE0x/ITNoQElgSmLF8H72ees2kVI5TeIuSWlY5gToIfm64on7dHXY/hO",
+	"ZByvI+MxNRQ8WlKJCQ7EObv00mAp08ri5M6NKrbKEk04FZlKtuU7+vr0MA9QBSNrLpomqu7svKnxjct6",
+	"bups6AC3zc6nR/ls8lnON5SmLUEEDiVCbr6MaxDzICalhWd6a4kVnZ5j+L+pFAZxibOglaYk3uK7FoU+",
+	"xRmQcZBE4i8FtuC7m0Uqukr1Fgm6JTmiBpf8JCFwvImWolFpWFGlXGjajil4iLni52neQLNuHzM9pWvK",
+	"myLejwmppNFS0A6v/W7czpzBc1gof6ZK/1nM2shk7/Z+EbNuh61t133XbbuVJK7ws3Fo8/FNx7Hmpow3",
+	"S6KEUes5s1lkw14qEhYZDkq/GP20IVx/ma0In5ZQOvB8q+W26fl2h9nERvx4Lb34tL7QLvDrSIagDt7R",
+	"miQZ0RTjohuJVEVCehL1DwinBzEIO0NwB18immvENQz5kjJJ1aVyPVoSWcJjw/7E74XS5pchpCLNEmPG",
+	"GUGcMHStu1Rb6CPvxHgFxhcJHUmxKYXqSwygUIPe8UkzRRR+4Ce8vYPjCfxXHV0Mkq4Z3Uy50E0Ybn6/",
+	"dIaOm+Q6MnTyV5QieMPBwJjJaSrF2iWwGBx1/1yLC/yXxclQIkvImvLYV+wov8J8I7U7qF1kK8m8ZyFq",
+	"pf7n7m61ggj3GYmlyVu31shLqkTdkOyCg7bucWpFCVdgPRTO7iru41j8aiajRtSph8bUb3QPPAxG74LD",
+	"01EDIBwhSMBxnZJl3hot7pVYpQkzive50f4Cj4Yq/3ttaU6Bci23aKjU5gHGISFxTCUIGVP5HP5JpRjh",
+	"e5LVMxUwHiWZjTrLcS+Qa52/gzW8mVXkcRG9xvH5ym4KX7yI1Ax/WQmlk23lx/K/m+Ow6qLKJXCVdhm6",
+	"2VYqccD9ef/1fJbUZvLXPCVku/duYrK1IRqKk1QthVZDEElMlbavuM0XQNaLKUrkaRqV74Bnq5m9gvxV",
+	"30bQBK8pdrdUIcGQyJgTlph/BmdpXKAGUjd5dev+82KNna0ffHcI+sabM4rAWxc9twNXt4kpsoZDXom7",
+	"aym1zRYCJrB24yHeuzjWADuqxcF22HslIrHDeE+IXUcfNn9L/GI4LrNDJCzC7AwDKGzYvLpsJhXO+LlU",
+	"cmGvb7Yxw9BuLkvoXqysst0uN3u4KAys1bjp84jw/zQG7e6WC79Ip21y7tjLoejh1inmaNmsCME2Jcqo",
+	"+tO5LLI5a95aOwIMjBScQN99Ag/AAWsAJJJCKUzOtb5ZOB2PH44r6o3ILN7usGotNEmm1BpyXutrcSdZ",
+	"DmGdQlJsFGyWVGJqHqZguChopmySnpC4zfERceg7sAnttRHgn0X61sLney8hLk1xZeZ9SYortmdo72q2",
+	"V6biy26vxFt2XSzIxKYXjFdes633VlHK85ghOzIuZbrnf/r5ksb2tSYPdyzQ0ME2NEjs+JqBwgVLU2sH",
+	"1lwqh1qBufFXvoz9Gb1/kiJLQ06zJJR1+5oqtuAjTGcCHAMXdAt9Ol6MgfG5GPSuKE6h423WUU4xWytB",
+	"TSOXWBXEq9I7QvgBFHNHpnOyYsk2oDafg/0JCMfHQ1gYMAJ+RRUI7j03cyFhRXhGEjsk7KtZUcN71ZKl",
+	"5bPY7+xLuwgeozkuIpuF02feSkpHBqqgstkoSgxHnTMqob8iW5jRwll/TZUvXPCAw06/z6FDuAooqtdU",
+	"QaPKbhrR2oYXtCD31aFTG7bkEXgGGRBbikM+h1WGj8lQx5ebxpP2u6teW2kfjcBvD9WyxNBZmuGMf2V6",
+	"eSaSJEtD1QJKtcL2znTuxu5Y2e7vQ7+/xtP9UGBmczY27+CTb3Dz2EUQzAeVlgtK0Obrb0hk+x7TRfLa",
+	"bDZhpW+D9ocQiw0fgjN3hjAejwcHmJX5hvLl95y/Eb6XtnEbF3ZYFnRzRLmnxfs6as/1lBjR6Ad5VVxF",
+	"hHMae9J3nkiMyeWCU/97s6+xZJ908qU4i/gA/0hO14eRpcPSAEkWSap7FHvvcykSTa0hXTtoscHGmzsv",
+	"uMDhV4eKLnqHSxdYvSm9xCKRB1xWwekarmIaVkbKWVe5+KkWsCp7OJlu+injuIXK23HTRbjN+vnqS4d2",
+	"XF6g8Vp+TOMDJfEViazGHZWEicGOJPk47z37Wwd07/02DJRAdPPs/drLr91ih+bPu7v9+bdh73tKEr1s",
+	"CQKcTV3WS+WOS9rsrhWyxDm35ZzukOKwplKFYwsD/mm0PiqbKSYI3YORMoXf2hdCCCBJ6Zcqwf6FckUg",
+	"IpokYgF+3HPIuEfaf/rEB72k+cBSfd4soeM9HuYu2TzWMdFxNPosjnEu5YAoViz7qe28+yH9VpIV3Qh5",
+	"0ejZC+iwYqNgRYytClrYIKG5n8fldVb9Pd7Js3v+/Lsmi7oEzsvuwkw1bvZF5s7L6jof0BfW6N9q2sG4",
+	"W+2GykNJdWF38pNic0AUEEipjCjXZGF2kPHYrm70hphGbEWS53Bq8bz0JVNwOoZPYkOlyjOBE8qNMiIk",
+	"9YWNf2J0MyIKoiVLVeUI80SgrVXzENawsnKdFbiG0bQ4/gGo2lJwKF+/u97SRA8hHWZNJUmSo2dsAhYK",
+	"Vzf3fji8p20ll6rKwREQyHlvqJRdlhw971mW0KCtFhGOUZ30i+4y43lE+Cs3vLuptwvCRruvvJ9hyQys",
+	"6D4WEt0uq1EPzYPUOjCK6xRCHZgQypND+Y/9CFlPt9cG7wG9ZtkZ5EQ156uf/jAehUh+gNLyqou64qzr",
+	"cThYlGspkimLgy8z+COwWOU5C3n8TyGqnjt/U8YTqhT8R/7DC3N3C7amuHb3ipe1TJSaYYU54IoaoyGi",
+	"Rq6W1bHSWL+tfSobeCAaigXBk+0Q8NUVlBaSxhAtaXQBItNppoNAxBR3HHVNTwFVCJzbbfkBO+c0HAh8",
+	"iVL0CAR33eSwqWk9DsBmq1bKM2XjtPGtcIi62RAc+g9ty4xBcMG8EHIYh/Hn5zAnSaJgRqILwxYchI7Q",
+	"uxtfgX0t5GoyUUkfLtVNLh5CSnSye+H7Cfvc5VSEzNbckXDDoUXu7afmMmhI5ykXfJknZJG3snAHM9ps",
+	"e7rQivEsGNT1ypVOMSqlcoFc9ptcEmRcUWrDtkLl0b7oKYpdEtS/vcfFJ9zAkmAmTnnrsKX66IC9PGFm",
+	"SrkZGMiZ+Ozp0iZpgBuIoAyCrZgzJZkKTikzWiZ6n7QTM5W6tyPvY8LcidGGxRT6MVN2aSHBpr2U7zZU",
+	"xmBHwamfNrDb4S5eB1AhgIEdSOnOq0N3TwvZD9WrCPUjebBf11i/q4nSK13PHuU0HJ/SPcCvHNx3mNvk",
+	"uKg+vKNjE5sbSlYY/pCQ7bSpDsNuthBfMym4T0EvVwQOzY8O3GOT4stPTIfmaKdTEsfSRQ7Wdrmv3oaQ",
+	"upJC8vTrrx9/vbcgl+sNkSP3PtDUFd22chj7n53cy1fp3E0o9BpTj9pysgpefYw9nNvCrlZCh4/LFTKS",
+	"UsRnN++5mSGPE/3t52GjzOcC8rqotjyaEf6o3cuMA1kQxpUutNrxDpKGIF8Tb+70TdB/S1hC48ubdiU1",
+	"v9WkM3ppWwT7nbT5fp821B0zacJGTLvtUkWY/Tjc1r7rYPdeiTQCOGEDMhvfEfLA0Zfv3/twVetU94jr",
+	"7FSh9ChH0NGcJZrKIaSSjjBLfHBM/Gh1b/sceu9ZJw02f6NufzsJPE68MF9gWQE/R47b0I+IoiPGFcUS",
+	"a2s66Pi4cK9Qt7j1du6q7e7faboKxBHIaMk0jbSLjN+rHVlKTSUTnqt1Lpo5bBDyh8jboMhvEb51gzv4",
+	"ANZ3vjYbBjEICOA7UZyqrjXv05KvTy0+um5WRT8OOzFLXpTjXCF3W5WrFv1YVZP5S86Xeq2S4+EhVCmU",
+	"s8voUpTE3uFpQrTZ1tT2DpkzKrt956ydDhbNfhPm+suGhW0dd4wq4bXx4Ga9JY9i66y35Dx9n2XfnOZX",
+	"wftQMZmdwtbhK0O6rXY52E+l9Zq8RxK7mSYvvG8htz+IzTKaUgbHpfZQRJbuus+79ZqoB6C1dEQwq3S/",
+	"mZ3hriBu43jJ1iyhC3rIGsFv9izU0IDicu0ilFoesO/66NYdh9Mm9/ZxMBTWJba60WlvUA5eALq0Xd3+",
+	"57bwFrzAehkrut9d7mdv3GGOwN8zpZu791jdD8miM6O1bKFU8mUvOR3ISOZov00TsrWiJ09MctqzWvZK",
+	"OGpgcKU1UVhXm+DGuYS4aIFfpU44XTORqSvf1n4lIOccXfcaat+yn90bSu+2Qnt2Wgn/A/fZmbraCp7p",
+	"g8OeGog3oCddQRK932DTWVuqiNUMzSqbw4S7L988nT59MgRixiIVXbM1em/SXbtJd6vGTi3ZkyktBbx7",
+	"DXMpVnBCdXQi1EjShBJFXdKnXNJkCNks4zobghTRxXYIEeVaqCGQZEUSxrMvQ4jpjBE+BJFSrjJFRwkl",
+	"6RBUQtXgOdj4d59U2TeTwq/uG/gVzAfwK5AkZRz/IaMl/AoLs4yAX0HoJZUD+Pjh/f+wdue717AxhuYq",
+	"1b7oTyrpKK+jOIbzlEauWQAGS4yKmojrh+PH41N4+Wr06NG4IwyvwAQMELgf+Ywm33bZyL+fkViODN19",
+	"Zs2kre7nys4GisGSJBlFiYguwA/2wVMJ0VRpmwhENY3RYdGfM87U0hZDHQG2PcH/GFTShMreMew/x1ZU",
+	"abJKFZCZolyPO6UO1d071b2Xt9K0Z/skkvHG3Y2PDqCxBQzLiF9vhmd+B/d7G1QrDzk7uwtE7hAe7HTB",
+	"4iuCw1HtMCqXVexyB1CNmIy86B2fi1AGscoSvGUCOQ8z5xmD73vj/bZTy9OmjM8FaLP9CY9Ekq34aC7k",
+	"yP6zjf2NJ3ynVT9JUyJXohIrtV/3PNxVLpIEE4cOYjoxUxfTuaR0uph1U2/xC/sYdNAnmaJx5y/mTNIN",
+	"SZKponLNQnF6fkQMv0I238CvwOd4Ywp+BZbm/0Tq6EKSxZK5f2D/N/+Iu0mtY5OO9058QSWnyfTQ8U4N",
+	"OeSTQ4T0iq6mZE0YjpquOl66+coiVtcvLqF/BVWv8Xgc1qdOrDZ1YnSpE6tJnRgKPbFa1InTobBf0o4O",
+	"deX6Eou7OtdZPE3YBe06vDMaCTVNJdV6e9Anh6BQMXw6z2wK0bU9DyiKenZja9o3fC5kxPgCfgXfxn1t",
+	"VOnXPrTU8Rlgc+BCG3VZ2ZLF+9fekPQgrG+0lisCoElQ2lziOxtbtydq7VL25x8+XG7nwt9xTZOELSiP",
+	"aFMTkAObW1Qjr0m8Nra2AoxIZ6XljF492wKZazPMN4yeZwmcZfwV1l/uPz5tbNH6cNnatPTx9Xew8Nvc",
+	"07j2gEapxYzVnhOMK21b1rouqaXWvacHdUw9oEtEx14Quxh02XYQAZw8oCNE6OujmkKUJ3qzdszo4Lr9",
+	"R1a4ty06DtTUbUsEX4+/FhiWCEVj0OSL4GK1fQboALEKxzgl0QVZ0LHzSfTucKW4cviifxYwtlhv2Esw",
+	"22ZFY5ZhhzK2WJbfBw4t/VaCZiV0sLzt6kV1wiL1yb07Xab64C5uBkQDctwok0p00XE6lyssr32um8qO",
+	"HGFoHoJiPqliH2E1VWeza5WlEb6ZjP282KJplfe8xeMIOT73y+5r4FCgkSo+2at+vWcR5cpCtYWLYuMy",
+	"Khs7mVxBF4Y5Jdq/VHf3aTI+XUgS0WlKJROdi6W4XnZGeSP4Zudr9g97XEwTCxTMlcI2OcEXRs2qr61z",
+	"SbGyXEr5BqvHpQkmLVIj8VLJFA1Ok2EB1FTSda2VaNOLHK5bSorMAddyvz9RyebbRg3bHXj6y0bvd/SW",
+	"B3dYsvGh78ZwpmGaAofU1N5yEHl0V4NtjQee2g4ewY1sCPaVu9R260zT772+fuhmPghjf0aoPbxaEs5p",
+	"QBd9CTFNGLoBIjtmDJ+XFDSRC6rhx7P38ABsuVAiKSgaSaox5tn854c3P705cy30aPzcfTVdMlu9BPvt",
+	"CT5yX5nJfJDgTuPXg98qSq7MQAJsNy7f+BaoyWJqY9abBcC/9rx+9rCFDhgLzPW5tgD2VUa92/wF2EZc",
+	"xAzvhdLYCqgGUm134ete9pZCXKixSkh0MY7EKlgT1Aed5PUyzejesLehM/N5mIVdSR1RVzbUPR8VWa3l",
+	"w1bu4bD6oQHkb6omWglFcp2fmlziR6bJHYlOu5hgCLGlOciMEkmlo9e5kODuEUiml2NwCTiUR3KbakOw",
+	"9g3FE/D4ylBEBljN54Kl9Jdap2oIaTZLWIRIOzhqe3VhWUEqs4uOuBHum+MItrvaHGK5e7tR+0U6brUo",
+	"xVcFr/27wnb2Jw6nTwrEG8N5lqbJlvEFZDIBSdOERNQ13bcMxOXJ9y3+CIdVg+e2E77/MqHYLbP0XcZd",
+	"DfBdzt7Kpe8KNTXhb6eSum2xhh9VRJLXIsq8r7G7KfGSw8fzVy/fw8Px6fgpvFSKKrVCJ45tGgaxmxf6",
+	"fz7/+GEwBIIx+nEW2UaQWFzvKwX0SyokYsDHlPwjo6AFfEwp/6sRQ2iHpESh7b6UIlssYU3ljGi2GoeE",
+	"0ae85W9TzGQpu3JXQBo0kSJTYYQ4sh2y11EXRHfpsGhd1UXaXrUoSbHFn1uPr87ogindFt12RF0vX8mr",
+	"MaatqbNz26T1OwtVCROHpBGeiYQ2TBUueWgLcJX37pcMAlkkLGJUndFEkLgZviLT2ND4MmygXs7ZT9m4",
+	"r+1rGjGFDbyau3of5ZPb3yzS7S5cdNGGKTT2mt+N9+jeBC0MpF510Z0lWvugnVH/oLHjwtUHM8vPmDDN",
+	"Y2r0B8MNIRXK2Io5kxzDW9t+m35x4e/gEvKeTXi1rvAQil41Q/A9SzDXdAjlpkpqOOF5RiJTKjMDtEin",
+	"lUE2HmPn/MeYPDHRZErUVMy7f+NHhUIpKaeyFNx5VT0cchCHcxYikdJpQmY0CdOnT+/uYkS4HGzfjaA0",
+	"dQVatbPmUBnm6Fa5kGZ8bc9pkjjmADZqaWAfD/XTBreVc+J9D6ldhWm5w39QSDdJoD3eu9D9VSVvVTyU",
+	"9xE8eZbQsNp+WEq8nyecWlZKba7lqWCdRNvDidm024TNJCk38G9MpsENtlWuqWwqWAqIGwxOsOCgraKM",
+	"xeJ8Er7bCsyk2CgqAx6XVi1tD+YUFWMlnbdK3yPrD1Zq0sJokp2ePqYQlcpk9BVZUVBLklKj97rSEfVu",
+	"ugVAG5Bd0hWNGfEn3YcnZ6XhraUu8oIAv8KSLZbwK9hnI/gVknLNtopRcyDEmhjlsKeLXk9B1HXVLr5S",
+	"QIxJCCnRS9smPiKpzqQxaIBosWIRlOaCvvly0rO/THqg2MLYh71uaSXhGoDlmhmFSo7Q2EG0+smq99dE",
+	"R2fVO97tlDFiPKapUR+4htKMXkOw4Vvm7BeW0iiJYSVimkB/TiKtMOjqOUimLiCha4r1Uw0ZEC0kWK1o",
+	"CGLDrWGWG1+DXbrMQ9YaMuMwsss1LVph0+k+F3xkW8gMKrunX1hTyMCKGoOdqVUg0ihmSjMeVSFRfOD7",
+	"YbBVmlCjWdm2bc7naD0IU0X1EFzcpI85HRxUmkbSmRB6OqNLsmahTlb+Kswwh4jPYGIOqUcpkWQ16UFf",
+	"abIwMDdjrItiCOaisWgJfjoAIWHS44JT8wEX2lCBizsGh8Nq5NYhXG2oHIS7YGMwufLhogHI+l9cfZ8C",
+	"uhLtHGyt56c5AFg1WiswqHLPoR3ugjlEQxiiv6TRxZs1wwicsECKxGpFePyVAkmtG4IZNkLdR9D3r532",
+	"5iozhggh0hlJGvr+40oNb5OsiFAIVFf5ktbbLJRDRvVSNLUIj6mUTT+JTDfwYVsZOO7wzucWL5+g8TIa",
+	"4qjyCqTTFQs1fTyjI5STPijHXAnWhBzkekM+hWsZZAvNf3tqX3xmYk0HY3iVkFVKYzOPgL99PYRH33xz",
+	"+nOvtdPNUTvCmCevXeUitbyzzNh88OgU0LjbFoPmDKn8sN02JiX/QJSmEtSG6WiZA4vEJLWWpA+kGgPG",
+	"dtl0ZdTDqhFdu2VCx/CRj2Jq8BmVGIXvahkn87lvwRFqbndAkFl7jFmgcGm/VLkU07AH4U3USuAej3T1",
+	"mSo3/P8/BS3gm28Pu8lK5d7jd1aZprKtR7itJwduyxUQPn5DboLKVr7GrTw9cCv7ogYt7eXoEWPE4NNT",
+	"VUIlg0X1NR8O4eFpw5IuU/q40+NTUNHwMPZ9cTsfuaFEQG1bdZYVRKXaRTbRwrC384djAiALln/ZwMeS",
+	"8Dgg4LH81VGBjmaC17lLtO4yUX4Pnax1M5dV6jHuoaE3RZdZ2npJWG2p9UBh10MtJG638bMxVv/DDnhh",
+	"yHZOjURBXkO/aEjJgj53OYZW16dfliRTVhJ0jGA0YuQggJZKibaqlnbmJoiYa2lXEZ3ROc+SBGLJkmQU",
+	"iw2HlGyN/otPUSis3Duw1xwzvpG2Y0+aZApWVJOYaBJwahid8rCjVxXboF/CI271POisHxlTEK3lNZUx",
+	"i/AJ1TUhCZf5CHTrsIkapcSdouF2Xv/uJjwwO5d6fNPkC5ZOGx8TmrsgYH/xX9HHDr/69gbwaxMYGktz",
+	"5sFyJeeCu8ehR5IdGLah9Vke5dWI1LFzm3hEwF6xqNKN4YMAhpVFdtpadC1MW2+RBv1qfdNJr9KDZNIb",
+	"dCjOUF1CcDqye9xt6wFiDpsl0UVXCgvFWn1c92UWjvC+fa9hyDG4JGpKG7mWLtX7Z8oefUlUqEuJuQZk",
+	"aqiKhDM1jiqb2+5LhF9h0pv0ipYNQd5zQxTZWJwXuaUFH44oXGoe2/rBgr2DSxbkDTCCHZ9iBQOauQD/",
+	"z4xmNFCu/x/498OSDJpS4PEHmXE1ZjG8eAE4N/wiZmD/u+T/VOMiRX1/OPtOTLTd9f6khWKRHJjFgZug",
+	"5TuvfJJ0zehmF2azLLqgOoBwj56AK7kzxPZUxupYikxahOFi8xzizBC1K0NszZTNUiirQU29eRJjLr8r",
+	"A824MtasNizMzNbSHCGjbWW8zcdTMZ8bMgv4kjOp8o1C/xReeKeKsavNt4Neh2zKYolhaT/7GxzY0Vxs",
+	"wm7uNjAZnkYSo81sfTRQ39t+SJOJWAyOaARzLgSnSgfXdI5k674uGt3gjVab9la6xijr2D667oXD3l/E",
+	"TLXQn13J5c0lW3DkEm5EyTnji0NndJ/tRwh/qdWt19Yd5iTVSJNF/eFdJaayS1TEre7yVaFuowvQRX5Y",
+	"+lO7Gkyppsnxcf6H5Ol0iGo5gj/jA+00V9jDzUcVxnm0/W4oqe33Uo3tUA+VXEZ0Ye9SXxLqTSqABR/8",
+	"6hEWfi3VZbGqQVjf05ItFlROlchkSLcSfOocn7/mBL6/NFshj0opUF4y1ZYs330oOqm4pMqN1q+nig9N",
+	"9PUTkcwA+OOaSsliGhAuovzTkUkFfhmM88Umjm5SWJMko2P49OPnanAvmtsrku7NKSu2t++MLf0I1n5I",
+	"qHeATDM1yox0yYeBEgZ1YbYFX0oqLJmtR1xN8+iOhsYEEa7iIjMknVNJORZOMLDwy4YfK9CblUk6XYUc",
+	"GHJBOPsnvtiNVEojNmcRIJyXIompBOcEw4Xy11+1FFkSA0k2ZGv2g/rQMBj76nIPwi+dGAszYjxfhXGg",
+	"CBJsTSAyDYTnyHBQsov7KKYNAT9OxVbhDmtlEKOCz2I1dLd60JMv4m+g8gUekq0dgkM/R3jrLKF6CNS/",
+	"tzjg7DcbHK55oPvVK8AY1nCuBIkashzcfKqgktCnPyoq93Sgoisne1pi5x8Pw625N0LGez79Zk9xuIMi",
+	"9mtnz+cZulOUdtUEjRbP9zGpY6uq4D444tHW8nab7lBRe1fBEEEmdiYSCu9eKyBKsQX3PcopGJiN4ZNI",
+	"s4Q4bmnDvJQGyuNUMK6h/6c3n+HEDFWD57amIvj6sQpWZIt5HMD0YV2CbqCQ4A5KNOKBSOhLhE0jZRjQ",
+	"Or3pEKz0nzWtrNpDPxHqnT3PFZTexyvs1KF9/WRVmeZdGaER5/Wrq7j27vzj6Junpw9RssRFicNwx+JV",
+	"8KHw5WxmJBqi5IJhwT77tLUbaxyoivcnAVqIJFoSxvM6gwatZ4wTucXqVSj2UMIFI4+NaAyIjNWMxnEe",
+	"GUn5gnEKK4EmpF+ob8/N+FwEnaV5Znco385nzyi6WlMJ/SSeJ2ShRoz/gs/2+wVQMb0/BgIph/WwfHm7",
+	"l/8bZsOHag2eY5fvU9iQ5ILxxUhd0IRqjGaTcxJR98wiKc05h7KeEfqFyohZSTrhc5Hx2MXBaRJdQL9U",
+	"jWQILKarVGjKo+0QSBYz7foQA+VrmoiUDlzku/UIloDWd1sc2DRma7j1TscPx6cjkqRLMn7oL4CkrPes",
+	"93h8On6MYkIvEa9PSMpO1g9PMLHfOU0XIZfMGaYOWj0YW92iYQBn37185XpS0Rgy7lzckkaUa8DCHGo8",
+	"4a9IklD5FVbL8ZHJ2DAdlQ9m7h/nU9bJzGaZps9hidqD9dpMuAvehqXYwIrwrXUDWM+nm93sBlSWppKi",
+	"50VZnv/juwm3Ya0Y5DLpfYA1UxhUdQI/uGUmPVfajaRs5MFhAW9VUCb4u9gQG9UvPbTw/ZqsqEae9bd/",
+	"9Zgz9NBpavl2L7ehLNOq1FPwmcqFN9J1mvXVLozuZHCiUjY86GxsWLzUDnpn+ePLsYQXKxmS+Vp764U3",
+	"7JvxGsy65UeHZ8u4ZsmVzeaepcvTdfzSBywUH+bGytenB1WH+rmoaI+E/Oj0tJ70k6aJS3g9+cU9VxTr",
+	"tglVj95Y/wYZZE1Yud/xkd0wmCd28dCc+SZPviOxVzXwk8dXtt83hlu+ccwyuGEu+HYlMuVYBcqQvI1Y",
+	"70duA2Hyc80pjaH/44d3Hz+gIWgrCih4UHk2gAdQplR4YLk3PICCUge4VM5l4xXjJy7J8pktPIG6hms7",
+	"WmU0n4TSL80XlcogPSv9qNLfiXh7ZTAMFjz5rSprXReqa8O7cAWUwH3iCLeGS1aAvitLh1WmtymNwfVw",
+	"GdRu+7XcjmTGAet/EE2BwJ//+hncreQ+AKzklmBXRqYDt5i61MpnNua4wzVWkzF71wjIhrTPACQ/UTky",
+	"0HKR05Bnbd40iVoNwXURtQ5GD9nq9dkzgbPq7EiYs4Sq0lOodynEEDOJBaEM3XwZeVweFXpI71lvd7n8",
+	"qpHu9ypFjj24+Fr3X1i1GHXEjWRaU+5szQl3xWNx3EiKTFNpFCPFlEZGQlaUxzYhff3QKHODMbxCmTPh",
+	"KVkw7sqzcyhVOIPXb85fjVEFema38ExSElulZsJRq8GNNek09qjdNBrtG4rvKDS+QBSJLrjYJDRe2Bb7",
+	"LDFHc1gvkjX+M2bK3ELD6+n16xg3qRvdKzS3qNAgbjeqM5Zefy/KTIVTFoReMq1qHPM9UzrnL7FnT33H",
+	"SWg8BGvAGX41CLC/k3+x+LdOhiGOx4fPPuNRkmF6kDb74iTBaDyqkCN6HgAnE54zAVsXS7MkAcQy3E8T",
+	"R4NuDO277bvXDTzN2MAFIrO4V1d1DuEw1469jYh7J/HPbOnJDer3iHdcaEBfSw3/zxlfJB45Z1tgcROS",
+	"PytJrbJCV13Nyrg8LK4s6arYauQ+3UXXHWRFDdH89rK0/E0h7dWbEniU92xOo22U0JIt8dttEImt5uTY",
+	"3l0gFsSKO0UtZv1vb279d7Y4qLWl8eUeY3x9aW2rXFZJuEQYmLNrKdBdaQMtO7nSTMcv+RZjpgoBZBt7",
+	"e8LO/35Jqn7tNnJP0fcUfU/R3gtjiQKpGXff93piowr6zGmN+yTzr2WJ/Ku3PHOy9rrnJan6zG3mnqrv",
+	"qfqeqnPnHBJFTtWNpOyo8iBSzinYk/QYinqtIt6O0SkCLqKMqgl3+Sb5F0ATkiqqngPeKV/AihKugPGY",
+	"zhlHDvCJKA0404RLZ9s+OT3txC0ChmjOL87die/5xbXxi9+d3+aexRzOYhwdFYqDpXpSxN1AX8gSSSfb",
+	"mkaRxUyf2NCEkldr139kxtlGIN284vn7/cFe1Fp3miNmIJH2ne+P+PreN32LvukCzZoc1Obv2PIUn5cd",
+	"5h7D8XbdwuUpoW9hPSp5hjndUKVhzqTSdTLSy5NELGxxw5anz0wv3+Owa5JKfv5berQurd/8zIoDbOM0",
+	"GmN/B3FBjeKhVEYd231482w3khSbK5IEn81/ePsScsAhstAos6m0f/u5EjDhokxPfOQuICLg23le7Rw+",
+	"f/z8KYgyrsrTXpwx43Zu7kkgUI+i9ARJ1+KC7j4Ym7/mgWJG61O0eCepbM6GdzZLBL38gfauGZl+oG2Y",
+	"9A4vTG9vHGc+CBsx4YFnEMZ2SdiBt1GaK/Bm+aZ3AX5Sq4LaDvxP1cLX13sPlRLlrTEUbhiGkdfAUWRd",
+	"lGMf8zJh+yE0J88ol8K2TW2nmR/evnxjh143bPxCrXCRYo31vc0Bfzx7l7efKOp+ZXppzh1hgg9J0zrs",
+	"cI0KoDKFXRaRuRiGFQZYp9Aqe45rjaqqrHGQgAqwOcOe8WDsFkSGWdyA3HX2shUW04Rsd/gtVjiSKywR",
+	"jvdHY5QsrsXFbGsPgf0zCOTlpCEoLbyAeWZTQ/bf6Cf3wSs7/vqutbrQZe/Wzwa+sWOh3t0Qe6cbyKW5",
+	"pDb43lyWDY66cXx75UzAfE8bKVzwfwnVEPY7/OErlX8WwKiCCz+TrvHEPrkT6FVxreF7La0xAqDKt1QF",
+	"ztssSWxEvD8m9IsmEsOyOBoWSZGYTxXQ9CWdS6qW+wnwzA28PspzK9xlfd9Qk+39kxImb0vNd4ByO3Gc",
+	"ewiuZ+PQ8nBMIu5HREUkpk6FBpf+TeNBqx1wJvDB1FbhLa31HFaMayDGfASCYbkP/AADkEb0GkVCXLAW",
+	"t/AZJbGNNfpe6/QjT7bw96JzpJvl72CnGYIUNuYIM/94TKVt21TZ7BA3q9xunXY7xCIN51SPXuFUCmZC",
+	"2/Jyds44n8SuZeu6gv1TaUtuvr+P4UdVpBu6avLw8tM7iBJmGB2xu0RPWEqkLWQ2enL60KhNcotN6EAJ",
+	"ZHDKWloEEqNX+o1sGI/FBmLBv9KwMKJWZPjypQVYSx0Edy3yGPcpLug3E5ludF4XFGdBcbv2j78OdwvP",
+	"c8051y5vjcwcIrinhWEbwY3hO4NOBvXdZ7ZcbZQYiyoeH0p1JRwsUZ631Poe3eaJ2FR5e9Gw5YR+iSge",
+	"qTne+W1CqYZ8IJo7w9zgT7aQZ4LNtr74Xt+JARoPJ5ykqRRrAwqvYgy91Z6DaTCGDyWv0xAiW7KQ6An/",
+	"uniIyXdRDwosjjQqjtQQI/gqH/umOH3nEGhbEGsncjg/cG/Y8wdGovnFFyL2joqif273OOIWr+ajUCf9",
+	"a3Ve5lB7z1TwlaYAa9WXeLuvL1XcaY6cfVvUby6wqoT/WBSlSk+FR61NqXxVGnaN11MsU8m5DoEnH1mU",
+	"KbLOjNu8pwKaeFEhB3bZhdnPty54sh20ZHzsTDxs0Wrrl3X1Wm2xQrVYRSfV9uE1bKMjqriSETdurP5k",
+	"U7ds+rRzSGDLKttxrHjQRJHrR5yffw8XdHvjj5w/ZIlmaULB5v1AXuK5ZswiMIGUULobBuMrchMXyoP3",
+	"Y5pQ2+20iuGv8e/Fpd5exHzALWI3F0OfqamNCHmBLQEGN/5SXsL6xjhzMdcjC+YjbtHdD3aT2yc0/ghZ",
+	"DQczG8/c7+LVv8Xi4+VLL9X7O0QOtRDxsygRvMU0fiVS5rsJ2+IMld3kzaC9I3ZFNJXmUL5Lra38b00H",
+	"KTbWxtRFC3vksCe2NSCLawZtllwAW6VCarQyjM1JtCYWKkuhKC9tBzRdpQkaMQKoGcTpJtm6CVxLgjwT",
+	"V9JRKsUqxb7J/umgdogm67UkWRF6v9/oq9pJ7raKYHZ4a9rBu70awTrXH3yS+I0zlfM6iRZbxBY8roSs",
+	"KmTKzUdnMTV1usoLLN8diSRhMfXeJ9cYDR/UK5pNXbFBbCgzxzKnwVuCvpvhv/7X/7YX5poW5X8YHKsL",
+	"xYwsuFCaReoZjZai3YP9uhj9xgwO84slJTGVBcd4V5TwGf2FblvZR6Xg29d7C741rPh/jV4VMWOjd+0x",
+	"Y9fEkQyAbskJb5duZkDm9yLc5ujo0K/3f/IDdhv7IPTLJBGbWyDSGu55jz6SaMzmWFJSY3x0/XHdwMg6",
+	"EfHI4PplP8/LV6lybSpf3qSZuDi6Q0aaKj36Rcy6E5r98DNV+s9itusPeXR1wKys1IZAfxYzfLhI0ce8",
+	"EfKCStgwbLdCWN1PhGW4RqeuyHxMV+I5OHDgu4IYiRRrz6dSRLY0ldObGB+5v7lFmsG7JklGNLWx5t2B",
+	"6z576SpNXQsjKK9xSxyhoaN8KCzFlgyJ3dCGq0z9KLxLd8BSlvtULyVVS5HEKn8ib7i5VNIVy1ajg6TP",
+	"J/vRnRBC/57yw/PyRzfHy10BJIiF7SIItooCBYdC0xJawZwSjZprzSmKU4wW+EZpUO553ny1dZqKeuX/",
+	"iE2V6p80Irr7fGT0NWzo1Bnbz+yX3wulzyjWRrrH+NvAeOjbAmlgGZu5SHRMDG73HSDfRwOzxigXy6pz",
+	"XM+/KT/vNNsQ1SX2Yre1M45A77/ih/f4fXfwG6/yLiB4YbsegOE7KWR7ULzdQPY4XuqpPaJfaJQdjuyl",
+	"ZvFv3Az3WP/vrseU8Gpq8SrPerwt0itt6ZlH9WYafODLRNZoMTALPAgfd5/GFYZRM1k3HcDTdxEEc/Kv",
+	"L1jkyMakNL8k5AEsRY0jF8YyBtuoYs3ohkpYZUo7J0NefHHC/ecS+ooaiveND+NMY+Tpk9NvB7thPG6N",
+	"8YQfHspjWFAeavLSna+Lr//L3XT252c5s21OrjnJOl8uRC3mxv39F9d1VwJ43M5uM4k6h94tJlJ/QCZb",
+	"duf5ckYu6tBRLFOVMfXcLUc6QEqzlK68javY8LZDmIoPiDuUqbSzj1K90+PYx5k9yD33uDLukaeT3HOP",
+	"PzT3sJRzHPNYi4u2ajBe/hS8AyNoQ8HAmMDQjwlfUCkyNbgKjoC7u+cIV8gR8PruHkNw6HPPD/Ji5p7y",
+	"wuWeEFpFRcYiNHpG50JSYFrZuP7q88g8oVSXkw9sbeDGxANsDy822MS4iNk/xzwIxiEhcUwlCGn+t++L",
+	"cw8nnAs+9avoIaREakaSIayE0sm2/FPpnxm/4GLDBxOeR0DlXZIx4abcKhnLkRcHyVvzTrjZL3NF4Ymr",
+	"ZTOGc5uQhDP/k0rhJitKHydYpXnCXe+ac6o14wsFStM0pVJBqZMNMbPOEgqKfRmZ9RKytak8uQnlas2r",
+	"iPCRLYvfkAqBse412F5rcHp4wYYeBbYyJ0aE2I65d8QhvSd3oLxjRN5SGkFBUI1Uoc09NxKFgUtMtoCf",
+	"AVksJF0gcmHLEpdMxjAr1qWG9X3Ly8enEx6TrRpClJBVSmN4OB5/ezp4BmRNJVlQUJEhX9dZWnGSqqXQ",
+	"PjRPDSe8ONkQtNAkwVAq37tS2QQ6i9wRkRLz7jxlTvic8dig9Rg+iY3BarNdHD1KzfJuGyWBDTFNNGnw",
+	"DiCguiH2Z4Tpjiyvyaga4BgHA67nObgwgOlvD4fw7enP2LFpN1HHfBDO03l802k6QRAEcPw1YYnHJ9vP",
+	"bAgiie9I1k4HoisfoIQ62h14l9Q4py4P8mQmKbmIxYY3EtxrKpkRhWmIIeWRqTnH/q//9b/hPCK217PR",
+	"Wx89nfCiNRA2HBjDd4THCrAXOFq7f48MCkSZkadTF52o/j7hS8PIJVVMPQPBE8bpC0lJtDT8/4H95sXp",
+	"EGK6kCSm8c6PVnF+8XA44Z4MX2Q8OCp6PAQDiBeVLx8PgdM1ldNUihmNX3BhRPJ4wl/Z86tshVG/VhMo",
+	"IFNKzUOoj8pQH+VQb6fe4ovv8mu6zuD04IKtsukuiCUr7PfQyJN8w8UZIb8G6FvkOvGIdOKx5cT8fFJG",
+	"gUGApIyCxKlqzX7DO33vB14338sXCj5U2N9AiiTJ0htPHX5ZFMCxBax88a07j0XflzjfbAuOj7DEIJPL",
+	"jd1FDtsWcmRruexHkTMc/sqN3iOy32LqMbb5Lfdos1r63Hy4EfJiKuncNpkkDJuWMAUXdFs0WmoQ5vkE",
+	"+woRdtqU+SDSyRZTYo3UINxu5eztq8ePH39b6SF7/QUbuxZKfHh6q5USAzgRzMbH1qMleF+us889N+jA",
+	"DXaBrqDvxIy9qkE9/3uHOaCJajOqmxQwp2mIOZjBU5lxZbvAOmcFfh2j5SEzq3dZx8J4wj/7NkR9VAyp",
+	"pvGJUa9oPACcyJjg9Au+U8djcFEMyho69RoDGANUKJhtuovRAP8TT3XdpFGsFLjT/wyAJiL892JNn+fI",
+	"ATFN9RJUmjAsJpb4gtSNBjWasnuFzTmO6ixk0O9jLN2pRXNEwxsVNj9fPz4JGbw869qwYL3nkV15ZLiY",
+	"hPWz9FOCRWNO0JMS0qu1SEfOwYLcZ7/29Fmkb+0H3+P43xFq/wH0lDr0Q5oK4Rc+19Ub+vdqynUbLarI",
+	"a155yOdeS+ibJSj6JvdRIX5wABWe4fh7KrwdKrTQb6ZCA+l7KrwZYwEpLUyF9sGgkQoXUmSp6tSL9E84",
+	"1L4m/OXTO3DrowZsfp9n7rHNmBN23gnvK6ap8oXHDIDh4zkUVTMHQ1uuADfPNPpt00zTGFZ0NaNywq0j",
+	"ycclhGwHu1aDyWB3fZ2mAq6wrxzUuQNWmmTKAcee2R5P3Xw5WItlzIYTl+pG3zbGd34JRCjmWPjA1WG0",
+	"f83RqXBDNtT48DWCDJ5Cf0V4hpVRDO6pJUsHWDugjLRbP2rCDcPH3ul2UTMy08L91wXd0hhbiqvpnKxY",
+	"svUxds4Crrc8akbjT0JZPL6mdFOc20Lipstf2GM1BLW4ehcWoLdW9cJep2t+kwew3JNqU77MTcfWvORl",
+	"svN1PrCShn9DJNoQsKXCpiJhDsl2ZGOg3lddRq7E2mUy2z30Hf8AVwR4UJFeJbq3MXTNhG+rdXnSv1MV",
+	"xO6poAMV3GCUGyJJYzmt176IWs5KU6KjZahsvo6WYNBpCCqbGQyxgSeRSIQcw18Ytz7PQkQCkXTC2WqV",
+	"YehUE67vk3Fm4ZvF9GsSpLaP3k0nrrUKUtcD4ZYFaeYAc884fj+MwyKzZxxfKYiZShOyhTmjSaya5OWJ",
+	"Yw8tvcKVYguugFh3HVavctq3E6KFUFcQY6CQEbFMTrgXr/j2YkPk0VODWv+T09Oj5W2uaP+AK/zeOZE9",
+	"xaW75OAsQOL4FkrPvSIcqTaODX7YnRhcKet89xzl98RRXuJVhol+Hzs5+Rc6cTsq5G4VDAKsrnMF+vjN",
+	"cYhhcFIHiOvX9x35SwTqvdq/j9ZqURwrm/zZhIhNCP9sRZg5EWlt6X1OtTU7S6NhnpAF2G6CYj6/vCQs",
+	"beT3Lg6Lo9xSdYlDlfR7Ovt9yLTPYrFIylpynSArdL6kJNHLtofO7+2Ia8REu0LriwWVaxZRgxF2w1jn",
+	"/+ubxIPSFnzwtGFrGSdrwhIyS2hrW588FvkBSEpihv/GQGvoEy74diWyWme2vYEgDZEfoWddytdMCr4y",
+	"cDriVViTxa1FK5lT7nvRwnjl2+9o0lTJDHuZLN1tdahR1tavxF/6dUim721N9dvrUWJLBO6559vvS+JD",
+	"CaA/IzbExzopWTqEVEg9BKqj8eDGXx++dzupPzwwDmUG0PDoYM5xeIExROvCFio3NngmqRLJek9xse+r",
+	"TXjO3Ddd9LvrsTtuuguGO3G5YfvttcP4IMrbyGUbvl350u2t9eDdaWxidaknxJJoW2J5RgFrWJsZ9yJd",
+	"WwuNOubVzZQsYKWgcsT4oqwUTVcipq4GPskUVShJPhnZ/Bl7YyjQAtQFS/M81qLVospmyvBKrkGz6MJW",
+	"u8EtJUX2EaaKJ3SuIeNaZNGSxkNQAiRV2aq2G0iZESVZmpfHgYQoDZJGQsY+VX8M64fjx+PToLmUIU0d",
+	"aixdGTFdj1y6fYNpn3D60dlMiNI3TbffV/pg1Gjyk0HrE8Q2CjleovapHB0qxo3VcDUyoEiDPVkypUWl",
+	"B3M4qCtLDZH9HcMP/45RYyObT2aJqZhx6ma0IZNm86USl2N4Q6IlUlxEUp1J9xSeUjlKyJZKbB2NmSFo",
+	"CjmPRZZo5n9HldwTWxuZOQX8h3xn37uj3hSxXTKC8+tbDeAMgq5V9Stfu002GpXS1u8KqX02qOXFhDG+",
+	"8zOOKojbx8BIh+J4jsHB9Ysd2XVqAWc2fTebv7n+N1OiQVE9uFvXWe361oU77u/0dpNX0ZSzWq5p44IW",
+	"ryAq/dH4dDCG3NXBFGSczOe2DuCdTYcy9/GaasKSvaZnjMOg7yreqkKYPgiA9I7hsm9jl7dfC+8eKJcs",
+	"WjpXUTdvhY/fCYTR3DjjuR710yp3d1TzxGt3Lvs74Ba5W2jvokZcRJh7/bIBI8cquujnyAmmuYSTFL/Q",
+	"SKuyPoCJCXU+GwmZZmaYFNliCYRPuG+7XjBeSChXY5sbjWD9orH2km8LmRBNlZ7wPAG6mkadV7BBAPR5",
+	"liSGt1Nu675MuBnNsUG7lwiuAIQzdG3Dd8wZIDaxcZpGesKr2Y1AzM8plUaxIQs6BMEptuNZkWQIp3ZJ",
+	"O5SpCTcCo8jA8CE22AOSrJwEmm3hgnJFzECSiEUe/T7h/Yz7r/9JYzu5r/BmTGzsN+nTT16/OX+FaR8T",
+	"nsfPvzx/NXbZYQn6yt789ObsfyDA+rmtcGKM/5TGJ9Rg4mA44coAhentCKvS0dhmk+CVsthMOrQc1lyU",
+	"FMmUxWhv2UqpE+7voiilWVxzn65SvQWhl1RumKID61MwuqP51JgymM4ULWl0ASLTaabxqcxsCeiXVChf",
+	"ddeMdaV6EMEMwGeGRIze9f9+/fhbe3KElJXkTOF9ZTwlC8bRnEV5PZ7ws53eG80p82BT1FrMpqJe1W2q",
+	"QVocpOMQHvtbdPlBeLvAYvW8koJUwmgirTnpMokyLO2HKUq4hbutFhW39J5y1doUtLh7w6eg7+oPWD71",
+	"oJQaU4LNA4d/dzHJ5075bwo6rkHZEKuB9BBWhG9LXGTN6Cb0nlgXXq5Kxk6+a9hLEzYQkNFlUlKup1ZM",
+	"vLAeFsvlbIrREDyrnG3Bs8+inCe40r9Ltlj6f69ozLKV/69EbNw/JzzjxlS0TDchSk+RGVoj0nD5MXxm",
+	"2vD0GjFGYkUnPHesMj5a0ZURA1a+WL5qhcxzJ6mW+V+QfZbee4egzSIwJ0aUzkh0gaWADFs38zDHhL0k",
+	"N+v627G0D5LaWkGuzgl+bRhRiB0ZwZ7zI1pnR8o62PNPvqowpwnHioYlYTS2InjqRaOr/ZwK9KqYzQ0h",
+	"lXSEziSzNJZ6O0QEtPD+t4hyDRnTN8D8fyBfnMiXiNdGXL5ypR9d4ceHp6c/P/cvHPDwtIlNtzjbHobq",
+	"QF6/ILrbAqV09W3S5G212Ghd27qXF+3yAuMNiDc5HGtOtr64QVmMSJc5v1dMePRpFhKvsV10pOvoe0G3",
+	"yteaLVlCNVmCJZVLieM8w1BPMXekuiKpo09KomVZmpQZq2G6b1B/zrk3Cs4l8QryjFIOztYZT/h3eKVo",
+	"PxmBmrLowqxa+rSs1TK6ObB41CGa8NsCxrfipb0u3bE4VyvN56MsEhjjpbhYe/3O8rmzVa3uHBNAQ6MA",
+	"bIn8EJJWi1sRY3KLDlzA1z9v5AGfSwuITfGETWKSYuVYP4N8tlMtezjh3BgLfkjsNFvHv8BIUbkmyTCv",
+	"8pCSTNmYRjXh/dzaLb+mP7C+BL+qrdBEudHf4nLEAKpXc7YYjOFl4SEVmUZnh/0ajySdKmxB53wNrpg8",
+	"AZ4lCZhTTNH5QjSMHN8hHNB7cFT59io9nftb+ENxifxUoeBLfwNO6UFnY8mfdc8Lej9aTAQhwb2oOchU",
+	"mMJHntOnJ0lEvwLH+y8zLezfNEtoFxOyWyF7Y1tkkubl5i9XyT53QA7B+R+H3s/nKtaP4TXZKkuZjo7d",
+	"yuiTITOFT685h5KSbJ+De6SdcBJF2SpDp2oxKMYK5LaOByyE2fJcyA2RcUMfmrbS9VX0b6hcfwPm0B+s",
+	"HH4IrI3V8H8vdfDvJDOxICyJcU/iiPXIoAWnxZdBLlKUKX+GTpzmDKNX6GfJnwYYH6VSREUc/YpES8ap",
+	"3PqQHyZiFkEiRAqZMvp6vwgnHM0lpfD51afRzJgCqPKnQmp49GgwNB8rfA3Qwmr5eTTf0CX6FqWo5pKq",
+	"JYbyJXoMtf62trWdIdRdE6FUJx9P3pT6ZBG6GP0KwXSDyX5X1MP34aNvOvXwvYGq/wjCM7yyYN1/FwRm",
+	"fz+yWty9ZXJ7La5eOpZgdURmgQJM5YHxjMM8YYtlnaWdb3m0lIKLTIHgo5iuLLmX6t8XM1ejJhs4XMxU",
+	"ZBSd7TOZ8Wbm9jGl3L69nZ9/D4ritQFZEMadGYdHyBR6a7UCF1sfT3jB1Ia21jX6rBOhaDxSVLsNz7CY",
+	"Sl+okaQJJYoOIcOsBSxhwPhcDCGeD0vZDAuqKZ8LGdEhEDKynv2hkZF0Q5JkgB23kK+aBe1DpBpClioq",
+	"tfPvWAtnaqaHBxBTblhOgm+1CKOxUNP/n7G9kmzFMVEhB2qp3PgQ0myWMLU0i9E15XqWqTHG7Tjo0tgy",
+	"Zrpipff2cQ78cf4qPuEki5kGnMYxZWeHIV8uPmlhx37Z7VnG7znxMRraOYL8HZ+LoHLm4euYMPzX//w/",
+	"7ikGo3pjsN+/JZFWv08OfetZpLss+uub7CJvY5aKFkV4xYb3xYwkRvEsJY84Xgf2rfLGUz8LbFQuCdSA",
+	"bWPIzHuKzQ87HVPDwuTjOcwZX1CZSsY15Pymu0gpmpu2Gt0oMIqejVgN1TtNSs/1mszgAfzViAccYts+",
+	"fbfNX7+8sitSyl3wchG38iDvITl4Dv/hrGdMpjGqr/3QBhCZeQMNXUl8VAtXZz+/KUBxg2y4Zvwu88D/",
+	"gP07J4mi+VQzIRJK+DUz2Bwq75nSrW1IVb1xx11p1Pp7sH9rz2ylCNoCKxuLvZ5nM9RVgv2US8lxD2SW",
+	"0DF85BQJcMJLxGcGeeorfYx6biI2tpldMctzIBMeZxZqNKfrJ6ff+ibtvgu7CweoVF4wNrQcT/guCeNX",
+	"Jfv2oD7MFSr+HQcJl5ow30rqdIeuzIG23b8zzWkH6+4kk7j5mrMomgsGEKw7661g2yQo2e32bAFKgowM",
+	"+vheuCFsTeXAaD2kVUVREeEtBfdszrkNJCbcWK3Qt+90PmI5EYuZEBdGaxhYy45jgyBlI8q+/+Hlq5Fi",
+	"C+5eCeEXMUOWtRHyAsNgaZSZFdaMwF8oV2QMPojt0emjUvNn/JrFuYVh/1srmsyRkapCiXsOzopkgk94",
+	"gq09Ga8HMpxU+mSZrZtpOBcZj3KF0ZmxYOxYw4BtuAJBSDQ6LVwDLCEn3HV52vE3QuFurAZr2XJLpbdH",
+	"NHbNYdsY83lE/m3s26uzfQzUzjLbrSsOP2c6pPdFxQ2WGAx2SB7fm7S/T68jMo/99OubtNVY8Bt7+0B4",
+	"yVysdJMivLuV6JxajM9Fp5Ya5YTUHd9dOYFkwdZGD0UHG3wSKT6S2rDekB8N+iUWavjxhH/6eP4ZGp2k",
+	"qNaab8yUleiNwXjCn5w+ca5DLvQULxrYHPpkUHhJMfEQhfMQ+rNBEYRsflFFSmc8NGv1o9KnTmTOMg25",
+	"2T/hGD4mNNLsllp3lOWYwvbsNz9aP2sxC8WwEiOAEBsoj/G1sf4QVLqnFkO35C/7A0R9tHv/3mMmE1QH",
+	"3sd7BP1nVgX9eAZcQMlrKjYGT3dUPBKXUsVK4+ckcnpi8MGWcU2ThC0MRp+g4tKtS4/tDmpd7fYvH8/h",
+	"XWkyiESS0EijSuMLnBji4nSTbFGtNUaskFoNISXRBVn42oQYFozeuAn3nZ1s3SV4lUklJLgUJqO9Cg4x",
+	"1Zh8VaQI2NDrCZ9twZVjGNqtTiMR0yLqeAjYkPck45olZWeVUKMyZBqot3zeNxZ2nUq2FSUiLu2gKk7V",
+	"a9CYnj7ZpzA1TO2BVJmY8mzVe/a3HrPsKhGb3rBnszl6w96SLQyn8pkfvZ+7L3aljZHxPq9stgiR7jpb",
+	"rj261YIdu2j8CRsvB5yLltwv1Zf5Djd8Qq/fDh8rc7pm3mkNxErh6MP1svKMRR5WkW2F+pl9/4QGbSmg",
+	"KRkZwuYTzkXtZNh91yhAaa7qYY6TFTHQz/WgCW9RhGBHDxpcjpWeYz/gP0KVuN1TBXUipfMAxnv1J6T+",
+	"5OGdu5oPQg9T7yu4nX/RqPkkLKJctfaXfu+GXCOGuCUQOdpSKNy4Uq/sAgR/ojaMxEfTJ+Wx0NeMyiHM",
+	"KdFWkfpHJjQxOhZGfVSjgLnQbO5Ook4M6+M0aa1U+6H0xSs//hoBFliv6SnM/VyvHtsurt4KOWNxTHnp",
+	"Lbr9C1c++Md6ueCqWClDFjxgoa9oJCnG/MTE6LBtpaLKU3QoJxuA1DUVlw2sdDtt/kJHbkEM76Nzt1C6",
+	"hEspNzeOYHmd1xCSdUWo3ZIoYWbQsSpZGPvuYG+527myvFPaZa5sf0GyO3MLp7dE48fdsdN32r/4IPTb",
+	"Ir7qKpDCl/EK4USASR0qKVpKed0mntyIPLqdbnkdcdWXl22+6puSR7eE+Hn7txsTYM80tXpTWH/6TJW+",
+	"yxLsM77nJ1RqiGnC1kXphD8ukpxTHgMBteV6STWLQBdA8PXVvGv6ALTRtGYYSope6U4enDM7FhI2k0Ru",
+	"n/nu4JQbbKIx2Ml8KN6EYyxeW5d5t3qDm8Std50Gll1iX1sOG3ZUOfx9L6FDXY11NFHQL4dsDkJomavf",
+	"rbiZPyPbr2C2BRYPwRY3ZXxhH1+x7hz8+fzjB1uCCNMmLoeat1eI+KopoB3r75H9TvkM7ZXtqY8reE4P",
+	"fQwSY1qVicAnuQbp7pkn1pbQN1sJEKtkCsb1iHF8adrJj7dZ595dFxNNJrxfL8BWlLN3xTofgH9XG/ry",
+	"NRnXQ9Aite+keVklG1aHJ1PANBbu5JC3znZAsJHBP/z0acL92RQIntjIDBtmh3U9XH0/DE9xJU6V4xOu",
+	"UE69/3YLp/iEBW/Nz3/yAD3eCHBcQcx+oRES7HU6l9rZQp2X3zOIQzpYelwAAm8TSnU5i+VNjonnbnyF",
+	"PEW1uuGuXBK2GN21iYuX8YpxXKW1FZBI6B3oY2bA1djHbJaxxHAtkA5mTQp0dZbKVTyzTtX2xlAILeci",
+	"vh4XwKtMabEy69xq17NiG60VVnEUQv3WWqB9yu/Xv73deJAlkgiLQZMLyptc3FEBq30IuusQ6FYK1dpw",
+	"fynqhubKQinHuahfJumcSsojqiacoIkq6YrGzDox3BGGeZCbmXHkTCaYSbFRtkSFDazHasxuPtQMbPR8",
+	"XuUZX+1YNBi6QqM0hihhlOuRYjHNpbKZa0d9N4dvUt6za2aSZoGmd7rPvq7qvSFZ49b5Ne4xJA2KlPDV",
+	"YxeiDr6Nl8vftjmO8wUrZJOnfOz1hxRZHr4lTvn9vZqROMTCuowvbJUBLJXmv4olS5JRLDYciHakAX36",
+	"JbUE5tu6K0oNXVp8V4Oxj/YzV1mkS+wGDc58xPaU6DzvLUQzniZDNHOOUDkw4O8me0I9KoeYPdwbYrZT",
+	"PSoHEYh5qVud2ORh74pSDv2zt68eP3787eA5iBWz96KJ1ObmsNwn3nlDdalAbF2nUL3rtP/NxbbxKpcV",
+	"ijH7HmEvFRJ3z+qaWN0dLr1bTd7Ycd0dxWM7O/ciwh0GWm7rm4raJh4uKz9L6FcK4kwao3/C11TGLPKF",
+	"Aoi2CNz3xV+KmOiKaqOGmCMxpWsWG6XE9ayQZLPTpuLDx8/AeMI4jWFJJX0Oc/S7MI29LawQssGCFPx8",
+	"peSJIBu2QYT7+PAfwe1ozmGbVTUxHryw2A25Zxx3iHFg2l8T4/joOjl8VaLTB5B3e7F1cAwDEY58cuK4",
+	"DBs5ESoiSQsz4TGV6Bg0FykddpHS28HH81cv38PD8en4KbxUiiq1olyDLa6mJjwWUYZ/wV4Vc8bxZeEB",
+	"iJmicm01LU/3gyG2SuFKyyyyXXHEyip+jkHZ9dFpWaT2fqWw7Y3UVOZpvFjkaWQrWk44kZrNSZ2tNTCT",
+	"TjodHvv3zkw+mst/7S4ohLHtl4v+8Hse8/vhMS9hsxRJiYj5HvIFT72XYTHoUjj5l/m/d/FvJ55t7dVg",
+	"8CWmop4U+oDLgjVLI7k7tWXCreAbuqdLw0awXJjho5FY2Yxao5Eo6Lv/HuZFxSbcqilDoF+YBpsFRr+k",
+	"mDd2QiKdkWRg68xVtR+j7TDbXgtLj0oh5jCjS+bqlLvdDX13LvuAYltBVQBm5p7wRZ5Pm2NU32dsjFwL",
+	"yloBJ6Wx1rGHD1Y3HRzAzs6yhL7xF3ODCf/VSS2KdM3yf/T109usYrcDthanlZFQ+bB7fnnX+KVwZkeb",
+	"buauER1lATZkKbTkkUrJNhEkHlwh5+ymq5XYpnu2FpmOxIo6tU0THpPEjCrx/glvYf4tqttgaBN3qyob",
+	"HKCxXcqzZujvxjSxPwDPulf4/u0ZWJkZXKP6h3UbKuXdT2yHk7ZXeFvtoVKo235zU2XBcbX2R1gbjmPP",
+	"giWN0Y+uQGWzkQ8xuVWkRBjueQ/KK0FUqtCvBGfaVqfBiKT8kDNyQeMR4/lpMVMgC9cddYXzrU/fzTEE",
+	"xRacuPL9pcr9eQfyvJaDFnBGjeQsF3S2hxq7Hjk22Toew3cG1W2L1bXtQo31nV29bMJjAxZseEvk1hZt",
+	"yfRIzEcSs7XXJMnyJoDw5PQ00JunDKBgpFLWjrXXELSwu9ANJyw07aAhX8FiUTV3+XdUEsAR1J7YJJec",
+	"0IGe9vJJ62s/jE+e229u6NLdagHI/UC1ZJG6I5nqV8ALS7xq5c72oNJgbJ6Q4JXmJa125V7zy7jrO0Lj",
+	"ojaPJTDoCwmvLfctyvZssJc5t+W5bOWqAXx6/+M5TrbDtUsyyjb8pvDjO6zaABKNByAwMRhE8X3Wfzbp",
+	"AZnPhYzxvEU7JWkY60hLlo4n/AdmbkaVWWe5oINrbwZr2wuxzmVzYLW3QbN4XwPNdSJ9bal/J83g43mp",
+	"NHlege0adAPo+8Z+U0UjePz09HQ8fnr65JvT0yFIounUNSF+OB5/bf5mKzlNBZ/iK+oU2+NGGlxt7WGZ",
+	"PKeLRMxIMuHux8EY3jRrFMB40V8IGf6El6p52kfNEkcowJIyA+Eszc9mdYtcGdEiBTG34WH0iwbNogtb",
+	"6ErAUuiRRJXHaUnAKY2xO+kxdJJrJCE6uXp1pL7KDesiweX/0IqIPUZHfaQTFbeLL7WhNG1pXMPpSMzn",
+	"sCI8IwngaMiUdWAb1J/0zjIOXGyqcsTXwT2nWjO+sPWixvDGl/mt9m+BX8TMFqjjWBrTVm80so+PytIY",
+	"0w5cF+28wUycN4mZEg3vzuHDj+/fjyf8exzsw5SKUWhQfPj4GSQd+Yqs7mERvfxAjNDU0XKUpUPrlADs",
+	"kxObL0rNHYqaw1a/yLgGMZ9wPEw+cy6KwUhivBLpehJatnMkH8jLJ+Y0co5XeRPUiCu1iUscYGCOCee3",
+	"7sk5hLTyMq0BHEUUtZE1eRNZRDeo42GI6Cq1wo5SG8vljXY1x/KvE44lpy+hPE64Q9kjlMcJL2mPEFAe",
+	"y8p4k9YYUDBbFcdd4PRuqKzXv6X6WC21dYMapFEgv3n6JKA/PjJ/21UPoaYdTnhH9RDq2uGEH6IeQkU7",
+	"nPBcPbRF9w7XDztSRK4iNlDE1WuJgYVuWFFs2sG9rljSFTuRbEhyqYjw4yTWeUT4rqTCV42SgJrwI90b",
+	"RkBN+KXdGxhYyb5gHInNvPUsx7qfwz3uv1KgGZUTnpDYrN/Ht9A0wQDNiGEe1X978szdlneVW4UyFQmL",
+	"tjBnCR0c1TPeUngB3t41x0L8+8m4/MLrNfoLyrk6ITeG9xaJVozb/HFJ4dX7lz98evMaO3RP+N++HsKj",
+	"b745/dn2eMlFX9HA++Hp6c/mhyU2XkfV7ReMbppwjF/wCAI0WgrqO4naLuBWZA2e2yeZKxeRkmIjZb+o",
+	"hduO92TCUT4+PVXoQimHCnSii1zy1eji6iVeaYEblnT1lcMSru/udfBvKesOIt9GgecHjlJJ14xuWkQf",
+	"iUcY9JdKYSgOi9LPbSZasfzUTwjGTHQM4Iue8EdPYCkyqaD/4eNnIBDL7UhmPLefB89QMpkxEGfUF4PI",
+	"S0LnTpZ8AWUEmwuTFIJTpXGpfAfx1JxwaD/3ngvnXsk9Jhm1j7SY9mUlH+E2aQ5imurlJQXXudvMJwfe",
+	"ayaa+nLBaAsHv+IefwcS69GTpcGFDZFxDQEtrw2jfyPar4lkZNaWJP2RU6Bcyy2G9vvx7vFfaXOA2KWb",
+	"2pxlG1ybYL98nygN/QvMVlVLlipYCUmL2gO55oBSrEh+nvBMUfUcMp7ZOFsnKI1OlaDCaWw8Ei3d9iIi",
+	"JfNNxeqzW/Lw9c2RJiWLqdVLFXW/I3HYpG4WKwNUMp+jULV1VgoSsVifSTpd2XdDWBFpc1uFXBDO/on4",
+	"MlIpjdicRUZTjOhSJEbs5+oq70u1VYlYTCVdCU2ntvfsELDHznbKdTpNhUiGMCOcUznV9IseYNbDhBdN",
+	"a9RSZEkMJNmQrQKL8QeL0wq1/pSjxTXTab5Qq7KJ+DBCNMgRFpSQLrYaw/fuPunmmdtR6TwXeRb3SNNV",
+	"mhiJVpwRfY45gRjk85jbonT++BkkRXyzCthb9Fl6jF+RFPpkpoz2bgCHCIMl9USYdNRgDL4/Yk7+9su+",
+	"ocXSA4HRBz1LsIccIMl61dSe58npqfneVyUT8znFcNQJv6Db58UJgf4jI4nb1w6/wIljKVKj0Bp6cCoq",
+	"W9HWh0H78metN6KXYN0xLty/zMfytoIrKhcVzHONolF9dW33LqO7VontetRXv8bHAn1uXpNt2MRunH2p",
+	"7EYFbzHda0NU4XP4Y2u4Z5aMq7Irp8ESKyhJ90xh2HRzxNGPOOAarxoX2FdP0gy6A+WRDLQayyNlDlJN",
+	"8bKlj9vq8hcAv3raNnPfasEjs4G993xbNY5+spGkqCDL3A1nO4zdAbwr6hUF6h6ZEftwb7fgEaJsx4r9",
+	"5mpuL49+X5n+m+z+bHC0Kd7+vOgx2fFW9lfpv13In94o8d+t2/QV97vc404mREFcrvQdUYoteHvpO4SR",
+	"Gf3SDv79Vtn3J7EHOUjeBIgdi79ZAN6CZPAGjbQl6OrJ1bgtfDhKqDFA9iIM1p9z6NCKMhk/CGl+9MPv",
+	"0aaENpKuxJrG0Ge+qbirnV1Wnc0Qf4WYyXj0Ja6NtWGP3MTRf3JDrpHZuiXa+K0bUlQdyftXxzRNxNal",
+	"Cg57ikYZtvp89refy1D7LmNJ7M9bTNMnXPDtStjuYfi9XHtErPUtExFJIKZIei7fLJNJ71lvqXWqnp2c",
+	"JGYE1oj95smTx73ffv7t/wsAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/server/api_helpers_test.go
+++ b/internal/server/api_helpers_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/kensa"
 	"github.com/Hanalyx/openwatch/internal/license"
 	"github.com/Hanalyx/openwatch/internal/liveness"
+	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	"github.com/Hanalyx/openwatch/internal/scheduler"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
@@ -272,6 +273,9 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	// Spec api-scans: wire the durable per-scan results reader so
 	// /api/v1/scans and its sub-routes reach a real handler.
 	s.WithScanResults(scanresult.NewReader(pool))
+	// Spec api-notifications: wire the notification-channel service so
+	// /api/v1/notifications/channels reaches a real handler.
+	s.WithNotifications(notification.NewService(pool))
 	// Variable catalog fixture: two corpus-style variables (one a
 	// configure-me placeholder) so the scan-variables endpoints are
 	// testable without the on-disk kensa corpus.

--- a/internal/server/api_notifications_test.go
+++ b/internal/server/api_notifications_test.go
@@ -1,0 +1,162 @@
+// @spec api-notifications
+//
+// CRUD + RBAC + write-only secret handling for the notification-channel
+// endpoints. DSN-gated via freshAPIServer.
+
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	b, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	return string(b)
+}
+
+// @ac AC-01
+func TestNotifications_ListRBAC(t *testing.T) {
+	t.Run("api-notifications/AC-01", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		// Anonymous → denied (401 or 403 per the auth/permission gate).
+		anon := asRole(t, "GET", url+"/api/v1/notifications/channels", "", nil)
+		if r := doReq(t, anon); r.StatusCode != http.StatusUnauthorized && r.StatusCode != http.StatusForbidden {
+			t.Errorf("anon list = %d, want 401 or 403", r.StatusCode)
+		}
+		// A read-holder (viewer) → 200 with a channels array.
+		r := doReq(t, asRole(t, "GET", url+"/api/v1/notifications/channels", auth.RoleViewer, nil))
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("viewer list = %d, want 200", r.StatusCode)
+		}
+		var list api.NotificationChannelList
+		if err := json.NewDecoder(r.Body).Decode(&list); err != nil {
+			t.Fatalf("decode list: %v", err)
+		}
+	})
+}
+
+// @ac AC-02
+func TestNotifications_CreateRedactsSecret(t *testing.T) {
+	t.Run("api-notifications/AC-02", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		body := map[string]any{
+			"type": "slack", "name": "ops",
+			"url": "https://hooks.slack.com/services/T/B/supersecret",
+		}
+		// Viewer lacks notification:write → 403.
+		if r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleViewer, body)); r.StatusCode != http.StatusForbidden {
+			t.Errorf("viewer create = %d, want 403", r.StatusCode)
+		}
+		// Admin → 201, and the secret must not appear anywhere in the JSON.
+		r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin, body))
+		raw := readBody(t, r)
+		if r.StatusCode != http.StatusCreated {
+			t.Fatalf("admin create = %d, want 201 (body %s)", r.StatusCode, raw)
+		}
+		if strings.Contains(raw, "supersecret") || strings.Contains(raw, "/services/T/B/") {
+			t.Errorf("create response leaked secret url: %s", raw)
+		}
+		if !strings.Contains(raw, "hooks.slack.com") {
+			t.Errorf("create response missing target_hint: %s", raw)
+		}
+	})
+}
+
+// @ac AC-05
+func TestNotifications_RejectsBadURLAnd503(t *testing.T) {
+	t.Run("api-notifications/AC-05", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		// http:// rejected → 400.
+		bad := map[string]any{"type": "webhook", "name": "x", "url": "http://example.com/h"}
+		if r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin, bad)); r.StatusCode != http.StatusBadRequest {
+			t.Errorf("http url create = %d, want 400", r.StatusCode)
+		}
+		// Private host rejected → 400.
+		priv := map[string]any{"type": "webhook", "name": "x", "url": "https://10.0.0.1/h"}
+		if r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin, priv)); r.StatusCode != http.StatusBadRequest {
+			t.Errorf("private url create = %d, want 400", r.StatusCode)
+		}
+	})
+}
+
+// @ac AC-05
+// Source inspection — the response struct exposes no secret field.
+func TestNotifications_ResponseHasNoSecretField(t *testing.T) {
+	t.Run("api-notifications/AC-05", func(t *testing.T) {
+		var c api.NotificationChannel
+		// Compile-time: target_hint is the only target field.
+		_ = c.TargetHint
+		// Reflect: no url/token field on the response type.
+		rt := reflect.TypeOf(c)
+		for _, banned := range []string{"Url", "Token", "URL", "ConfigCiphertext"} {
+			if _, ok := rt.FieldByName(banned); ok {
+				t.Errorf("NotificationChannel response exposes secret field %q", banned)
+			}
+		}
+	})
+}
+
+// @ac AC-03
+func TestNotifications_UpdateDeleteRBAC(t *testing.T) {
+	t.Run("api-notifications/AC-03", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		// Create one as admin.
+		r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin,
+			map[string]any{"type": "webhook", "name": "n1", "url": "https://example.com/h"}))
+		var created api.NotificationChannel
+		if err := json.NewDecoder(r.Body).Decode(&created); err != nil {
+			t.Fatalf("decode create: %v", err)
+		}
+		id := created.Id.String()
+		// PATCH name/enabled without url → secret untouched, 200.
+		pr := doReq(t, asRole(t, "PATCH", url+"/api/v1/notifications/channels/"+id, auth.RoleAdmin,
+			map[string]any{"name": "n2", "enabled": false}))
+		if pr.StatusCode != http.StatusOK {
+			t.Fatalf("patch = %d, want 200", pr.StatusCode)
+		}
+		// Viewer can't delete (notification:delete) → 403.
+		if dr := doReq(t, asRole(t, "DELETE", url+"/api/v1/notifications/channels/"+id, auth.RoleViewer, nil)); dr.StatusCode != http.StatusForbidden {
+			t.Errorf("viewer delete = %d, want 403", dr.StatusCode)
+		}
+		// Admin delete → 204.
+		if dr := doReq(t, asRole(t, "DELETE", url+"/api/v1/notifications/channels/"+id, auth.RoleAdmin, nil)); dr.StatusCode != http.StatusNoContent {
+			t.Errorf("admin delete = %d, want 204", dr.StatusCode)
+		}
+	})
+}
+
+// @ac AC-04
+func TestNotifications_TestEndpoint(t *testing.T) {
+	t.Run("api-notifications/AC-04", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		// Unknown id → 404.
+		missing := "00000000-0000-0000-0000-000000000000"
+		if r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels/"+missing+":test", auth.RoleAdmin, nil)); r.StatusCode != http.StatusNotFound {
+			t.Errorf("test missing = %d, want 404", r.StatusCode)
+		}
+		// Create then test: delivery to example.com fails (no real endpoint)
+		// → 400, proving the gate + path reach delivery (not a 403/404/503).
+		r := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin,
+			map[string]any{"type": "webhook", "name": "n1", "url": "https://example.invalid/h"}))
+		var created api.NotificationChannel
+		_ = json.NewDecoder(r.Body).Decode(&created)
+		tr := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels/"+created.Id.String()+":test", auth.RoleAdmin, nil))
+		if tr.StatusCode != http.StatusBadRequest {
+			t.Errorf("test bad endpoint = %d, want 400 (delivery failed)", tr.StatusCode)
+		}
+		// Viewer lacks notification:test → 403.
+		if vr := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels/"+created.Id.String()+":test", auth.RoleViewer, nil)); vr.StatusCode != http.StatusForbidden {
+			t.Errorf("viewer test = %d, want 403", vr.StatusCode)
+		}
+	})
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/kensa"
 	"github.com/Hanalyx/openwatch/internal/license"
 	"github.com/Hanalyx/openwatch/internal/liveness"
+	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/policy"
 	"github.com/Hanalyx/openwatch/internal/queue"
 	"github.com/Hanalyx/openwatch/internal/report"
@@ -111,6 +112,10 @@ type handlers struct {
 	// Kensa rule library (full normalized corpus). Set via
 	// (*Server).WithRuleLibrary; nil makes /api/v1/rules 503. Spec api-rules.
 	ruleLibrary *kensa.RuleLibrary
+
+	// Notification-channel CRUD + test. Set via (*Server).WithNotifications;
+	// nil makes the /api/v1/notifications endpoints 503. Spec api-notifications.
+	notificationSvc *notification.Service
 }
 
 // newHandlers constructs the ServerInterface implementation. The user

--- a/internal/server/notifications_handlers.go
+++ b/internal/server/notifications_handlers.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/notification"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+	openapitypes "github.com/oapi-codegen/runtime/types"
+
+	"github.com/google/uuid"
+)
+
+// notificationsReady writes 503 when the notification service is not
+// wired (tests / early boot) and reports false. Mirrors the other
+// optional-service guards.
+func (h *handlers) notificationsReady(w http.ResponseWriter) bool {
+	if h.notificationSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "service.unavailable", "server",
+			"notification service not configured", true)
+		return false
+	}
+	return true
+}
+
+// GetNotificationChannels lists channels with secrets redacted.
+// Spec api-notifications AC-01.
+func (h *handlers) GetNotificationChannels(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.NotificationRead); denied {
+		return
+	}
+	if !h.notificationsReady(w) {
+		return
+	}
+	list, err := h.notificationSvc.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"list notification channels failed", true)
+		return
+	}
+	out := make([]api.NotificationChannel, len(list))
+	for i, c := range list {
+		out[i] = toAPINotificationChannel(c)
+	}
+	writeJSON(w, http.StatusOK, api.NotificationChannelList{Channels: out})
+}
+
+// PostNotificationChannel creates a channel. Spec api-notifications AC-02.
+func (h *handlers) PostNotificationChannel(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.NotificationWrite); denied {
+		return
+	}
+	if !h.notificationsReady(w) {
+		return
+	}
+	var req api.NotificationChannelCreate
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"type, name, url required", false)
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	p := notification.CreateParams{
+		Type:      notification.ChannelType(req.Type),
+		Name:      req.Name,
+		Enabled:   enabled,
+		Config:    notification.Config{URL: req.Url},
+		TagFilter: derefTagFilter(req.TagFilter),
+	}
+	if req.Token != nil {
+		p.Config.Token = *req.Token
+	}
+	c, err := h.notificationSvc.Create(r.Context(), p)
+	if err != nil {
+		writeNotificationErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toAPINotificationChannel(c))
+}
+
+// GetNotificationChannel fetches one channel (secret redacted).
+// Spec api-notifications AC-01.
+func (h *handlers) GetNotificationChannel(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.NotificationRead); denied {
+		return
+	}
+	if !h.notificationsReady(w) {
+		return
+	}
+	c, err := h.notificationSvc.Get(r.Context(), uuid.UUID(id))
+	if err != nil {
+		writeNotificationErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPINotificationChannel(c))
+}
+
+// PatchNotificationChannel updates a channel. Spec api-notifications AC-03.
+func (h *handlers) PatchNotificationChannel(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.NotificationWrite); denied {
+		return
+	}
+	if !h.notificationsReady(w) {
+		return
+	}
+	var req api.NotificationChannelUpdate
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"name, enabled required", false)
+		return
+	}
+	p := notification.UpdateParams{
+		Name:      req.Name,
+		Enabled:   req.Enabled,
+		TagFilter: derefTagFilter(req.TagFilter),
+	}
+	// A url supplied in the patch replaces the encrypted config; omitting
+	// it leaves the existing secret untouched.
+	if req.Url != nil {
+		p.ReplaceConfig = true
+		p.Config.URL = *req.Url
+		if req.Token != nil {
+			p.Config.Token = *req.Token
+		}
+	}
+	c, err := h.notificationSvc.Update(r.Context(), uuid.UUID(id), p)
+	if err != nil {
+		writeNotificationErr(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPINotificationChannel(c))
+}
+
+// DeleteNotificationChannel removes a channel. Spec api-notifications AC-04.
+func (h *handlers) DeleteNotificationChannel(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.NotificationDelete); denied {
+		return
+	}
+	if !h.notificationsReady(w) {
+		return
+	}
+	if err := h.notificationSvc.Delete(r.Context(), uuid.UUID(id)); err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"delete notification channel failed", true)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// TestNotificationChannel sends a synthetic alert through the channel.
+// Spec api-notifications AC-05.
+func (h *handlers) TestNotificationChannel(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.NotificationTest); denied {
+		return
+	}
+	if !h.notificationsReady(w) {
+		return
+	}
+	if err := h.notificationSvc.Test(r.Context(), uuid.UUID(id)); err != nil {
+		if errors.Is(err, notification.ErrChannelNotFound) {
+			writeError(w, http.StatusNotFound, "notifications.not_found", "client",
+				"channel not found", false)
+			return
+		}
+		// Delivery failed (unreachable, non-2xx, blocked host). Client-fault
+		// 400 so the operator fixes the channel config, not a server bug.
+		writeError(w, http.StatusBadRequest, "notifications.delivery_failed", "client",
+			"test delivery failed", false)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func toAPINotificationChannel(c notification.Channel) api.NotificationChannel {
+	tags := c.TagFilter
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	return api.NotificationChannel{
+		Id:         openapitypes.UUID(c.ID),
+		Type:       api.NotificationChannelType(c.Type),
+		Name:       c.Name,
+		Enabled:    c.Enabled,
+		TargetHint: c.TargetHint,
+		TagFilter:  tags,
+		CreatedAt:  c.CreatedAt,
+		UpdatedAt:  c.UpdatedAt,
+	}
+}
+
+func derefTagFilter(m *map[string]string) map[string]string {
+	if m == nil {
+		return map[string]string{}
+	}
+	return *m
+}
+
+// writeNotificationErr maps service errors to HTTP status.
+func writeNotificationErr(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, notification.ErrChannelNotFound):
+		writeError(w, http.StatusNotFound, "notifications.not_found", "client",
+			"channel not found", false)
+	case errors.Is(err, notification.ErrInvalidConfig):
+		writeError(w, http.StatusBadRequest, "notifications.invalid", "client",
+			err.Error(), false)
+	default:
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"notification channel operation failed", true)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/kensa"
 	"github.com/Hanalyx/openwatch/internal/license"
+	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/report"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	"github.com/Hanalyx/openwatch/internal/server/api"
@@ -156,6 +157,14 @@ func (s *Server) WithReports(rep *report.Service) *Server {
 // makes the scan endpoints 503. Spec api-scans.
 func (s *Server) WithScanResults(rd *scanresult.Reader) *Server {
 	s.handlers.scanResultSvc = rd
+	return s
+}
+
+// WithNotifications threads the notification-channel service into the API
+// handlers so /api/v1/notifications/channels is routable. Nil makes the
+// notification endpoints 503. Spec api-notifications.
+func (s *Server) WithNotifications(svc *notification.Service) *Server {
+	s.handlers.notificationSvc = svc
 	return s
 }
 

--- a/specs/api/notifications.spec.yaml
+++ b/specs/api/notifications.spec.yaml
@@ -1,0 +1,83 @@
+spec:
+  id: api-notifications
+  title: Notification channels REST API
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: >-
+      CRUD + test for operator-managed alert-delivery channels under
+      /api/v1/notifications/channels. Backed by internal/notification
+      (system-notifications). Secrets (URL + token) are write-only: never
+      returned in any response.
+    description: >-
+      Six operations: list, create, get, patch, delete, and test-send.
+      Each is RBAC-gated by a distinct notification:* permission. Responses
+      carry only the non-secret channel metadata (id, type, name, enabled,
+      target_hint, tag_filter, timestamps). When the service is not wired,
+      every endpoint returns 503.
+    related_specs:
+      - system-notifications
+      - system-rbac
+
+  objective:
+    summary: >-
+      Lock the route contracts, the per-verb RBAC, the write-only secret
+      handling (no url/token in any response), and the 503-when-unwired
+      behavior.
+    scope:
+      includes:
+        - "GET /api/v1/notifications/channels (notification:read)"
+        - "POST /api/v1/notifications/channels (notification:write)"
+        - "GET/PATCH/DELETE /api/v1/notifications/channels/{id} (read/write/delete)"
+        - "POST /api/v1/notifications/channels/{id}:test (notification:test)"
+      excludes:
+        - "Delivery history endpoints (follow-up)"
+
+  constraints:
+    - id: C-01
+      description: >-
+        Each operation MUST enforce its permission via
+        auth.EnforcePermission before any work: list/get → notification:read,
+        create/patch → notification:write, delete → notification:delete,
+        test → notification:test. A caller lacking it gets 403.
+      type: security
+      enforcement: error
+    - id: C-02
+      description: >-
+        No response body across any notification endpoint MUST contain the
+        channel url or token. The API response schema (NotificationChannel)
+        has no url/token field; only target_hint (the non-secret host).
+      type: security
+      enforcement: error
+    - id: C-03
+      description: >-
+        When notificationSvc is nil every endpoint MUST return 503. A create
+        with a non-https or private-host url MUST return 400 (mapped from
+        ErrInvalidConfig); an unknown id on get/patch/test MUST return 404.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: GET /notifications/channels returns 200 with a channels array (NotificationChannelList) for a caller with notification:read; an anonymous caller gets 401 and a caller without the permission gets 403.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: POST /notifications/channels with a valid slack/webhook body creates the channel and returns 201 with the redacted NotificationChannel (target_hint set, no url/token key anywhere in the JSON).
+      priority: critical
+      references_constraints: [C-01, C-02]
+    - id: AC-03
+      description: PATCH /notifications/channels/{id} updates name/enabled/tag_filter (and replaces the secret only when url is supplied) and returns 200 redacted; DELETE returns 204 and gates on notification:delete.
+      priority: high
+      references_constraints: [C-01, C-02]
+    - id: AC-04
+      description: "POST /notifications/channels/{id}:test gates on notification:test and returns 204 on delivery success / 404 for an unknown id / 400 when delivery fails."
+      priority: high
+      references_constraints: [C-01]
+    - id: AC-05
+      description: A POST with an http:// or private-host url returns 400 (ErrInvalidConfig). With notificationSvc nil, every endpoint returns 503. Source inspection — the api.NotificationChannel response struct declares no Url/Token field.
+      priority: critical
+      references_constraints: [C-02, C-03]

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.4.0"
+  version: "1.5.0"
   status: draft
   tier: 2
 
@@ -62,7 +62,8 @@ spec:
         - "Users & teams — list from GET /api/v1/users (admin-gated), with roles per member, Invite (POST /users) and Manage (role assign/unassign + soft-delete) modals (v1.4.0)"
         - "Audit log — filterable, cursor-paginated GET /api/v1/audit/events, audit:read gated, read-only (v1.3.0)"
         - "About — version from GET /api/v1/version + license state from GET /api/v1/license (v1.3.0)"
-        - "Notifications, Integrations, Security — structural shells with Backend Pending banner"
+        - "Notifications — Slack/webhook channel CRUD + test over /api/v1/notifications/channels, notification:read gated, secrets write-only (v1.5.0)"
+        - "Integrations, Security — structural shells with Backend Pending banner"
         - "All control widgets themed via --ow-* tokens"
       excludes:
         - "PATCH /auth/me wiring (backend endpoint deferred)"
@@ -140,10 +141,9 @@ spec:
       enforcement: error
     - id: C-09
       description: >-
-        The remaining stubbed pages (Notifications, Integrations,
-        Security) MUST each render a BackendPendingBanner identifying
-        the slice that unblocks them. Every interactive control on
-        these pages MUST be disabled
+        The remaining stubbed pages (Integrations, Security) MUST each
+        render a BackendPendingBanner identifying the slice that unblocks
+        them. Every interactive control on these pages MUST be disabled
       type: technical
       enforcement: error
     - id: C-10
@@ -187,6 +187,18 @@ spec:
         /api/v1/license (tier, status, entitled features, expiry) —
         never hardcoded. Version stays sourced from GET /api/v1/version.
       type: technical
+      enforcement: error
+    - id: C-15
+      description: >-
+        v1.5.0 — Notifications (src/pages/settings/NotificationsPage.tsx)
+        MUST be gated on hasPermission('notification:read') (ForbiddenPage
+        otherwise) and list channels from GET /api/v1/notifications/channels
+        keyed ['notification-channels']. Add/Edit MUST POST/PATCH and Delete
+        MUST DELETE that resource, and Test MUST POST the :test sub-route;
+        every mutation invalidates ['notification-channels']. The page MUST
+        render only the non-secret target_hint (never a url/token) and gate
+        write/delete/test controls on notification:write/delete/test.
+      type: security
       enforcement: error
 
   acceptance_criteria:
@@ -247,7 +259,7 @@ spec:
       priority: critical
       references_constraints: [C-08]
     - id: AC-15
-      description: v1.3.0 — Each remaining stubbed Settings page (Notifications, Integrations, Security — three now that Audit log and About are wired and Compliance policies hosts the live scan-variables section) renders a single BackendPendingBanner naming the slice. Visible controls render disabled. PoliciesPage lives in its own file with per-section banners on its remaining stub sections.
+      description: v1.5.0 — Each remaining stubbed Settings page (Integrations, Security — two now that Notifications, Audit log and About are wired and Compliance policies hosts the live scan-variables section) renders a single BackendPendingBanner naming the slice. Visible controls render disabled. PoliciesPage lives in its own file with per-section banners on its remaining stub sections.
       priority: high
       references_constraints: [C-09]
     - id: AC-16
@@ -278,3 +290,7 @@ spec:
       description: "v1.4.0 source-inspection: per-member Manage opens ManageUserModal, which assigns/unassigns roles via POST /api/v1/users/{id}/roles:assign and :unassign, soft-deletes via DELETE /api/v1/users/{id}, sources the assignable list from GET /api/v1/roles, and invalidates the ['users'] query on every mutation success."
       priority: high
       references_constraints: [C-08]
+    - id: AC-23
+      description: "v1.5.0 source-inspection: NotificationsPage gates on hasPermission('notification:read') returning ForbiddenPage when absent; it lists from GET /api/v1/notifications/channels keyed ['notification-channels']; Add/Edit call api.POST/PATCH '/api/v1/notifications/channels', Delete calls api.DELETE, Test calls POST '/api/v1/notifications/channels/{id}:test', and every mutation invalidates ['notification-channels']; the page renders channel.target_hint and references no response url/token field. AC-15 stub set excludes Notifications."
+      priority: high
+      references_constraints: [C-15]

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,0 +1,107 @@
+spec:
+  id: system-notifications
+  title: Notification channels — encrypted store + SSRF-guarded delivery
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: >-
+      Operator-managed alert-delivery channels (Slack, generic webhook).
+      A row per channel in notification_channels carries its routing tag
+      filter and an AES-256-GCM encrypted config (target URL + optional
+      bearer token). The notification.DispatchChannel adapts the store to
+      the existing alertrouter.Channel seam, fanning every fired alert out
+      to all enabled, tag-matching channels.
+    description: >-
+      Slice 2a ships Slack + webhook (both https POST). Email/SMTP is a
+      follow-up. Secrets never touch a column in plaintext and are never
+      returned by the API; the non-secret target_hint (URL host) is stored
+      alongside for display so the list/read path never decrypts. Outbound
+      delivery is SSRF-guarded: only https URLs to public hosts are dialed
+      (literal private/loopback/link-local IPs rejected at validate time;
+      the resolved IP re-checked at dial time to close the TOCTOU gap).
+    related_specs:
+      - api-notifications
+      - system-alerts
+      - system-credential-store
+
+  objective:
+    summary: >-
+      Lock the encrypted-at-rest channel store, the SSRF guard, the
+      secret-free list/read path, and the alertrouter dispatch fan-out.
+    scope:
+      includes:
+        - "notification_channels migration 0030 (config_ciphertext BYTEA, target_hint, tag_filter JSONB)"
+        - "Create/List/Get/Update/Delete with config encrypted via secretkey.Active()"
+        - "SSRF guard: https-only, public-host-only, dial-time re-check"
+        - "DispatchChannel.Send fans out to enabled tag-matching channels"
+      excludes:
+        - "Email/SMTP channel (follow-up slice 2b)"
+        - "Delivery retry/backoff + per-delivery history (follow-up)"
+
+  constraints:
+    - id: C-01
+      description: >-
+        The channel target (URL + optional token) MUST be encrypted with
+        secretkey.Active() before persistence (config_ciphertext BYTEA) and
+        MUST NEVER be stored in a plaintext column. The list/read paths
+        (List, Get) MUST NOT decrypt — they return target_hint (the URL
+        host) only. Decryption happens only on the delivery + test paths.
+      type: security
+      enforcement: error
+    - id: C-02
+      description: >-
+        Outbound delivery MUST be SSRF-guarded. safeURLHost MUST reject any
+        non-https URL and any literal loopback/private/link-local/
+        unspecified IP (and localhost names) at validate time; the delivery
+        HTTP client MUST re-check the post-DNS resolved IP at dial time and
+        refuse non-public addresses.
+      type: security
+      enforcement: error
+    - id: C-03
+      description: >-
+        DispatchChannel.Send MUST deliver only to enabled channels whose
+        tag filter matches the alert (empty filter = wildcard), and a
+        delivery failure to one channel MUST NOT stop delivery to the
+        others (it returns the first error for the router's failure metric).
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: >-
+        The notification package MUST NOT import any external notification
+        SDK (Slack/webhook clients); delivery uses net/http + encoding/json
+        only, mirroring alertrouter's no-SDK rule.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: Create encrypts the config and persists config_ciphertext + target_hint; a round-trip getDecrypted returns the original URL + token, and the ciphertext column never equals the plaintext URL bytes.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: List and Get return channels with Config zero (TargetHint set, no URL/token); they issue no decrypt. Source inspection — neither List nor Get calls decryptConfig.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-03
+      description: "safeURLHost rejects http:// URLs, returns ErrInvalidConfig for literal private/loopback/link-local IPs (127.0.0.1, 10.0.0.1, 169.254.169.254, ::1) and localhost, and accepts a public https host returning its hostname."
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: isBlockedIP returns true for loopback, RFC1918 private, link-local, and unspecified addresses, and false for a public address (e.g. 1.1.1.1); the delivery client's dial Control refuses a blocked resolved IP.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-05
+      description: DispatchChannel.Send delivers to an enabled wildcard channel and to a channel whose tag filter matches the alert tags, and skips a disabled channel and a non-matching tag filter; matchesTags treats an empty filter as a wildcard.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-06
+      description: Update with ReplaceConfig=false leaves config_ciphertext + target_hint unchanged (name/enabled/tag_filter only); Update with ReplaceConfig=true re-encrypts and refreshes target_hint. Delete is idempotent for a missing id.
+      priority: high
+      references_constraints: [C-01]
+    - id: AC-07
+      description: Source inspection — the notification package imports no external Slack/webhook SDK (only net/http + encoding/json for delivery).
+      priority: high
+      references_constraints: [C-04]

--- a/specter.yaml
+++ b/specter.yaml
@@ -80,6 +80,8 @@ domains:
             - frontend-scan-detail
             - api-rules
             - frontend-rules-library
+            - system-notifications
+            - api-notifications
 settings:
     specs_dir: specs
     # Honored by `specter coverage` (not by `specter sync` — CI passes


### PR DESCRIPTION
## Settings activation — Phase 2a (Notifications)

The Notifications page was a stub. The `alertrouter` dispatch seam already existed, but only the `stdout` channel was wired. This ships operator-managed **Slack + webhook** alert delivery end to end. (Email/SMTP is the deferred 2b slice, per the agreed scope.)

### Backend — `internal/notification`
- **Migration 0030** `notification_channels`: the target (URL + optional bearer token) is **AES-256-GCM encrypted** via the shared `secretkey` DEK; a non-secret `target_hint` (URL host) is stored alongside so the list/read path **never decrypts**; `tag_filter` JSONB for routing.
- **Store CRUD** — encrypt on write, decrypt only on the delivery + test paths.
- **SSRF guard** — `https`-only + public-host-only at validate time; the delivery HTTP client re-checks the **resolved IP at dial time** (blocks loopback / RFC1918 / link-local incl. the `169.254.169.254` metadata endpoint). No external SDK (`net/http` + `encoding/json` only, enforced by a source test).
- **DispatchChannel** — one `alertrouter.Channel` that fans every fired alert out to enabled, tag-matching channels, so new channels take effect with no re-registration. Wired in `main.go` next to `stdout`.
- **API** `/api/v1/notifications/channels` (list/create/get/patch/delete + `:test`), RBAC per verb (`notification:read`/`write`/`delete`/`test`). **Secrets are write-only**: no response carries `url`/`token`, only `target_hint`.

### Frontend
`NotificationsPage` — channel cards, add/edit modal (type/name/url/token/severity-routing/enabled), Test, Delete, permission-gated controls. Added `notification:*` to the synthesized admin baseline.

## SDD
- `system-notifications` (7 AC) + `api-notifications` (5 AC) — both **100% against the real test DB** (encryption round-trip + ciphertext≠plaintext, SSRF guard incl. dial-control, dispatch selection, secret redaction, per-verb RBAC).
- `frontend-settings` → **v1.5.0** (C-15, AC-23; stub set narrowed to Integrations/Security).

## Verification
- Go: gofmt/vet/build clean; `go mod tidy` clean; `internal/notification` + `internal/server` notification tests pass against the real DB.
- Frontend: `specter check` 99 specs; `frontend-settings` 23/23 ACs; full vitest **280/280**; tsc + eslint clean.

> Visual Chrome check deferred (the dev session is logged out after the earlier backend restart; I don't authenticate on the user's behalf). Behavior is covered by the real-DB backend tests + source-inspection AC-23.

Part of the sequenced settings-activation plan. Remaining: Phase 2b (email/SMTP), Phase 3 (Security/SSO), Phase 4 (Integrations, Profile edit, framework-lenses).