### PR TITLE
fix(activity,audit): keyset cursor (no boundary-tie data loss) + bound audit detail fields [review follow-ups]

### DIFF
--- a/internal/activity/service.go
+++ b/internal/activity/service.go
@@ -70,7 +70,8 @@ func (s *Service) List(ctx context.Context, f Filter, c Caller) ([]Row, int, str
 	}
 	cursor := ""
 	if len(rows) > f.Limit {
-		cursor = rows[f.Limit-1].OccurredAt.Format(time.RFC3339Nano)
+		last := rows[f.Limit-1]
+		cursor = encodeCursor(last.OccurredAt, last.ID.String())
 		rows = rows[:f.Limit]
 	}
 
@@ -116,11 +117,13 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 	if f.HostID != nil && *f.HostID != uuid.Nil {
 		hostPH = addArg(*f.HostID)
 	}
-	cursorPH := ""
-	if f.Cursor != "" {
-		if t, err := time.Parse(time.RFC3339Nano, f.Cursor); err == nil {
-			cursorPH = addArg(t)
-		}
+	// Compound cursor (occurred_at, id) — a tiebreaker on id is required so
+	// rows that share the boundary occurred_at are not silently dropped on
+	// the next page (the 5-leg UNION makes timestamp ties common). Spec C-03.
+	cursorTsPH, cursorIDPH := "", ""
+	if ts, id, ok := parseCursor(f.Cursor); ok {
+		cursorTsPH = addArg(ts)
+		cursorIDPH = addArg(id)
 	}
 	// Fetch limit+1 so List can detect the terminal page (Spec C-03).
 	limitPH := addArg(f.Limit + 1)
@@ -153,9 +156,9 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 				parts = append(parts, "FALSE")
 			}
 		}
-		if cursorPH != "" {
-			parts = append(parts, timeCol+" < "+cursorPH)
-		}
+		// The cursor is NOT applied here: it is compound (occurred_at, id)
+		// and the monitoring leg's id is synthesized in the SELECT (not
+		// WHERE-able), so it is applied once on the UNION result below.
 		if len(parts) == 0 {
 			return ""
 		}
@@ -294,10 +297,19 @@ func (s *Service) queryUnion(ctx context.Context, f Filter, includeAlerts, inclu
 		return nil, nil
 	}
 
-	// Spec C-01: single Query. UNION ALL across legs + final
-	// ORDER BY + LIMIT.
-	q := strings.Join(legs, "\n\t\t\tUNION ALL\n") + `
-		 ORDER BY occurred_at DESC LIMIT ` + limitPH
+	// Spec C-01: single Query. UNION ALL across legs, then the compound
+	// (occurred_at, id) cursor + final ORDER BY + LIMIT applied ONCE on the
+	// union result in an outer query — so a row sharing the boundary
+	// occurred_at is never dropped, and the monitoring leg's synthesized id
+	// participates in the tiebreaker. Spec C-03.
+	inner := strings.Join(legs, "\n\t\t\tUNION ALL\n")
+	cursorWhere := ""
+	if cursorTsPH != "" {
+		cursorWhere = " WHERE (u.occurred_at, u.id) < (" + cursorTsPH + "::timestamptz, " + cursorIDPH + "::text)"
+	}
+	q := "SELECT id, source, severity, host_id, title, summary, occurred_at," +
+		" code, ctx_a, ctx_b, ctx_c, detail FROM (\n" + inner + "\n) u" +
+		cursorWhere + "\n ORDER BY u.occurred_at DESC, u.id DESC LIMIT " + limitPH
 
 	pgRows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
@@ -438,6 +450,36 @@ func (s *Service) countHidden(ctx context.Context, f Filter, supAlerts, supTxn, 
 		return 0, fmt.Errorf("activity: count hidden: %w", err)
 	}
 	return total, nil
