### PR TITLE
chore(deps): zod 3→4 + @hookform/resolvers 3→5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/styled": "^11.13.5",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@hookform/resolvers": "^3.9.1",
+        "@hookform/resolvers": "^5.4.0",
         "@mui/material": "^7.0.0",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.170.15",
@@ -23,7 +23,7 @@
         "react-dom": "^19.2.7",
         "react-dropzone": "^15.0.0",
         "react-hook-form": "^7.79.0",
-        "zod": "^3.24.0",
+        "zod": "^4.4.3",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
@@ -1310,12 +1310,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2095,6 +2098,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tanstack/history": {
       "version": "1.162.0",
@@ -7818,9 +7827,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@emotion/styled": "^11.13.5",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@hookform/resolvers": "^3.9.1",
+    "@hookform/resolvers": "^5.4.0",
     "@mui/material": "^7.0.0",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.15",
@@ -33,7 +33,7 @@
     "react-dom": "^19.2.7",
     "react-dropzone": "^15.0.0",
     "react-hook-form": "^7.79.0",
-    "zod": "^3.24.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/frontend/src/components/hosts/EditHostModal.tsx
+++ b/frontend/src/components/hosts/EditHostModal.tsx
@@ -22,7 +22,11 @@ const editSchema = z.object({
     .min(1, 'IP address is required')
     .max(64)
     .refine((v) => ipv4.test(v) || ipv6.test(v), 'Invalid IP address'),
-  port: z.coerce.number().int().min(1).max(65535),
+  // register('port', { valueAsNumber: true }) already yields a number, so
+  // z.number() (not z.coerce.number()) keeps input/output types aligned for
+  // the zod-4 resolver and rejects an empty field (NaN) instead of coercing
+  // it to 0.
+  port: z.number().int().min(1).max(65535),
   environment: z.string().min(1, 'Environment is required').max(64),
   display_name: z.string().max(256).optional(),
   description: z.string().max(1024).optional(),


### PR DESCRIPTION
App runtime deps, bumped together (the resolver adapts zod schemas to react-hook-form).

**One migration fix:** `EditHostModal` used `z.coerce.number()` for the SSH port. zod 4 infers `z.coerce.number()` with an `unknown` *input* type, which breaks the `zodResolver` field-values type (`port: unknown` vs the form's `port: number`). The field already registers with `valueAsNumber: true`, so `z.number()` is both correct and better behavior (an empty field → NaN is rejected, instead of `z.coerce` turning `""` into port `0`).

Verified locally: `tsc --noEmit`, `vite build`, and the full vitest suite (44 files / 286 tests) all green.

Supersedes Dependabot #545 + #548 with a lockfile against current main. Closes #545, closes #548.