### PR TITLE
fix(audit): attribute automated events to 'The system', not 'Someone'

### DIFF
--- a/internal/activity/format.go
+++ b/internal/activity/format.go
@@ -91,10 +91,14 @@ func statusWord(status string) string {
 	}
 }
 
+// actorWord renders a readable actor when no actor_label was recorded. An
+// empty/unknown actor_type means the event was NOT attributed to a person
+// (real user actions record the user) — so it reads as automated ("The
+// system"), never the misleading "Someone".
 func actorWord(actorType string) string {
 	switch actorType {
-	case "system":
-		return "System"
+	case "system", "":
+		return "The system"
 	case "scheduler":
 		return "The scheduler"
 	case "api_key", "api_token":
@@ -104,9 +108,6 @@ func actorWord(actorType string) string {
 	case "user":
 		return "A user"
 	default:
-		if actorType == "" {
-			return "Someone"
-		}
 		return titleCaseWord(actorType)
 	}
 }

--- a/internal/activity/format_test.go
+++ b/internal/activity/format_test.go
@@ -54,8 +54,14 @@ func TestFormatters_HumanReadable(t *testing.T) {
 		}
 		// actor_label empty -> readable actor_type; no UUID anywhere.
 		title, _ = FormatAudit("authz.permission.denied", "", "system", "")
-		if title != "System was denied permission" {
+		if title != "The system was denied permission" {
 			t.Errorf("audit fallback title = %q", title)
+		}
+		// Empty actor_type (an unattributed/automated event) reads as
+		// "The system", never the misleading "Someone".
+		title, _ = FormatAudit("host.discovery.completed", "", "", "host")
+		if title != "The system completed host discovery" {
+			t.Errorf("empty-actor title = %q, want 'The system completed host discovery'", title)
 		}
 	})
 }

--- a/internal/intelligence/discovery/audit_actor_test.go
+++ b/internal/intelligence/discovery/audit_actor_test.go
@@ -1,0 +1,45 @@
+// @spec system-host-discovery
+//
+//	AC-23  TestEmitAuditSuccess_ActorAttribution
+
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/auth"
+)
+
+// @ac AC-23
+func TestEmitAuditSuccess_ActorAttribution(t *testing.T) {
+	t.Run("system-host-discovery/AC-23", func(t *testing.T) {
+		var captured audit.Event
+		svc := &Service{emit: func(_ context.Context, _ audit.Code, ev audit.Event) { captured = ev }}
+		host := uuid.Must(uuid.NewV7())
+
+		// Automated scheduled run: no identity on the background ctx -> system.
+		svc.emitAuditSuccess(context.Background(), host, SystemFacts{})
+		if captured.ActorType != "system" {
+			t.Errorf("scheduled actor_type = %q, want system", captured.ActorType)
+		}
+		if captured.ActorID != "" {
+			t.Errorf("scheduled actor_id = %q, want empty", captured.ActorID)
+		}
+
+		// Operator-triggered (Reconnect / Run now / add host): a bound
+		// identity on ctx -> user + its id.
+		uid := uuid.Must(uuid.NewV7()).String()
+		ctx := auth.SetIdentity(context.Background(), auth.Identity{ID: uid, RoleID: auth.RoleAdmin})
+		svc.emitAuditSuccess(ctx, host, SystemFacts{})
+		if captured.ActorType != "user" {
+			t.Errorf("operator-triggered actor_type = %q, want user", captured.ActorType)
+		}
+		if captured.ActorID != uid {
+			t.Errorf("actor_id = %q, want %q", captured.ActorID, uid)
+		}
+	})
+}

--- a/internal/intelligence/discovery/discovery.go
+++ b/internal/intelligence/discovery/discovery.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/connprofile"
 	"github.com/Hanalyx/openwatch/internal/credential"
 	"github.com/Hanalyx/openwatch/internal/eventbus"
@@ -512,7 +513,7 @@ func (s *Service) emitAuditSuccess(ctx context.Context, hostID uuid.UUID, f Syst
 	if s.emit == nil {
 		return
 	}
-	s.emit(ctx, audit.HostDiscoveryCompleted, audit.Event{
+	ev := audit.Event{
 		ResourceType: "host",
 		ResourceID:   hostID.String(),
 		Outcome:      audit.OutcomeSuccess,
@@ -523,5 +524,17 @@ func (s *Service) emitAuditSuccess(ctx context.Context, hostID uuid.UUID, f Syst
 			"architecture":   f.Architecture,
 			"discovered_at":  f.CollectedAt.Format(time.RFC3339Nano),
 		}),
-	})
+	}
+	// Attribute the trigger so the audit trail distinguishes an operator
+	// action (Reconnect / "Run now" / adding a host — the request identity
+	// is bound on ctx) from an automated scheduled run (the scheduler's
+	// background ctx has no identity). Without this the event was emitted
+	// with no actor and read as the misleading "Someone".
+	if id := auth.FromContext(ctx); !id.IsAnonymous {
+		ev.ActorType = "user"
+		ev.ActorID = id.ID
+	} else {
+		ev.ActorType = "system"
+	}
+	s.emit(ctx, audit.HostDiscoveryCompleted, ev)
 }

