### PR TITLE
chore(release): 0.2.0-rc.9 (Eyrie) docs freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.2.0-rc.9] Eyrie — 2026-06-17
+
+Two fixes that came out of production hardening: password login now works on
+PAM-hardened hosts, and compliance scans run across the fleet in parallel
+instead of one host at a time.
+
+### Changed
+
+- Compliance scans now run several hosts at once instead of strictly one at a
+  time. A new `scan_concurrency` setting (under `[server]`, default 4) controls
+  how many hosts scan in parallel; different hosts run concurrently while two
+  scans of the same host never overlap. Clearing a large fleet that used to take
+  many hours of serial scanning now finishes far sooner (#592).
+
+### Fixed
+
+- Password authentication now works against hardened hosts that accept passwords
+  only through PAM keyboard-interactive (servers with `PasswordAuthentication no`
+  but `UsePAM yes`). Such a host advertised only `keyboard-interactive`, so a
+  password credential previously failed the handshake with "no supported methods
+  remain" even though the password was correct (SSH-key auth was unaffected, and
+  development hosts that offer plain password auth were never affected) (#591).
+
+---
+
 ## [0.2.0-rc.8] Eyrie — 2026-06-17
 
 Settings became a working control panel, OpenWatch started learning how to

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenWatch is the compliance operating system for teams managing Linux infrastruc
 > Python/FastAPI implementation was archived out of the repo on 2026-06-05). The
 > Go tree lives at the **repo root**: Go 1.26 backend (`cmd/`, `internal/`),
 > React 19 + TanStack frontend (`frontend/`), PostgreSQL-only. The current
-> version is `0.2.0-rc.8`, a pre-release — not a GA build.
+> version is `0.2.0-rc.9`, a pre-release — not a GA build.
 
 ![OpenWatch Compliance Dashboard](docs/images/dashboard-preview.png)
 

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.8"
+VERSION="0.2.0-rc.9"
 CODENAME="Eyrie"


### PR DESCRIPTION
## Release prep: 0.2.0-rc.9 (Eyrie)

The docs-freeze (RELEASING.md Stage 1) for rc.9. It bundles the two fixes merged since rc.8.

### Changes
- **`packaging/version.env`**: `0.2.0-rc.8` -> `0.2.0-rc.9`.
- **`CHANGELOG.md`**: new `[0.2.0-rc.9] Eyrie — 2026-06-17` section; fresh empty `[Unreleased]`:
  - **Fixed** — PAM keyboard-interactive password auth (#591): password login now works on hardened hosts (`PasswordAuthentication no` + PAM), which previously failed with "no supported methods remain".
  - **Changed** — bounded scan-concurrency pool (#592): scans run several hosts at once via `[server].scan_concurrency` (default 4) instead of strictly one at a time.
- **`README.md`**: current-version string -> `0.2.0-rc.9`.

### Verification
- `release-changelog` test green; `specter check` clean (108 specs).
- **No new DB migrations** this cycle (last is 0036, already in rc.8).
- Install-guide examples already use globs (post-#589), so no version strings to bump there.

### After merge (release captain)
1. `git tag -a v0.2.0-rc.9 -m "…" <commit> && git push origin v0.2.0-rc.9` — triggers `release.yml` (signed RPM/DEB + SBOMs, pre-release) and `package-smoke`.
2. Stage-3 manual fleet verification + `release-admin-signoff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
