### PR TITLE
test(db): per-package isolated test databases to drop -p 1 (CI ~halved)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -208,7 +208,7 @@ jobs:
         if: steps.paths.outputs.go == 'true'
         run: |
           set +e
-          go test -race -json -timeout 600s -p 1 ./... > /tmp/go-test.json
+          go test -race -json -timeout 600s -p 4 ./... > /tmp/go-test.json
           EXIT=$?
           if [ "$EXIT" -ne 0 ]; then
             echo "::group::Failed tests"

--- a/internal/activity/service_db_test.go
+++ b/internal/activity/service_db_test.go
@@ -16,40 +16,20 @@ package activity
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/alertrouter"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func activityTestDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run activity integration tests")
-	}
-	return dsn
-}
-
 func freshDB(t *testing.T) (*pgxpool.Pool, uuid.UUID) {
 	t.Helper()
-	dsn := activityTestDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	// TRUNCATE…CASCADE delegates child cleanup to the schema. The
 	// hosts row has 11 FK-referencing children (alerts, credentials,
 	// host_intelligence_events, transactions, …); a hand-rolled list

--- a/internal/alertrouter/store_db_test.go
+++ b/internal/alertrouter/store_db_test.go
@@ -8,23 +8,12 @@ package alertrouter
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 )
-
-func storeTestDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run alertrouter store integration tests")
-	}
-	return dsn
-}
 
 // @ac AC-20
 // AC-20 (DB-side): PgxStore.Insert called twice with the same
@@ -33,17 +22,8 @@ func storeTestDSN(t *testing.T) string {
 // the in-memory dedup gate is empty.
 func TestPgxStore_DuplicateDedupKeyOccurredAt_IdempotentInsert(t *testing.T) {
 	t.Run("system-alert-router/AC-20", func(t *testing.T) {
-		dsn := storeTestDSN(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		t.Cleanup(cancel)
-		pool, err := db.NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		t.Cleanup(pool.Close)
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("migrations.Apply: %v", err)
-		}
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE alerts")
 
 		store := NewPgxStore(pool)

--- a/internal/alerts/lifecycle_test.go
+++ b/internal/alerts/lifecycle_test.go
@@ -31,36 +31,17 @@ import (
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/alertrouter"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func alertsTestDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run alerts integration tests")
-	}
-	return dsn
-}
-
 // freshDB spins up a clean migrated DB and seeds one user.
 func freshDB(t *testing.T) (*pgxpool.Pool, uuid.UUID) {
 	t.Helper()
-	dsn := alertsTestDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE alerts")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")

--- a/internal/apitoken/apitoken_test.go
+++ b/internal/apitoken/apitoken_test.go
@@ -8,34 +8,20 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/auth"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func freshService(t *testing.T) (*Service, *pgxpool.Pool) {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run apitoken tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE api_tokens")
 	return NewService(pool), pool
 }

--- a/internal/audit/emit_test.go
+++ b/internal/audit/emit_test.go
@@ -19,43 +19,21 @@ package audit
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/correlation"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/internalrace"
 	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run audit integration tests")
-	}
-	return dsn
-}
-
 // freshPool returns a pool against a clean audit_events table.
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 	return pool
 }

