### PR TITLE
feat(settings): readable Audit log rows (Phase 3a)

### DIFF
--- a/frontend/src/pages/settings/AuditPage.tsx
+++ b/frontend/src/pages/settings/AuditPage.tsx
@@ -14,6 +14,7 @@ import {
   StatusPill,
 } from '@/components/settings/primitives';
 import { ForbiddenPage } from '@/pages/ForbiddenPage';
+import { relativeTime, severityLabel } from '@/api/eventDisplay';
 import type { components } from '@/api/schema';
 
 type AuditEvent = components['schemas']['AuditEvent'];
@@ -41,18 +42,6 @@ function severityTier(severity?: string): 'ok' | 'warn' | 'crit' {
   if (s === 'critical' || s === 'error' || s === 'high') return 'crit';
   if (s === 'warn' || s === 'warning' || s === 'medium') return 'warn';
   return 'ok';
-}
-
-function relTime(iso: string): string {
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return iso;
-  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 export function AuditPage() {
@@ -233,7 +222,7 @@ export function AuditPage() {
                   }}
                 >
                   <span role="columnheader">When</span>
-                  <span role="columnheader">Action</span>
+                  <span role="columnheader">Event</span>
                   <span role="columnheader">Severity</span>
                   <span role="columnheader">Actor</span>
                   <span role="columnheader">Resource</span>
@@ -279,9 +268,12 @@ function AuditRow({ ev }: { ev: AuditEvent }) {
         }}
       >
         <span style={{ fontSize: 12, color: 'var(--ow-fg-2)' }} title={ev.occurred_at}>
-          {relTime(ev.occurred_at)}
+          {relativeTime(ev.occurred_at)}
         </span>
         <span style={{ minWidth: 0 }}>
+          {/* Primary: the server-rendered readable sentence; the raw action
+              code sits beneath as a small mono line for auditors who need it.
+              The full envelope (UUIDs, detail) is in the expandable drawer. */}
           {hasDetail ? (
             <button
               type="button"
@@ -292,44 +284,30 @@ function AuditRow({ ev }: { ev: AuditEvent }) {
                 border: 0,
                 padding: 0,
                 color: 'var(--ow-fg-0)',
-                fontFamily: 'var(--ow-font-mono)',
-                fontSize: 12,
+                fontSize: 13,
                 cursor: 'pointer',
                 textAlign: 'left',
               }}
             >
-              {open ? '▾' : '▸'} {ev.action}
+              {open ? '▾' : '▸'} {ev.message || ev.action}
             </button>
           ) : (
-            <span style={{ fontFamily: 'var(--ow-font-mono)', fontSize: 12 }}>{ev.action}</span>
+            <span style={{ fontSize: 13, color: 'var(--ow-fg-0)' }}>{ev.message || ev.action}</span>
           )}
+          <div style={{ fontFamily: 'var(--ow-font-mono)', fontSize: 11, color: 'var(--ow-fg-3)' }}>
+            {ev.action}
+          </div>
         </span>
         <span>
-          <StatusPill tier={severityTier(ev.severity)}>{ev.severity || 'info'}</StatusPill>
+          <StatusPill tier={severityTier(ev.severity)}>
+            {severityLabel(ev.severity || 'info')}
+          </StatusPill>
         </span>
         <span style={{ fontSize: 12, color: 'var(--ow-fg-1)', minWidth: 0 }}>
-          {ev.actor_type}
-          {ev.actor_id ? (
-            <span style={{ color: 'var(--ow-fg-3)', fontFamily: 'var(--ow-font-mono)' }}>
-              {' '}
-              {ev.actor_id}
-            </span>
-          ) : null}
+          {ev.actor_label || actorTypeWord(ev.actor_type)}
         </span>
         <span style={{ fontSize: 12, color: 'var(--ow-fg-2)', minWidth: 0 }}>
