### PR TITLE
chore(deps): lucide-react 0.460 → 1.18.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "^7.0.0",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.170.15",
-        "lucide-react": "^0.460.0",
+        "lucide-react": "^1.18.0",
         "openapi-fetch": "^0.17.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -5591,12 +5591,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.460.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
-      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.20.0.tgz",
+      "integrity": "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "@mui/material": "^7.0.0",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.15",
-    "lucide-react": "^0.460.0",
+    "lucide-react": "^1.18.0",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
App runtime dep (icons). The 0→1 major is a stabilization release; verified locally that all **26 icon import sites** are unaffected:
- `npm run typecheck` (`tsc --noEmit`) — green (icons are imported by name, so a removed/renamed icon would be a type error)
- `npm run build` — green
- `npm run test` — 44 files / 286 tests pass

Supersedes Dependabot #544 with a lockfile regenerated against current main. Closes #544.