### PR TITLE
chore(release): Kensa v0.5.2 + prepare 0.2.0-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0-rc.11] Eyrie — 2026-06-19
+
+The bundled Kensa scan engine moves to v0.5.2, which corrects a class of false
+compliance FAILs on TAB-delimited rules; the GA-readiness pass also hardened CI
+and the release workflow.
+
 ### Changed
 
+- Updated the bundled Kensa scan engine and rule corpus to v0.5.2. v0.5.2 fixes
+  a `config_value` matching bug so a `" "` delimiter matches any whitespace
+  (including TAB), correcting a class of false FAILs on TAB-delimited rules such
+  as RHEL `login.defs` — affected hosts may see their compliance score improve.
+  It also adds rule-engine correctness gates (check-method parameter contracts,
+  value-domain validation, a comparator + delimiter engine, and a schema/engine
+  parity gate). The corpus stays at 539 rules and the engine's frozen API
+  surface is unchanged, so OpenWatch's library integration is unaffected
+  (kensa v0.5.2).
 - CI release safety: the release workflow now fails closed on a `v*` tag push
   when no GPG signing key is configured, rather than publishing unsigned
   packages. Manual `workflow_dispatch` trial builds stay permissive (warn +

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenWatch is the compliance operating system for teams managing Linux infrastruc
 > Python/FastAPI implementation was archived out of the repo on 2026-06-05). The
 > Go tree lives at the **repo root**: Go 1.26 backend (`cmd/`, `internal/`),
 > React 19 + TanStack frontend (`frontend/`), PostgreSQL-only. The current
-> version is `0.2.0-rc.10`, a pre-release — not a GA build.
+> version is `0.2.0-rc.11`, a pre-release — not a GA build.
 
 ![OpenWatch Compliance Dashboard](docs/images/dashboard-preview.png)
 

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -11,7 +11,7 @@ contract source of truth is `api/openapi.yaml` in the repository; the running
 binary serves the same document, and `GET /api/v1/version` reports the build it
 came from.
 
