### PR TITLE
fix(release): normalize '~' in asset filenames so SHA256SUMS matches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,22 @@ jobs:
       - name: Build packages (amd64 + arm64)
         run: make packages
 
+      # Pre-release packages carry a '~' in their filename (e.g.
+      # openwatch-0.2.0~rc.8-1.x86_64.rpm). GitHub release assets replace '~'
+      # with '.', which would desync the served asset names from the
+      # SHA256SUMS manifest computed below and break `sha256sum -c`. Normalize
+      # to the form GitHub will serve BEFORE signing, SBOMs, and checksums so
+      # they all agree. The package INTERNAL version keeps the '~' (that is what
+      # dnf/apt compare); only the filename label changes.
+      - name: Normalize artifact filenames for GitHub Releases
+        run: |
+          shopt -s nullglob
+          cd dist
+          for f in *~*; do
+            mv -- "$f" "${f//\~/.}"
+          done
+          ls -1
+
       # Detect which signing keys are configured. The `secrets` context is not
       # allowed in `if:`, so resolve presence here (secrets ARE allowed via env)
       # and gate the signing steps on these outputs.

--- a/docs/engineering/install_guide.md
+++ b/docs/engineering/install_guide.md
@@ -99,7 +99,7 @@ PGPASSWORD='replace-with-a-strong-password' \
 ### Step 3 — Install the packages
 
 ```bash
-sudo dnf install -y ./openwatch-0.2.0~rc.8-1.x86_64.rpm ./kensa-rules-0.4.3-1.noarch.rpm
+sudo dnf install -y ./openwatch-*.x86_64.rpm ./kensa-rules-*.noarch.rpm
 ```
 
 Install **both** files in one transaction. `openwatch` declares a hard
@@ -247,7 +247,7 @@ PGPASSWORD='replace-with-a-strong-password' \
 ### Step 3 — Install the packages
 
 ```bash
-sudo apt install -y ./openwatch_0.2.0~rc.8_amd64.deb ./kensa-rules_0.4.3_all.deb
+sudo apt install -y ./openwatch_*_amd64.deb ./kensa-rules_*_all.deb
 ```
 
 Install **both** files together — `openwatch` `Depends` on `kensa-rules` (the


### PR DESCRIPTION
GitHub sanitizes '~' to '.' in release-asset filenames, desyncing the served packages from the `SHA256SUMS` manifest (breaks `sha256sum -c`; install + GPG/`rpm -K` were unaffected). Normalize artifact filenames ('~'→'.') before signing/SBOM/checksum so they agree, and switch install-guide examples to globs.

Verified the normalization locally (all '~'→'.', kensa-rules untouched, SBOM names follow). Tag-triggered release.yml isn't exercised by this PR; the change is a self-contained shell step.

After merge: final rc.8 re-spin so the published manifest matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)