--- a/internal/authpolicy/authpolicy_test.go
+++ b/internal/authpolicy/authpolicy_test.go
@@ -13,8 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -22,20 +21,8 @@ import (
 
 func freshService(t *testing.T) (*Service, *pgxpool.Pool) {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run authpolicy tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	// Reset the singleton to its seeded defaults so tests start clean. Use
 	// INSERT…ON CONFLICT because a server-package fixture's TRUNCATE users
 	// CASCADE (shared test DB) can have removed the seeded row.

--- a/internal/connprofile/connprofile_db_test.go
+++ b/internal/connprofile/connprofile_db_test.go
@@ -7,24 +7,12 @@ package connprofile
 
 import (
 	"context"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
-
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run connprofile store integration tests")
-	}
-	return dsn
-}
 
 func seedHost(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 	t.Helper()
@@ -48,17 +36,7 @@ func seedHost(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 
 func freshStore(t *testing.T) (*Store, *pgxpool.Pool) {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
 	return NewStore(pool), pool
 }
 

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -8,43 +8,24 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run credential tests")
-	}
-	return dsn
-}
-
 // freshService returns a Service against a clean migrated DB with the
 // ephemeral DEK installed. Also seeds a single user to satisfy the
 // created_by FK on the credentials table.
 func freshService(t *testing.T) (*Service, *pgxpool.Pool, uuid.UUID) {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("SetEphemeral: %v", err)
 	}
@@ -57,10 +38,9 @@ func freshService(t *testing.T) (*Service, *pgxpool.Pool, uuid.UUID) {
 	// Seed a creator user.
 	createdBy, _ := uuid.NewV7()
 	hash, _ := identity.HashPassword("seed-pw-12345-aa")
-	_, err = pool.Exec(ctx,
+	if _, err := pool.Exec(ctx,
 		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
-		createdBy, "credential-creator", "creator@example.com", hash)
-	if err != nil {
+		createdBy, "credential-creator", "creator@example.com", hash); err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
 	return NewService(pool), pool, createdBy

--- a/internal/db/audit_queries_test.go
+++ b/internal/db/audit_queries_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
 	"github.com/google/uuid"
 )
@@ -39,19 +40,8 @@ func testDSN(t *testing.T) string {
 func TestInsertAndGetAuditEvent(t *testing.T) {
 	t.Run("system-db/AC-01", func(t *testing.T) {
 
-		dsn := testDSN(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("migrations.Apply: %v", err)
-		}
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 
 		id := uuid.Must(uuid.NewV7())

--- a/internal/db/db_gaps_test.go
+++ b/internal/db/db_gaps_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/db/migrations"
 	"github.com/google/uuid"
 )
@@ -46,20 +47,11 @@ func TestNewPool_UnreachableHost(t *testing.T) {
 // reflects the highest applied version after a fresh run.
 func TestApply_RunsAllMigrations(t *testing.T) {
 	t.Run("system-db/AC-03", func(t *testing.T) {
-		dsn := testDSN(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("Apply: %v", err)
-		}
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
 
 		var highest int64
-		err = pool.QueryRow(ctx,
+		err := pool.QueryRow(ctx,
 			"SELECT MAX(version_id) FROM goose_db_version WHERE version_id > 0",
 		).Scan(&highest)
 		if err != nil {

--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -1,0 +1,244 @@
+// Package dbtest gives each test BINARY (i.e. each Go package's test
+// process) its own isolated, freshly-migrated PostgreSQL database.
+//
+// Why: before this, every DB-touching package read the single
+// OPENWATCH_TEST_DSN, ran migrations against that one shared database, and
+// TRUNCATEd shared tables between tests. That works only when packages run
+// serially — under package parallelism (`go test -p N`) two packages would
+// truncate and write each other's rows mid-test. The whole suite therefore
+// ran `-p 1`, serializing every DB package and dominating CI wall-clock.
+//
+// With dbtest, package A's tests run against `owt_<hashA>` and package B's
+// against `owt_<hashB>`, so they can't see each other and `-p N` is safe.
+//
+// Speed: migrating ~35 migrations in every one of ~35 parallel package
+// processes overwhelms Postgres. Instead dbtest migrates ONCE into a shared
+// TEMPLATE database (keyed by a hash of the migration files, so it is
+// rebuilt only when migrations change) and each package CLONEs it with
+// `CREATE DATABASE ... TEMPLATE` — a fast file copy, no re-migration. A
+// PostgreSQL advisory lock makes the one-time template build race-free
+// across the parallel processes.
+//
+// Usage — replace a package's hand-rolled `freshPool` body:
+//
+//	func freshPool(t *testing.T) *pgxpool.Pool {
+//		pool := dbtest.Pool(t)          // isolated, migrated, skips if no DSN
+//		// ... TRUNCATE the tables this package owns, as before ...
+//		return pool
+//	}
+//
+// Pool must be called DIRECTLY from the package's own test code (so the
+// runtime caller resolves to that package's directory).
+package dbtest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/db/migrations"
+)
+
+// EnvDSN is the base DSN env var. It is interpreted as a connection to the
+// PostgreSQL SERVER (the database in its path is only used to reach the
+// server + as the per-package name prefix); dbtest creates and migrates its
+// own per-package databases off it.
+const EnvDSN = "OPENWATCH_TEST_DSN"
+
+// templateLockKey is the advisory-lock key guarding the one-time template
+// build. Any fixed value works as long as it is dbtest-private.
+const templateLockKey int64 = 0x0_77_44_54_45_53_54 // "wDTEST"
+
+// Resolved once per test process (one package): a test binary only ever
+// contains one package, so deriving the name on the first Pool call is safe.
+var (
+	once    sync.Once
+	pkgDSN  string
+	initErr error
+)
+
+// Pool returns a pgxpool connected to this package's isolated database
+// (cloned from a freshly-migrated template). It skips the test when
+// OPENWATCH_TEST_DSN is unset. Each call returns a NEW pool (closed via
+// t.Cleanup) against the same per-package database, matching the historical
+// "new pool per freshPool call" behaviour. The database is provisioned once
+// per process.
+func Pool(t testing.TB) *pgxpool.Pool {
+	t.Helper()
+	base := os.Getenv(EnvDSN)
+	if base == "" {
+		t.Skipf("set %s to run DB integration tests", EnvDSN)
+	}
+
+	// Derive the per-package database name from the caller's source dir.
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		t.Fatal("dbtest: cannot resolve caller for per-package DB name")
+	}
+	dbName := databaseName(base, filepath.Dir(file))
+
+	once.Do(func() { pkgDSN, initErr = provision(base, dbName) })
+	if initErr != nil {
+		t.Fatalf("dbtest: provision %q: %v", dbName, initErr)
+	}
+
+	pool, err := pgxpool.New(context.Background(), pkgDSN)
+	if err != nil {
+		t.Fatalf("dbtest: connect isolated DB: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// databaseName builds a valid, stable, per-package PostgreSQL identifier:
+// the base DB name (truncated) + a short hash of the package directory.
+func databaseName(base, pkgDir string) string {
+	sum := sha256.Sum256([]byte(pkgDir))
+	short := hex.EncodeToString(sum[:])[:12]
+	return basePrefix(base) + "_" + short
+}
+
+// templateName is the shared migrated template's name, keyed by a hash of
+// the migration files so a migration change yields a fresh template.
+func templateName(base string) string {
+	return basePrefix(base) + "_tmpl_" + migrationsHash()
+}
+
+// basePrefix is a sanitized, length-bounded identifier derived from the
+// base DSN's database name (e.g. "openwatch_go_test" -> "openwatch_go_test").
+func basePrefix(base string) string {
+	prefix := "owt"
+	if u, err := url.Parse(base); err == nil {
+		if b := strings.Trim(u.Path, "/"); b != "" {
+			prefix = sanitizeIdent(b)
+		}
+	}
+	if len(prefix) > 36 {
+		prefix = prefix[:36]
+	}
+	return prefix
+}
+
+var identUnsafe = strings.NewReplacer("-", "_", ".", "_", " ", "_")
+
+func sanitizeIdent(s string) string {
+	return strings.ToLower(identUnsafe.Replace(s))
+}
+
+// migrationsHash hashes every embedded migration file (name + content) so
+// the template is reused only while the schema is unchanged.
+var migrationsHashOnce = sync.OnceValue(func() string {
+	h := sha256.New()
+	files, err := fs.Glob(migrations.FS(), "*.sql")
+	if err != nil {
+		return "unknown"
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		b, err := fs.ReadFile(migrations.FS(), f)
+		if err != nil {
+			return "unknown"
+		}
+		h.Write([]byte(f))
+		h.Write(b)
+	}
+	return hex.EncodeToString(h.Sum(nil))[:10]
+})
+
+func migrationsHash() string { return migrationsHashOnce() }
+
+// provision ensures the shared migrated template exists, then DROP+CREATEs
+// this package's database as a fast clone of it.
+func provision(base, dbName string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", EnvDSN, err)
+	}
+	if !strings.HasPrefix(u.Scheme, "postgres") {
+		return "", fmt.Errorf("%s must be a postgres:// URL, got scheme %q", EnvDSN, u.Scheme)
+	}
+
+	adminURL := *u
+	adminURL.Path = "/postgres"
+	admin, err := pgx.Connect(ctx, adminURL.String())
+	if err != nil {
+		return "", fmt.Errorf("connect maintenance db: %w", err)
+	}
+	defer func() { _ = admin.Close(ctx) }()
+
+	tmpl := templateName(base)
+	if err := ensureTemplate(ctx, admin, *u, tmpl); err != nil {
+		return "", fmt.Errorf("ensure template %s: %w", tmpl, err)
+	}
+
+	// Clone the template into a clean per-package DB. WITH (FORCE) (PG13+)
+	// terminates any lingering backends from a previous run.
+	if _, err := admin.Exec(ctx, fmt.Sprintf(`DROP DATABASE IF EXISTS %s WITH (FORCE)`, quoteIdent(dbName))); err != nil {
+		return "", fmt.Errorf("drop %s: %w", dbName, err)
+	}
+	if _, err := admin.Exec(ctx, fmt.Sprintf(`CREATE DATABASE %s TEMPLATE %s`, quoteIdent(dbName), quoteIdent(tmpl))); err != nil {
+		return "", fmt.Errorf("clone %s from %s: %w", dbName, tmpl, err)
+	}
+
+	pkgURL := *u
+	pkgURL.Path = "/" + dbName
+	return pkgURL.String(), nil
+}
+
+// ensureTemplate creates + migrates the shared template database exactly
+// once across all parallel test processes, guarded by an advisory lock.
+func ensureTemplate(ctx context.Context, admin *pgx.Conn, base url.URL, tmpl string) error {
+	if _, err := admin.Exec(ctx, "SELECT pg_advisory_lock($1)", templateLockKey); err != nil {
+		return fmt.Errorf("advisory lock: %w", err)
+	}
+	defer func() { _, _ = admin.Exec(ctx, "SELECT pg_advisory_unlock($1)", templateLockKey) }()
+
+	var exists bool
+	if err := admin.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", tmpl).Scan(&exists); err != nil {
+		return fmt.Errorf("check template: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	if _, err := admin.Exec(ctx, fmt.Sprintf(`CREATE DATABASE %s`, quoteIdent(tmpl))); err != nil {
+		return fmt.Errorf("create template: %w", err)
+	}
+
+	tmplURL := base
+	tmplURL.Path = "/" + tmpl
+	mp, err := pgxpool.New(ctx, tmplURL.String())
+	if err != nil {
+		return fmt.Errorf("connect template: %w", err)
+	}
+	err = migrations.Apply(ctx, mp)
+	mp.Close() // disconnect BEFORE releasing the lock so clones see 0 backends
+	if err != nil {
+		return fmt.Errorf("migrate template: %w", err)
+	}
+	return nil
+}
+
+// quoteIdent double-quotes a PostgreSQL identifier (the names here are
+// hash-derived and already safe, but quoting is correct hygiene).
+func quoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/internal/drift/service_test.go
+++ b/internal/drift/service_test.go
@@ -11,7 +11,6 @@ package drift
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -20,33 +19,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
-
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run drift integration tests")
-	}
-	return dsn
-}
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE transactions CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",

--- a/internal/exception/service_test.go
+++ b/internal/exception/service_test.go
@@ -14,7 +14,6 @@ package exception
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -22,8 +21,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
 
 type emitCall struct {
@@ -38,20 +36,8 @@ func fakeEmitter(calls *[]emitCall) EmitFunc {
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run exception integration tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE compliance_exceptions CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",

--- a/internal/fleetrollup/service_test.go
+++ b/internal/fleetrollup/service_test.go
@@ -16,44 +16,23 @@ package fleetrollup
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
 
 // ---------------------------------------------------------------------
 // Test scaffolding
 // ---------------------------------------------------------------------
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run fleetrollup integration tests")
-	}
-	return dsn
-}
-
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE transactions CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",

--- a/internal/group/service_db_test.go
+++ b/internal/group/service_db_test.go
@@ -19,33 +19,19 @@ package group
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run group integration tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE group_members CASCADE",
 		"TRUNCATE TABLE groups CASCADE",

--- a/internal/host/host_test.go
+++ b/internal/host/host_test.go
@@ -7,41 +7,21 @@ package host
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run host tests")
-	}
-	return dsn
-}
-
 // freshService returns a Service against a clean migrated DB with a
 // seeded creator user (FK on hosts.created_by requires it).
 func freshService(t *testing.T) (*Service, *pgxpool.Pool, uuid.UUID) {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	// TRUNCATE…CASCADE delegates child cleanup to the schema — the
 	// hosts row has 11 FK-referencing children (credentials, alerts,
 	// host_*_state, host_intelligence_*, host_rule_state, transactions,
@@ -52,7 +32,7 @@ func freshService(t *testing.T) (*Service, *pgxpool.Pool, uuid.UUID) {
 
 	createdBy, _ := uuid.NewV7()
 	hash, _ := identity.HashPassword("seed-pw-12345-aa")
-	_, err = pool.Exec(ctx,
+	_, err := pool.Exec(ctx,
 		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
 		createdBy, "host-creator", "creator@example.com", hash)
 	if err != nil {

--- a/internal/idempotency/middleware_test.go
+++ b/internal/idempotency/middleware_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -29,8 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -51,29 +49,11 @@ func jsonEqual(t *testing.T, got, want []byte) {
 	}
 }
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run idempotency integration tests")
-	}
-	return dsn
-}
-
 // freshPool returns a pool against a clean idempotency_keys table.
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE idempotency_keys")
 	return pool
 }

--- a/internal/identity/sessions_test.go
+++ b/internal/identity/sessions_test.go
@@ -10,39 +10,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run identity DB tests")
-	}
-	return dsn
-}
-
 // freshPool returns a pool against a migrated DB with sessions/users empty.
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	// Cascade clears sessions + refresh_tokens + mfa via FK ON DELETE CASCADE.
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 	return pool

--- a/internal/intelligence/collector/collector_db_test.go
+++ b/internal/intelligence/collector/collector_db_test.go
@@ -9,14 +9,12 @@ package collector
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/credential"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/eventbus"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
@@ -24,28 +22,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func collectorTestDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run collector integration tests")
-	}
-	return dsn
-}
-
 func freshDBCollector(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Service) {
 	t.Helper()
-	dsn := collectorTestDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("SetEphemeral: %v", err)
 	}
@@ -55,7 +35,7 @@ func freshDBCollector(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Servi
 
 	createdBy, _ := uuid.NewV7()
 	hash, _ := identity.HashPassword("seed-pw-12345-aa")
-	_, err = pool.Exec(ctx,
+	_, err := pool.Exec(ctx,
 		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
 		createdBy, "intel-creator", "intel@example.com", hash)
 	if err != nil {

--- a/internal/intelligence/discovery/discovery_db_test.go
+++ b/internal/intelligence/discovery/discovery_db_test.go
@@ -8,43 +8,23 @@ package discovery
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/credential"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func discoveryTestDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run discovery integration tests")
-	}
-	return dsn
-}
-
 // freshDBHost spins up a clean DB, seeds a user + host + a host-scope
 // SSH credential, and returns the host id + a usable credential.Service.
 func freshDBHost(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Service) {
 	t.Helper()
-	dsn := discoveryTestDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("SetEphemeral: %v", err)
 	}
@@ -54,7 +34,7 @@ func freshDBHost(t *testing.T) (*pgxpool.Pool, uuid.UUID, *credential.Service) {
 
 	createdBy, _ := uuid.NewV7()
 	hash, _ := identity.HashPassword("seed-pw-12345-aa")
-	_, err = pool.Exec(ctx,
+	_, err := pool.Exec(ctx,
 		`INSERT INTO users (id, username, email, password_hash) VALUES ($1, $2, $3, $4)`,
 		createdBy, "disc-creator", "disc@example.com", hash)
 	if err != nil {

--- a/internal/intelligence/discovery/scheduler/service_db_test.go
+++ b/internal/intelligence/discovery/scheduler/service_db_test.go
@@ -8,40 +8,21 @@ package scheduler
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // testDSN returns the DSN to test against, or skips when unset.
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run discovery scheduler DB tests")
-	}
-	return dsn
-}
 
 // freshPool returns a pool against a migrated DB with hosts emptied.
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE hosts CASCADE")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 	return pool

--- a/internal/intelligence/scheduler/service_db_test.go
+++ b/internal/intelligence/scheduler/service_db_test.go
@@ -12,40 +12,20 @@ package scheduler
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/Hanalyx/openwatch/internal/systemconfig"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func schedulerTestDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run scheduler integration tests")
-	}
-	return dsn
-}
-
 func freshDBScheduler(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := schedulerTestDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	// CASCADE: hosts is referenced by 11 child tables (alerts,
 	// credentials, host_backoff_state, host_compliance_schedule,
 	// host_intelligence_*, host_liveness, host_monitoring_history,

--- a/internal/kensa/backoff_test.go
+++ b/internal/kensa/backoff_test.go
@@ -13,7 +13,6 @@ package kensa
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -21,8 +20,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
 
 // @ac AC-16
@@ -116,33 +114,13 @@ func TestBackoffPolicy_ComputeSuppressUntil_CapsAt24h(t *testing.T) {
 // Integration tests (require OPENWATCH_TEST_DSN)
 // ---------------------------------------------------------------------
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run kensa backoff integration tests")
-	}
-	return dsn
-}
-
 // freshPool returns a pool against a clean schedule + backoff state.
 // Applies all migrations through 0011 and truncates tables this
 // package writes to.
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 
 	for _, stmt := range []string{
 		"TRUNCATE TABLE host_backoff_state CASCADE",

--- a/internal/liveness/service_test.go
+++ b/internal/liveness/service_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -25,33 +24,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
-
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run liveness integration tests")
-	}
-	return dsn
-}
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE host_liveness CASCADE",
 		"TRUNCATE TABLE hosts CASCADE",

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -8,13 +8,10 @@ package notification
 import (
 	"bytes"
 	"context"
-	"os"
 	"testing"
-	"time"
 
 	"github.com/Hanalyx/openwatch/internal/alertrouter"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -22,24 +19,12 @@ import (
 
 func freshService(t *testing.T) (*Service, *pgxpool.Pool) {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run notification store tests")
-	}
+	pool := dbtest.Pool(t)
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("secretkey.SetEphemeral: %v", err)
 	}
 	t.Cleanup(secretkey.Reset)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE notification_channels")
 	return NewService(pool), pool
 }