-This guide reflects OpenWatch `0.2.0-rc.10`, a pre-release. The API surface is
+This guide reflects OpenWatch `0.2.0-rc.11`, a pre-release. The API surface is
 still growing — endpoints that the legacy Python API exposed (scan execution,
 remediation, exceptions, posture history, audit exports, the rule-reference
 browser) are not yet part of `api/v1`. See [What is not yet in the
@@ -276,7 +276,7 @@ curl -s --cacert /etc/openwatch/tls/ca.crt https://localhost:8443/api/v1/health 
 ```
 
 ```json
-{"status": "healthy", "db_connected": true, "version": "0.2.0-rc.10"}
+{"status": "healthy", "db_connected": true, "version": "0.2.0-rc.11"}
 ```
 
 `status` is `healthy` or `degraded`; the endpoint returns `503` when the service
@@ -354,7 +354,7 @@ configuration steps, see
 ## What is not yet in the API
 
 The compliance scanning workflow runs through Kensa and the background worker,
-not yet through public REST endpoints. As of `0.2.0-rc.10`, `api/v1` does not
+not yet through public REST endpoints. As of `0.2.0-rc.11`, `api/v1` does not
 include:
 
 - Scan execution or scan-result endpoints (`/api/v1/scans/…`).

--- a/docs/guides/MONITORING_SETUP.md
+++ b/docs/guides/MONITORING_SETUP.md
@@ -54,7 +54,7 @@ curl -k https://localhost:8443/api/v1/health
 A healthy response returns `200 OK`:
 
 ```json
-{"status": "healthy", "db_connected": true, "version": "0.2.0-rc.10"}
+{"status": "healthy", "db_connected": true, "version": "0.2.0-rc.11"}
 ```
 
 When the database ping fails, the endpoint returns `503 Service Unavailable`
@@ -76,7 +76,7 @@ curl -k https://localhost:8443/api/v1/version
 
 ```json
 {
-  "openwatch": "0.2.0-rc.10",
+  "openwatch": "0.2.0-rc.11",
   "kensa": "<embedded engine version>",
   "go": "<go toolchain>",
   "commit": "<abbrev commit>",

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -12,7 +12,7 @@ touches lightly: process layout, TLS, the background worker, backups, upgrades,
 and incident runbooks.
 
 > Verify the version you deploy. The current line is a pre-release
-> (`0.2.0-rc.10` per `packaging/version.env`), not a GA build. Treat it
+> (`0.2.0-rc.11` per `packaging/version.env`), not a GA build. Treat it
 > accordingly until a GA tag ships.
 
 ---

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -49,7 +49,7 @@ A healthy response looks like this:
 {
   "status": "healthy",
   "db_connected": true,
-  "version": "0.2.0-rc.10"
+  "version": "0.2.0-rc.11"
 }
 ```
 

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -13,7 +13,7 @@ database backup and restore commands referenced below, see
 [`BACKUP_RECOVERY.md`](BACKUP_RECOVERY.md). For migration mechanics, see
 [`DATABASE_MIGRATIONS.md`](DATABASE_MIGRATIONS.md).
 
-> Version note: the current release line is a pre-release (`0.2.0-rc.10`). Treat
+> Version note: the current release line is a pre-release (`0.2.0-rc.11`). Treat
 > upgrades between pre-release builds as potentially breaking and always back up
 > first.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/Hanalyx/kensa v0.5.1
+	github.com/Hanalyx/kensa v0.5.2
 	github.com/getkin/kin-openapi v0.139.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-chi/chi/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Hanalyx/kensa v0.5.1 h1:ggIqW2fMXHUopAwn86EKq1n4qUsgKeVW62yQQC8rGy8=
-github.com/Hanalyx/kensa v0.5.1/go.mod h1:oEJt9i8spIWwy6i6uF1YgShrLS67kFXKIWr+J1eYBOY=
+github.com/Hanalyx/kensa v0.5.2 h1:9bp5KION7N1FlmJA4f0AKFS4uVXijXZWDiP8ucViriQ=
+github.com/Hanalyx/kensa v0.5.2/go.mod h1:oEJt9i8spIWwy6i6uF1YgShrLS67kFXKIWr+J1eYBOY=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/internal/kensa/types.go
+++ b/internal/kensa/types.go
@@ -10,7 +10,7 @@ import (
 // KensaModuleVersion is the version pin recorded in the spec's context
 // block. AC-10 source-inspects to verify this matches the corresponding
 // entry in app/go.mod.
-const KensaModuleVersion = "v0.5.1"
+const KensaModuleVersion = "v0.5.2"
 
 // Sentinel errors returned by Executor.Run. Tests use errors.Is for
 // classification; the audit emission path maps each to a typed

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.10"
+VERSION="0.2.0-rc.11"
 CODENAME="Eyrie"

--- a/specs/system/kensa-executor.spec.yaml
+++ b/specs/system/kensa-executor.spec.yaml
@@ -10,7 +10,7 @@ spec:
     feature: Kensa scan execution bridge
     description: >
       The executor invokes Kensa (Go module github.com/Hanalyx/kensa
-      pinned to v0.5.1) to run a scan against a single host using the
+      pinned to v0.5.2) to run a scan against a single host using the
       FULL rule corpus applicable to the host's detected OS
       capabilities. The Kensa API (`Kensa.Scan(ctx, host, rules,
       opts...)` per kensa-go/api/kensa.go:228) takes a `[]*api.Rule`
@@ -131,7 +131,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-13
-      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.5.1 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
+      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.5.2 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
       type: technical
       enforcement: error
     - id: C-14


### PR DESCRIPTION
## Bump Kensa to v0.5.2 + prepare 0.2.0-rc.11

### Kensa v0.5.2 review (done before upgrading)
PATCH release; **frozen `api/` surface untouched**, so OpenWatch's library integration (`pkg/kensa.Default`, `ScanResult.Outcomes`, `mapStatus`) needs no code changes.

- **Operationally significant fix:** `config_value` `" "` delimiter now matches any whitespace (incl. TAB), fixing a class of **false FAILs on TAB-delimited rules** (RHEL `login.defs`). → affected hosts may see their compliance score improve. Called out in the changelog.
- Adds rule-engine correctness gates (param contracts, value-domain validation, comparator + delimiter engine, schema/engine parity) — Kensa-internal.
- jsonl `skipped`-not-error fix (kensa#104) — **confirmed no-impact for OpenWatch** (library path consumes `Outcomes`), matching the reply on issue #603.

### Changes
- `go.mod`: kensa `v0.5.1 → v0.5.2` (+ `go mod tidy`). `KensaModuleVersion` and the `system-kensa-executor` spec pin updated to match — version-pin tests pass; corpus stays at **539 rules** and the variable-catalog AC still sees exactly 3 placeholders.
- `packaging/version.env → 0.2.0-rc.11`; README + 5 operator guides updated; CHANGELOG cut a `[0.2.0-rc.11]` section (Kensa bump + the GA-readiness CI/release hardening that was already on `main`).

### Verified locally
Full `internal/kensa` package green on v0.5.2; version-pin + variable-catalog + version-consistency tests pass; Specter 110 specs valid; gofmt clean; build OK; no stray `rc.10` refs.

> Tagging `v0.2.0-rc.11` (which triggers the signed RPM/DEB + SBOM release workflow) is a separate operator step once this merges.