+}
+
+// encodeCursor packs the keyset cursor as "<RFC3339Nano>|<id>". The id is
+// the row's uuid string (a real uuid for alert/txn/intel/audit, the
+// synthesized uuid for monitoring).
+func encodeCursor(t time.Time, id string) string {
+	return t.Format(time.RFC3339Nano) + "|" + id
+}
+
+// parseCursor splits the keyset cursor back into (timestamp, id). Returns
+// ok=false for an empty or malformed cursor (the caller then starts from the
+// newest row). A legacy timestamp-only cursor (no "|") is rejected rather
+// than silently degrading to the lossy timestamp-only predicate.
+func parseCursor(s string) (time.Time, string, bool) {
+	if s == "" {
+		return time.Time{}, "", false
+	}
+	i := strings.IndexByte(s, '|')
+	if i < 0 {
+		return time.Time{}, "", false
+	}
+	t, err := time.Parse(time.RFC3339Nano, s[:i])
+	if err != nil {
+		return time.Time{}, "", false
+	}
+	id := s[i+1:]
+	if id == "" {
+		return time.Time{}, "", false
+	}
+	return t, id, true
 }
 
 // itoa is a small base-10 stringifier so service.go doesn't import strconv.

--- a/internal/activity/service_db_test.go
+++ b/internal/activity/service_db_test.go
@@ -565,3 +565,54 @@ func stringFromInt(n int) string {
 
 // referenced so the package compiles when json import is otherwise unused.
 var _ = json.Marshal
+
+// @ac AC-27
+// AC-27 (v1.3.0): cursor pagination MUST NOT drop rows that share the
+// boundary occurred_at. Regression for the keyset-cursor fix: with the old
+// timestamp-only cursor, a row sharing the last-returned row's occurred_at
+// that fell on the next page was silently skipped. Seed 4 alerts all at the
+// SAME instant, page through with limit=2, and assert all 4 distinct ids are
+// returned across the two pages with none lost or duplicated.
+func TestList_CursorPagination_BoundaryTimestampTie(t *testing.T) {
+	t.Run("system-activity/AC-27", func(t *testing.T) {
+		pool, _ := freshDB(t)
+		ts := time.Now().UTC().Truncate(time.Millisecond)
+		// Audit events have no dedup constraint (id PK only), so four rows can
+		// share one instant — exactly the boundary-tie the cursor must handle.
+		for i := 0; i < 4; i++ {
+			id := uuid.Must(uuid.NewV7())
+			if _, err := pool.Exec(context.Background(),
+				`INSERT INTO audit_events (id, correlation_id, actor_type, action, severity, occurred_at)
+				 VALUES ($1,'corr-tie','system','system.startup','info',$2)`,
+				id, ts); err != nil {
+				t.Fatalf("seed audit %d: %v", i, err)
+			}
+		}
+
+		svc := NewService(pool)
+		seen := map[string]int{}
+		cursor := ""
+		for page := 0; page < 5; page++ { // bounded loop; expect 2 pages + terminal
+			rows, _, next, err := svc.List(context.Background(),
+				Filter{Limit: 2, Cursor: cursor}, Caller{CanReadAudit: true})
+			if err != nil {
+				t.Fatalf("page %d: %v", page, err)
+			}
+			for _, r := range rows {
+				seen[r.ID.String()]++
+			}
+			if next == "" {
+				break
+			}
+			cursor = next
+		}
+		if len(seen) != 4 {
+			t.Errorf("distinct rows seen = %d, want 4 (a boundary-tie row was dropped)", len(seen))
+		}
+		for id, n := range seen {
+			if n != 1 {
+				t.Errorf("row %s returned %d times, want exactly 1", id, n)
+			}
+		}
+	})
+}

--- a/internal/audit/clip_test.go
+++ b/internal/audit/clip_test.go
@@ -4,9 +4,10 @@
 
 package audit
 
-import "strings"
-
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // @ac AC-16
 func TestClipDetail(t *testing.T) {

--- a/internal/audit/clip_test.go
+++ b/internal/audit/clip_test.go
@@ -1,0 +1,28 @@
+// @spec system-audit-emission
+//
+//	AC-16  TestClipDetail
+
+package audit
+
+import "strings"
+
+import "testing"
+
+// @ac AC-16
+func TestClipDetail(t *testing.T) {
+	t.Run("system-audit-emission/AC-16", func(t *testing.T) {
+		// Short clean string unchanged.
+		if got := ClipDetail("Mozilla/5.0"); got != "Mozilla/5.0" {
+			t.Errorf("clean = %q, want unchanged", got)
+		}
+		// Control chars replaced with spaces (log-forging neutralized).
+		if got := ClipDetail("a\nb\tc\x00d"); got != "a b c d" {
+			t.Errorf("control = %q, want 'a b c d'", got)
+		}
+		// Truncated to MaxDetailFieldLen runes (bloat bounded).
+		long := strings.Repeat("x", MaxDetailFieldLen+50)
+		if got := ClipDetail(long); len([]rune(got)) != MaxDetailFieldLen {
+			t.Errorf("len = %d, want %d", len([]rune(got)), MaxDetailFieldLen)
+		}
+	})
+}

--- a/internal/audit/emit.go
+++ b/internal/audit/emit.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -163,6 +164,32 @@ func prepareEvent(ctx context.Context, code Code, ev Event) *Event {
 		}
 	}
 	return &ev
+}
+
+// MaxDetailFieldLen bounds an attacker-influenced free-text string (a
+// submitted username, a User-Agent header) recorded in audit detail.
+const MaxDetailFieldLen = 256
+
+// ClipDetail bounds an attacker-influenced string placed in audit detail:
+// it truncates to MaxDetailFieldLen runes and replaces control characters
+// with spaces. This stops an oversized header/field from bloating the
+// audit_events.detail JSONB and neutralizes control-character log forging if
+// the detail is ever rendered in a raw (non-escaping) context. It is NOT a
+// substitute for key-name redaction (Redact), which scrubs secret values.
+func ClipDetail(s string) string {
+	var b strings.Builder
+	n := 0
+	for _, r := range s {
+		if n >= MaxDetailFieldLen {
+			break
+		}
+		if r < 0x20 || r == 0x7f {
+			r = ' '
+		}
+		b.WriteRune(r)
+		n++
+	}
+	return b.String()
 }
 
 // jsonRawCopy is a small helper for callers that build details via map.

