### PR TITLE
ci: harden rpmbuild install against flaky third-party apt repos

### DIFF
--- a/.github/scripts/install-rpmbuild.sh
+++ b/.github/scripts/install-rpmbuild.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Install rpmbuild (the `rpm` package) on a GitHub-hosted ubuntu runner,
+# resiliently.
+#
+# Why this exists: the hosted ubuntu image preconfigures third-party apt repos
+# (packages.microsoft.com, azure-cli, dl.google.com) that intermittently return
+# 403 / "no longer signed". `apt-get update` fails as a whole if ANY configured
+# repo errors, so an unrelated broken repo kills the step even though `rpm`
+# ships from the standard Ubuntu archive. This has flaked the package-smoke and
+# release builds. Strip those unneeded third-party sources first, then update
+# and install with a short retry for genuine transient mirror blips.
+set -euo pipefail
+
+# 1. Drop third-party apt sources we never need for `rpm`. Matched by content
+#    (not filename) so it survives the runner renaming the files. Guard each
+#    grep so an unreadable/odd file never aborts the loop.
+while IFS= read -r -d '' f; do
+    if grep -qE 'packages\.microsoft\.com|azure-cli|dl\.google\.com' "$f" 2>/dev/null; then
+        sudo rm -f "$f"
+        echo "install-rpmbuild: removed unneeded third-party apt source: $f"
+    fi
+done < <(find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) -print0 2>/dev/null)
+
+# 2. Update + install with a few retries (a real transient archive hiccup).
+for attempt in 1 2 3; do
+    if sudo apt-get update && sudo apt-get install -y --no-install-recommends rpm; then
+        echo "install-rpmbuild: rpm installed"
+        exit 0
+    fi
+    echo "install-rpmbuild: apt attempt ${attempt} failed; retrying in $((attempt * 5))s" >&2
+    sleep "$((attempt * 5))"
+done
+
+echo "install-rpmbuild: could not install rpm after 3 attempts" >&2
+exit 1

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -18,6 +18,7 @@ on:
     paths:
       - 'packaging/**'
       - '.github/workflows/package-smoke.yml'
+      - '.github/scripts/install-rpmbuild.sh'
   workflow_dispatch:
 
 permissions:
@@ -38,7 +39,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - name: Install rpmbuild
-        run: sudo apt-get update && sudo apt-get install -y rpm
+        run: bash .github/scripts/install-rpmbuild.sh
       - name: Build packages
         run: make packages
       - uses: actions/upload-artifact@v4
@@ -138,6 +139,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - name: Install rpmbuild
-        run: sudo apt-get update && sudo apt-get install -y rpm
+        run: bash .github/scripts/install-rpmbuild.sh
       - name: Build old+new RPMs and run the container upgrade test
         run: bash packaging/tests/run-upgrade-container-test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install rpmbuild
-        run: sudo apt-get update && sudo apt-get install -y rpm
+        run: bash .github/scripts/install-rpmbuild.sh
 
       # Builds all four artifacts: RPM + DEB for amd64 and arm64. arm64 is a
       # CGO-disabled cross-compile, so no C cross-toolchain is required.


### PR DESCRIPTION
## Harden the `rpmbuild` install against flaky third-party apt repos

### Problem
PR #585's `Package upgrade (rpm -U auto-migrate)` and package-smoke jobs failed
on first run, then passed on rerun. Root cause was **not** the test logic — it
was the `Install rpmbuild` step:

```
sudo apt-get update && sudo apt-get install -y rpm
```

The GitHub-hosted ubuntu image preconfigures third-party apt repos
(`packages.microsoft.com`, `azure-cli`, `dl.google.com`). When one of them
intermittently returns `403 / "no longer signed"`, `apt-get update` fails as a
whole — and the step dies even though `rpm` ships from the standard Ubuntu
archive and has nothing to do with those repos. Observed in CI:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/.../InRelease  403  Forbidden
E: The repository '... azure-cli noble InRelease' is no longer signed.
##[error]Process completed with exit code 100.
```

This pattern appeared in **three** identical steps across two workflows
(`package-smoke.yml` x2, `release.yml` x1) — including the real release build.

### Fix
Add `.github/scripts/install-rpmbuild.sh`, used by all three steps. It:

1. Strips the unneeded third-party apt sources before updating — matched by
   **content** (`packages.microsoft.com|azure-cli|dl.google.com`), not filename,
   so it survives the runner renaming the files. `rpm` doesn't come from any of
   them, so removing them is safe.
2. Runs `apt-get update` + `apt-get install -y --no-install-recommends rpm` with
   a short 3-attempt retry for a genuine transient archive hiccup.

Also adds `.github/scripts/install-rpmbuild.sh` to package-smoke's `paths:`
trigger so future edits to the script re-run the smoke matrix.

### Validation
- `bash -n` + the repo's `shellcheck` pre-commit hook pass on the new script.
- This PR touches `package-smoke.yml`, so the package-smoke matrix (which now
  uses the hardened step) runs on the PR itself — green CI here demonstrates the
  fix end to end. `release.yml` is tag-triggered and not exercised by the PR,
  but uses the identical shared script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