--- a/specs/system/host-discovery.spec.yaml
+++ b/specs/system/host-discovery.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-host-discovery
   title: Host OS fingerprint discovery via SSH
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 1
 
@@ -111,7 +111,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-07
-      description: 'Successful Discover MUST emit audit.HostDiscoveryCompleted with detail {os_family, os_version, kernel_release, architecture, discovered_at}. Audit emission is mandatory — Discovery is the genesis of an operator-visible fact'
+      description: 'Successful Discover MUST emit audit.HostDiscoveryCompleted with detail {os_family, os_version, kernel_release, architecture, discovered_at}. Audit emission is mandatory — Discovery is the genesis of an operator-visible fact. v1.4.0: the event MUST be attributed to its trigger — when an operator identity is bound on the context (Reconnect / "Run now" / adding a host) it sets actor_type=user with that identity''s actor_id; an automated scheduled run (no bound identity) sets actor_type=system. The event MUST NOT be emitted with an empty actor (which renders as the misleading "Someone")'
       type: security
       enforcement: error
     - id: C-08
@@ -200,3 +200,7 @@ spec:
       description: 'v1.3.0 — deriveOSFamily(osID, osIDLike) MUST return (a) the lower-cased trimmed osID when non-empty (so Ubuntu hosts persist os_family="ubuntu", Rocky→"rocky", AlmaLinux→"almalinux", openSUSE-Leap→"opensuse-leap" — NOT the family rollup); (b) when osID is empty, the first recognized rollup from osIDLike scanning rhel/fedora/centos/rocky/almalinux/ol/amzn → "rhel", ubuntu/debian/raspbian → "debian", opensuse/opensuse-leap/opensuse-tumbleweed/sles/suse → "suse", alpine → "alpine", arch/manjaro → "arch", gentoo → "gentoo"; (c) the literal "other" when neither produces a match. Case folding and leading/trailing whitespace on osID MUST be tolerated.'
       priority: critical
       references_constraints: [C-12]
+    - id: AC-23
+      description: 'v1.4.0 — emitAuditSuccess attributes the trigger: called with a context carrying a bound operator identity (auth.SetIdentity), the emitted audit.HostDiscoveryCompleted event has actor_type="user" and actor_id equal to that identity''s id; called with an anonymous/background context (no bound identity, i.e. the scheduled sweep), it has actor_type="system". The event is never emitted with an empty actor_type.'
+      priority: high
+      references_constraints: [C-07]


### PR DESCRIPTION
The audit log showed **"Someone completed host discovery"** / "Someone mounted a filesystem" for automated runs — misleading, because no person did it. Root cause: those events were emitted with **no actor recorded** (empty `actor_type`), and the formatter's empty fallback was the person-implying "Someone".

## Two fixes

1. **Formatter** (`system-activity`): an empty/unknown `actor_type` means the event was **not** attributed to a person (real user actions record the user), so it now renders **"The system"** — never "Someone". `actor_type=system` reads "The system" too, for consistency.

2. **Discovery emission** (`system-host-discovery` v1.4.0 — C-07/AC-23): `host.discovery.completed` now **attributes its trigger** — a bound operator identity on the context (Reconnect / "Run now" / adding a host) sets `actor_type=user` + `actor_id`; an automated scheduled sweep (no bound identity) sets `actor_type=system`. Never emitted with an empty actor.

## Net effect
- Scheduled discovery → "The system completed host discovery".
- Operator clicks Reconnect / Run-now → a **user-attributed** event ("A user …" today).

**Verified live** on `owas-tst01`: the audit log now reads "The system completed host discovery", "The system mounted a filesystem".

## Noted follow-up
Showing the **exact username** ("alice@example.com" instead of "A user") needs the user's display label carried on `auth.Identity` (the binder looks up the role but not the username) — a small, security-sensitive change to the identity binder + `Lookups` interface + the `system-auth-identity` spec. Tracked for a follow-up.

Full activity + discovery suites + specter (111, structural 100%) green.