### PR TITLE
feat(hosts): edit + delete host actions in the kebab menus

### DIFF
--- a/frontend/src/components/hosts/HostActionsMenu.tsx
+++ b/frontend/src/components/hosts/HostActionsMenu.tsx
@@ -97,7 +97,12 @@ export function HostActionsMenu({
       if (!response.ok || !data) {
         throw new Error(apiErrorMessage(error, `Failed to load host (HTTP ${response.status})`));
       }
-      setEditHost(data as unknown as FullHost);
+      // GET /hosts/{id} wraps the record under `host` (alongside liveness +
+      // compliance_summary). The edit form needs the unwrapped host so its
+      // fields pre-fill — passing the wrapper leaves every field blank.
+      const wrapper = data as unknown as { host?: FullHost };
+      const full = (wrapper.host ?? (data as unknown as FullHost)) as FullHost;
+      setEditHost(full);
     } catch (e) {
       setEditError((e as Error).message);
     } finally {

--- a/frontend/src/components/hosts/HostActionsMenu.tsx
+++ b/frontend/src/components/hosts/HostActionsMenu.tsx
@@ -1,0 +1,303 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { MoreVertical, Pencil, Trash2, Loader2, AlertTriangle } from 'lucide-react';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { useAuthStore } from '@/store/useAuthStore';
+import { Modal, Btn, Callout } from '@/components/settings/primitives';
+import { EditHostModal } from '@/components/hosts/EditHostModal';
+
+// HostActionsMenu — the three-dot (kebab) menu that surfaces Edit + Delete
+// for a host. Used on the /hosts cards + rows and the host-detail header.
+//
+// Permission-gated per the RBAC registry: Edit needs host:write, Delete
+// needs host:delete (dangerous). A user with neither sees no menu at all.
+// Delete always goes through an explicit confirmation modal.
+//
+// On the list, Edit fetches the full host first (the list row carries only
+// a summary shape); on detail the parent already has it, but this component
+// is self-contained so it fetches there too. After a delete, the detail
+// variant navigates back to /hosts; the list variant just invalidates.
+//
+// Dropdown behaviour (Escape + click-outside to close) mirrors the shell
+// AccountMenu.
+
+interface FullHost {
+  id: string;
+  hostname: string;
+  ip_address: string;
+  port?: number;
+  environment?: string;
+  display_name?: string;
+  description?: string;
+  username?: string;
+  tags?: string[];
+}
+
+interface Props {
+  hostId: string;
+  hostname: string;
+  // Show the Edit item (list). Detail passes false — it has its own Edit
+  // button next to the kebab.
+  showEdit?: boolean;
+  // Where to go after a successful delete.
+  afterDelete?: 'navigate' | 'invalidate';
+  // Style for the trigger button so it matches each call site's icon button.
+  buttonStyle?: React.CSSProperties;
+  iconSize?: number;
+}
+
+export function HostActionsMenu({
+  hostId,
+  hostname,
+  showEdit = true,
+  afterDelete = 'invalidate',
+  buttonStyle,
+  iconSize = 14,
+}: Props) {
+  const canWrite = useAuthStore((s) => s.hasPermission('host:write'));
+  const canDelete = useAuthStore((s) => s.hasPermission('host:delete'));
+  const [open, setOpen] = useState(false);
+  const [editHost, setEditHost] = useState<FullHost | null>(null);
+  const [loadingEdit, setLoadingEdit] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const showEditItem = showEdit && canWrite;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onMouseDown);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onMouseDown);
+    };
+  }, [open]);
+
+  // A user with no applicable action gets no menu.
+  if (!showEditItem && !canDelete) return null;
+
+  const startEdit = async () => {
+    setOpen(false);
+    setEditError(null);
+    setLoadingEdit(true);
+    try {
+      const { data, response, error } = await api.GET('/api/v1/hosts/{id}', {
+        params: { path: { id: hostId } },
+      });
+      if (!response.ok || !data) {
+        throw new Error(apiErrorMessage(error, `Failed to load host (HTTP ${response.status})`));
+      }
+      setEditHost(data as unknown as FullHost);
+    } catch (e) {
+      setEditError((e as Error).message);
+    } finally {
+      setLoadingEdit(false);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        aria-label={`Actions for ${hostname}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        style={buttonStyle ?? defaultBtn}
+      >
+        {loadingEdit ? <Loader2 size={iconSize} /> : <MoreVertical size={iconSize} />}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label={`Actions for ${hostname}`}
+          style={{
+            position: 'absolute',
+            top: 30,
+            right: 0,
+            minWidth: 168,
+            background: 'var(--ow-bg-1)',
+            border: '1px solid var(--ow-line)',
+            borderRadius: 8,
+            boxShadow: '0 8px 24px rgba(0,0,0,0.25)',
+            padding: '6px 0',
+            zIndex: 50,
+          }}
+        >
+          {showEditItem && (
+            <button type="button" role="menuitem" onClick={startEdit} style={menuItem}>
+              <Pencil size={13} /> Edit host
+            </button>
+          )}
+          {canDelete && (
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setOpen(false);
+                setConfirmDelete(true);
+              }}
+              style={{ ...menuItem, color: 'var(--ow-crit)' }}
+            >
+              <Trash2 size={13} /> Delete host
+            </button>
+          )}
+        </div>
+      )}
+
+      {editError && (
+        <div style={{ position: 'absolute', top: 30, right: 0, zIndex: 50, width: 240 }}>
+          <Callout tier="crit">{editError}</Callout>
+        </div>
+      )}
+
+      {editHost && <EditHostModal open onClose={() => setEditHost(null)} host={editHost} />}
+
+      {confirmDelete && (
+        <DeleteHostModal
+          hostId={hostId}
+          hostname={hostname}
+          afterDelete={afterDelete}
+          onClose={() => setConfirmDelete(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// DeleteHostModal — explicit confirmation before DELETE /api/v1/hosts/{id}
+// (host:delete). Deletion removes the host record and its scan-history
+// pointer and cannot be undone, so the operator must confirm.
+function DeleteHostModal({
+  hostId,
+  hostname,
+  afterDelete,
+  onClose,
+}: {
+  hostId: string;
+  hostname: string;
+  afterDelete: 'navigate' | 'invalidate';
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      const { response, error: e } = await api.DELETE('/api/v1/hosts/{id}', {
+        params: { path: { id: hostId } },
+      });
+      if (!response.ok) {
+        throw new Error(apiErrorMessage(e, `Failed to delete host (HTTP ${response.status})`));
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['hosts'] });
+      queryClient.removeQueries({ queryKey: ['host', hostId] });
+      onClose();
+      if (afterDelete === 'navigate') {
+        navigate({ to: '/hosts' });
+      }
+    },
+    onError: (e: Error) => setError(e.message),
+  });
+
+  const submitting = deleteMutation.isPending;
+
+  return (
+    <Modal
+      open
+      onClose={() => {
+        if (!submitting) onClose();
+      }}
+      title="Delete host"
+      width={460}
+      preventClose={submitting}
+      footer={
+        <>
+          <Btn onClick={onClose} disabled={submitting}>
+            Cancel
+          </Btn>
+          <Btn
+            variant="danger"
+            disabled={submitting}
+            onClick={() => {
+              setError(null);
+              deleteMutation.mutate();
+            }}
+          >
+            {submitting ? (
+              <>
+                <Loader2 size={14} /> Deleting…
+              </>
+            ) : (
+              <>
+                <Trash2 size={14} /> Delete host
+              </>
+            )}
+          </Btn>
+        </>
+      }
+    >
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+        <AlertTriangle size={20} style={{ color: 'var(--ow-crit)', flexShrink: 0, marginTop: 2 }} />
+        <div style={{ fontSize: 13, color: 'var(--ow-fg-1)', lineHeight: 1.5 }}>
+          Delete{' '}
+          <strong style={{ color: 'var(--ow-fg-0)', fontFamily: 'var(--ow-font-mono)' }}>
+            {hostname}
+          </strong>
+          ? This removes the host record and its scan-history pointer. This action cannot be undone.
+        </div>
+      </div>
+      {error && (
+        <div style={{ marginTop: 12 }}>
+          <Callout tier="crit">{error}</Callout>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+const defaultBtn: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 28,
+  height: 28,
+  background: 'transparent',
+  border: '1px solid var(--ow-line)',
+  borderRadius: 6,
+  color: 'var(--ow-fg-2)',
+  cursor: 'pointer',
+  padding: 0,
+};
+
+const menuItem: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  width: '100%',
+  padding: '8px 12px',
+  background: 'transparent',
+  border: 0,
+  color: 'var(--ow-fg-0)',
+  textAlign: 'left',
+  fontSize: 13,
+  cursor: 'pointer',
+};

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -12,7 +12,6 @@ import {
   Clock,
   FileText,
   LayoutGrid,
-  MoreVertical,
   Package,
   Pencil,
   Play,
@@ -30,6 +29,8 @@ import api from '@/api/client';
 import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { apiErrorCode, apiErrorMessage } from '@/api/errors';
 import { EditHostModal } from '@/components/hosts/EditHostModal';
+import { HostActionsMenu } from '@/components/hosts/HostActionsMenu';
+import { useAuthStore } from '@/store/useAuthStore';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { CardSystem, pickNumber, pickString } from '@/pages/host-detail/CardSystem';
 import { osDisplayLabel } from '@/utils/osLabel';
@@ -502,6 +503,7 @@ function PageHead({
   intelligenceSnapshot: Record<string, unknown> | null;
 }) {
   const [editOpen, setEditOpen] = useState(false);
+  const canWrite = useAuthStore((s) => s.hasPermission('host:write'));
   const band: MonitoringBand =
     host.maintenance_mode === true ? 'maintenance' : (liveness?.monitoring_state ?? 'unknown');
 
@@ -646,17 +648,23 @@ function PageHead({
             <TerminalIcon size={14} /> Terminal
           </button>
           <RunScanButton host={host} />
-          <button
-            type="button"
-            onClick={() => setEditOpen(true)}
-            aria-label={`Edit ${host.hostname}`}
-            style={ghostBtn}
-          >
-            <Pencil size={12} /> Edit
-          </button>
-          <button type="button" style={iconBtn} title="More" disabled>
-            <MoreVertical size={14} />
-          </button>
+          {canWrite && (
+            <button
+              type="button"
+              onClick={() => setEditOpen(true)}
+              aria-label={`Edit ${host.hostname}`}
+              style={ghostBtn}
+            >
+              <Pencil size={12} /> Edit
+            </button>
+          )}
+          <HostActionsMenu
+            hostId={host.id}
+            hostname={host.hostname}
+            showEdit={false}
+            afterDelete="navigate"
+            buttonStyle={iconBtn}
+          />
         </div>
       </div>
       <EditHostModal open={editOpen} onClose={() => setEditOpen(false)} host={host} />

--- a/frontend/src/pages/HostsListPage.tsx
+++ b/frontend/src/pages/HostsListPage.tsx
@@ -11,7 +11,6 @@ import {
   List as TableIcon,
   PlayCircle,
   BarChart3,
-  MoreVertical,
   Server,
   Shield,
   AlertTriangle,
@@ -19,6 +18,7 @@ import {
 } from 'lucide-react';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
+import { HostActionsMenu } from '@/components/hosts/HostActionsMenu';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { osDisplayLabel } from '@/utils/osLabel';
@@ -995,9 +995,7 @@ function HostCard({ host }: { host: DevHost }) {
             <OSChip os={host.os} />
           </div>
         </div>
-        <button type="button" style={iconBtnSm} aria-label="More">
-          <MoreVertical size={14} />
-        </button>
+        <HostActionsMenu hostId={host.id} hostname={displayName} buttonStyle={iconBtnSm} />
       </div>
 
       {/* Status row */}
@@ -1340,9 +1338,7 @@ function HostRow({ host }: { host: DevHost }) {
           <button type="button" style={iconBtnSm} aria-label="View report">
             <BarChart3 size={14} />
           </button>
-          <button type="button" style={iconBtnSm} aria-label="More">
-            <MoreVertical size={14} />
-          </button>
+          <HostActionsMenu hostId={host.id} hostname={displayName} buttonStyle={iconBtnSm} />
         </div>
       </td>
     </tr>

--- a/frontend/tests/pages/host-detail.test.ts
+++ b/frontend/tests/pages/host-detail.test.ts
@@ -137,4 +137,28 @@ describe('frontend-host-detail — structural', () => {
       expect(PAGE_SRC).not.toMatch(re);
     }
   });
+
+  // @ac AC-39
+  test('frontend-host-detail/AC-39 — Edit gated on host:write; three-dot Delete gated on host:delete with confirm + navigate', () => {
+    // Edit button is permission-gated (hidden without host:write).
+    expect(PAGE_SRC).toMatch(/hasPermission\('host:write'\)/);
+    expect(PAGE_SRC).toMatch(/canWrite\s*&&[\s\S]{0,200}setEditOpen\(true\)/);
+    // The page-head mounts the actions menu in delete-only mode, navigating
+    // back to /hosts after a successful delete.
+    expect(PAGE_SRC).toContain('HostActionsMenu');
+    expect(PAGE_SRC).toMatch(/showEdit=\{false\}/);
+    expect(PAGE_SRC).toMatch(/afterDelete="navigate"/);
+
+    const MENU_SRC = readFileSync(
+      resolve(process.cwd(), 'src/components/hosts/HostActionsMenu.tsx'),
+      'utf8',
+    );
+    // Delete is host:delete-gated, confirmed, and hits DELETE /hosts/{id}.
+    expect(MENU_SRC).toMatch(/hasPermission\('host:delete'\)/);
+    expect(MENU_SRC).toContain('DeleteHostModal');
+    expect(MENU_SRC).toContain("api.DELETE('/api/v1/hosts/{id}'");
+    expect(MENU_SRC).toMatch(/cannot be undone/i);
+    // Navigates to /hosts on the detail variant after delete.
+    expect(MENU_SRC).toMatch(/navigate\(\{\s*to:\s*'\/hosts'\s*\}\)/);
+  });
 });

--- a/frontend/tests/pages/hosts-list.test.ts
+++ b/frontend/tests/pages/hosts-list.test.ts
@@ -262,6 +262,9 @@ describe('frontend-hosts-list v1.5.0 — card/row actions menu', () => {
     // Edit fetches the full host then opens EditHostModal (PATCH path).
     expect(MENU_SRC).toContain("api.GET('/api/v1/hosts/{id}'");
     expect(MENU_SRC).toContain('EditHostModal');
+    // The GET response nests the record under `host`; the menu MUST unwrap it
+    // so the edit form pre-fills (passing the wrapper leaves every field blank).
+    expect(MENU_SRC).toMatch(/\.host\b/);
     // Delete is confirmed before the DELETE call and invalidates ['hosts'].
     expect(MENU_SRC).toContain('DeleteHostModal');
     expect(MENU_SRC).toContain("api.DELETE('/api/v1/hosts/{id}'");

--- a/frontend/tests/pages/hosts-list.test.ts
+++ b/frontend/tests/pages/hosts-list.test.ts
@@ -242,3 +242,30 @@ describe('frontend-hosts-list v1.4.0 — fleet trend delta', () => {
     expect(PAGE_SRC).toMatch(/avgCompliance: \{ value: avgCompliance, target: 80, delta: '',/);
   });
 });
+
+describe('frontend-hosts-list v1.5.0 — card/row actions menu', () => {
+  // @ac AC-20
+  test('frontend-hosts-list/AC-20 — card + row render HostActionsMenu; edit (host:write) + delete (host:delete) with confirm', () => {
+    // Both the card and the table row mount the actions menu.
+    expect(PAGE_SRC).toContain('HostActionsMenu');
+    expect((PAGE_SRC.match(/<HostActionsMenu/g) ?? []).length).toBeGreaterThanOrEqual(2);
+
+    const MENU_SRC = readFileSync(
+      resolve(process.cwd(), 'src/components/hosts/HostActionsMenu.tsx'),
+      'utf8',
+    );
+    // Permission gating: Edit -> host:write, Delete -> host:delete; a caller
+    // with neither gets no menu.
+    expect(MENU_SRC).toMatch(/hasPermission\('host:write'\)/);
+    expect(MENU_SRC).toMatch(/hasPermission\('host:delete'\)/);
+    expect(MENU_SRC).toMatch(/if \(!showEditItem && !canDelete\) return null/);
+    // Edit fetches the full host then opens EditHostModal (PATCH path).
+    expect(MENU_SRC).toContain("api.GET('/api/v1/hosts/{id}'");
+    expect(MENU_SRC).toContain('EditHostModal');
+    // Delete is confirmed before the DELETE call and invalidates ['hosts'].
+    expect(MENU_SRC).toContain('DeleteHostModal');
+    expect(MENU_SRC).toContain("api.DELETE('/api/v1/hosts/{id}'");
+    expect(MENU_SRC).toMatch(/cannot be undone/i);
+    expect(MENU_SRC).toContain("queryKey: ['hosts']");
+  });
+});

--- a/specs/frontend/host-detail.spec.yaml
+++ b/specs/frontend/host-detail.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-detail
   title: Host Detail page layout, behavior, and empty-state contracts
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -230,3 +230,7 @@ spec:
       description: 'v1.4.0 - the Compliance trend card is LIVE: it queries /api/v1/hosts/{id}/compliance/trend with queryKey ["host", hostId, "compliance_trend"] (the host prefix gives free scan.completed refresh), renders the score sparkline plus the latest score and the over-window delta when snapshots exist, and an honest empty state ("No snapshots yet", naming the hourly rollup) when none do; the loading guard is isPending'
       priority: high
       references_constraints: [C-04]
+
+    - id: AC-39
+      description: 'v1.5.0 - the page-head Edit button is gated on host:write (hidden for callers without it), and the page-head three-dot actions menu (HostActionsMenu with showEdit false) offers Delete gated on host:delete: an explicit confirmation modal precedes DELETE /api/v1/hosts/{id}, and on success the app navigates to /hosts. Source-inspection of HostDetailPage.tsx + HostActionsMenu.tsx.'
+      priority: high

--- a/specs/frontend/hosts-list.spec.yaml
+++ b/specs/frontend/hosts-list.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-hosts-list
   title: Hosts list — fleet dashboard with search, filter, card/table views
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -155,4 +155,8 @@ spec:
       references_constraints: [C-02]
     - id: AC-19
       description: 'v1.4.0 - the average-compliance KPI delta reads the fleet trend (GET /api/v1/fleet/compliance/trend, queryKey ["fleet", "compliance", "trend"]): with two or more snapshot days it renders "(+/-)N% vs yesterday" (tier ok when rising, crit when falling, neutral on no change); with fewer days the delta stays empty - never a fabricated zero'
+      priority: high
+
+    - id: AC-20
+      description: 'v1.5.0 - each host card and table row renders a three-dot (kebab) actions menu (HostActionsMenu). Edit (gated on host:write) fetches the full host via GET /api/v1/hosts/{id} then opens EditHostModal (PATCH /api/v1/hosts/{id}). Delete (gated on host:delete, dangerous) opens an explicit confirmation modal before calling DELETE /api/v1/hosts/{id} and invalidating the ["hosts"] query on success. A caller with neither host:write nor host:delete sees no menu at all. Source-inspection of HostActionsMenu.tsx + HostsListPage.tsx.'
       priority: high

--- a/specs/frontend/hosts-list.spec.yaml
+++ b/specs/frontend/hosts-list.spec.yaml
@@ -158,5 +158,5 @@ spec:
       priority: high
 
     - id: AC-20
-      description: 'v1.5.0 - each host card and table row renders a three-dot (kebab) actions menu (HostActionsMenu). Edit (gated on host:write) fetches the full host via GET /api/v1/hosts/{id} then opens EditHostModal (PATCH /api/v1/hosts/{id}). Delete (gated on host:delete, dangerous) opens an explicit confirmation modal before calling DELETE /api/v1/hosts/{id} and invalidating the ["hosts"] query on success. A caller with neither host:write nor host:delete sees no menu at all. Source-inspection of HostActionsMenu.tsx + HostsListPage.tsx.'
+      description: 'v1.5.0 - each host card and table row renders a three-dot (kebab) actions menu (HostActionsMenu). Edit (gated on host:write) fetches the full host via GET /api/v1/hosts/{id}, unwraps the record nested under the response `host` key, and opens EditHostModal (PATCH /api/v1/hosts/{id}) with every available field pre-filled. Delete (gated on host:delete, dangerous) opens an explicit confirmation modal before calling DELETE /api/v1/hosts/{id} and invalidating the ["hosts"] query on success. A caller with neither host:write nor host:delete sees no menu at all. Source-inspection of HostActionsMenu.tsx + HostsListPage.tsx.'
       priority: high


### PR DESCRIPTION
## Summary

The three-dot (kebab) menus on the `/hosts` cards + table rows and the host-detail header were inert placeholders. This wires them to real **Edit** and **Delete** actions, RBAC-gated, with a confirmation step before deletion.

Frontend-only — the `PATCH`/`DELETE /api/v1/hosts/{id}` endpoints and `EditHostModal` already exist; this surfaces them.

## New: `HostActionsMenu`

A reusable kebab menu (mirrors the shell `AccountMenu` dropdown — Escape + click-outside to close):

- **Edit** (`host:write`): fetches the full host via `GET /api/v1/hosts/{id}` (the list row carries only a summary shape) then opens the existing `EditHostModal` → `PATCH /api/v1/hosts/{id}`.
- **Delete** (`host:delete`, dangerous): opens an **explicit confirmation modal** ("…cannot be undone") before `DELETE /api/v1/hosts/{id}`. On success it invalidates `['hosts']`; the **detail** variant navigates back to `/hosts`.
- A caller with **neither** permission sees **no menu** at all.

## Wiring

| Surface | Menu |
|---|---|
| `/hosts` card kebab | Edit + Delete |
| `/hosts` table-row kebab | Edit + Delete |
| `/hosts/<id>` header kebab | Delete only (header already has a dedicated Edit button) |

The detail header's existing **Edit** button is now also gated on `host:write`, so a read-only role no longer sees an action it can't perform.

## Permission matrix (built-in roles)

| Role | Edit | Delete |
|---|---|---|
| viewer / auditor (`host:read`) | — | — (no menu) |
| ops_lead (`host:write`) | ✓ | — |
| security_admin / admin (`host:*`) | ✓ | ✓ |

(Server-side enforcement is unchanged: `PATCH`→`host:write`, `DELETE`→`host:delete`; verified anonymous DELETE → 403.)

## Specs & tests

- `frontend-hosts-list` → v1.5.0 (AC-20), `frontend-host-detail` → v1.5.0 (AC-39).
- Source-inspection tests assert the gating, the confirmation copy, the GET-then-edit flow, the DELETE call, and the post-delete navigation.
- 284 frontend tests pass (44 files); tsc / eslint / prettier clean; `specter check` green (103 specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)