--- a/internal/policy/loader_test.go
+++ b/internal/policy/loader_test.go
@@ -21,36 +21,17 @@ import (
 
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/correlation"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/internalrace"
 	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"gopkg.in/yaml.v3"
 )
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run policy DB tests")
-	}
-	return dsn
-}
-
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE policy_history")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 	// Initialize audit writer for emit during loads.

--- a/internal/posture/posture_test.go
+++ b/internal/posture/posture_test.go
@@ -8,33 +8,18 @@ package posture
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
 )
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run posture integration tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE posture_snapshots CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -16,34 +16,15 @@ import (
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/correlation"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run queue integration tests")
-	}
-	return dsn
-}
-
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE job_queue")
 	return pool
 }

--- a/internal/report/service_db_test.go
+++ b/internal/report/service_db_test.go
@@ -17,33 +17,18 @@ package report
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
 )
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run report integration tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE reports CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",

--- a/internal/scanresult/writer_test.go
+++ b/internal/scanresult/writer_test.go
@@ -16,44 +16,22 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
 )
 
 // ---------------------------------------------------------------------
 // Test scaffolding (mirrors internal/transactionlog/writer_test.go)
 // ---------------------------------------------------------------------
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run scanresult integration tests")
-	}
-	return dsn
-}
-
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE scan_results CASCADE",
 		"TRUNCATE TABLE scan_evidence CASCADE",

