### PR TITLE
fix(ssh): support PAM keyboard-interactive password auth

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2747,15 +2747,6 @@
         "line_number": 296
       }
     ],
-    "internal/ssh/ssh_test.go": [
-      {
-        "type": "Secret Keyword",
-        "filename": "internal/ssh/ssh_test.go",
-        "hashed_secret": "e0cd5376ad38a7f916845e2430f9c1e2d123cd9d",
-        "is_verified": false,
-        "line_number": 324
-      }
-    ],
     "internal/ssh/sudo_test.go": [
       {
         "type": "Secret Keyword",
@@ -2867,5 +2858,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T01:00:11Z"
+  "generated_at": "2026-06-17T15:23:32Z"
 }

--- a/internal/ssh/authorder.go
+++ b/internal/ssh/authorder.go
@@ -12,7 +12,7 @@ import (
 // ssh package stays decoupled from connprofile — callers translate.
 const (
 	PreferKey      = "key"
-	PreferPassword = "password"
+	PreferPassword = "password" // pragma: allowlist secret
 )
 
 // authObserver records which auth method crypto/ssh last attempted during
@@ -58,7 +58,16 @@ func (o *authObserver) Last() string {
 // leads with it. This is the "preference, not a lock" property: the hint
 // optimizes the common case and self-heals when the host changes.
 func orderedAuthMethods(cred *credential.Credential, prefer string, obs *authObserver) ([]ssh.AuthMethod, error) {
-	var keyM, pwM ssh.AuthMethod
+	var keyM ssh.AuthMethod
+	// The password family: the bare "password" method AND a keyboard-interactive
+	// method that replays the same password. Hardened servers commonly set
+	// PasswordAuthentication no while keeping PAM keyboard-interactive
+	// (UsePAM yes + KbdInteractiveAuthentication yes), so a password login is
+	// reachable ONLY via keyboard-interactive — the bare "password" method is
+	// never offered. Offering both makes a password credential work whether the
+	// server advertises "password" (most dev hosts) or "keyboard-interactive"
+	// (hardened/PAM hosts), without weakening the server. See C-08.
+	var pwMethods []ssh.AuthMethod
 
 	if cred.PrivateKey != "" {
 		signer, err := parseSigner([]byte(cred.PrivateKey), cred.PrivateKeyPassphrase)
@@ -72,30 +81,55 @@ func orderedAuthMethods(cred *credential.Credential, prefer string, obs *authObs
 	}
 	if cred.Password != "" {
 		pw := cred.Password
-		pwM = ssh.PasswordCallback(func() (string, error) {
-			obs.note(PreferPassword)
-			return pw, nil
-		})
+		pwMethods = append(pwMethods,
+			ssh.PasswordCallback(func() (string, error) {
+				obs.note(PreferPassword)
+				return pw, nil
+			}),
+			ssh.KeyboardInteractive(passwordKbdChallenge(pw, func() { obs.note(PreferPassword) })),
+		)
 	}
 
-	out := make([]ssh.AuthMethod, 0, 2)
+	out := make([]ssh.AuthMethod, 0, 1+len(pwMethods))
 	if prefer == PreferPassword {
-		// Lead with password, then key as fallback.
-		if pwM != nil {
-			out = append(out, pwM)
-		}
+		// Lead with the password family, then key as fallback.
+		out = append(out, pwMethods...)
 		if keyM != nil {
 			out = append(out, keyM)
 		}
 		return out, nil
 	}
-	// Default order (prefer == "key" or unset): key first, then password.
-	// Matches the historical pre-learning behaviour.
+	// Default order (prefer == "key" or unset): key first, then the password
+	// family. Matches the historical pre-learning behaviour.
 	if keyM != nil {
 		out = append(out, keyM)
 	}
-	if pwM != nil {
-		out = append(out, pwM)
-	}
+	out = append(out, pwMethods...)
 	return out, nil
+}
+
+// passwordKbdChallenge builds a keyboard-interactive challenge that replays pw
+// for PAM password prompts. It answers HIDDEN (non-echoed) prompts — the shape
+// of a "Password:" challenge — with pw, and leaves echoed/visible prompts empty
+// so the password is never sent into an unexpected visible challenge (e.g. a
+// displayed OTP or an informational prompt). onAnswer fires only when the
+// password was actually supplied for at least one hidden prompt, so the
+// observer records the password method only when it really authenticated. See
+// C-08. OpenWatch is single-factor: a multi-prompt MFA challenge cannot be
+// satisfied by a lone password and simply fails, which is correct.
+func passwordKbdChallenge(pw string, onAnswer func()) ssh.KeyboardInteractiveChallenge {
+	return func(_, _ string, questions []string, echos []bool) ([]string, error) {
+		answers := make([]string, len(questions))
+		answered := false
+		for i := range questions {
+			if i < len(echos) && !echos[i] {
+				answers[i] = pw
+				answered = true
+			}
+		}
+		if answered && onAnswer != nil {
+			onAnswer()
+		}
+		return answers, nil
+	}
 }

--- a/internal/ssh/authorder_test.go
+++ b/internal/ssh/authorder_test.go
@@ -3,10 +3,15 @@
 // AC traceability (this file):
 //
 //	AC-04  TestOrderedAuthMethods_PreferenceNotExclusion / TestAuthObserver_RecordsLast
+//	AC-13  TestKeyboardInteractive_PasswordReplay
 
 package ssh
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 // @ac AC-04
 // AC-04: every available auth method is offered (preference orders, does
@@ -14,20 +19,23 @@ import "testing"
 func TestOrderedAuthMethods_PreferenceNotExclusion(t *testing.T) {
 	t.Run("system-connection-profile/AC-04", func(t *testing.T) {
 		both, _ := generateEd25519CredAndAuthKey(t)
-		both.Password = "pw" // promote to a key+password credential
+		both.Password = "pw" // promote to a key+password credential // pragma: allowlist secret
 
-		// Both methods offered regardless of which is preferred.
+		// Every method offered regardless of which is preferred. A key+password
+		// credential offers three: publickey, password, and keyboard-interactive
+		// (the password family is two methods — see AC-13).
 		for _, prefer := range []string{"", PreferKey, PreferPassword} {
 			m, err := orderedAuthMethods(both, prefer, &authObserver{})
 			if err != nil {
 				t.Fatalf("prefer %q: %v", prefer, err)
 			}
-			if len(m) != 2 {
-				t.Errorf("prefer %q: %d methods, want 2 (preference is order, not exclusion)", prefer, len(m))
+			if len(m) != 3 {
+				t.Errorf("prefer %q: %d methods, want 3 (preference is order, not exclusion)", prefer, len(m))
 			}
 		}
 
-		// Key-only and password-only creds offer exactly their one method.
+		// Key-only offers one (publickey); password-only offers two (password +
+		// keyboard-interactive).
 		keyOnly := *both
 		keyOnly.Password = ""
 		if m, _ := orderedAuthMethods(&keyOnly, "", &authObserver{}); len(m) != 1 {
@@ -35,8 +43,8 @@ func TestOrderedAuthMethods_PreferenceNotExclusion(t *testing.T) {
 		}
 		pwOnly := *both
 		pwOnly.PrivateKey = ""
-		if m, _ := orderedAuthMethods(&pwOnly, "", &authObserver{}); len(m) != 1 {
-			t.Errorf("password-only: %d methods, want 1", len(m))
+		if m, _ := orderedAuthMethods(&pwOnly, "", &authObserver{}); len(m) != 2 {
+			t.Errorf("password-only: %d methods, want 2 (password + keyboard-interactive)", len(m))
 		}
 	})
 }
@@ -55,5 +63,66 @@ func TestAuthObserver_RecordsLast(t *testing.T) {
 		if o.Last() != PreferPassword {
 			t.Errorf("Last = %q, want %q", o.Last(), PreferPassword)
 		}
+	})
+}
+
+// @ac AC-13
+// AC-13: the keyboard-interactive challenge replays the password for hidden
+// (non-echoed) PAM prompts only, never for echoed/visible prompts, and notes
+// the password method only when it actually supplied the password. This is
+// what lets a password credential authenticate against a hardened server that
+// serves passwords via PAM keyboard-interactive (PasswordAuthentication no).
+func TestKeyboardInteractive_PasswordReplay(t *testing.T) {
+	t.Run("system-connection-profile/AC-13", func(t *testing.T) {
+		const pw = "s3cret-pw" // pragma: allowlist secret
+
+		run := func(questions []string, echos []bool) (answers []string, noted bool) {
+			ch := passwordKbdChallenge(pw, func() { noted = true })
+			answers, err := ch("", "", questions, echos)
+			if err != nil {
+				t.Fatalf("challenge error: %v", err)
+			}
+			return answers, noted
+		}
+
+		// A single hidden "Password:" prompt is answered with the password.
+		if a, noted := run([]string{"Password: "}, []bool{false}); len(a) != 1 || a[0] != pw || !noted {
+			t.Errorf("hidden prompt: answers=%q noted=%v, want [%q] true", a, noted, pw)
+		}
+		// An echoed/visible prompt is NEVER answered with the password.
+		if a, noted := run([]string{"One-time token: "}, []bool{true}); len(a) != 1 || a[0] != "" || noted {
+			t.Errorf("echoed prompt: answers=%q noted=%v, want [\"\"] false (password must not leak)", a, noted)
+		}
+		// Mixed: password to the hidden prompt, empty to the visible one.
+		if a, noted := run([]string{"Password: ", "Show this: "}, []bool{false, true}); len(a) != 2 || a[0] != pw || a[1] != "" || !noted {
+			t.Errorf("mixed prompts: answers=%q noted=%v, want [%q \"\"] true", a, noted, pw)
+		}
+		// An informational challenge with no questions supplies nothing and does
+		// not record a password attempt.
+		if a, noted := run(nil, nil); len(a) != 0 || noted {
+			t.Errorf("no questions: answers=%q noted=%v, want [] false", a, noted)
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13 (end to end): a password credential authenticates against a server
+// that offers ONLY keyboard-interactive — no bare "password" method — which is
+// the hardened prod config (PasswordAuthentication no + PAM keyboard-interactive)
+// that produced "ssh: unable to authenticate ... [none] ... no supported
+// methods remain". Before keyboard-interactive support this dial failed; now it
+// succeeds via the replayed password.
+func TestDial_KeyboardInteractiveOnlyServer(t *testing.T) {
+	t.Run("system-connection-profile/AC-13", func(t *testing.T) {
+		host, port, hostKey, _ := startTestServer(t, testServerOpts{kbdInteractivePassword: "tester-pw-1"})
+		store := NewMemoryStore()
+		_ = store.Put(host, hostKey) // strict: pre-seed the host key
+
+		client, err := Dial(context.Background(), host, port, passwordCred("tester-pw-1"),
+			DialOptions{Mode: ModeStrict, Store: store, Timeout: 5 * time.Second})
+		if err != nil {
+			t.Fatalf("dial against keyboard-interactive-only server: %v", err)
+		}
+		_ = client.Close()
 	})
 }

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -32,6 +32,10 @@ import (
 type testServerOpts struct {
 	password         string
 	authorizedKeyPEM string
+	// kbdInteractivePassword, when set (and password unset), makes the server
+	// offer ONLY keyboard-interactive — no bare "password" method — mirroring a
+	// hardened host with PasswordAuthentication no + PAM keyboard-interactive.
+	kbdInteractivePassword string
 }
 
 func startTestServer(t *testing.T, opts testServerOpts) (host string, port int, hostKeyMarshalled []byte, stop func()) {
@@ -63,6 +67,15 @@ func startTestServer(t *testing.T, opts testServerOpts) (host string, port int, 
 	}
 	if opts.password != "" {
 		srv.PasswordHandler = func(_ gossh.Context, pw string) bool { return pw == opts.password }
+	}
+	if opts.kbdInteractivePassword != "" {
+		// PAM-style: challenge with a single hidden "Password:" prompt and
+		// accept the answer. No PasswordHandler is set, so the server advertises
+		// keyboard-interactive but NOT the bare password method.
+		srv.KeyboardInteractiveHandler = func(_ gossh.Context, challenge cryptossh.KeyboardInteractiveChallenge) bool {
+			answers, err := challenge("", "", []string{"Password: "}, []bool{false})
+			return err == nil && len(answers) == 1 && answers[0] == opts.kbdInteractivePassword
+		}
 	}
 	if opts.authorizedKeyPEM != "" {
 		// Parse the authorized client public key.
@@ -321,7 +334,7 @@ func TestKnownHosts_TOFU(t *testing.T) {
 // private key. Forced auth failure; inspect error text.
 func TestDial_NoCredentialLeakInError(t *testing.T) {
 	t.Run("system-ssh-connectivity/AC-08", func(t *testing.T) {
-		const secretPW = "super-secret-do-not-leak"
+		const secretPW = "super-secret-do-not-leak" // pragma: allowlist secret
 		host, port, hostKey, _ := startTestServer(t, testServerOpts{password: "correct-pw"})
 		store := NewMemoryStore()
 		_ = store.Put(host, hostKey)

--- a/specs/system/connection-profile.spec.yaml
+++ b/specs/system/connection-profile.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-connection-profile
   title: Per-host SSH connection learning (auth method + sudo mode)
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -83,6 +83,23 @@ spec:
       description: The OS discovery, OS intelligence (collector), and liveness privilege-probe paths MUST lead sudo with the host's recorded sudo mode (leading with `sudo -S` only when the mode is password AND the credential password may be fed per C-05's gate) and MUST record the mode confirmed to work. To avoid misrecording, a mode MUST be recorded ONLY on a confirmed exit-0 of a given sudo form — never inferred from a command that exited non-zero for its own reasons. Learning MUST be best-effort and MUST NOT change the sudo password gate (C-05) or fail the connection on a store miss/error.
       type: technical
       enforcement: error
+    - id: C-08
+      description: >- # pragma: allowlist secret
+        When a credential carries a password, the dial layer MUST offer a
+        keyboard-interactive auth method IN ADDITION to the bare password
+        method. Hardened servers commonly set PasswordAuthentication no while
+        keeping PAM keyboard-interactive (UsePAM yes + KbdInteractiveAuthentication
+        yes), so a password login is reachable ONLY via keyboard-interactive and
+        the bare `password` method is never offered — a password-only credential
+        would otherwise fail the handshake with "no supported methods remain"
+        ([none]). The keyboard-interactive challenge MUST replay the credential
+        password for HIDDEN (non-echoed) PAM prompts only, and MUST NOT answer
+        echoed/visible prompts with the password (so it never leaks the password
+        into an unexpected visible challenge such as a displayed OTP). This is
+        password-equivalent auth: the observer records it as the password method
+        so learning leads with password next time.
+      type: security
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -133,3 +150,14 @@ spec:
       description: The liveness privilege probe records the sudo mode it confirms via the `true` sentinel (the authoritative learner, run every cycle), and on a host recorded as needing a password it leads with `sudo -S` (zero `sudo -n` calls); a confirmed mode equal to the stored one is not re-recorded.
       priority: high
       references_constraints: [C-07]
+    - id: AC-13
+      description: >- # pragma: allowlist secret
+        orderedAuthMethods offers a keyboard-interactive method whenever the
+        credential has a password: a password-only credential yields TWO methods
+        (password + keyboard-interactive), a key-only credential yields one, and
+        a both credential yields three. The keyboard-interactive challenge
+        replays the password for non-echoed (hidden) questions, leaves echoed
+        questions empty, and notes the password method as used only when it
+        actually answered a hidden prompt.
+      priority: critical
+      references_constraints: [C-08]


### PR DESCRIPTION
## Fix: password auth fails on hardened (PAM keyboard-interactive) hosts

**Symptom (production):** `ssh: handshake failed: ssh: unable to authenticate, attempted methods [none], no supported methods remain` — but **only with a password credential; SSH keys work**, and **only in production** (dev is fine).

### Root cause
OpenWatch's dial layer (`internal/ssh/authorder.go`) only ever offered two SSH auth methods: `publickey` and the bare `password`. Hardened hosts commonly set `PasswordAuthentication no` while keeping PAM keyboard-interactive (`UsePAM yes` + `KbdInteractiveAuthentication yes`), so a password login is reachable **only** via `keyboard-interactive` — the bare `password` method is never advertised. With a password credential, OpenWatch's offered methods (`password`) don't intersect the server's (`publickey,keyboard-interactive`), so after the "none" probe there's nothing to try → `[none]`. Confirmed against the prod target: `passwordauthentication no`, `usepam yes`, `kbdinteractiveauthentication yes`. (Dev hosts advertise `publickey,password`, so they always worked — explaining why it was prod-only.)

### Fix
Offer a `keyboard-interactive` method alongside the bare `password` method whenever the credential has a password. The challenge replays the password for **hidden (non-echoed) PAM prompts only** — never echoed/visible prompts — so it can't leak the password into an unexpected visible challenge (e.g. a displayed OTP). It's recorded as the password method for the per-host learning. **The server's hardening is unchanged** — this works *with* `PasswordAuthentication no`.

### Tests (SDD: spec → test → code)
- Spec `system-connection-profile` v1.3.0, new **C-08 / AC-13**.
- Unit: the replay logic (password to hidden prompts, empty to echoed, records only when actually used) + the method counts (password-only now offers 2: password + keyboard-interactive).
- **End-to-end:** an in-process SSH server that offers **only** keyboard-interactive; a password credential now authenticates. This test **fails without the change** (reproduces the exact `[none]` error) — verified.

Full `internal/ssh` suite green; `gofmt`/`vet`/`specter` clean.

> After merge this needs to reach prod via a build — happy to fold it into the next RC (rc.9) or a re-spin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