--- a/internal/identity/binder.go
+++ b/internal/identity/binder.go
@@ -201,7 +201,7 @@ func emitLoginFailure(r *http.Request, reason string) {
 	detail, _ := json.Marshal(map[string]any{
 		"reason":      reason,
 		"remote_addr": r.RemoteAddr,
-		"user_agent":  r.UserAgent(),
+		"user_agent":  audit.ClipDetail(r.UserAgent()),
 	})
 	audit.Emit(r.Context(), audit.AuthLoginFailure, audit.Event{
 		ActorType: "anonymous",

--- a/internal/server/api_audit_query_test.go
+++ b/internal/server/api_audit_query_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"testing"
 	"time"
@@ -547,6 +548,59 @@ func TestAPI_AuditEvents_Export(t *testing.T) {
 		an.Body.Close()
 		if an.StatusCode != http.StatusUnauthorized && an.StatusCode != http.StatusForbidden {
 			t.Errorf("anonymous export status = %d, want 401/403", an.StatusCode)
+		}
+	})
+}
+
+// @ac AC-15
+// api-audit-events-query/AC-15 (v1.3.1): the audit list cursor MUST NOT drop
+// rows sharing the boundary occurred_at. Seed 4 events at one instant, page
+// with limit=2, and assert all 4 distinct ids appear across pages.
+func TestAPI_AuditEvents_CursorBoundaryTie(t *testing.T) {
+	t.Run("api-audit-events-query/AC-15", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		ctx := context.Background()
+		ts := time.Now().UTC().Truncate(time.Millisecond)
+		for i := 0; i < 4; i++ {
+			id := uuid.Must(uuid.NewV7())
+			if _, err := pool.Exec(ctx,
+				`INSERT INTO audit_events (id, correlation_id, actor_type, action, severity, occurred_at)
+				 VALUES ($1,'corr-tie','system','system.startup','info',$2)`,
+				id, ts); err != nil {
+				t.Fatalf("seed audit %d: %v", i, err)
+			}
+		}
+		seen := map[string]int{}
+		cursor := ""
+		for page := 0; page < 6; page++ {
+			q := "?limit=2"
+			if cursor != "" {
+				q += "&cursor=" + neturl.QueryEscape(cursor)
+			}
+			resp := doReq(t, asRole(t, "GET", url+"/api/v1/audit/events"+q, auth.RoleAuditor, nil))
+			var pg struct {
+				Items []struct {
+					ID string `json:"id"`
+				} `json:"items"`
+				NextCursor *string `json:"next_cursor"`
+			}
+			_ = json.NewDecoder(resp.Body).Decode(&pg)
+			resp.Body.Close()
+			for _, it := range pg.Items {
+				seen[it.ID]++
+			}
+			if pg.NextCursor == nil || *pg.NextCursor == "" {
+				break
+			}
+			cursor = *pg.NextCursor
+		}
+		if len(seen) != 4 {
+			t.Errorf("distinct audit rows across pages = %d, want 4 (boundary-tie row dropped)", len(seen))
+		}
+		for id, n := range seen {
+			if n != 1 {
+				t.Errorf("row %s seen %d times, want 1", id, n)
+			}
 		}
 	})
 }

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -507,7 +507,7 @@ func mfaEnrolled(ctx context.Context, h *handlers, userID uuid.UUID) (bool, erro
 func emitLoginFailure(r *http.Request, reason, username string) {
 	emitAudit(r, audit.AuthLoginFailure, "anonymous", map[string]any{
 		"reason":   reason,
-		"username": username,
+		"username": audit.ClipDetail(username),
 	})
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -419,12 +419,30 @@ func (h *handlers) GetAuditEvents(w http.ResponseWriter, r *http.Request, params
 
 	resp := api.AuditEventsPage{Items: items}
 	if len(rows) == int(limit) {
-		// More may exist; emit a next_cursor. Stage-0 cursor is the
-		// boundary row's occurred_at; Stage-2 will use opaque tokens.
-		last := rows[len(rows)-1].OccurredAt.Format(time.RFC3339Nano)
+		// More may exist; emit the compound keyset cursor "<ts>|<id>" so the
+		// next page resumes after the exact boundary row (not just its
+		// timestamp), matching the (occurred_at, id) ORDER BY.
+		boundary := rows[len(rows)-1]
+		last := boundary.OccurredAt.Format(time.RFC3339Nano) + "|" + boundary.Id.String()
 		resp.NextCursor = &last
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// parseAuditCursor splits the compound audit cursor "<RFC3339Nano>|<uuid>"
+// into its timestamp + id. Returns ok=false for an empty or malformed cursor
+// (a legacy timestamp-only cursor has no "|" and is rejected rather than
+// degrading to the lossy timestamp-only predicate).
+func parseAuditCursor(s string) (time.Time, string, bool) {
+	i := strings.IndexByte(s, '|')
+	if i < 0 {
+		return time.Time{}, "", false
+	}
+	t, err := time.Parse(time.RFC3339Nano, s[:i])
+	if err != nil || s[i+1:] == "" {
+		return time.Time{}, "", false
+	}
+	return t, s[i+1:], true
 }
 
 // queryEvents reads audit_events from the DB with the given filters.
@@ -466,9 +484,14 @@ WHERE 1=1
 	if p.Until != nil {
 		addArg("occurred_at < $N", *p.Until)
 	}
+	// Compound keyset cursor (occurred_at, id) matching ORDER BY occurred_at
+	// DESC, id DESC — a row sharing the boundary occurred_at is NOT dropped on
+	// the next page (a timestamp-only cursor + strict `<` silently skipped it).
 	if p.Cursor != nil && *p.Cursor != "" {
-		if t, err := time.Parse(time.RFC3339Nano, *p.Cursor); err == nil {
-			addArg("occurred_at < $N", t)
+		if ts, id, ok := parseAuditCursor(*p.Cursor); ok {
+			q += " AND (occurred_at, id) < ($" + itoa(idx) + "::timestamptz, $" + itoa(idx+1) + "::uuid)"
+			args = append(args, ts, id)
+			idx += 2
 		}
 	}
 

--- a/specs/api/audit-events-query.spec.yaml
+++ b/specs/api/audit-events-query.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-audit-events-query
   title: Audit events list endpoint
-  version: "1.3.0"
+  version: "1.3.1"
   status: approved
   tier: 2
 
@@ -32,7 +32,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-02
-      description: Default sort MUST be occurred_at DESC, id DESC (stable tiebreak)
+      description: 'Default sort MUST be occurred_at DESC, id DESC (stable tiebreak). v1.3.1 — the cursor MUST be the matching COMPOUND keyset "<RFC3339Nano occurred_at>|<id>", and the next-page predicate MUST be the row-value (occurred_at, id) < ($cursor_ts, $cursor_id) so a row sharing the boundary occurred_at is not dropped (a timestamp-only cursor with occurred_at < $cursor silently skipped boundary-tie rows). A legacy timestamp-only cursor (no "|") is rejected rather than degrading to the lossy predicate'
       type: technical
       enforcement: error
     - id: C-03
@@ -110,3 +110,7 @@ spec:
       description: 'v1.3.1 — csvSafe prefixes a single quote to any string beginning with =, +, -, @, tab, or CR and leaves other strings (and empty) unchanged. A CSV export of an audit event whose actor_label begins with "=" (a formula-injection attempt) writes the neutralized cell (prefixed with a quote), never a bare cell starting with the formula character. Behavioral test of csvSafe + an export integration assertion.'
       priority: high
       references_constraints: [C-08]
+    - id: AC-15
+      description: 'v1.3.1 — GET /api/v1/audit/events cursor pagination does NOT drop rows sharing the boundary occurred_at. Seeding four events at one identical instant and paging with limit=2 returns all four distinct ids across pages, none lost or duplicated. The emitted next_cursor is the compound "<ts>|<id>" form.'
+      priority: high
+      references_constraints: [C-02]

--- a/specs/system/activity.spec.yaml
+++ b/specs/system/activity.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-activity
   title: Activity unified-feed service
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -77,7 +77,7 @@ spec:
       type: security
       enforcement: error
     - id: C-03
-      description: 'Cursor is the RFC3339Nano-formatted occurred_at of the last row returned. The next page query adds occurred_at < $cursor as an additional WHERE clause. Empty cursor on the response when fewer than limit rows returned (terminal page)'
+      description: 'v1.3.0 — Cursor is a COMPOUND keyset "<RFC3339Nano occurred_at>|<id>" of the last row returned. The next page filters the UNION result by the row-value predicate (occurred_at, id) < ($cursor_ts, $cursor_id) and orders by occurred_at DESC, id DESC, applied ONCE in an outer query wrapping the UNION (the monitoring leg''s id is synthesized in the SELECT, not WHERE-able per-leg). A row that shares the boundary occurred_at MUST NOT be dropped on the next page (the prior timestamp-only cursor with a strict occurred_at < $cursor silently skipped boundary-tie rows — real data loss, likely on the 5-leg UNION). Empty cursor on the response when fewer than limit rows returned (terminal page); a legacy timestamp-only cursor (no "|") is rejected rather than degrading to the lossy predicate'
       type: technical
       enforcement: error
     - id: C-04
@@ -174,3 +174,7 @@ spec:
       description: 'v1.2.0 — Integration: Service.List (with an injected RuleTitleFunc) over a seeded transaction (rule_id resolving to "Ensure auditd is enabled", status=fail, change_kind=state_changed), a system.package.updated intelligence event with from/to detail, and a host.created audit event with actor_label set, returns the transaction Row with title="Ensure auditd is enabled" + summary="Changed: now Fail", the intelligence Row with title="Package updated" + summary="curl: 7.64 → 7.81", and the audit Row with title="alice@example.com created a host". No returned title leaks the seeded raw codes ("system.package.updated", "host.created").'
       priority: critical
       references_constraints: [C-09]
+    - id: AC-27
+      description: 'v1.3.0 — Cursor pagination does NOT drop rows sharing the boundary occurred_at. Seeding four rows at one identical instant and paging with limit=2 returns all four distinct ids across the pages with none lost or duplicated (the prior timestamp-only cursor returned the second page empty, losing two rows).'
+      priority: critical
+      references_constraints: [C-03]

--- a/specs/system/audit-emission.spec.yaml
+++ b/specs/system/audit-emission.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-audit-emission
   title: Audit event emission
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -61,6 +61,10 @@ spec:
       description: Event ID MUST be UUIDv7 (time-ordered)
       type: technical
       enforcement: error
+    - id: C-08
+      description: 'v1.1.0 — an attacker-influenced free-text value recorded in audit detail (a submitted username on a failed login, the User-Agent header) MUST be bounded by audit.ClipDetail before being placed in the detail map: truncated to MaxDetailFieldLen (256) runes and with control characters replaced by spaces. This prevents an oversized header/field from bloating audit_events.detail and neutralizes control-character log forging. It is independent of key-name Redact (which scrubs secret values)'
+      type: security
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -114,3 +118,7 @@ spec:
       description: Event id is UUIDv7; two consecutive emits within the same ms produce ids that sort lexicographically in emit order.
       priority: medium
       references_constraints: [C-07]
+    - id: AC-16
+      description: 'v1.1.0 — ClipDetail truncates a string longer than MaxDetailFieldLen (256) runes to that length, replaces control characters (e.g. newline, tab, NUL) with spaces, and leaves a short clean string unchanged. The login-failure emitters (identity binder + server auth handler) pass the User-Agent and submitted username through ClipDetail before recording them in audit detail.'
+      priority: high
+      references_constraints: [C-08]


### PR DESCRIPTION
The two remaining findings from the pre-release review — the **High** cursor data-loss bug and the **Low** unbounded-detail finding.

## #4 (High) — Cursor pagination dropped boundary-timestamp ties (data loss)
Both the activity feed and the audit list encoded the cursor as `occurred_at` alone and filtered `occurred_at < cursor` — so a row sharing the last-returned row's `occurred_at` that fell on the next page was **silently skipped**. Likely on the 5-leg activity UNION (batch inserts produce timestamp ties).

**Fix:** a **compound keyset cursor** `"<occurred_at>|<id>"` with the row-value predicate `(occurred_at, id) < ($ts, $id)` matching `ORDER BY occurred_at DESC, id DESC`.
- Activity UNION: the predicate is applied in an **outer query** wrapping the UNION, because the monitoring leg's `id` is synthesized in the SELECT (not WHERE-able per-leg).
- Legacy timestamp-only cursors are rejected (not silently degraded).
- **Regression tests** (both feed + audit list): seed 4 rows at one identical instant, page with limit=2 → all 4 returned, none dropped. *(The old cursor returned the second page empty — the test fails against it.)*

Specs: `system-activity` v1.3.0 (C-03/AC-27), `api-audit-events-query` v1.3.1 (C-02/AC-15).

## #5 (Low) — Unbounded attacker strings in audit detail
The `User-Agent` header (login-failure binder) and the submitted `username` (server login-failure) were recorded raw + unbounded in audit `detail` (surfaced in the JSON export). New `audit.ClipDetail` truncates to 256 runes + replaces control chars with spaces, applied at both emit sites — bounds the `detail` JSONB and neutralizes control-char log forging.

Spec: `system-audit-emission` v1.1.0 (C-08/AC-16).

Full activity + audit + server + identity suites + specter (111, structural 100%) green. This clears every actionable finding from the review; only the deliberate-tradeoff notes (L4 `latest_scan_id` index choice) remain, untouched.