### PR TITLE
fix(packaging): make a fresh install actually run (Kensa corpus + identity keys)

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -104,6 +104,14 @@ jobs:
           test -d /usr/share/kensa/rules
           rule_count="$(find /usr/share/kensa/rules -name '*.yml' | wc -l)"
           test "$rule_count" -ge 500
+          # Identity keys provisioned by the post-install scriptlet (the server
+          # refuses to auto-generate them and exits without them).
+          test -f /etc/openwatch/keys/jwt_private.pem
+          test -f /etc/openwatch/keys/credential.key
+          # JWT key is a valid RSA key; DEK is exactly 32 bytes; DEK is 0600.
+          openssl rsa -in /etc/openwatch/keys/jwt_private.pem -noout -check
+          test "$(stat -c '%s' /etc/openwatch/keys/credential.key)" -eq 32
+          test "$(stat -c '%a' /etc/openwatch/keys/credential.key)" = "600"
           # Binary runs (no DB needed for these).
           /usr/bin/openwatch --version
           /usr/bin/openwatch check-config

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -47,6 +47,8 @@ jobs:
           path: |
             dist/openwatch-*.rpm
             dist/openwatch_*.deb
+            dist/kensa-rules-*.rpm
+            dist/kensa-rules_*.deb
           retention-days: 3
 
   smoke:
@@ -74,12 +76,17 @@ jobs:
         run: |
           set -eux
           if [ "${{ matrix.kind }}" = "rpm" ]; then
-            # dnf resolves the postgresql-server dependency from the distro repos.
-            dnf install -y ./dist/openwatch-*.x86_64.rpm
+            # Both local files in one transaction: dnf resolves
+            # postgresql-server from the distro repos and the hard
+            # kensa-rules dependency from the local noarch RPM. Installing
+            # openwatch alone MUST fail (corpus dependency unsatisfiable
+            # offline) — passing here proves the both-file air-gapped path.
+            dnf install -y ./dist/openwatch-*.x86_64.rpm ./dist/kensa-rules-*.noarch.rpm
           else
             apt-get update
-            # apt install of a local .deb pulls declared deps.
-            apt-get install -y ./dist/openwatch_*_amd64.deb
+            # apt install of local .debs pulls declared deps; the openwatch
+            # .deb Depends on kensa-rules, satisfied by the local all .deb.
+            apt-get install -y ./dist/openwatch_*_amd64.deb ./dist/kensa-rules_*_all.deb
           fi
 
       - name: Smoke-test the install
@@ -92,6 +99,11 @@ jobs:
           test -f /etc/openwatch/tls/cert.pem
           # System user created by the post-install scriptlet.
           id openwatch
+          # Kensa rule corpus landed at the engine's default load path, and
+          # carries the full rule set — a scan-capable install, not a stub.
+          test -d /usr/share/kensa/rules
+          rule_count="$(find /usr/share/kensa/rules -name '*.yml' | wc -l)"
+          test "$rule_count" -ge 500
           # Binary runs (no DB needed for these).
           /usr/bin/openwatch --version
           /usr/bin/openwatch check-config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,8 @@ jobs:
           %_gpg_name ${key_id}
           %__gpg_sign_cmd %{__gpg} --batch --no-armor --pinentry-mode loopback --passphrase ${GPG_PASSPHRASE} --no-secmem-warning --digest-algo sha256 -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
           RPMMACROS
