### PR TITLE
chore(kensa): update Kensa engine + rule corpus to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the bundled Kensa scan engine and rule corpus to v0.5.0. v0.5.0 adds
+  native sudo-with-password support for hosts where passwordless sudo is
+  disallowed (a common CIS/STIG control); the change is backward-compatible and
+  OpenWatch's existing scan behavior is unchanged. The corpus stays at 539
+  rules. The `kensa-rules` package version tracks the engine, so it becomes
+  0.5.0 in the next build.
+
 ---
 
 ## [0.2.0-rc.9] Eyrie — 2026-06-17

--- a/docs/engineering/install_guide.md
+++ b/docs/engineering/install_guide.md
@@ -106,7 +106,7 @@ Install **both** files in one transaction. `openwatch` declares a hard
 dependency on `kensa-rules` — the rule corpus the scan engine loads from
 `/usr/share/kensa/rules`. Installing `openwatch` alone fails the dependency
 check (by design: a corpus-less node cannot scan). `kensa-rules` is `noarch`
-and versioned on the Kensa content line (e.g. `0.4.3`), independent of the
+and versioned on the Kensa content line (e.g. `0.5.0`), independent of the
 platform version, so the rules can update without re-releasing OpenWatch.
 
 Use the filenames you downloaded (`aarch64` for the arm64 openwatch RPM; the

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/Hanalyx/kensa v0.4.3
+	github.com/Hanalyx/kensa v0.5.0
 	github.com/getkin/kin-openapi v0.139.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-chi/chi/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Hanalyx/kensa v0.4.3 h1:C9Zj/+m4jJivizK5aXPJ+u2PYA4la3qHHNILoGdBwkQ=
-github.com/Hanalyx/kensa v0.4.3/go.mod h1:oEJt9i8spIWwy6i6uF1YgShrLS67kFXKIWr+J1eYBOY=
+github.com/Hanalyx/kensa v0.5.0 h1:yXDD/Oj+Czq3v5dB/LjWk1F8HEfw692jqTdWi6LSFfU=
+github.com/Hanalyx/kensa v0.5.0/go.mod h1:oEJt9i8spIWwy6i6uF1YgShrLS67kFXKIWr+J1eYBOY=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/internal/kensa/types.go
+++ b/internal/kensa/types.go
@@ -10,7 +10,7 @@ import (
 // KensaModuleVersion is the version pin recorded in the spec's context
 // block. AC-10 source-inspects to verify this matches the corresponding
 // entry in app/go.mod.
-const KensaModuleVersion = "v0.4.3"
+const KensaModuleVersion = "v0.5.0"
 
 // Sentinel errors returned by Executor.Run. Tests use errors.Is for
 // classification; the audit emission path maps each to a typed

--- a/specs/system/kensa-executor.spec.yaml
+++ b/specs/system/kensa-executor.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-kensa-executor
   title: Kensa executor wrapper
-  version: "2.4.0"
+  version: "2.5.0"
   status: approved
   tier: 1
 
@@ -10,7 +10,7 @@ spec:
     feature: Kensa scan execution bridge
     description: >
       The executor invokes Kensa (Go module github.com/Hanalyx/kensa
-      pinned to v0.4.3) to run a scan against a single host using the
+      pinned to v0.5.0) to run a scan against a single host using the
       FULL rule corpus applicable to the host's detected OS
       capabilities. The Kensa API (`Kensa.Scan(ctx, host, rules,
       opts...)` per kensa-go/api/kensa.go:228) takes a `[]*api.Rule`
@@ -131,7 +131,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-13
-      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.4.3 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
+      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.5.0 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
       type: technical
       enforcement: error
     - id: C-14


### PR DESCRIPTION
## Update Kensa to v0.5.0

Bumps `github.com/Hanalyx/kensa` **v0.4.3 → v0.5.0** (engine + rule corpus).

### What v0.5.0 brings
Native **sudo-with-password** support — an additive `api.HostConfig.SudoPassword` field for hosts whose sudoers policy isn't NOPASSWD (a common CIS/STIG control). The rest of the frozen `api/` surface is untouched (MINOR bump).

### Compatibility
**Backward-compatible, no behavior change for OpenWatch.** OpenWatch's scan transport does its own sudo wrapping (`internal/kensa/transport.go` `wrap()`), and doesn't set the new `SudoPassword` field, so Kensa behaves exactly as before. `go build ./...` clean, full `internal/kensa` + `internal/worker` scan suites green. The corpus stays at **539 rules**.

> Opportunity (not in this PR): now that Kensa has native sudo-password, OpenWatch *could* drop its own `sudo -S` wrapping in favor of `HostConfig.SudoPassword`. That's a deliberate refactor with its own testing — left for later.

### Version pins kept in lockstep
`internal/kensa/types.go` `KensaModuleVersion` and the `system-kensa-executor` spec context both → `v0.5.0` (enforced by AC-10 source inspection — go.mod, the constant, and the spec must all agree). Spec bumped to v2.5.0.

The `kensa-rules` package version auto-derives from the module (`stage-kensa-rules.sh`), so it becomes `0.5.0` at build time — verified by `package_test.go` AC-15 (corpus ships 500+ rules) in go-ci.

CHANGELOG `[Unreleased]` + the install-guide content-line example updated. This lands after rc.9, so it ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
