### PR TITLE
chore(release): 0.2.0-rc.8 (Eyrie) docs freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0-rc.8] Eyrie — 2026-06-17
+
 Settings became a working control panel, OpenWatch started learning how to
 reach each host over SSH, package upgrades became a single safe command, and a
 pre-release security review closed a batch of perimeter and access-control
@@ -45,6 +49,14 @@ gaps.
   so the interface renders completely in air-gapped deployments (#561).
 - Updated the frontend build and CI tooling (Vite, Vitest, lucide-react, zod,
   and several GitHub Actions) to current major versions (#571, #572, #573).
+- The web UI now loads faster with no extra infrastructure: the embedded
+  single-page app is gzip-compressed and its content-hashed assets are served
+  with long-lived immutable caching, so the browser fetches each one only once
+  (#582).
+- Seven database migrations land this cycle (0030 through 0036: notification
+  channels, API tokens, authentication policy, SSO, per-host connection profile,
+  and the SSH known-hosts store); the one-command upgrade applies them
+  automatically with a pre-upgrade backup (#552 through #558, #566, #584).
 
 ### Fixed
 
@@ -55,6 +67,8 @@ gaps.
   instead of opening blank (#561).
 - Removed leftover demo and sample data that could appear on the dashboard,
   the activity feed, and the host lists (#562).
+- An expired or invalid session now redirects you to the login page instead of
+  leaving you on a page that silently fails to load (#583).
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenWatch is the compliance operating system for teams managing Linux infrastruc
 > Python/FastAPI implementation was archived out of the repo on 2026-06-05). The
 > Go tree lives at the **repo root**: Go 1.26 backend (`cmd/`, `internal/`),
 > React 19 + TanStack frontend (`frontend/`), PostgreSQL-only. The current
-> version is `0.2.0-rc.7`, a pre-release — not a GA build.
+> version is `0.2.0-rc.8`, a pre-release — not a GA build.
 
 ![OpenWatch Compliance Dashboard](docs/images/dashboard-preview.png)
 

--- a/docs/engineering/install_guide.md
+++ b/docs/engineering/install_guide.md
@@ -247,7 +247,7 @@ PGPASSWORD='replace-with-a-strong-password' \
 ### Step 3 — Install the packages
 
 ```bash
-sudo apt install -y ./openwatch_0.2.0-rc.7_amd64.deb ./kensa-rules_0.4.3_all.deb
+sudo apt install -y ./openwatch_0.2.0-rc.8_amd64.deb ./kensa-rules_0.4.3_all.deb
 ```
 
 Install **both** files together — `openwatch` `Depends` on `kensa-rules` (the

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.7"
+VERSION="0.2.0-rc.8"
 CODENAME="Eyrie"


### PR DESCRIPTION
## Release prep: 0.2.0-rc.8 (Eyrie) docs freeze

The docs-freeze step from `docs/runbooks/RELEASING.md` (Stage 1), so the only
thing left before cutting `rc.8` is tagging + the manual fleet verification.

### Changes
- **`packaging/version.env`**: `0.2.0-rc.7` -> `0.2.0-rc.8` (single source of truth; the binary ldflags + RPM/DEB specs read it).
- **`CHANGELOG.md`**: promoted `[Unreleased]` to `[0.2.0-rc.8] Eyrie — 2026-06-17`, with a fresh empty `[Unreleased]` retained. Added the two user-facing fixes that merged *after* the section was first drafted:
  - SPA gzip + immutable caching (#582)
  - expired/invalid session now redirects to `/login` (#583)
  
  Plus a migration note: 0030–0036 land this cycle (notification channels, API tokens, auth policy, SSO, per-host connection profile, SSH known-hosts); the one-command upgrade applies them with a pre-upgrade backup.
- **`README.md`** + **`docs/engineering/install_guide.md`**: current-version strings -> `0.2.0-rc.8`.

### Verification
- `specter check` clean (108 specs); `release-changelog` test green (the changelog meets the human-readable spec).
- The 100% AC-coverage gate (`release-admin-signoff` C-01) is enforced green by `go-ci` on `main`.
- `docs/guides/INSTALLATION.md` carries no version strings; `api/openapi.yaml` is already current on `main`.

### Still the release captain's job (NOT in this PR)
Per RELEASING.md Stage 2–3, after this merges:
1. `git tag v0.2.0-rc.8 && git push origin v0.2.0-rc.8` — triggers `release.yml` (signed RPM/DEB + SBOMs, pre-release) and `package-smoke`.
2. **Manual fleet verification** on clean RHEL- and Debian-family VMs: install + upgrade path + functional walkthrough (login → add host → scan → posture → drift → exceptions → export → RBAC), then record the `release-admin-signoff` Definition-of-Done.

GA (`v0.2.0`) only after that gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