-          {ev.resource_type ? (
-            <>
-              {ev.resource_type}
-              {ev.resource_id ? (
-                <span style={{ color: 'var(--ow-fg-3)', fontFamily: 'var(--ow-font-mono)' }}>
-                  {' '}
-                  {ev.resource_id}
-                </span>
-              ) : null}
-            </>
-          ) : (
-            <span style={{ color: 'var(--ow-fg-3)' }}>{'—'}</span>
-          )}
+          {ev.resource_type ? capitalize(ev.resource_type) : ''}
         </span>
       </div>
       {open && hasDetail && (
@@ -341,6 +319,17 @@ function AuditRow({ ev }: { ev: AuditEvent }) {
             correlation:{' '}
             <span style={{ fontFamily: 'var(--ow-font-mono)' }}>{ev.correlation_id}</span>
           </div>
+          {ev.actor_id ? (
+            <div style={{ fontSize: 11, color: 'var(--ow-fg-3)', marginBottom: 2 }}>
+              actor id: <span style={{ fontFamily: 'var(--ow-font-mono)' }}>{ev.actor_id}</span>
+            </div>
+          ) : null}
+          {ev.resource_id ? (
+            <div style={{ fontSize: 11, color: 'var(--ow-fg-3)', marginBottom: 6 }}>
+              resource id:{' '}
+              <span style={{ fontFamily: 'var(--ow-font-mono)' }}>{ev.resource_id}</span>
+            </div>
+          ) : null}
           {ev.redactions && ev.redactions.length > 0 && (
             <div style={{ fontSize: 11, color: 'var(--ow-warn)', marginBottom: 6 }}>
               redacted fields: {ev.redactions.join(', ')}
@@ -368,6 +357,28 @@ function AuditRow({ ev }: { ev: AuditEvent }) {
       )}
     </Fragment>
   );
+}
+
+// capitalize a single word; actorTypeWord renders a readable actor type
+// (the fallback when an event carries no actor_label).
+function capitalize(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+function actorTypeWord(actorType: string): string {
+  switch (actorType) {
+    case 'system':
+    case '':
+      return 'The system';
+    case 'scheduler':
+      return 'The scheduler';
+    case 'user':
+      return 'A user';
+    case 'api_key':
+    case 'api_token':
+      return 'An API token';
+    default:
+      return capitalize(actorType);
+  }
 }
 
 const labelStyle = { fontSize: 11, color: 'var(--ow-fg-3)' } as const;

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -496,4 +496,23 @@ describe('frontend-settings — structural', () => {
     expect(FRAME_SRC).toContain('hydrateFromServer');
     expect(FRAME_SRC).toMatch(/useEffect\(/);
   });
+
+  // @ac AC-31
+  test('frontend-settings/AC-31 — Audit log rows are readable: message primary, actor name not UUID', () => {
+    // Primary line = server message (fallback to raw action); raw action as a sub-line.
+    expect(AUDIT_SRC).toMatch(/ev\.message \|\| ev\.action/);
+    // Actor shows the label (name), not the raw UUID, in the main row.
+    expect(AUDIT_SRC).toMatch(/ev\.actor_label \|\| actorTypeWord\(ev\.actor_type\)/);
+    // The raw UUIDs are not rendered inline in the row's actor/resource cells
+    // (they moved to the expanded detail under "actor id" / "resource id").
+    expect(AUDIT_SRC).toContain('actor id:');
+    expect(AUDIT_SRC).toContain('resource id:');
+    // Shared display helpers; the local relTime + em-dash are gone.
+    expect(AUDIT_SRC).toContain("from '@/api/eventDisplay'");
+    expect(AUDIT_SRC).toMatch(/relativeTime\(ev\.occurred_at\)/);
+    expect(AUDIT_SRC).not.toMatch(/function relTime/);
+    expect(AUDIT_SRC).not.toContain('—');
+    // Still read-only.
+    expect(AUDIT_SRC).not.toMatch(/api\.(POST|PATCH|PUT|DELETE)\(/);
+  });
 });

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.11.0"
+  version: "1.12.0"
   status: draft
   tier: 2
 
@@ -368,3 +368,8 @@ spec:
       description: "v1.11.0 source-inspection: usePreferencesStore keeps the Zustand persist('ow-preferences') localStorage cache AND syncs server-side — every setter calls push() which PATCHes /api/v1/users/me/preferences (best-effort, errors swallowed), and hydrateFromServer() GETs /api/v1/users/me/preferences and applies present keys to state. AppFrame calls hydrateFromServer once on mount via useEffect, so the authenticated shell reconciles preferences with the account."
       priority: high
       references_constraints: [C-06]
+
+    - id: AC-31
+      description: "v1.12.0 source-inspection: the Audit log row renders the server-rendered readable message (ev.message || ev.action) as the primary line with the raw ev.action as a small mono sub-line; the Actor column shows ev.actor_label (falling back to a readable actorTypeWord, never a raw UUID); the Resource column shows the capitalized resource_type only (no UUID); the raw actor_id and resource_id UUIDs appear only in the expanded detail drawer. Time uses the shared relativeTime and severity the shared severityLabel from @/api/eventDisplay (no local relTime, no em-dash). The page remains read-only and audit:read-gated (AC-19)."
+      priority: high
+      references_constraints: [C-13]


### PR DESCRIPTION
**Phase 3a** of the activity readability initiative — make the **settings Audit log** readable (it now consumes the server-rendered `message` added in Phase 2b).

Before: the primary column was the raw dotted action code (`scheduler.tick.dispatched`) and actor/resource were inline UUIDs. After:

- **EVENT**: `ev.message` (the sentence, e.g. "The system ran a scheduled tick") as the primary line, with the raw `ev.action` as a small mono sub-line for auditors who need the code.
- **ACTOR**: `ev.actor_label` (the name), falling back to a readable actor-type word — never a raw UUID.
- **RESOURCE**: capitalized `resource_type` only; the raw `actor_id`/`resource_id` UUIDs move to the expand drawer.
- Time + severity use the shared `eventDisplay` helpers (`relativeTime`, `severityLabel`); the local `relTime` and its em-dash are gone.

Read-only + `audit:read` gating unchanged (AC-19).

**Verified live** at `/settings/audit`.

Spec `frontend-settings` v1.12.0 (AC-31). Full frontend suite (322) + specter (111, structural 100%) green.

Next (Phase 3b): CSV/JSON **export** of the filtered audit query (the AU-7 compliance piece).