### PR TITLE
test(auth): spec the JWT signature-verification deny path (AC-26)

### DIFF
--- a/internal/identity/jwt_test.go
+++ b/internal/identity/jwt_test.go
@@ -224,8 +224,12 @@ func TestJWT_RoundTripLatency(t *testing.T) {
 	})
 }
 
-// VerifyJWT against a tampered token returns ErrJWTInvalid. Defensive
-// test; not an AC.
+// @ac AC-26
+// AC-26: VerifyJWT fails closed on a bad signature (the deny side of C-08,
+// complementing the AC-11 happy round-trip). A tampered signature and a
+// garbage bearer value both return ErrJWTInvalid with no claims — so a
+// regression that relaxes verification fails the suite instead of silently
+// passing.
 func TestJWT_VerifyTampered(t *testing.T) {
 	ensureKey(t)
 	userID, _ := uuid.NewV7()
@@ -233,10 +237,25 @@ func TestJWT_VerifyTampered(t *testing.T) {
 	if err != nil {
 		t.Fatalf("IssueJWT: %v", err)
 	}
-	// Flip a byte in the middle of the signature (last segment).
-	tampered := signed[:len(signed)-3] + "AAA"
-	_, err = VerifyJWT(tampered)
-	if !errors.Is(err, ErrJWTInvalid) {
-		t.Errorf("err = %v, want ErrJWTInvalid", err)
-	}
+
+	t.Run("system-auth-identity/AC-26", func(t *testing.T) {
+		// Flip the tail of the signature (last segment) — a structurally
+		// valid JWT whose RS256 signature no longer verifies.
+		tampered := signed[:len(signed)-3] + "AAA"
+		claims, terr := VerifyJWT(tampered)
+		if !errors.Is(terr, ErrJWTInvalid) {
+			t.Errorf("tampered signature: err = %v, want ErrJWTInvalid", terr)
+		}
+		if claims.Role != "" || claims.Subject != "" {
+			t.Errorf("tampered signature: leaked claims (role=%q sub=%q), want none", claims.Role, claims.Subject)
+		}
+	})
+
+	t.Run("garbage token returns ErrJWTInvalid", func(t *testing.T) {
+		for _, tok := range []string{"", "not-a-jwt", "a.b.c", signed + "x"} {
+			if _, terr := VerifyJWT(tok); !errors.Is(terr, ErrJWTInvalid) {
+				t.Errorf("VerifyJWT(%q): err = %v, want ErrJWTInvalid", tok, terr)
+			}
+		}
+	})
 }

--- a/specs/system/auth-identity.spec.yaml
+++ b/specs/system/auth-identity.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-auth-identity
   title: Auth identity primitives (password, session, JWT, MFA)
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -206,3 +206,7 @@ spec:
       description: Browser API client (src/api/client.ts) attaches an onResponse middleware that intercepts HTTP 401. On a 401 the middleware calls POST /api/v1/auth/refresh-cookie once and, if it returns 200, replays the original request exactly once with the rotated cookies. If refresh-cookie itself returns 401 the middleware clears useAuthStore.identity and navigates to /login. The retry MUST NOT loop — a second 401 on the same request after refresh returns the error to the caller.
       priority: critical
       references_constraints: [C-14]
+    - id: AC-26
+      description: "VerifyJWT fails closed on a bad signature — the deny side of C-08, not only the happy round-trip (AC-11). A token whose RS256 signature does not verify against the system public key (e.g. a tampered signature segment) returns ErrJWTInvalid, and a structurally malformed/garbage bearer value returns ErrJWTInvalid; in neither case are claims returned. This makes the signature-verification deny path a spec'd contract so a regression that relaxes verification (accepting an unsigned/alg=none/foreign-key token) fails the suite rather than silently passing."
+      priority: critical
+      references_constraints: [C-08]


### PR DESCRIPTION
## Context

Follow-up to the scan kill-switch bug earlier this session — that bug passed all 988 tests + the specter gate because **no AC required the scan to honor the kill-switch** (fixed by `system-connection-profile/AC-07`). The goal here was to generalize that negative-path pattern: every security gate should have a spec'd AC for the **disallowed** path, so a gate that silently stops enforcing fails the suite instead of staying green.

## What the audit found

I mapped the security gates (auth/session, RBAC, API-token, license, MFA, sudo kill-switch) and checked each for a deny-path AC + test. **Coverage is already strong** — most gates the premise worried about are covered:

| Gate | Deny-path AC |
|------|-------------|
| Session invalid / expired / revoked | AC-08, AC-09, AC-10 |
| RBAC permission denied (incl. anonymous) | `system-rbac` AC-09, AC-11 |
| API token unknown / revoked / expired | `system-api-tokens` AC-03 |
| New settings endpoints (users/notifications/sso/tokens) | each has a spec-linked **403** deny test |
| License feature unavailable (402) | `system-license-features` AC-10 |
| MFA OTP out-of-window / replay | AC-15, AC-16 |
| Refresh-token reuse | AC-13, AC-23 |
| Binder 401 on bad session/JWT | AC-18, AC-21 |
| Sudo password kill-switch + auth-method gate | `system-connection-profile` AC-07 |

(Two suspected gaps turned out **not** to exist as gates: there is no HTTP rate limiter in the Go rebuild — those matches are the scan *scheduler* — and API tokens are role-scoped, so there is no per-token scope-escalation path. Hard-required-MFA is not implemented, so it isn't specced.)

## The one genuine gap

`VerifyJWT`'s bad-signature rejection was exercised only by `TestJWT_VerifyTampered`, explicitly commented **"Defensive test; not an AC."** So a regression that relaxed RS256 verification (accepting an unsigned / `alg=none` / foreign-key token) would not have failed any acceptance criterion — exactly the class of bug this task targets.

## Change

- `system-auth-identity` **v1.1.0 → v1.2.0**: add **AC-26** — the deny side of C-08 (JWT must be RS256-signed by the system keypair), complementing the AC-11 happy round-trip.
- Promote + strengthen `TestJWT_VerifyTampered`: assert that a **tampered signature** and a **garbage bearer value** both return `ErrJWTInvalid` with **no claims leaked**, under the `system-auth-identity/AC-26` coverage token.

Tier-1 spec stays at 100% AC coverage. `specter check` 0 errors; `gofmt`/`go vet` clean; identity suite green.

## Honest scope note

This is deliberately a **small** PR. The audit's value was largely confirming the deny-path coverage is already solid rather than uncovering a pile of gaps — I'd rather close the one real gap than manufacture redundant ACs for already-covered behavior. The mapping is preserved in the commit body for future reference.