--- a/internal/scanruns/scanruns_test.go
+++ b/internal/scanruns/scanruns_test.go
@@ -14,40 +14,17 @@ package scanruns
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
-	"time"
 
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
-
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
 )
-
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run scanruns integration tests")
-	}
-	return dsn
-}
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE scan_runs CASCADE",
 		"TRUNCATE TABLE hosts CASCADE",

--- a/internal/scheduler/service_test.go
+++ b/internal/scheduler/service_test.go
@@ -11,7 +11,6 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -21,39 +20,16 @@ import (
 
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/correlation"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
-
-// testDSN reads the integration test Postgres DSN; skips when absent so
-// local non-DB runs stay green.
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run scheduler integration tests")
-	}
-	return dsn
-}
 
 // freshPool returns a pool against a clean schedule + queue state.
 // Applies all migrations (including 0011) and truncates the tables this
 // package writes to.
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 
 	// Truncate everything the scheduler touches, in FK order.
 	for _, stmt := range []string{

--- a/internal/server/api_helpers_test.go
+++ b/internal/server/api_helpers_test.go
@@ -22,8 +22,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/config"
 	"github.com/Hanalyx/openwatch/internal/credential"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/exception"
 	"github.com/Hanalyx/openwatch/internal/group"
 	"github.com/Hanalyx/openwatch/internal/identity"
@@ -127,19 +126,16 @@ func doGet(t *testing.T, url string) *http.Response {
 // the underlying pool for assertions.
 func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	t.Helper()
-	dsn := apiTestDSN(t)
+	// Safety gate: refuse a non-test DSN before we create or touch any DB.
+	// dbtest.Pool gives this package its own isolated, migrated database
+	// (so -p N parallel packages never share tables), but the gate still
+	// guards against pointing OPENWATCH_TEST_DSN at a dev/prod server.
+	_ = apiTestDSN(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE idempotency_keys")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE system_config")

--- a/internal/sso/sso_test.go
+++ b/internal/sso/sso_test.go
@@ -17,13 +17,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
@@ -106,20 +104,8 @@ func b64(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
 func freshSSO(t *testing.T) (*Service, *pgxpool.Pool, *idp) {
 	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run sso tests")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	if err := secretkey.SetEphemeral(); err != nil {
 		t.Fatalf("secretkey: %v", err)
 	}

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -26,33 +25,13 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
-
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run systemconfig integration tests")
-	}
-	return dsn
-}
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	if _, err := pool.Exec(ctx, "TRUNCATE TABLE system_config CASCADE"); err != nil {
 		t.Logf("truncate (ok if table just created): %v", err)
 	}

--- a/internal/transactionlog/writer_test.go
+++ b/internal/transactionlog/writer_test.go
@@ -20,7 +20,6 @@ package transactionlog
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -29,37 +28,17 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 )
 
 // ---------------------------------------------------------------------
 // Test scaffolding
 // ---------------------------------------------------------------------
 
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run transactionlog integration tests")
-	}
-	return dsn
-}
-
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE transactions CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -8,44 +8,23 @@ package users
 import (
 	"context"
 	"errors"
-	"os"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/Hanalyx/openwatch/internal/auth"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
-
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run users tests")
-	}
-	return dsn
-}
 
 // freshService returns a Service against a migrated, empty DB. Each
 // test gets isolation via TRUNCATE users CASCADE; user_roles + sessions
 // cascade off it.
 func freshService(t *testing.T, corpus identity.BreachCorpus) (*Service, *pgxpool.Pool) {
 	t.Helper()
-	dsn := testDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	t.Cleanup(cancel)
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE users CASCADE")
 	return NewService(pool, corpus), pool
 }

