### PR TITLE
docs: release-readiness sweep — spec + populate changelog, refresh guides, future-proof upgrade test

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -165,14 +165,14 @@
         "filename": "docs/engineering/install_guide.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 146
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/engineering/install_guide.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 370
+        "line_number": 377
       }
     ],
     "docs/engineering/prototypes/openwatch-v1/Host Management.html": [
@@ -2867,5 +2867,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-15T21:15:28Z"
+  "generated_at": "2026-06-17T01:00:11Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,74 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+Settings became a working control panel, OpenWatch started learning how to
+reach each host over SSH, package upgrades became a single safe command, and a
+pre-release security review closed a batch of perimeter and access-control
+gaps.
+
+### Added
+
+- Settings > Users now lets you invite people, manage their accounts, and
+  assign roles from the UI instead of showing a placeholder (#552, #553).
+- Settings > Notifications can now send compliance alerts to Slack, a generic
+  webhook, or email over SMTP, and each channel can be edited after creation
+  (#554, #555).
+- Settings > Security is live end to end: scoped API tokens you can create and
+  revoke, an authentication policy (password strength and session timeouts),
+  and single sign-on through an OIDC identity provider (#556, #557, #558).
+- Settings > Audit and About now browse the audit log in-app and show the live
+  license and build details instead of static text (#552).
+- Each host's actions menu now has Edit and Delete entries so you can correct
+  or remove a host without leaving the list (#560).
+- OpenWatch now learns how to reach each host: it records which SSH
+  authentication method and sudo style actually worked and reuses them on the
+  next discovery, intelligence, and liveness pass, so it stops retrying
+  combinations that already failed (#566, #575, #576).
+
+### Changed
+
+- Upgrading is now one command. `dnf update` (or `apt upgrade`) applies any
+  pending database migrations automatically, takes a full database backup
+  first, and on a failed migration leaves the service stopped with clear
+  recovery steps instead of running against a half-migrated schema. The
+  PostgreSQL engine upgrade itself stays an operator-supervised step (#569).
+- Web fonts now ship inside the application instead of loading from a font CDN,
+  so the interface renders completely in air-gapped deployments (#561).
+- Updated the frontend build and CI tooling (Vite, Vitest, lucide-react, zod,
+  and several GitHub Actions) to current major versions (#571, #572, #573).
+
+### Fixed
+
+- A fresh install now boots on the first try: the Kensa rule corpus and the
+  server identity keys are provisioned during installation rather than failing
+  at first startup (#564).
+- The SMTP notification channel edit form now pre-fills its current settings
+  instead of opening blank (#561).
+- Removed leftover demo and sample data that could appear on the dashboard,
+  the activity feed, and the host lists (#562).
+
+### Security
+
+A pre-release security review (six parallel audit dimensions, every
+high-severity finding re-verified by hand) closed eight findings (#584):
+
+- State-changing requests made with a session cookie are now CSRF-protected
+  with a double-submit token; a request without a matching token is rejected.
+- The login and MFA-verify endpoints are now rate-limited per client address
+  to slow online password and one-time-code guessing.
+- Every response now carries security headers: HSTS, a content-security policy
+  that forbids framing, no-sniff, and a strict referrer policy.
+- SSH host keys learned on first connection are now stored in the database, so
+  a restart no longer re-trusts every host and a changed host key is detected
+  across restarts.
+- New passwords are now screened against a built-in list of common and breached
+  passwords, with an option to point at a full breach corpus; the check now
+  runs in production instead of being silently skipped.
+- Reading the audit-event API now requires the audit-read permission instead of
+  being open to any caller.
+- Creating an API token or assigning a role can no longer grant more access
+  than the caller already holds.
+
 ---
 
 ## [0.2.0-rc.7] Eyrie — 2026-06-14

--- a/docs/engineering/install_guide.md
+++ b/docs/engineering/install_guide.md
@@ -247,7 +247,7 @@ PGPASSWORD='replace-with-a-strong-password' \
 ### Step 3 — Install the packages
 
 ```bash
-sudo apt install -y ./openwatch_0.2.0-rc.5_amd64.deb ./kensa-rules_0.4.3_all.deb
+sudo apt install -y ./openwatch_0.2.0-rc.7_amd64.deb ./kensa-rules_0.4.3_all.deb
 ```
 
 Install **both** files together — `openwatch` `Depends` on `kensa-rules` (the
@@ -401,6 +401,63 @@ curl -k https://localhost:8443/api/v1/health
 
 The database ping inside `/health` failed. Check `journalctl -u openwatch` for
 the underlying error.
+
+---
+
+## Upgrading
+
+Upgrading is one command. Download the newer `openwatch` package (and the newer
+`kensa-rules` package if the rule corpus moved) and install it the same way you
+did originally:
+
+```bash
+# RHEL family
+sudo dnf install -y ./openwatch-<new>.x86_64.rpm ./kensa-rules-<new>.noarch.rpm
+
+# Debian / Ubuntu
+sudo apt install -y ./openwatch_<new>_amd64.deb ./kensa-rules_<new>_all.deb
+```
+
+On an upgrade (and only on an upgrade — never on a fresh install) the package
+post-install step runs the upgrade helper, which:
+
+1. Checks the database is reachable. If it is not, it leaves the service alone,
+   prints how to finish later (`openwatch migrate && systemctl restart
+   openwatch`), and does **not** fail the package transaction.
+2. Stops the service so the old binary never runs against a half-migrated
+   schema.
+3. Takes a full `pg_dump` restore point into `/var/lib/openwatch/backups/`
+   before touching the schema. If the backup fails, it aborts **without**
+   migrating (fail-closed) — your data is untouched.
+4. Applies any pending migrations, then starts the service again.
+
+If a migration fails, the helper leaves the service **stopped** and exits
+non-zero so the package manager surfaces the problem, and it prints the restore
+path. Your data is intact (each migration runs in its own transaction and rolls
+back on error). After fixing the cause:
+
+```bash
+openwatch migrate            # re-apply; reads the same DSN from secrets.env
+sudo systemctl start openwatch
+```
+
+To preview what an upgrade would apply without changing anything:
+
+```bash
+sudo -u openwatch openwatch migrate --status
+```
+
+Tunables live in `/etc/openwatch/upgrade.conf` (a `noreplace` config file):
+`AUTO_BACKUP=yes|no` toggles the pre-migration dump, and
+`BACKUP_RETENTION_DAYS` controls pruning. A `systemd` timer
+(`openwatch-backup-cleanup.timer`) prunes old dumps daily but **always keeps the
+most recent one** regardless of age.
+
+> Scope: this automates the OpenWatch **application** schema only. A PostgreSQL
+> **engine** major-version upgrade (for example PostgreSQL 15 -> 16) is a
+> separate, operator-supervised `pg_upgrade` and is never triggered from a
+> package scriptlet. See `specs/release/upgrade.spec.yaml` for the full
+> contract.
 
 ---
 

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -1,6 +1,6 @@
 # OpenWatch security hardening guide
 
-**Applies to:** OpenWatch 0.2.0-rc.5 (Go single-binary build; pre-release)
+**Applies to:** OpenWatch 0.2.0 pre-release (rc series; Go single-binary build)
 **Audience:** System administrators, security engineers, compliance officers
 
 This guide covers the security controls you operate when you deploy OpenWatch
@@ -61,6 +61,20 @@ Hardening steps you perform at the host level:
 
 Source: `packaging/common/openwatch.service`,
 `docs/engineering/install_guide.md` (Step 2).
+
+### Outbound SSH to managed hosts
+
+When OpenWatch connects to a managed host it validates the host key on a
+trust-on-first-use basis and **persists** the accepted key in PostgreSQL
+(`ssh_known_hosts`, migration 0036). The first connection records the key; every
+later connection compares against it and is rejected if the key changed
+(`ErrHostKeyMismatch`). Because the store is durable, a service restart does not
+re-trust hosts, so an attacker cannot MITM the first scan after a restart to
+harvest credentials. Presented keys are also strength-validated per NIST SP
+800-57 (RSA >= 2048, Ed25519 always accepted). To rotate a host's key
+intentionally (a re-provisioned host), delete its row from `ssh_known_hosts` so
+the next connection re-learns it. Source: `internal/knownhosts/store.go`,
+`internal/ssh/`.
 
 ---
 
@@ -164,7 +178,7 @@ Source: `packaging/common/openwatch.service`, `internal/config/config.go`
 | Session inactivity timeout | 15 minutes | `internal/identity/sessions.go` (`SessionInactivityWindow`) |
 | Session absolute timeout | 12 hours | `internal/identity/sessions.go` (`SessionAbsoluteWindow`) |
 | Password policy | Length only — 8 chars (regular), 15 chars (admin), max 128; NIST SP 800-63B | `internal/identity/password.go` |
-| Breach check | Optional corpus lookup rejects known-compromised passwords | `internal/identity/password.go` |
+| Breach check | Always-on in production: new passwords are screened against an embedded common/breached corpus (airgap-safe); point `OPENWATCH_BREACH_CORPUS_FILE` at a full HIBP list to extend it | `internal/identity/password.go`, `internal/identity/breach_corpus_default.go` |
 | MFA | TOTP enrollment and verification | `internal/identity/mfa.go` |
 
 The password policy is deliberately length-based with no character-class rules,
@@ -173,12 +187,12 @@ per NIST SP 800-63B. The first admin is created out-of-band with
 
 Source: `internal/identity/`, `cmd/openwatch/main.go` (`cmdCreateAdmin`).
 
-> Not yet implemented: there is no failed-login throttle, account lockout, or
-> per-IP brute-force backoff in the auth handlers. The Argon2id cost (~50–100 ms
-> per verification) is the only built-in slow-down on online guessing. Until
-> rate limiting lands (Section 9), protect `/api/v1/auth/login` with an upstream
-> control (a reverse proxy with rate limiting, or network ACLs) if you expose
-> 8443 beyond a trusted network. Source: `internal/server/auth_handlers.go`.
+`/api/v1/auth/login` and `/auth/mfa:verify` are rate-limited per client IP
+(Section 10), which throttles online guessing in addition to the Argon2id cost
+(~50-100 ms per verification). There is still no per-account lockout after N
+failed attempts, so for an internet-facing 8443 a reverse proxy or network ACL
+is still worthwhile as defense in depth. Source:
+`internal/server/auth_handlers.go`, `internal/server/ratelimit.go`.
 
 ---
 
@@ -297,7 +311,7 @@ Hardening steps:
 
 ---
 
-## 10. Rate limiting and request controls — current state
+## 10. Rate limiting, CSRF, and security headers
 
 The HTTP server sets request-hardening timeouts and size limits:
 
@@ -309,15 +323,22 @@ The HTTP server sets request-hardening timeouts and size limits:
 | `IdleTimeout` | 120 s | `internal/server/server.go` |
 | `MaxHeaderBytes` | 64 KiB | `internal/server/server.go` |
 
-> Not yet implemented: there is no per-user or per-IP HTTP rate-limiting
-> middleware, and no HTTP security-header middleware (HSTS, CSP, `X-Frame-Options`,
-> `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`). The
-> `RateLimit` constants in the codebase belong to the intelligence and discovery
-> schedulers (how many hosts to enqueue per tick), not to the HTTP surface.
-> Until these land, enforce request rate limiting and inject security response
-> headers at an upstream reverse proxy if you expose 8443 publicly. Source:
-> `internal/server/server.go`, `internal/intelligence/scheduler/service.go`,
-> `internal/intelligence/discovery/scheduler/service.go`.
+The single binary serves the SPA and the API from one origin with no required
+edge proxy, so the perimeter controls run in the application itself:
+
+| Control | Behavior | Source |
+|---------|----------|--------|
+| Auth rate limiting | Per-client-IP sliding window on `POST /api/v1/auth/login` and `/auth/mfa:verify`; over the limit returns `429` + `Retry-After` and skips the credential check. The key is the direct connection address (`RemoteAddr`), not a client-supplied `X-Forwarded-For`. | `internal/server/ratelimit.go` |
+| CSRF | Double-submit token: login and refresh set a non-HttpOnly `XSRF-TOKEN` cookie, and unsafe (POST/PUT/PATCH/DELETE) cookie-authenticated requests must echo it in `X-CSRF-Token` (constant-time compare) or get `403 authz.csrf_invalid`. Bearer/token requests and `/api/v1/auth/*` are exempt. | `internal/server/csrf.go` |
+| Security headers | Every response carries HSTS (>=1 year, includeSubDomains), a Content-Security-Policy that denies framing (`frame-ancestors 'none'`, `default-src 'self'`; `/docs` relaxes script/style for Swagger but still denies framing), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: no-referrer`. | `internal/server/security_headers.go` |
+
+> Scope notes: auth rate limiting covers the credential-guessing surface, not
+> every route — there is still no general per-route HTTP limiter, and no request
+> body-size cap (`http.MaxBytesReader`) on JSON endpoints. If you expose 8443
+> publicly, an upstream reverse proxy is still useful for global rate limiting
+> and body-size enforcement. The scheduler `RateLimit` constants are unrelated
+> (they bound how many hosts the intelligence and discovery schedulers enqueue
+> per tick), see `internal/intelligence/scheduler/service.go`.
 
 ---
 

--- a/packaging/tests/changelog_test.go
+++ b/packaging/tests/changelog_test.go
@@ -1,0 +1,193 @@
+// @spec release-changelog
+//
+// Source-inspection tests for CHANGELOG.md authoring discipline. The
+// changelog is the operator-facing record of what changed between releases;
+// these tests gate its structure (dated version sections, Keep a Changelog
+// categories), the human-readability of newly authored entries (the
+// [Unreleased] section), and the repo-wide no-emoji rule. Released sections
+// authored before release-changelog are grandfathered: the strict per-entry
+// checks run only against [Unreleased], the surface authors actively edit.
+
+package packaging_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// changelogPath returns the repo-root CHANGELOG.md (two dirs up from
+// packaging/tests/), so the test behaves the same regardless of cwd.
+func changelogPath(t *testing.T) string {
+	t.Helper()
+	_, here, _, _ := runtime.Caller(0)
+	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", "..", "CHANGELOG.md"))
+}
+
+func readChangelog(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(changelogPath(t))
+	if err != nil {
+		t.Fatalf("read CHANGELOG.md: %v", err)
+	}
+	return string(b)
+}
+
+// unreleasedBlock returns the lines of the [Unreleased] section (between its
+// `## [Unreleased]` heading and the next `## [` version heading).
+func unreleasedBlock(t *testing.T, doc string) []string {
+	t.Helper()
+	lines := strings.Split(doc, "\n")
+	start := -1
+	for i, ln := range lines {
+		if strings.HasPrefix(ln, "## [Unreleased]") {
+			start = i + 1
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatal("CHANGELOG.md has no `## [Unreleased]` section")
+	}
+	var out []string
+	for _, ln := range lines[start:] {
+		if strings.HasPrefix(ln, "## [") {
+			break
+		}
+		out = append(out, ln)
+	}
+	return out
+}
+
+// @ac AC-01
+//
+// Every `## [<version>]` heading other than [Unreleased] carries an ISO date;
+// the [Unreleased] accumulator exists and carries no date.
+func TestChangelog_VersionSectionsDated(t *testing.T) {
+	t.Run("release-changelog/AC-01", func(t *testing.T) {
+		doc := readChangelog(t)
+		isoDate := regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+		sawUnreleased := false
+		for _, ln := range strings.Split(doc, "\n") {
+			if !strings.HasPrefix(ln, "## [") {
+				continue
+			}
+			if strings.HasPrefix(ln, "## [Unreleased]") {
+				sawUnreleased = true
+				if isoDate.MatchString(ln) {
+					t.Errorf("[Unreleased] heading must not carry a date: %q", ln)
+				}
+				continue
+			}
+			if !isoDate.MatchString(ln) {
+				t.Errorf("released version heading lacks an ISO date: %q", ln)
+			}
+		}
+		if !sawUnreleased {
+			t.Error("CHANGELOG.md has no `## [Unreleased]` section")
+		}
+	})
+}
+
+// @ac AC-02
+//
+// Category headings in the [Unreleased] section are drawn only from the Keep a
+// Changelog vocabulary.
+func TestChangelog_UnreleasedCategoriesAreStandard(t *testing.T) {
+	t.Run("release-changelog/AC-02", func(t *testing.T) {
+		allowed := map[string]bool{
+			"Added": true, "Changed": true, "Deprecated": true,
+			"Removed": true, "Fixed": true, "Security": true,
+		}
+		for _, ln := range unreleasedBlock(t, readChangelog(t)) {
+			if !strings.HasPrefix(ln, "### ") {
+				continue
+			}
+			cat := strings.TrimSpace(strings.TrimPrefix(ln, "### "))
+			if !allowed[cat] {
+				t.Errorf("non-standard category heading in [Unreleased]: %q (allowed: Added/Changed/Deprecated/Removed/Fixed/Security)", cat)
+			}
+		}
+	})
+}
+
+// @ac AC-03
+//
+// Top-level entries in [Unreleased] read as user-facing sentences: at least 5
+// words and not a raw conventional-commit subject.
+func TestChangelog_UnreleasedEntriesAreHumanReadable(t *testing.T) {
+	t.Run("release-changelog/AC-03", func(t *testing.T) {
+		commitPrefix := regexp.MustCompile(`^(feat|fix|chore|docs|refactor|test|ci|perf|build|style)(\([^)]*\))?:`)
+		// Strip markdown emphasis and inline-code ticks so word counting and
+		// prefix detection see the prose, not the formatting.
+		strip := strings.NewReplacer("**", "", "`", "", "*", "")
+		for _, ln := range unreleasedBlock(t, readChangelog(t)) {
+			// Only top-level bullets ("- "); continuation/sub-bullets are indented.
+			if !strings.HasPrefix(ln, "- ") {
+				continue
+			}
+			entry := strings.TrimSpace(strip.Replace(strings.TrimPrefix(ln, "- ")))
+			if commitPrefix.MatchString(entry) {
+				t.Errorf("entry reads as a raw commit subject, not a user-facing sentence: %q", entry)
+			}
+			if n := len(strings.Fields(entry)); n < 5 {
+				t.Errorf("entry too terse to be human-readable (%d words, need >=5): %q", n, entry)
+			}
+		}
+	})
+}
+
+// @ac AC-05
+//
+// An [Unreleased] entry that calls out a regression must name the version it
+// regressed in, so an operator can judge exposure.
+func TestChangelog_RegressionsNameAVersion(t *testing.T) {
+	t.Run("release-changelog/AC-05", func(t *testing.T) {
+		versionTok := regexp.MustCompile(`\d+\.\d+(\.\d+)?(-rc\.\d+)?|v\d+\.\d+`)
+		for _, ln := range unreleasedBlock(t, readChangelog(t)) {
+			if !strings.HasPrefix(ln, "- ") {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(ln), "regression") {
+				continue
+			}
+			if !versionTok.MatchString(ln) {
+				t.Errorf("regression entry names no version: %q", strings.TrimSpace(ln))
+			}
+		}
+	})
+}
+
+// @ac AC-04
+//
+// The whole changelog is emoji-free, matching the repo-wide no-emoji rule.
+// Arrows (U+2190..U+21FF) and box-drawing are intentionally NOT treated as
+// emoji — the changelog uses "->" arrows in prose.
+func TestChangelog_NoEmoji(t *testing.T) {
+	t.Run("release-changelog/AC-04", func(t *testing.T) {
+		doc := readChangelog(t)
+		isEmoji := func(r rune) bool {
+			switch {
+			case r >= 0x1F000 && r <= 0x1FAFF: // pictographs, symbols, supplemental
+				return true
+			case r >= 0x2600 && r <= 0x27BF: // misc symbols + dingbats
+				return true
+			case r >= 0x2B00 && r <= 0x2BFF: // stars, decorative arrows
+				return true
+			case r == 0xFE0F: // emoji variation selector
+				return true
+			}
+			return false
+		}
+		for i, ln := range strings.Split(doc, "\n") {
+			for _, r := range ln {
+				if isEmoji(r) {
+					t.Errorf("emoji %q (U+%04X) on line %d: %q", string(r), r, i+1, ln)
+					break
+				}
+			}
+		}
+	})
+}

--- a/packaging/tests/run-upgrade-container-test.sh
+++ b/packaging/tests/run-upgrade-container-test.sh
@@ -22,11 +22,21 @@ RPMS="$(mktemp -d)"
 trap 'rm -rf "$RPMS"' EXIT
 mkdir -p "$RPMS/old" "$RPMS/new"
 
-echo ">> building OLD (release 1) and NEW (release 2) RPMs"
+# Pin to the host/container RPM arch. dist/ can hold leftover cross-built
+# RPMs of the other arch (the packaging Go suite cross-builds arm64), and the
+# rockylinux:9 container runs the host platform — so glob a single arch only,
+# or installing both arches collides on /usr/bin/openwatch.
+case "$(uname -m)" in
+    x86_64)          RPM_ARCH=x86_64 ;;
+    aarch64|arm64)   RPM_ARCH=aarch64 ;;
+    *) echo "unsupported host arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+echo ">> building OLD (release 1) and NEW (release 2) ${RPM_ARCH} RPMs"
 make rpm >/dev/null
-cp dist/openwatch-*-1.*.rpm "$RPMS/old/"
+cp dist/openwatch-*-1."${RPM_ARCH}".rpm "$RPMS/old/"
 RPM_RELEASE=2 bash packaging/rpm/build-rpm.sh >/dev/null
-cp dist/openwatch-*-2.*.rpm "$RPMS/new/"
+cp dist/openwatch-*-2."${RPM_ARCH}".rpm "$RPMS/new/"
 
 # Derive the current head migration so the in-container test never hardcodes a
 # migration number: HEAD_VER is its goose version_id (filename digits, leading

--- a/packaging/tests/run-upgrade-container-test.sh
+++ b/packaging/tests/run-upgrade-container-test.sh
@@ -28,8 +28,21 @@ cp dist/openwatch-*-1.*.rpm "$RPMS/old/"
 RPM_RELEASE=2 bash packaging/rpm/build-rpm.sh >/dev/null
 cp dist/openwatch-*-2.*.rpm "$RPMS/new/"
 
+# Derive the current head migration so the in-container test never hardcodes a
+# migration number: HEAD_VER is its goose version_id (filename digits, leading
+# zeros stripped — 0036 -> 36) and HEAD_DOWN is its `-- +goose Down` SQL, which
+# the test runs to reverse exactly that migration and simulate the prior version.
+HEAD_FILE="$(ls "$APP_DIR"/internal/db/migrations/*.sql | sort | tail -1)"
+HEAD_VER="$(basename "$HEAD_FILE" | grep -oE '^[0-9]+' | sed 's/^0*//')"
+HEAD_DOWN="$(awk '/-- \+goose Down/{flag=1;next} flag' "$HEAD_FILE")"
+[ -n "$HEAD_VER" ] || { echo "could not derive HEAD_VER from $HEAD_FILE" >&2; exit 1; }
+[ -n "$HEAD_DOWN" ] || { echo "head migration $HEAD_FILE has no -- +goose Down block" >&2; exit 1; }
+echo ">> head migration: $(basename "$HEAD_FILE") (version_id=$HEAD_VER)"
+
 echo ">> running the upgrade in a rockylinux:9 container"
 exec docker run --rm --network host \
+    -e HEAD_VER="$HEAD_VER" \
+    -e HEAD_DOWN="$HEAD_DOWN" \
     -v "$RPMS:/rpms:ro" \
     -v "$APP_DIR/packaging/tests/upgrade-container-test.sh:/test.sh:ro" \
     rockylinux:9 bash /test.sh

--- a/packaging/tests/upgrade-container-test.sh
+++ b/packaging/tests/upgrade-container-test.sh
@@ -8,8 +8,20 @@
 # $1=2) migrated the DB to head and took a pre-upgrade backup — with a
 # systemctl shim standing in for systemd (no init in the container).
 #
+# Migration-number-agnostic: the host driver derives the current head
+# migration's goose version_id (HEAD_VER) and its `-- +goose Down` SQL
+# (HEAD_DOWN) from the source tree and passes them in via the environment, so
+# this test does not hardcode any migration number or table name and survives
+# every new migration. It asserts the upgrade advanced the schema by exactly
+# the head migration (HEAD_VER-1 -> HEAD_VER), took a backup, and stop/started
+# the service.
+#
 # Invoke from the host via packaging/tests/run-upgrade-container-test.sh.
 set -euo pipefail
+
+: "${HEAD_VER:?HEAD_VER must be passed in (head migration goose version_id)}"
+: "${HEAD_DOWN:?HEAD_DOWN must be passed in (head migration -- +goose Down SQL)}"
+PREV_VER=$((HEAD_VER - 1))
 
 echo "### prerequisites"
 dnf install -y -q postgresql-server postgresql openssl findutils >/dev/null
@@ -22,7 +34,7 @@ su postgres -c "pg_ctl -D $PGDATA -o '-c listen_addresses=127.0.0.1 -p 55432' -l
     || { echo '--- pg log ---'; cat /tmp/pg.log; exit 1; }
 su postgres -c "psql -p 55432 -q -c \"CREATE USER ow PASSWORD 'ow' SUPERUSER;\""
 su postgres -c "createdb -p 55432 -O ow owdb"
-DSN="postgres://ow:ow@127.0.0.1:55432/owdb?sslmode=disable"
+DSN="postgres://ow:ow@127.0.0.1:55432/owdb?sslmode=disable"  # pragma: allowlist secret  (throwaway container-local Postgres)
 
 echo "### systemctl shim (records the helper's stop/start)"
 # Overwrite the real systemctl: there is no systemd init in the container, and
@@ -36,14 +48,16 @@ echo "### install OLD package (release 1)"
 rpm -i --nodeps /rpms/old/openwatch-*.rpm
 echo "OPENWATCH_DATABASE_DSN=$DSN" > /etc/openwatch/secrets.env
 
-echo "### bring DB to head, then roll back migration 0035 to simulate the prior version"
+echo "### bring DB to head, then roll back the head migration ($HEAD_VER) to simulate the prior version"
 set -a; . /etc/openwatch/secrets.env; set +a
 openwatch migrate >/dev/null
+# Reverse exactly the head migration using its own `-- +goose Down` SQL, then
+# forget its goose bookkeeping row so the NEW package's %post re-applies it.
+PGPASSWORD=ow psql -h 127.0.0.1 -p 55432 -U ow -d owdb -q -c "$HEAD_DOWN"
 PGPASSWORD=ow psql -h 127.0.0.1 -p 55432 -U ow -d owdb -q \
-    -c "DROP TABLE IF EXISTS host_connection_profile CASCADE; DELETE FROM goose_db_version WHERE version_id=35;"
+    -c "DELETE FROM goose_db_version WHERE version_id=$HEAD_VER;"
 before=$(PGPASSWORD=ow psql -h 127.0.0.1 -p 55432 -U ow -d owdb -tAc 'SELECT max(version_id) FROM goose_db_version')
-hcp_before=$(PGPASSWORD=ow psql -h 127.0.0.1 -p 55432 -U ow -d owdb -tAc "SELECT to_regclass('host_connection_profile')")
-echo "BEFORE upgrade: version=$before host_connection_profile=${hcp_before:-<absent>}"
+echo "BEFORE upgrade: version=$before (expected prior=$PREV_VER, head=$HEAD_VER)"
 : > /tmp/systemctl.log
 
 echo "### UPGRADE: rpm -U the NEW package (release 2) — triggers %post with \$1=2"
@@ -51,21 +65,19 @@ rpm -U --nodeps /rpms/new/openwatch-*.rpm
 
 echo "### results"
 after=$(PGPASSWORD=ow psql -h 127.0.0.1 -p 55432 -U ow -d owdb -tAc 'SELECT max(version_id) FROM goose_db_version')
-hcp_after=$(PGPASSWORD=ow psql -h 127.0.0.1 -p 55432 -U ow -d owdb -tAc "SELECT to_regclass('host_connection_profile')")
-echo "AFTER  upgrade: version=$after host_connection_profile=${hcp_after:-<absent>}"
+echo "AFTER  upgrade: version=$after (expected head=$HEAD_VER)"
 echo "systemctl during upgrade: $(tr '\n' ',' < /tmp/systemctl.log)"
 echo "backups: $(ls /var/lib/openwatch/backups/ 2>/dev/null || echo none)"
 
 echo "### assertions"
 fail=0
-[ "$before" = "34" ] || { echo "FAIL: pre-upgrade version != 34"; fail=1; }
-[ "$after" = "35" ]  || { echo "FAIL: post-upgrade version != 35 (migration did not apply)"; fail=1; }
-[ "$hcp_after" = "host_connection_profile" ] || { echo "FAIL: 0035 table not created by the upgrade"; fail=1; }
+[ "$before" = "$PREV_VER" ] || { echo "FAIL: pre-upgrade version $before != prior $PREV_VER"; fail=1; }
+[ "$after" = "$HEAD_VER" ]  || { echo "FAIL: post-upgrade version $after != head $HEAD_VER (migration did not apply)"; fail=1; }
 ls /var/lib/openwatch/backups/openwatch-pre-upgrade-*.sql >/dev/null 2>&1 || { echo "FAIL: no pre-upgrade backup"; fail=1; }
 grep -q "stop openwatch.service"  /tmp/systemctl.log || { echo "FAIL: service not stopped"; fail=1; }
 grep -q "start openwatch.service" /tmp/systemctl.log || { echo "FAIL: service not restarted"; fail=1; }
 if [ "$fail" -eq 0 ]; then
-    echo "RESULT: PASS - the package upgrade migrated 34 -> 35 with a backup and a stop/start"
+    echo "RESULT: PASS - the package upgrade migrated $PREV_VER -> $HEAD_VER with a backup and a stop/start"
 else
     echo "RESULT: FAIL"
     exit 1

--- a/specs/release/changelog.spec.yaml
+++ b/specs/release/changelog.spec.yaml
@@ -1,0 +1,120 @@
+spec:
+  id: release-changelog
+  title: Human-readable changelog
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: CHANGELOG.md authoring discipline
+    description: >
+      CHANGELOG.md is the operator-facing record of what changed between
+      releases. Its audience is the system administrator who upgrades the
+      appliance, not the engineer who wrote the code. Every entry therefore
+      describes an observable change in behavior in plain language — what the
+      operator can now do, what no longer breaks, what moved — rather than the
+      internal mechanics, the package layout, or the commit subject. The file
+      follows Keep a Changelog grouping (Added / Changed / Deprecated / Removed
+      / Fixed / Security) and Semantic Versioning, and accumulates entries under
+      an [Unreleased] section between tagged releases.
+    related_specs:
+      - release-package-build
+      - release-commit-conventions
+
+  objective:
+    summary: >
+      Make every changelog line readable by a non-engineer operator: a
+      complete sentence that states the user-visible effect, optionally noting
+      the version a regression was introduced in. No raw commit subjects, no
+      bare file paths, no emoji.
+    scope:
+      includes:
+        - CHANGELOG.md at the repo root
+        - Keep a Changelog category headings (Added/Changed/Deprecated/Removed/Fixed/Security)
+        - One human-readable sentence per entry, describing observable behavior
+        - Optional trailing PR reference for traceability
+        - ISO-dated version sections; an [Unreleased] accumulator
+      excludes:
+        - Per-commit messages (covered by release-commit-conventions)
+        - Auto-generated release notes from PR titles
+        - Marketing copy / release announcements
+
+  constraints:
+    - id: C-01
+      description: >-
+        Every released version section heading MUST be of the form
+        `## [<version>] ... <ISO-date>` (YYYY-MM-DD). The sole exception is the
+        `## [Unreleased]` accumulator, which carries no date.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: >-
+        Entries MUST be grouped under a category heading drawn ONLY from the
+        Keep a Changelog vocabulary: Added, Changed, Deprecated, Removed, Fixed,
+        Security. No ad-hoc category names.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: >-
+        Each entry MUST be human-readable: a sentence (>= 5 words) describing
+        the observable, user-facing effect of the change. An entry MUST NOT be a
+        raw commit subject — it MUST NOT begin with a conventional-commit prefix
+        (feat:, fix:, chore:, docs:, refactor:, test:, ci:, perf:, build:,
+        style:) — and MUST NOT be only a bare file path or identifier. It SHOULD
+        lead with the effect (what the operator now sees / can do), not the
+        implementation. Enforcement applies to the actively-edited [Unreleased]
+        section; released sections authored before this spec are grandfathered.
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: >-
+        A changelog entry that fixes a regression SHOULD name the version the
+        regression was introduced in, e.g. "(regression in 0.2.0-rc.5)", so an
+        operator can judge whether they are exposed.
+      type: technical
+      enforcement: warning
+    - id: C-05
+      description: >-
+        CHANGELOG.md MUST contain no emoji, matching the repository-wide
+        no-emoji code-quality rule.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: >-
+        Every `## [<version>]` heading in CHANGELOG.md other than `[Unreleased]`
+        carries an ISO date (YYYY-MM-DD); the `[Unreleased]` section exists and
+        carries no date.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: >-
+        Every `###` category heading in the actively-edited [Unreleased]
+        section is one of Added, Changed, Deprecated, Removed, Fixed, Security.
+        (Released sections predating this spec are grandfathered.)
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: >-
+        Every top-level list entry in the [Unreleased] section is at least 5
+        words long and does not begin with a conventional-commit prefix
+        (feat:/fix:/chore:/docs:/refactor:/test:/ci:/perf:/build:/style:), so
+        each line reads as a user-facing sentence rather than a commit subject.
+        (Released sections predating this spec are grandfathered.)
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-04
+      description: >-
+        CHANGELOG.md contains no emoji code points (verified by scanning for
+        characters in the common emoji Unicode ranges).
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-05
+      description: >-
+        Any [Unreleased] entry that describes a regression (contains the word
+        "regression") also names a version token (e.g. "0.2.0-rc.5" or a
+        "vX.Y" form) so an operator can tell whether they are exposed.
+      priority: medium
+      references_constraints: [C-04]

--- a/specter.yaml
+++ b/specter.yaml
@@ -26,6 +26,7 @@ domains:
             - system-job-queue
             - system-policy
             - release-package-build
+            - release-changelog
             - release-upgrade
             - release-fips-build
             - release-stage-0-signoff


### PR DESCRIPTION
## Release-readiness docs + changelog sweep

Brings docs, the changelog, and the upgrade postscripts up to date for the
release, and specs the changelog format so entries stay human-readable.

### Changelog is now specced and populated
- New `specs/release/changelog.spec.yaml` (`release-changelog`): every entry is
  a user-facing sentence (>=5 words, no commit-subject prefix), Keep a Changelog
  categories, dated version sections, no emoji. Enforced by
  `packaging/tests/changelog_test.go` (source-inspection, AC-01..05), scoped to
  the actively-edited `[Unreleased]` section so history is grandfathered.
- Registered in `specter.yaml` (108 specs total now).
- Populated `[Unreleased]` with the post-rc.7 work in that style: Settings
  activation (users, notifications, security/SSO), per-host SSH auth/sudo
  learning, one-command safe upgrade, airgap + fresh-install fixes, and the
  pre-release security-hardening batch (#584).

### Docs refreshed to match `main`
- `docs/guides/SECURITY_HARDENING.md`: removed the "not yet implemented"
  rate-limit/headers callout (those shipped in #584). Documents auth rate
  limiting, CSRF double-submit, and security headers as live; notes always-on
  breach-password screening; adds an outbound-SSH persistent known-hosts
  subsection (migration 0036). Version line to the 0.2.0 rc series.
- `docs/engineering/install_guide.md`: fixed the stale DEB version example
  (rc.5 -> rc.7) and added an **Upgrading** section documenting the
  one-command auto-migrate + pre-upgrade pg_dump + fail-safe flow and
  `/etc/openwatch/upgrade.conf`.

### Upgrade postscripts: verified and made future-proof
- The RPM/DEB upgrade scriptlets, `openwatch-upgrade.sh`, and `dbbackup` already
  match the `release-upgrade` spec; the Go gates (`upgrade_test.go` AC-01..07,
  `dbbackup` tests, the full `packaging/tests` build suite) pass.
- Rewrote the container integration test (`upgrade-container-test.sh` +
  `run-upgrade-container-test.sh`) to stop hardcoding migration `34->35` and the
  `host_connection_profile` table — it broke the moment migration 0036 landed
  and would re-break on every new migration. The host driver now derives the
  head migration's goose version_id and its `-- +goose Down` SQL and passes them
  in; the test reverses exactly the head migration and asserts a generic
  prior->head advance. Also pinned the driver to the host RPM arch (a leftover
  cross-built arm64 RPM in `dist/` was colliding in the container).
- **Validated end-to-end**: a real `rpm -U` in rockylinux:9 ran the `%post`
  helper ($1=2), stopped the service, took a pg_dump restore point, applied
  0036 (35 -> 36), and restarted. RESULT: PASS.

### Note on CLAUDE.md
`CLAUDE.md` was also refreshed locally (spec count 97 -> 108; current Go security
controls), but it is intentionally gitignored (`do not commit`, commit
7a733534), so that change stays local and is not part of this PR.

### Not included
The three still-open PRs (#580 distro matrix, #582 SPA caching, #583 auth
redirect) are not yet on `main`, so they are not in `[Unreleased]`; each should
add its own changelog line on merge (now gated by `release-changelog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