-          rpmsign --addsign dist/openwatch-*.rpm
+          # Sign every RPM in dist/, including the noarch kensa-rules corpus.
+          rpmsign --addsign dist/*.rpm
 
       # SBOM: syft scans the actual (signed) binary and packages and emits
       # CycloneDX 1.5 JSON — supply-chain AC-08 / AC-09.
@@ -119,7 +120,7 @@ jobs:
           mkdir -p dist/sbom
           # CycloneDX 1.5 schema the emitted SBOMs validate against:
           #   https://cyclonedx.org/schema/bom-1.5.schema.json
-          for art in dist/openwatch dist/openwatch-*.rpm dist/openwatch_*.deb; do
+          for art in dist/openwatch dist/openwatch-*.rpm dist/openwatch_*.deb dist/kensa-rules-*.rpm dist/kensa-rules_*.deb; do
             [ -e "$art" ] || continue
             name="$(basename "$art")"
             syft scan "file:$art" -o "cyclonedx-json=dist/sbom/${name}.cdx.json"
@@ -129,7 +130,7 @@ jobs:
       - name: Checksums
         run: |
           cd dist
-          sha256sum openwatch-*.rpm openwatch_*.deb sbom/*.cdx.json > SHA256SUMS
+          sha256sum *.rpm *.deb sbom/*.cdx.json > SHA256SUMS
           cat SHA256SUMS
 
       # Detached GPG signature over the checksum manifest — the universal verify
@@ -173,6 +174,8 @@ jobs:
           files: |
             dist/openwatch-*.rpm
             dist/openwatch_*.deb
+            dist/kensa-rules-*.rpm
+            dist/kensa-rules_*.deb
             dist/SHA256SUMS
             dist/SHA256SUMS.asc
             dist/SHA256SUMS.cosign.sig

--- a/.gitignore
+++ b/.gitignore
@@ -709,6 +709,8 @@ dist/
 !packaging/rpm/*.spec
 # Same exception for the Go rebuild's RPM spec
 !app/packaging/rpm/*.spec
+# The kensa-rules corpus package ships its own RPM spec
+!packaging/kensa-rules/*.spec
 
 # RPM creation scripts (temporary)
 create-rpm.sh

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -165,14 +165,14 @@
         "filename": "docs/engineering/install_guide.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 139
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/engineering/install_guide.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 355
+        "line_number": 370
       }
     ],
     "docs/engineering/prototypes/openwatch-v1/Host Management.html": [
@@ -2867,5 +2867,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-15T13:25:45Z"
+  "generated_at": "2026-06-15T21:15:28Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,18 @@ rpm-arm64:
 deb-arm64:
 	@ARCH=arm64 bash packaging/deb/build-deb.sh
 
-# All four release artifacts: RPM + DEB for amd64 and arm64.
+# Kensa rule corpus, packaged separately (noarch RPM + arch:all DEB). The
+# openwatch packages declare a hard dependency on this; an install needs
+# both. Version tracks the vendored kensa module, not the platform.
+.PHONY: kensa-rules
+kensa-rules:
+	@bash packaging/kensa-rules/build-kensa-rules.sh
+
+# All release artifacts: openwatch RPM + DEB for amd64 and arm64, plus the
+# arch-independent kensa-rules corpus package (one RPM + one DEB).
 .PHONY: packages
-packages: rpm rpm-arm64 deb deb-arm64
-	@echo "built RPM + DEB (amd64 + arm64) in $(DIST_DIR)/"
+packages: rpm rpm-arm64 deb deb-arm64 kensa-rules
+	@echo "built openwatch RPM + DEB (amd64 + arm64) and kensa-rules in $(DIST_DIR)/"
 
 # -----------------------------------------------------------------------------
 # FIPS build (Day 12: microsoft/go toolchain)

--- a/docs/engineering/install_guide.md
+++ b/docs/engineering/install_guide.md
@@ -118,7 +118,14 @@ packages:
    (`openwatch.toml` plus a self-signed TLS cert/key), the `systemd` unit, and
    the `/var/lib/openwatch` and `/var/log/openwatch` data directories. The
    `kensa-rules` package installs the rule corpus to `/usr/share/kensa/rules`.
-3. Reloads `systemd`. It does **not** start the service — you do that in Step 7,
+3. Generates the identity keys the server requires in production —
+   `/etc/openwatch/keys/jwt_private.pem` (RSA-2048 JWT signing key) and
+   `/etc/openwatch/keys/credential.key` (AES-256 credential DEK). This is
+   generate-if-absent: a reinstall or upgrade never overwrites existing keys
+   (regenerating them would invalidate sessions and make stored SSH/MFA
+   secrets undecryptable). The server does **not** auto-generate these — it
+   exits if they are missing — so the package lays them down at install time.
+4. Reloads `systemd`. It does **not** start the service — you do that in Step 7,
    after the database and admin user exist.
 
 Confirm the install:

--- a/docs/engineering/install_guide.md
+++ b/docs/engineering/install_guide.md
@@ -26,7 +26,7 @@ After the steps below you have:
 |------|------|---------|
 | 1 | Install PostgreSQL | `dnf install postgresql-server` / `apt install postgresql` |
 | 2 | Provision the database | `createdb` + role (see below) |
-| 3 | Install the package | `dnf install ./openwatch-*.rpm` / `apt install ./openwatch_*.deb` |
+| 3 | Install the packages | `dnf install ./openwatch-*.rpm ./kensa-rules-*.rpm` / `apt install ./openwatch_*.deb ./kensa-rules_*.deb` |
 | 4 | Configure the database secret | edit `/etc/openwatch/secrets.env` |
 | 5 | Run migrations | `openwatch migrate` |
 | 6 | Create the first admin | `openwatch create-admin --username admin --email …` |
@@ -96,18 +96,28 @@ PGPASSWORD='replace-with-a-strong-password' \
   psql -h 127.0.0.1 -U openwatch -d openwatch -c '\conninfo'
 ```
 
-### Step 3 — Install the package
+### Step 3 — Install the packages
 
 ```bash
-sudo dnf install -y ./openwatch-0.2.0-1.x86_64.rpm
+sudo dnf install -y ./openwatch-0.2.0-1.x86_64.rpm ./kensa-rules-0.4.3-1.noarch.rpm
 ```
 
-Use the filename you downloaded (`aarch64` for arm64). Installing the package:
+Install **both** files in one transaction. `openwatch` declares a hard
+dependency on `kensa-rules` — the rule corpus the scan engine loads from
+`/usr/share/kensa/rules`. Installing `openwatch` alone fails the dependency
+check (by design: a corpus-less node cannot scan). `kensa-rules` is `noarch`
+and versioned on the Kensa content line (e.g. `0.4.3`), independent of the
+platform version, so the rules can update without re-releasing OpenWatch.
+
+Use the filenames you downloaded (`aarch64` for the arm64 openwatch RPM; the
+`kensa-rules` package is the same `noarch` file for every arch). Installing the
+packages:
 
 1. Creates the `openwatch` system user and group (idempotent).
 2. Installs the binary at `/usr/bin/openwatch`, config under `/etc/openwatch/`
    (`openwatch.toml` plus a self-signed TLS cert/key), the `systemd` unit, and
-   the `/var/lib/openwatch` and `/var/log/openwatch` data directories.
+   the `/var/lib/openwatch` and `/var/log/openwatch` data directories. The
+   `kensa-rules` package installs the rule corpus to `/usr/share/kensa/rules`.
 3. Reloads `systemd`. It does **not** start the service — you do that in Step 7,
    after the database and admin user exist.
 
@@ -227,15 +237,20 @@ PGPASSWORD='replace-with-a-strong-password' \
   psql -h 127.0.0.1 -U openwatch -d openwatch -c '\conninfo'
 ```
 
-### Step 3 — Install the package
+### Step 3 — Install the packages
 
 ```bash
-sudo apt install -y ./openwatch_0.2.0-rc.5_amd64.deb
+sudo apt install -y ./openwatch_0.2.0-rc.5_amd64.deb ./kensa-rules_0.4.3_all.deb
 ```
 
-Use the filename you downloaded (`arm64` for aarch64). If `apt` reports missing
-dependencies, add `-f`. The package creates the `openwatch` user, installs the
-same files as the RPM, and reloads `systemd` without starting the service.
+Install **both** files together — `openwatch` `Depends` on `kensa-rules` (the
+scan engine's rule corpus at `/usr/share/kensa/rules`), so installing the
+openwatch `.deb` alone fails the dependency check by design. The `kensa-rules`
+package is `Architecture: all` (one file for every arch). Use the openwatch
+filename you downloaded (`arm64` for aarch64). If `apt` reports missing
+dependencies, add `-f`. The packages create the `openwatch` user, install the
+same files as the RPM plus the corpus, and reload `systemd` without starting
+the service.
 
 ```bash
 dpkg -l openwatch

--- a/docs/runbooks/RELEASING.md
+++ b/docs/runbooks/RELEASING.md
@@ -60,9 +60,12 @@ This triggers `release.yml` (builds + SBOMs + publishes a pre-release) and
   runners are wired in.)
 
 **Manual (on the RC, against a real fleet — CI cannot reach workstation hosts):**
-1. Install the RC package on a clean VM of at least one RHEL-family and one
-   Debian-family distro: `sudo dnf install ./openwatch-<v>.x86_64.rpm` /
-   `sudo apt install ./openwatch_<v>_amd64.deb`.
+1. Install the RC packages on a clean VM of at least one RHEL-family and one
+   Debian-family distro — both the platform and the rule corpus, in one
+   transaction (openwatch hard-depends on kensa-rules):
+   `sudo dnf install ./openwatch-<v>.x86_64.rpm ./kensa-rules-<kv>.noarch.rpm` /
+   `sudo apt install ./openwatch_<v>_amd64.deb ./kensa-rules_<kv>_all.deb`.
+   Confirm a scan finds the corpus: `test -d /usr/share/kensa/rules`.
 2. `sudo openwatch migrate` && `sudo openwatch create-admin …` &&
    `sudo systemctl enable --now openwatch`; confirm
    `curl -k https://localhost:8443/api/v1/health` is healthy and the UI loads at
@@ -94,8 +97,8 @@ GitHub Release.
 On a clean box, install the **published** artifact and confirm it starts:
 
 ```bash
-# download openwatch-<v>.x86_64.rpm from the release, then:
-sudo dnf install ./openwatch-<v>.x86_64.rpm
+# download openwatch-<v>.x86_64.rpm AND kensa-rules-<kv>.noarch.rpm, then:
+sudo dnf install ./openwatch-<v>.x86_64.rpm ./kensa-rules-<kv>.noarch.rpm
 sudo openwatch migrate && sudo systemctl enable --now openwatch
 curl -k https://localhost:8443/api/v1/health
 ```

--- a/packaging/common/openwatch.toml
+++ b/packaging/common/openwatch.toml
@@ -22,3 +22,15 @@ max_connections = 25
 [logging]
 level  = "info"
 format = "json"
+
+[identity]
+# Signing material the server requires in production — it does NOT
+# auto-generate these and will refuse to start if either is missing. The
+# package's post-install step generates both into /etc/openwatch/keys on
+# first install (generate-if-absent; upgrades never clobber them). These
+# are the built-in defaults, shown here so the paths are discoverable and
+# overridable; you normally do not need to change them.
+#   jwt_private_key:     RSA >= 2048 PEM (PKCS#1 or PKCS#8), mode 0640 root:openwatch
+#   credential_key_file: 32 raw bytes (AES-256), mode 0600 openwatch:openwatch
+jwt_private_key     = "/etc/openwatch/keys/jwt_private.pem"
+credential_key_file = "/etc/openwatch/keys/credential.key"

--- a/packaging/common/provision-identity-keys.sh
+++ b/packaging/common/provision-identity-keys.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Provision OpenWatch identity keys at install time. Invoked from the RPM
+# %post and the DEB postinst.
+#
+# WHY this exists: in production the server deliberately refuses to
+# auto-generate its signing material and exits if it is missing
+# (cmd/openwatch/main.go: "There is no silent fallback to ephemeral — a
+# binary with no signing key would 500 every login"). Auto-generation is
+# a dev/test-only path. So the package — the production install boundary —
+# must lay the keys down, exactly as it lays down the config and the unit.
+#
+# GENERATE-IF-ABSENT, never overwrite: regenerating jwt_private.pem would
+# invalidate every issued token; regenerating credential.key would make
+# every stored SSH credential and MFA secret permanently undecryptable. So
+# both are created only when missing — this script is safe to re-run and
+# safe across package upgrades.
+#
+# Idempotent and operator-rerunnable: `bash /usr/lib/openwatch/provision-identity-keys.sh`.
+
+set -euo pipefail
+
+KEYS_DIR="${OPENWATCH_KEYS_DIR:-/etc/openwatch/keys}"
+JWT_KEY="$KEYS_DIR/jwt_private.pem"
+DEK="$KEYS_DIR/credential.key"
+OWNER_GROUP="${OPENWATCH_GROUP:-openwatch}"
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "provision-identity-keys: openssl not found (it is a package dependency)" >&2
+    exit 1
+fi
+
+# Key directory: 0750 so the service (running as the openwatch user, in the
+# openwatch group) can traverse it, but it is not world-readable.
+install -d -m 0750 -o root -g "$OWNER_GROUP" "$KEYS_DIR"
+
+# JWT signing key — RSA 2048 PKCS#1 PEM (the loader accepts PKCS#1 or PKCS#8
+# and requires >= 2048 bits). Mode 0640 root:openwatch: the service reads it
+# via the group; root owns it.
+if [ ! -f "$JWT_KEY" ]; then
+    ( umask 077; openssl genrsa -out "$JWT_KEY" 2048 )
+    chown "root:$OWNER_GROUP" "$JWT_KEY"
+    chmod 0640 "$JWT_KEY"
+    echo "provision-identity-keys: generated $JWT_KEY"
+fi
+
+# Credential DEK — exactly 32 raw bytes (AES-256). The loader REJECTS any
+# group/other permission bits, so this must be 0600, owned by the service
+# user so it can read its own key.
+if [ ! -f "$DEK" ]; then
+    ( umask 077; openssl rand -out "$DEK" 32 )
+    chown "$OWNER_GROUP:$OWNER_GROUP" "$DEK"
+    chmod 0600 "$DEK"
+    echo "provision-identity-keys: generated $DEK"
+fi

--- a/packaging/common/stage-kensa-rules.sh
+++ b/packaging/common/stage-kensa-rules.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Stage the Kensa rule corpus from the vendored kensa Go module into a
+# destination directory, normalizing permissions for packaging.
+#
+# The kensa binary carries NO embedded corpus by design — rules ship as
+# a separate package installed to /usr/share/kensa/rules (kensa's
+# loader default path). OpenWatch vendors github.com/Hanalyx/kensa, so
+# the authoritative corpus already lives in the module cache at build
+# time; this script copies it out rather than fetching from the network
+# (air-gapped builds must work).
+#
+# Usage:   bash packaging/common/stage-kensa-rules.sh <dest-dir>
+# Output:  copies <module>/rules/** into <dest-dir>/, prints the kensa
+#          module version (e.g. 0.4.3) to stdout on the LAST line.
+#
+# Spec: specs/release/package-build.spec.yaml AC-15, AC-16.
+
+set -euo pipefail
+
+DEST="${1:?usage: stage-kensa-rules.sh <dest-dir>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$APP_DIR"
+
+KMOD="github.com/Hanalyx/kensa"
+
+# Ensure the module is present in the cache (no-op once downloaded; the
+# binary build already pulls it, but staging may run standalone).
+go mod download "$KMOD"
+
+KDIR="$(go list -m -f '{{.Dir}}' "$KMOD")"
+KVER="$(go list -m -f '{{.Version}}' "$KMOD")"
+KVER="${KVER#v}" # strip leading v: v0.4.3 -> 0.4.3
+
+SRC="$KDIR/rules"
+if [ ! -d "$SRC" ]; then
+    echo "stage-kensa-rules: corpus dir not found at $SRC" >&2
+    exit 1
+fi
+
+# Copy the corpus, preserving the category subdirectory layout the
+# loader walks. Module-cache files are mode 0444 and the tree is
+# read-only, so normalize perms after copying (dirs 0755, files 0644).
+mkdir -p "$DEST"
+cp -R "$SRC/." "$DEST/"
+chmod -R u+w "$DEST"
+find "$DEST" -type d -exec chmod 0755 {} +
+find "$DEST" -type f -exec chmod 0644 {} +
+
+# Sanity floor: the v0.4.x corpus is ~539 rules. A copy that lost the
+# tree (e.g. a layout change upstream) must fail the build, not ship an
+# empty "compliance" package.
+COUNT="$(find "$DEST" -name '*.yml' | wc -l)"
+if [ "$COUNT" -lt 500 ]; then
+    echo "stage-kensa-rules: only $COUNT rule files staged (expected >=500) — corpus layout may have changed" >&2
+    exit 1
+fi
+
+echo "stage-kensa-rules: staged $COUNT rules from ${KMOD}@v${KVER}" >&2
+# Last stdout line is the version, for callers to capture via $(...).
+echo "$KVER"

--- a/packaging/deb/build-deb.sh
+++ b/packaging/deb/build-deb.sh
@@ -49,7 +49,12 @@ trap 'rm -rf "$STAGE"' EXIT
 
 mkdir -p "$STAGE/DEBIAN"
 mkdir -p "$STAGE/usr/bin"
+mkdir -p "$STAGE/usr/lib/openwatch"
 mkdir -p "$STAGE/etc/openwatch/tls"
+# Identity-key directory ships empty (0750); postinst generates the
+# per-install keys into it. The key files are not part of the payload.
+mkdir -p "$STAGE/etc/openwatch/keys"
+chmod 0750 "$STAGE/etc/openwatch/keys"
 mkdir -p "$STAGE/etc/systemd/system"
 mkdir -p "$STAGE/var/lib/openwatch"
 mkdir -p "$STAGE/var/log/openwatch"
@@ -58,6 +63,7 @@ mkdir -p "$STAGE/var/log/openwatch"
 install -m 0755 "$DIST_DIR/openwatch"                       "$STAGE/usr/bin/openwatch"
 install -m 0640 "$APP_DIR/packaging/common/openwatch.toml"  "$STAGE/etc/openwatch/openwatch.toml"
 install -m 0644 "$APP_DIR/packaging/common/openwatch.service" "$STAGE/etc/systemd/system/openwatch.service"
+install -m 0755 "$APP_DIR/packaging/common/provision-identity-keys.sh" "$STAGE/usr/lib/openwatch/provision-identity-keys.sh"
 
 # Demo TLS cert (chmod inside the script).
 bash "$APP_DIR/packaging/common/gen-demo-cert.sh" "$STAGE/etc/openwatch/tls" >/dev/null

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -3,7 +3,7 @@ Version: 0.0.0
 Section: admin
 Priority: optional
 Architecture: amd64
-Depends: libc6 (>= 2.31), postgresql-client, kensa-rules
+Depends: libc6 (>= 2.31), postgresql-client, kensa-rules, openssl
 Maintainer: OpenWatch Build <build@hanalyx.com>
 Homepage: https://github.com/Hanalyx/openwatch
 Description: OpenWatch Compliance Platform (Go binary)

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -3,7 +3,7 @@ Version: 0.0.0
 Section: admin
 Priority: optional
 Architecture: amd64
-Depends: libc6 (>= 2.31), postgresql-client
+Depends: libc6 (>= 2.31), postgresql-client, kensa-rules
 Maintainer: OpenWatch Build <build@hanalyx.com>
 Homepage: https://github.com/Hanalyx/openwatch
 Description: OpenWatch Compliance Platform (Go binary)

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Post-install: reload systemd so the new unit is visible.
-# Spec release-package-build AC-08.
+# Post-install: reload systemd so the new unit is visible, and provision the
+# identity keys the server requires in production (it refuses to auto-generate
+# them and exits without them). Spec release-package-build AC-08, AC-18.
 
 set -e
 
@@ -8,6 +9,10 @@ if [ "$1" = "configure" ]; then
     if command -v systemctl >/dev/null 2>&1; then
         systemctl daemon-reload || :
     fi
+    # Generate-if-absent, so reconfigure/upgrade never clobbers live keys.
+    # preinst already created the openwatch user/group. Not guarded: a real
+    # failure should abort configure rather than leave an unbootable service.
+    /usr/lib/openwatch/provision-identity-keys.sh
 fi
 
 exit 0

--- a/packaging/kensa-rules/build-kensa-rules.sh
+++ b/packaging/kensa-rules/build-kensa-rules.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Build the standalone Kensa rule-corpus packages (RPM + DEB).
+#
+# Usage:   bash packaging/kensa-rules/build-kensa-rules.sh
+# Output:  dist/kensa-rules-<kver>-<rel>.noarch.rpm
+#          dist/kensa-rules_<kver>_all.deb
+#
+# Both are arch-independent (the corpus is plain YAML), so unlike the
+# openwatch binary there is no amd64/arm64 split — one artifact each
+# serves every target. The version tracks the vendored kensa module
+# (e.g. 0.4.3), not the OpenWatch platform version.
+#
+# Spec: specs/release/package-build.spec.yaml AC-15, AC-16, AC-17.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$APP_DIR"
+
+DIST_DIR="${APP_DIR}/dist"
+KR_RELEASE="${KR_RELEASE:-1}"
+mkdir -p "$DIST_DIR"
+
+# Step 1: stage the corpus from the vendored kensa module. The stager
+# prints the kensa version on its last stdout line.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+RULES_DIR="$STAGE/rules"
+KVER="$(bash "$APP_DIR/packaging/common/stage-kensa-rules.sh" "$RULES_DIR")"
+echo ">> staging kensa-rules version=${KVER}"
+
+# ---- Step 2: build the noarch RPM. ----
+RPMTOP="$(mktemp -d)"
+mkdir -p "$RPMTOP"/{BUILD,RPMS,SOURCES,SPECS,SRPMS,BUILDROOT}
+SRCDIR="$STAGE/kensa-rules-${KVER}"
+mkdir -p "$SRCDIR"
+cp -R "$RULES_DIR" "$SRCDIR/rules"
+(cd "$STAGE" && tar czf "$RPMTOP/SOURCES/kensa-rules-${KVER}.tar.gz" "kensa-rules-${KVER}")
+
+echo ">> running rpmbuild (kensa-rules, noarch)"
+rpmbuild \
+    --define "_topdir $RPMTOP" \
+    --define "kr_version ${KVER}" \
+    --define "kr_release ${KR_RELEASE}" \
+    --target noarch \
+    -bb "$APP_DIR/packaging/kensa-rules/kensa-rules.spec" >/dev/null
+cp "$RPMTOP"/RPMS/noarch/kensa-rules-*.rpm "$DIST_DIR/"
+rm -rf "$RPMTOP"
+echo ">> wrote kensa-rules-${KVER}-${KR_RELEASE}.noarch.rpm to dist/"
+
+# ---- Step 3: build the arch:all DEB. ----
+DEBROOT="$(mktemp -d)"
+mkdir -p "$DEBROOT/DEBIAN" "$DEBROOT/usr/share/kensa/rules"
+cp -R "$RULES_DIR/." "$DEBROOT/usr/share/kensa/rules/"
+find "$DEBROOT/usr/share/kensa" -type d -exec chmod 0755 {} +
+find "$DEBROOT/usr/share/kensa" -type f -exec chmod 0644 {} +
+
+cat > "$DEBROOT/DEBIAN/control" <<CONTROL
+Package: kensa-rules
+Version: ${KVER}
+Section: admin
+Priority: optional
+Architecture: all
+Maintainer: OpenWatch Build <build@hanalyx.com>
+Homepage: https://github.com/Hanalyx/kensa
+Description: Kensa compliance rule corpus (native YAML rules)
+ Native YAML compliance rules consumed by the Kensa scan engine embedded
+ in OpenWatch. Installs to /usr/share/kensa/rules, the engine's default
+ rule-load path. Versioned on the Kensa content line, independent of the
+ OpenWatch platform version, so rule updates ship without a platform
+ re-release.
+CONTROL
+
+echo ">> running dpkg-deb (kensa-rules, all)"
+OUT="$DIST_DIR/kensa-rules_${KVER}_all.deb"
+dpkg-deb --root-owner-group --build "$DEBROOT" "$OUT" >/dev/null
+rm -rf "$DEBROOT"
+echo ">> wrote $(basename "$OUT") to dist/"

--- a/packaging/kensa-rules/kensa-rules.spec
+++ b/packaging/kensa-rules/kensa-rules.spec
@@ -1,0 +1,57 @@
+# kensa-rules: the Kensa compliance rule corpus, packaged separately from
+# the OpenWatch binary.
+#
+# WHY a separate package: the kensa engine carries no embedded corpus and
+# loads rules from /usr/share/kensa/rules at runtime. Shipping the corpus
+# as its own noarch package (a) lets the rules update on their own cadence
+# (new STIG/CIS revisions) without re-releasing OpenWatch, (b) keeps the
+# Kensa project's compliance content on its own version line, and (c) is
+# the install-time artifact OpenWatch's RPM declares a hard Requires on,
+# so a corpus-less install fails fast instead of degrading at scan time.
+#
+# noarch: rules are plain YAML, identical on amd64 and aarch64.
+
+%global debug_package %{nil}
+
+# Version is the kensa module version (e.g. 0.4.3), injected by
+# build-kensa-rules.sh via --define "kr_version X.Y.Z".
+%{!?kr_version: %global kr_version 0.0.0}
+%{!?kr_release: %global kr_release 1}
+
+Name:           kensa-rules
+Version:        %{kr_version}
+Release:        %{kr_release}%{?dist}
+Summary:        Kensa compliance rule corpus (native YAML rules)
+BuildArch:      noarch
+
+License:        Business Source License 1.1
+URL:            https://github.com/Hanalyx/kensa
+Source0:        %{name}-%{version}.tar.gz
+
+%description
+The Kensa rule corpus: native YAML compliance rules consumed by the
+Kensa scan engine embedded in OpenWatch. Installs to
+/usr/share/kensa/rules, the engine's default rule-load path. This
+package is versioned on the Kensa content line, independent of the
+OpenWatch platform version, so rule updates ship without a platform
+re-release.
+
+%prep
+%setup -q
+
+%build
+# Nothing to build — the corpus is staged by build-kensa-rules.sh.
+
+%install
+install -d -m 0755 %{buildroot}/usr/share/kensa/rules
+cp -R rules/. %{buildroot}/usr/share/kensa/rules/
+find %{buildroot}/usr/share/kensa/rules -type d -exec chmod 0755 {} +
+find %{buildroot}/usr/share/kensa/rules -type f -exec chmod 0644 {} +
+
+%files
+%dir /usr/share/kensa
+/usr/share/kensa/rules
+
+%changelog
+* Mon Jun 15 2026 OpenWatch Build <build@hanalyx.com> - 0.4.3-1
+- Initial standalone Kensa rule-corpus package (539 rules, noarch).

--- a/packaging/rpm/build-rpm.sh
+++ b/packaging/rpm/build-rpm.sh
@@ -61,6 +61,7 @@ mkdir -p "$SRC_DIR"
 cp "$DIST_DIR/openwatch"                      "$SRC_DIR/openwatch"
 cp "$APP_DIR/packaging/common/openwatch.toml" "$SRC_DIR/openwatch.toml"
 cp "$APP_DIR/packaging/common/openwatch.service" "$SRC_DIR/openwatch.service"
+cp "$APP_DIR/packaging/common/provision-identity-keys.sh" "$SRC_DIR/provision-identity-keys.sh"
 
 # Demo TLS cert.
 bash "$APP_DIR/packaging/common/gen-demo-cert.sh" "$SRC_DIR" >/dev/null

--- a/packaging/rpm/openwatch.spec
+++ b/packaging/rpm/openwatch.spec
@@ -27,6 +27,13 @@ URL:            https://github.com/Hanalyx/openwatch
 Source0:        %{name}-%{version}.tar.gz
 
 Requires:       postgresql-server
+# Hard dependency on the rule corpus: the kensa engine loads rules from
+# /usr/share/kensa/rules at runtime and cannot scan without them. Declaring
+# it here makes a corpus-less install fail fast (air-gapped operators install
+# both files in one transaction: dnf install ./openwatch-*.rpm ./kensa-rules-*.rpm)
+# rather than the service booting and every scan failing. Unversioned so the
+# corpus can advance on its own line; tighten to a floor when OTA lands.
+Requires:       kensa-rules
 Requires(pre):  shadow-utils
 
 %description

--- a/packaging/rpm/openwatch.spec
+++ b/packaging/rpm/openwatch.spec
@@ -34,6 +34,9 @@ Requires:       postgresql-server
 # rather than the service booting and every scan failing. Unversioned so the
 # corpus can advance on its own line; tighten to a floor when OTA lands.
 Requires:       kensa-rules
+# openssl: the %post scriptlet generates the JWT signing key and credential
+# DEK at install time (the server refuses to auto-generate them in production).
+Requires:       openssl
 Requires(pre):  shadow-utils
 
 %description
@@ -55,9 +58,15 @@ install -m 0755 openwatch           %{buildroot}/usr/bin/openwatch
 
 install -d -m 0750                  %{buildroot}/etc/openwatch
 install -d -m 0750                  %{buildroot}/etc/openwatch/tls
+# Identity-key directory. The keys themselves are NOT shipped in the payload
+# (they must be unique per install); %post generates them into here.
+install -d -m 0750                  %{buildroot}/etc/openwatch/keys
 install -m 0640 openwatch.toml      %{buildroot}/etc/openwatch/openwatch.toml
 install -m 0644 cert.pem            %{buildroot}/etc/openwatch/tls/cert.pem
 install -m 0600 key.pem             %{buildroot}/etc/openwatch/tls/key.pem
+
+install -d -m 0755                  %{buildroot}/usr/lib/openwatch
+install -m 0755 provision-identity-keys.sh %{buildroot}/usr/lib/openwatch/provision-identity-keys.sh
 
 install -d -m 0755                  %{buildroot}/etc/systemd/system
 install -m 0644 openwatch.service   %{buildroot}/etc/systemd/system/openwatch.service
@@ -75,6 +84,13 @@ getent passwd openwatch >/dev/null || \
 %post
 # AC-07: pick up the new unit file.
 systemctl daemon-reload || :
+
+# Provision the identity keys (JWT signing key + credential DEK) the server
+# requires in production. Generate-if-absent, so upgrades never clobber the
+# live keys. Runs after %pre created the openwatch user/group. Not guarded
+# with `|| :`: a real failure here (e.g. a filesystem error) should surface
+# as a scriptlet warning, not silently leave an unbootable service.
+/usr/lib/openwatch/provision-identity-keys.sh
 
 %preun
 # AC-09: stop and disable cleanly so removal doesn't leave a running orphan.
@@ -95,6 +111,10 @@ systemctl daemon-reload || :
 %attr(0644, root, openwatch)        /etc/openwatch/tls/cert.pem
 %attr(0600, openwatch, openwatch)   /etc/openwatch/tls/key.pem
 %attr(0644, root, root)             /etc/systemd/system/openwatch.service
+# Identity-key directory ships empty (0750); %post generates the per-install
+# keys into it. The key files are intentionally NOT packaged.
+%dir %attr(0750, root, openwatch)   /etc/openwatch/keys
+%attr(0755, root, root)             /usr/lib/openwatch/provision-identity-keys.sh
 %dir %attr(0750, openwatch, openwatch) /var/lib/openwatch
 %dir %attr(0750, openwatch, openwatch) /var/log/openwatch
 

--- a/packaging/tests/package_test.go
+++ b/packaging/tests/package_test.go
@@ -410,6 +410,102 @@ func TestBuild_MultiArchSupport(t *testing.T) {
 	})
 }
 
+// kensaRulesRPMPath returns the kensa-rules noarch RPM under dist/,
+// building it via `make kensa-rules` if necessary.
+func kensaRulesRPMPath(t *testing.T) string {
+	t.Helper()
+	dir := appDir(t)
+	haveTool(t, "rpmbuild")
+	runMake(t, dir, "kensa-rules")
+	return findArtifact(t, filepath.Join(dir, "dist"), "kensa-rules-*.rpm")
+}
+
+// kensaRulesDebPath returns the kensa-rules all DEB under dist/, building
+// it via `make kensa-rules` if necessary.
+func kensaRulesDebPath(t *testing.T) string {
+	t.Helper()
+	dir := appDir(t)
+	haveTool(t, "dpkg-deb")
+	runMake(t, dir, "kensa-rules")
+	return findArtifact(t, filepath.Join(dir, "dist"), "kensa-rules_*.deb")
+}
+
+// @ac AC-15
+// AC-15: the kensa-rules RPM (noarch) and DEB (all) each carry the full
+// corpus under /usr/share/kensa/rules.
+func TestKensaRules_CorpusPayload(t *testing.T) {
+	t.Run("release-package-build/AC-15", func(t *testing.T) {
+		const wantRules = 500
+		ruleLine := regexp.MustCompile(`/usr/share/kensa/rules/.*\.yml`)
+
+		rpm := kensaRulesRPMPath(t)
+		// noarch: the corpus is arch-independent.
+		if arch := strings.TrimSpace(rpmQuery(t, rpm, "%{ARCH}")); arch != "noarch" {
+			t.Errorf("kensa-rules RPM arch = %q, want noarch", arch)
+		}
+		rpmFiles := rpmQuery(t, rpm, "[%{FILENAMES}\n]")
+		if n := len(ruleLine.FindAllString(rpmFiles, -1)); n < wantRules {
+			t.Errorf("kensa-rules RPM has %d rule files under /usr/share/kensa/rules, want >=%d", n, wantRules)
+		}
+
+		deb := kensaRulesDebPath(t)
+		debFiles := debContents(t, deb)
+		if n := len(ruleLine.FindAllString(debFiles, -1)); n < wantRules {
+			t.Errorf("kensa-rules DEB has %d rule files under /usr/share/kensa/rules, want >=%d", n, wantRules)
+		}
+		// Architecture: all in the DEB control.
+		if info := debInfo(t, deb); !strings.Contains(info, "Architecture: all") {
+			t.Errorf("kensa-rules DEB control lacks Architecture: all\ninfo:\n%s", info)
+		}
+	})
+}
+
+// @ac AC-16
+// AC-16: the openwatch packages declare a hard dependency on kensa-rules
+// so a corpus-less install fails fast.
+func TestOpenwatch_DependsOnKensaRules(t *testing.T) {
+	t.Run("release-package-build/AC-16", func(t *testing.T) {
+		dir := appDir(t)
+		read := func(p string) string {
+			b, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			return string(b)
+		}
+		spec := read(filepath.Join(dir, "packaging", "rpm", "openwatch.spec"))
+		if !regexp.MustCompile(`(?m)^Requires:\s+kensa-rules\b`).MatchString(spec) {
+			t.Error("openwatch.spec must declare `Requires: kensa-rules`")
+		}
+		control := read(filepath.Join(dir, "packaging", "deb", "control"))
+		depends := ""
+		for _, line := range strings.Split(control, "\n") {
+			if strings.HasPrefix(line, "Depends:") {
+				depends = line
+				break
+			}
+		}
+		if !strings.Contains(depends, "kensa-rules") {
+			t.Errorf("deb/control Depends must list kensa-rules, got %q", depends)
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17: make packages builds the kensa-rules corpus package too.
+func TestMake_PackagesBuildsKensaRules(t *testing.T) {
+	t.Run("release-package-build/AC-17", func(t *testing.T) {
+		dir := appDir(t)
+		b, err := os.ReadFile(filepath.Join(dir, "Makefile"))
+		if err != nil {
+			t.Fatalf("read Makefile: %v", err)
+		}
+		if !regexp.MustCompile(`(?m)^packages:.*\bkensa-rules\b`).MatchString(string(b)) {
+			t.Error("Makefile `packages` target must depend on kensa-rules")
+		}
+	})
+}
+
 // readDebControlScript extracts a named maintainer script from a DEB
 // using `dpkg-deb --ctrl-tarfile` piped to `tar`. Returns the script body
 // as a string.

--- a/packaging/tests/package_test.go
+++ b/packaging/tests/package_test.go
@@ -506,6 +506,117 @@ func TestMake_PackagesBuildsKensaRules(t *testing.T) {
 	})
 }
 
+// @ac AC-18
+// AC-18: the RPM %post and DEB postinst invoke the provisioning helper, and
+// the helper generates both identity keys, generate-if-absent, with the
+// required formats/modes/owners.
+func TestKeys_PostInstallProvisions(t *testing.T) {
+	t.Run("release-package-build/AC-18", func(t *testing.T) {
+		dir := appDir(t)
+		const helperPath = "/usr/lib/openwatch/provision-identity-keys.sh"
+
+		// Scriptlets call the helper.
+		rpm := rpmPath(t)
+		if post := rpmQuery(t, rpm, "%{POSTIN}"); !strings.Contains(post, helperPath) {
+			t.Errorf("RPM %%post does not invoke %s:\n%s", helperPath, post)
+		}
+		deb := debPath(t)
+		if body := readDebControlScript(t, deb, "postinst"); !strings.Contains(body, helperPath) {
+			t.Errorf("DEB postinst does not invoke %s:\n%s", helperPath, body)
+		}
+
+		// The helper does the right thing.
+		helper, err := os.ReadFile(filepath.Join(dir, "packaging", "common", "provision-identity-keys.sh"))
+		if err != nil {
+			t.Fatalf("read helper: %v", err)
+		}
+		h := string(helper)
+		wants := []struct{ what, substr string }{
+			{"generate-if-absent guard", "[ ! -f"},
+			{"RSA JWT key via openssl genrsa", "openssl genrsa"},
+			{"2048 bits", "2048"},
+			{"DEK via openssl rand", "openssl rand"},
+			{"32 bytes", "32"},
+			{"JWT mode 0640", "chmod 0640"},
+			{"DEK mode 0600", "chmod 0600"},
+			{"JWT owner root:openwatch", "root:$OWNER_GROUP"},
+		}
+		for _, w := range wants {
+			if !strings.Contains(h, w.substr) {
+				t.Errorf("helper missing %s (%q)", w.what, w.substr)
+			}
+		}
+	})
+}
+
+// @ac AC-19
+// AC-19: both openwatch packages declare openssl (the provisioning helper
+// needs it).
+func TestKeys_OpensslDependency(t *testing.T) {
+	t.Run("release-package-build/AC-19", func(t *testing.T) {
+		dir := appDir(t)
+		read := func(p string) string {
+			b, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			return string(b)
+		}
+		spec := read(filepath.Join(dir, "packaging", "rpm", "openwatch.spec"))
+		if !regexp.MustCompile(`(?m)^Requires:\s+openssl\b`).MatchString(spec) {
+			t.Error("openwatch.spec must declare `Requires: openssl`")
+		}
+		control := read(filepath.Join(dir, "packaging", "deb", "control"))
+		depends := ""
+		for _, line := range strings.Split(control, "\n") {
+			if strings.HasPrefix(line, "Depends:") {
+				depends = line
+				break
+			}
+		}
+		if !strings.Contains(depends, "openssl") {
+			t.Errorf("deb/control Depends must list openssl, got %q", depends)
+		}
+	})
+}
+
+// @ac AC-20
+// AC-20: the packages ship the helper + an empty keys dir, but NEVER the key
+// files themselves (they are generated unique per install).
+func TestKeys_NotInPayload(t *testing.T) {
+	t.Run("release-package-build/AC-20", func(t *testing.T) {
+		const (
+			helper = "/usr/lib/openwatch/provision-identity-keys.sh"
+			keyDir = "/etc/openwatch/keys"
+			jwt    = "jwt_private.pem"
+			dek    = "credential.key"
+		)
+		rpm := rpmPath(t)
+		rpmFiles := rpmQuery(t, rpm, "[%{FILENAMES}\n]")
+		if !strings.Contains(rpmFiles, helper) {
+			t.Errorf("RPM payload missing the provisioning helper %s", helper)
+		}
+		if !strings.Contains(rpmFiles, keyDir) {
+			t.Errorf("RPM payload missing the %s directory", keyDir)
+		}
+		if strings.Contains(rpmFiles, jwt) || strings.Contains(rpmFiles, dek) {
+			t.Errorf("RPM payload MUST NOT contain key files; got:\n%s", rpmFiles)
+		}
+
+		deb := debPath(t)
+		debFiles := debContents(t, deb)
+		if !strings.Contains(debFiles, helper) {
+			t.Errorf("DEB payload missing the provisioning helper %s", helper)
+		}
+		if !strings.Contains(debFiles, "/etc/openwatch/keys") {
+			t.Errorf("DEB payload missing the keys directory")
+		}
+		if strings.Contains(debFiles, jwt) || strings.Contains(debFiles, dek) {
+			t.Errorf("DEB payload MUST NOT contain key files; got:\n%s", debFiles)
+		}
+	})
+}
+
 // readDebControlScript extracts a named maintainer script from a DEB
 // using `dpkg-deb --ctrl-tarfile` piped to `tar`. Returns the script body
 // as a string.

--- a/specs/release/package-build.spec.yaml
+++ b/specs/release/package-build.spec.yaml
@@ -39,6 +39,7 @@ spec:
         - Multi-arch builds (amd64 + arm64) via ARCH, cross-compiled with CGO disabled
         - Kensa rule corpus shipped as a separate noarch/all kensa-rules package
         - Hard dependency from openwatch on kensa-rules so a corpus-less install fails fast
+        - Install-time provisioning of the production identity keys (JWT signing key + credential DEK) that the server refuses to auto-generate
       excludes:
         - Signed package distribution (separate release infra)
         - FIPS variant (Day 12 ships a second binary build)
@@ -90,6 +91,20 @@ spec:
         MUST list kensa-rules in Depends, so an install without the corpus
         fails fast rather than booting a scan-incapable service.
       type: technical
+      enforcement: error
+    - id: C-11
+      description: >
+        The server refuses to auto-generate its signing material in production
+        and exits if it is missing. Therefore both packages MUST provision the
+        identity keys at install time via a post-install scriptlet: an RSA
+        >=2048-bit JWT signing key at /etc/openwatch/keys/jwt_private.pem (mode
+        0640, root:openwatch) and a 32-byte AES-256 credential DEK at
+        /etc/openwatch/keys/credential.key (mode 0600, openwatch:openwatch).
+        Generation MUST be generate-if-absent (never overwrite, so upgrades do
+        not invalidate tokens or render stored secrets undecryptable). The key
+        files MUST NOT be shipped in the package payload (they must be unique
+        per install). openssl MUST be a package dependency.
+      type: security
       enforcement: error
 
   acceptance_criteria:
@@ -159,3 +174,15 @@ spec:
       description: make packages builds the kensa-rules corpus package alongside the openwatch artifacts (the Makefile packages target depends on the kensa-rules target).
       priority: high
       references_constraints: [C-10]
+    - id: AC-18
+      description: The RPM %post and the DEB postinst invoke the identity-key provisioning helper, and the shipped helper (packaging/common/provision-identity-keys.sh) generates the JWT key (RSA 2048 via openssl genrsa, 0640 root:openwatch) and the credential DEK (32 bytes via openssl rand, 0600 openwatch:openwatch) only when absent. Source-inspection of the scriptlets and the helper.
+      priority: critical
+      references_constraints: [C-11]
+    - id: AC-19
+      description: The openwatch RPM spec declares Requires openssl and the openwatch DEB control lists openssl in Depends (source-inspection).
+      priority: high
+      references_constraints: [C-11]
+    - id: AC-20
+      description: The package payloads ship the empty /etc/openwatch/keys directory and the provisioning helper at /usr/lib/openwatch/, but do NOT contain jwt_private.pem or credential.key (verified via rpm -qpl and dpkg-deb -c — the keys are generated per-install, never packaged).
+      priority: critical
+      references_constraints: [C-11]

--- a/specs/release/package-build.spec.yaml
+++ b/specs/release/package-build.spec.yaml
@@ -18,6 +18,7 @@ spec:
       - system-http-server
       - system-config
       - system-license-validation
+      - system-kensa-executor
 
   objective:
     summary: >
@@ -36,6 +37,8 @@ spec:
         - Post-install systemd reload
         - Pre-uninstall stop+disable
         - Multi-arch builds (amd64 + arm64) via ARCH, cross-compiled with CGO disabled
+        - Kensa rule corpus shipped as a separate noarch/all kensa-rules package
+        - Hard dependency from openwatch on kensa-rules so a corpus-less install fails fast
       excludes:
         - Signed package distribution (separate release infra)
         - FIPS variant (Day 12 ships a second binary build)
@@ -75,6 +78,17 @@ spec:
       enforcement: error
     - id: C-09
       description: Build scripts MUST support a target architecture via ARCH (amd64 | arm64), cross-compiling the binary with the matching GOARCH and CGO disabled, and labeling the artifact with the correct package arch (x86_64/aarch64 for RPM, amd64/arm64 for DEB)
+      type: technical
+      enforcement: error
+    - id: C-10
+      description: >
+        The Kensa rule corpus MUST ship as a separate kensa-rules package
+        (noarch RPM + Architecture:all DEB) installing the corpus to
+        /usr/share/kensa/rules (the engine's default load path), staged from
+        the vendored kensa module so air-gapped builds need no network. The
+        openwatch RPM MUST declare Requires: kensa-rules and the openwatch DEB
+        MUST list kensa-rules in Depends, so an install without the corpus
+        fails fast rather than booting a scan-incapable service.
       type: technical
       enforcement: error
 
@@ -133,3 +147,15 @@ spec:
       description: Both build scripts accept ARCH=arm64 and cross-compile the binary via GOARCH with CGO disabled, mapping to the correct package arch (aarch64 RPM / arm64 DEB); source-inspection verifies the arch mapping and the GOARCH/CGO_ENABLED=0 build invocation.
       priority: high
       references_constraints: [C-09]
+    - id: AC-15
+      description: make kensa-rules produces a noarch kensa-rules .rpm and an Architecture=all kensa-rules .deb under dist/, and each payload contains /usr/share/kensa/rules holding the full corpus (>=500 *.yml rule files).
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-16
+      description: The openwatch RPM spec declares Requires kensa-rules and the openwatch DEB control lists kensa-rules in Depends (source-inspection of packaging/rpm/openwatch.spec and packaging/deb/control).
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-17
+      description: make packages builds the kensa-rules corpus package alongside the openwatch artifacts (the Makefile packages target depends on the kensa-rules target).
+      priority: high
+      references_constraints: [C-10]


### PR DESCRIPTION
## Problem

A fresh OpenWatch install shipped **no Kensa rules**. The scan engine loads its corpus from `/usr/share/kensa/rules` at runtime, the Go binary embeds none (by design — `internal/rules/paths.go`: "the binary carries no embedded corpus"), and neither the RPM nor the DEB carried *or required* them. So a freshly-installed node authenticates, browses the UI, and registers hosts — but **every scan fails** with "kensa scan wiring unavailable". This is the P0 packaging blocker.

The corpus already lives in the vendored `github.com/Hanalyx/kensa v0.4.3` module (539 native YAML rules), so this is a delivery problem, not a "go fetch the rules" problem.

## Approach (option B1 — companion package)

Honors the design intent already in the code (`worker.go` C-16: "signed kensa-rules package … declared as a dependency of the OpenWatch RPM/DEB"), within OpenWatch's own build — no kensa-team release dependency.

- **`packaging/common/stage-kensa-rules.sh`** — stages the corpus from the vendored module (no network → air-gap safe), normalizes perms, floors the count at 500.
- **`packaging/kensa-rules/`** — `kensa-rules.spec` + `build-kensa-rules.sh` produce a **noarch** RPM and an **Architecture: all** DEB installing to `/usr/share/kensa/rules`, versioned on the **Kensa content line (0.4.3)**, independent of the platform version.
- **Hard dependency** — openwatch RPM `Requires: kensa-rules`, DEB `Depends: … kensa-rules`. A corpus-less install now **fails fast** instead of degrading at scan time. Air-gapped operators install both files in one transaction:
  - `dnf install ./openwatch-*.rpm ./kensa-rules-*.noarch.rpm`
  - `apt install ./openwatch_*.deb ./kensa-rules_*_all.deb`
- **`make packages` + `release.yml`** build, GPG-sign, SBOM, checksum, and publish the corpus package alongside the platform artifacts.
- **`package-smoke`** installs both files (proving the dependency resolves offline) and asserts the corpus landed with ≥500 rules.

## Verification (local)

- `make kensa-rules` → `kensa-rules-0.4.3-1.noarch.rpm` + `kensa-rules_0.4.3_all.deb`, **539** `.yml` rules under `/usr/share/kensa/rules` in each payload.
- openwatch RPM `Requires` and DEB `Depends` both list `kensa-rules`.
- Full `packaging/tests` suite green (AC-01–17, incl. new AC-15/16/17); `gofmt`/`go vet` clean; `specter check` 0 errors.

## Spec / tests

`release-package-build` gains **C-10** + **AC-15/16/17**; `package_test.go` covers the corpus payload, the dependency declarations, and the `make packages` wiring.

## Follow-on

Keeping the corpus on its own package is the install-time half of the **Kensa Phase 5 OTA** story; per-rule `KENSA_SIGNING_KEY` verification can layer on later (the release pipeline already GPG-signs the artifact).