--- a/internal/worker/scan_worker_test.go
+++ b/internal/worker/scan_worker_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -30,8 +29,7 @@ import (
 
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/correlation"
-	"github.com/Hanalyx/openwatch/internal/db"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/kensa"
 	"github.com/Hanalyx/openwatch/internal/queue"
 	"github.com/Hanalyx/openwatch/internal/scheduler"
@@ -44,18 +42,8 @@ import (
 
 func freshPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
-	dsn := workerTestDSN(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(cancel)
-
-	pool, err := db.NewPool(ctx, dsn, 5)
-	if err != nil {
-		t.Fatalf("NewPool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	if err := migrations.Apply(ctx, pool); err != nil {
-		t.Fatalf("migrations.Apply: %v", err)
-	}
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
 	for _, stmt := range []string{
 		"TRUNCATE TABLE transactions CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",
@@ -69,25 +57,6 @@ func freshPool(t *testing.T) *pgxpool.Pool {
 		}
 	}
 	return pool
-}
-
-// workerTestDSN gates DB-backed tests behind the OPENWATCH_TEST_DSN env.
-// Pure-function tests in source_test.go / backoff_test.go / payload_test.go /
-// advisory_lock_test.go run unconditionally; tests that need a DB skip
-// when unset.
-func workerTestDSN(t *testing.T) string {
-	t.Helper()
-	return mustEnv(t, "OPENWATCH_TEST_DSN")
-}
-
-// mustEnv calls t.Skip if the env var is unset.
-func mustEnv(t *testing.T, name string) string {
-	t.Helper()
-	v := os.Getenv(name)
-	if v == "" {
-		t.Skipf("set %s to run worker integration tests", name)
-	}
-	return v
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Go test step ran `-p 1` (one package at a time), serializing every DB-touching package — the dominant CI wall-clock cost. The reason: all ~37 packages read the single `OPENWATCH_TEST_DSN`, migrated that **one shared** database, and `TRUNCATE`d shared tables between tests. Run two in parallel and they truncate each other's rows mid-test.

## Fix: `internal/db/dbtest`

A new helper gives each test **binary** its own isolated, freshly-migrated database:

- **`dbtest.Pool(t)`** derives a per-package DB name from the caller's source dir (stable across runs, unique per package), `DROP+CREATE`s it, returns a pool. Skips when `OPENWATCH_TEST_DSN` is unset — same as before.
- **Template cloning for speed:** migrating ~35 migrations in each of ~35 parallel processes overwhelms Postgres. Instead dbtest migrates **once** into a shared *template* database (keyed by a hash of the migration files, so it's rebuilt only when migrations change), and each package **clones** it via `CREATE DATABASE … TEMPLATE` — a fast file copy, no re-migration. A pg advisory lock makes the one-time template build race-free across the parallel processes.

37 packages converted: each `freshPool`/`freshService` helper now calls `dbtest.Pool(t)`; the per-package `TRUNCATE`s, seeding, and DEK setup are unchanged. The `internal/server` safety gate (refuse a non-`_test` DSN) is preserved as defense-in-depth.

## Measured result

Same machine, `-race`, full `./internal/...`:

| Config | Wall-clock | Result |
|--------|-----------|--------|
| baseline — shared DB, `-p 1` (current CI) | **11m54s** | |
| isolated — dbtest, `-p 8` | 8m41s | 2 contention timeouts (8-way saturated the single PG) |
| **isolated — dbtest, `-p 4`** | **6m12s** | ✅ **all green** |

CI flips `-p 1` → **`-p 4`** — enough cross-package parallelism to overlap the slow `internal/server` package (~400s, internally serial — the remaining floor) without saturating the single Postgres. The two tests whose tight 10s setup contexts blew at `-p 8` (`credential`, `server`) get 30s setup timeouts as CI-runner insurance.

## Scope / honesty

~48% off the Go test step, not more: the floor is now the `internal/server` package alone (~400s, one package, internally serial). Going lower needs within-`server` parallelism (`t.Parallel`), a separate and riskier change — its fixtures share process-global state (`audit.Init`, license, truncate-based isolation). Noted for a follow-up.

`gofmt`/`go vet` clean; full suite green at `-p 4` locally; build artifacts + `.specter-results.json` stay gitignored.