### PR TITLE
chore(release): finalize 0.2.0-rc.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,31 +10,39 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0-rc.10] Eyrie — 2026-06-17
+
+Per-host SSH credentials become directly manageable from the UI, the bundled
+Kensa engine moves to v0.5.0, and a packaging fix stops upgrades from
+overwriting an operator's TLS certificate.
+
 ### Added
 
 - SSH credentials can now be edited in place. The Settings credentials page
   updates a credential directly instead of deleting and recreating it, so
   changing a name, username, or authentication method no longer forces you to
   re-enter the key or password. Leave a secret field blank to keep the stored
-  one.
+  one (#595).
 - Per-host SSH credential management from the host detail page. A host can be
   given its own credential, have that credential edited in place, or be reverted
   to the workspace default, all from the host Edit dialog and the Connectivity
-  card's Edit credentials link.
+  card's Edit credentials link (#595).
 - A Reconnect action on the host Connectivity card runs OS discovery
   immediately, ahead of the scan queue, so you can confirm a host is reachable
-  and its SSH credential works right after changing it.
+  and its SSH credential works right after changing it (#595).
 
 ### Changed
 
 - The host Connectivity card now shows the credential the host actually uses
-  (its own override or the workspace default) instead of a fixed label.
+  (its own override or the workspace default) instead of a fixed label (#595).
 - Updated the bundled Kensa scan engine and rule corpus to v0.5.0. v0.5.0 adds
   native sudo-with-password support for hosts where passwordless sudo is
   disallowed (a common CIS/STIG control); the change is backward-compatible and
   OpenWatch's existing scan behavior is unchanged. The corpus stays at 539
   rules. The `kensa-rules` package version tracks the engine, so it becomes
-  0.5.0 in the next build.
+  0.5.0 in the next build (#594).
 
 ### Fixed
 
@@ -44,7 +52,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   certificate with a fresh self-signed demo on every upgrade. The demo
   certificate is now generated at install time only when the TLS files are
   absent (the same generate-if-absent model already used for the server's
-  identity keys), so a certificate you put in place survives upgrades untouched.
+  identity keys), so a certificate you put in place survives upgrades untouched
+  (#596).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenWatch is the compliance operating system for teams managing Linux infrastruc
 > Python/FastAPI implementation was archived out of the repo on 2026-06-05). The
 > Go tree lives at the **repo root**: Go 1.26 backend (`cmd/`, `internal/`),
 > React 19 + TanStack frontend (`frontend/`), PostgreSQL-only. The current
-> version is `0.2.0-rc.9`, a pre-release — not a GA build.
+> version is `0.2.0-rc.10`, a pre-release — not a GA build.
 
 ![OpenWatch Compliance Dashboard](docs/images/dashboard-preview.png)
 

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.9"
+VERSION="0.2.0-rc.10"
 CODENAME="Eyrie"


### PR DESCRIPTION
## Summary

Release-prep for **0.2.0-rc.10** (Eyrie). Bumps `packaging/version.env` and promotes the `[Unreleased]` CHANGELOG entries into a dated rc.10 section. No code changes — just version + docs.

Bundles the three changes that landed on `main` since rc.9:
- **#594** — Kensa engine + rule corpus to v0.5.0 (native sudo-with-password; corpus stays 539 rules)
- **#595** — per-host SSH credential management + in-place credential editing (PATCH endpoint, shared host-credential modal, resolved Auth label, live Reconnect)
- **#596** — packaging fix: demo TLS cert generated at install (generate-if-absent) instead of shipped, so `dnf update`/`apt upgrade` no longer overwrites an operator's certificate

## Verification
- `binary --version` reports `0.2.0-rc.10` (ldflags from version.env)
- Changelog spec test passes; `[Unreleased]` left empty, rc.10 section dated `2026-06-17`
- `specter check` 108 specs pass; no stale `0.2.0-rc.9` references remain

Once merged, the `v0.2.0-rc.10` tag is pushed to trigger `release.yml` (signed RPM/DEB amd64+arm64, SBOMs, pre-release) and `package-smoke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)