### PR TITLE
refactor(reports): snapshot/faces model — report_snapshots + content addressing (A3a)

### DIFF
--- a/internal/db/migrations/0042_report_snapshots.sql
+++ b/internal/db/migrations/0042_report_snapshots.sql
@@ -1,0 +1,63 @@
+-- 0042_report_snapshots.sql
+--
+-- Reports A3a (snapshot/faces model). Promotes the reports table to the
+-- content-addressed, signable "snapshot" the reports design is built on,
+-- and adds the report_faces table that later rendered projections hang
+-- off (PDF in A3b, CSV/OSCAL later).
+--
+-- WHY a rename rather than a new table + data copy: the existing reports
+-- rows ARE snapshots already (immutable, point-in-time, scope + content),
+-- so RENAME preserves them and the 0041 scope column with no copy and no
+-- downtime.
+--
+-- content_sha256 is the snapshot's content address: the hex SHA-256 of the
+-- canonical (service-marshaled) content. It is the stable identity a later
+-- Ed25519 signature (A4) signs over, so identical content yields an
+-- identical hash. signature + signing_key_id are reserved now (nullable,
+-- unset until A4) so signing is a pure write, not another migration.
+-- NOTE for A4: a verifier must recompute this hash over the SAME canonical
+-- bytes the service hashed, NOT over the jsonb column re-serialized by
+-- Postgres (jsonb normalizes whitespace/key order on store). Settle the
+-- canonical-bytes contract when signing lands. Existing rows are
+-- backfilled here with Postgres sha256(content::text) as a deterministic
+-- stand-in; they predate signing and are never signed retroactively.
+--
+-- report_faces is created here but gets its first writer in A3b (the PDF
+-- face). The executive JSON is served directly from the snapshot content
+-- (the canonical "json face"), so it is NOT duplicated into report_faces.
+--
+-- Spec: api-reports v1.3.0.
+
+-- +goose Up
+ALTER TABLE reports RENAME TO report_snapshots;
+ALTER INDEX reports_created_at RENAME TO report_snapshots_created_at;
+
+ALTER TABLE report_snapshots ADD COLUMN content_sha256 TEXT;
+UPDATE report_snapshots
+   SET content_sha256 = encode(sha256(convert_to(content::text, 'UTF8')), 'hex')
+ WHERE content_sha256 IS NULL;
+ALTER TABLE report_snapshots ALTER COLUMN content_sha256 SET NOT NULL;
+
+ALTER TABLE report_snapshots ADD COLUMN signature      BYTEA;
+ALTER TABLE report_snapshots ADD COLUMN signing_key_id TEXT;
+
+CREATE TABLE report_faces (
+    snapshot_id  UUID NOT NULL REFERENCES report_snapshots(id) ON DELETE CASCADE,
+    face         TEXT NOT NULL,            -- json | pdf | csv | oscal_sar | oscal_poam
+    media_type   TEXT NOT NULL,
+    content      BYTEA,                    -- inline rendered bytes (small faces)
+    size_bytes   BIGINT NOT NULL DEFAULT 0,
+    blob_sha256  TEXT,                     -- content address of the rendered face
+    status       TEXT NOT NULL DEFAULT 'ready'
+                 CHECK (status IN ('pending', 'ready', 'failed')),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (snapshot_id, face)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS report_faces;
+ALTER TABLE report_snapshots DROP COLUMN IF EXISTS signing_key_id;
+ALTER TABLE report_snapshots DROP COLUMN IF EXISTS signature;
+ALTER TABLE report_snapshots DROP COLUMN IF EXISTS content_sha256;
+ALTER INDEX report_snapshots_created_at RENAME TO reports_created_at;
+ALTER TABLE report_snapshots RENAME TO reports;

--- a/internal/report/service.go
+++ b/internal/report/service.go
@@ -2,6 +2,8 @@ package report
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,13 +60,13 @@ func (s *Service) WithGroups(g GroupScoper) *Service {
 	return s
 }
 
-const reportCols = `id, title, kind, scope_label, scope, data_as_of, generated_by, format, content, created_at`
+const reportCols = `id, title, kind, scope_label, scope, data_as_of, generated_by, format, content, content_sha256, created_at`
 
 func scanReport(row pgx.Row) (Report, error) {
 	var rep Report
 	var scopeRaw []byte
 	err := row.Scan(&rep.ID, &rep.Title, &rep.Kind, &rep.ScopeLabel, &scopeRaw,
-		&rep.DataAsOf, &rep.GeneratedBy, &rep.Format, &rep.Content, &rep.CreatedAt)
+		&rep.DataAsOf, &rep.GeneratedBy, &rep.Format, &rep.Content, &rep.ContentSHA256, &rep.CreatedAt)
 	if err != nil {
 		return rep, err
 	}
@@ -117,14 +119,19 @@ func (s *Service) Generate(ctx context.Context, generatedBy string, req Generate
 	if err != nil {
 		return Report{}, fmt.Errorf("report: marshal scope: %w", err)
 	}
+	// content_sha256 is the snapshot's content address, computed over the
+	// canonical marshaled content (the exact bytes stored). Identical
+	// content yields an identical hash - the stable identity A4 will sign.
+	sum := sha256.Sum256(raw)
+	contentSHA := hex.EncodeToString(sum[:])
 
 	dataAsOf := time.Now().UTC()
 	row := s.pool.QueryRow(ctx, `
-		INSERT INTO reports (id, title, kind, scope_label, scope, data_as_of, generated_by, format, content)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO report_snapshots (id, title, kind, scope_label, scope, data_as_of, generated_by, format, content, content_sha256)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING `+reportCols,
 		uuid.New(), executiveTitle, KindExecutive, scopeLabel(scope), scopeRaw,
-		dataAsOf, generatedBy, "json", raw)
+		dataAsOf, generatedBy, "json", raw, contentSHA)
 	rep, err := scanReport(row)
 	if err != nil {
 		return Report{}, fmt.Errorf("report: generate insert: %w", err)
@@ -303,7 +310,7 @@ func compliancePct(passing, evaluated int) *int {
 
 // List returns every report, newest first.
 func (s *Service) List(ctx context.Context) ([]Report, error) {
-	rows, err := s.pool.Query(ctx, `SELECT `+reportCols+` FROM reports ORDER BY created_at DESC`)
+	rows, err := s.pool.Query(ctx, `SELECT `+reportCols+` FROM report_snapshots ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, fmt.Errorf("report: list: %w", err)
 	}
@@ -324,7 +331,7 @@ func (s *Service) List(ctx context.Context) ([]Report, error) {
 
 // Get returns one report by id, or ErrNotFound.
 func (s *Service) Get(ctx context.Context, id uuid.UUID) (Report, error) {
-	row := s.pool.QueryRow(ctx, `SELECT `+reportCols+` FROM reports WHERE id = $1`, id)
+	row := s.pool.QueryRow(ctx, `SELECT `+reportCols+` FROM report_snapshots WHERE id = $1`, id)
 	rep, err := scanReport(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Report{}, ErrNotFound

--- a/internal/report/service_db_test.go
+++ b/internal/report/service_db_test.go
@@ -32,7 +32,7 @@ func freshPool(t *testing.T) *pgxpool.Pool {
 	pool := dbtest.Pool(t)
 	ctx := context.Background()
 	for _, stmt := range []string{
-		"TRUNCATE TABLE reports CASCADE",
+		"TRUNCATE TABLE report_snapshots CASCADE",
 		"TRUNCATE TABLE groups CASCADE",
 		"TRUNCATE TABLE host_rule_state CASCADE",
 		"TRUNCATE TABLE hosts CASCADE",
@@ -277,6 +277,52 @@ func TestListAndGet_RoundTripAndNotFound(t *testing.T) {
 
 		if _, err := svc.Get(ctx, uuid.New()); err != ErrNotFound {
 			t.Errorf("Get(unknown) err = %v, want ErrNotFound", err)
+		}
+	})
+}
+
+// @ac AC-11
+// Generate stores the snapshot content-addressed: content_sha256 is a
+// 64-char hex SHA-256 over the canonical content. Identical fleet posture
+// yields identical content and therefore an identical hash across two
+// distinct snapshots (content addressing); a posture change produces a
+// different hash.
+func TestGenerate_ContentAddressed(t *testing.T) {
+	t.Run("api-reports/AC-11", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		svc := NewService(pool)
+		owner := seedUser(t, pool)
+		h := seedHost(t, pool, owner, false)
+		seedRuleState(t, pool, h, "r1", "pass", "low")
+
+		a, err := svc.Generate(ctx, "alice@example.com", GenerateRequest{})
+		if err != nil {
+			t.Fatalf("Generate a: %v", err)
+		}
+		b, err := svc.Generate(ctx, "alice@example.com", GenerateRequest{})
+		if err != nil {
+			t.Fatalf("Generate b: %v", err)
+		}
+		if len(a.ContentSHA256) != 64 {
+			t.Errorf("content_sha256 = %q, want 64 hex chars", a.ContentSHA256)
+		}
+		if a.ID == b.ID {
+			t.Fatalf("two generations share an id: %s", a.ID)
+		}
+		// Same posture -> same content -> same hash (content addressing).
+		if a.ContentSHA256 != b.ContentSHA256 {
+			t.Errorf("identical posture gave different hashes: %s vs %s", a.ContentSHA256, b.ContentSHA256)
+		}
+
+		// Change the posture: a new failing rule -> different content -> hash.
+		seedRuleState(t, pool, h, "r2", "fail", "high")
+		c, err := svc.Generate(ctx, "alice@example.com", GenerateRequest{})
+		if err != nil {
+			t.Fatalf("Generate c: %v", err)
+		}
+		if c.ContentSHA256 == a.ContentSHA256 {
+			t.Errorf("posture change did not change the content hash: %s", c.ContentSHA256)
 		}
 	})
 }

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -27,8 +27,9 @@ const (
 	KindExecutive Kind = "executive"
 )
 
-// Report is one row of the reports table. Content holds the rendered
-// JSON posture document (see ExecutiveContent for the executive shape).
+// Report is one row of the report_snapshots table. Content holds the
+// rendered JSON posture document (see ExecutiveContent for the executive
+// shape).
 type Report struct {
 	ID          uuid.UUID
 	Title       string
@@ -39,7 +40,12 @@ type Report struct {
 	GeneratedBy string
 	Format      string
 	Content     json.RawMessage
-	CreatedAt   time.Time
+	// ContentSHA256 is the snapshot's content address: the hex SHA-256 of
+	// the canonical (marshaled) Content. Identical content yields an
+	// identical hash; it is the stable identity a later signature signs
+	// over. Not yet exposed on the API wire.
+	ContentSHA256 string
+	CreatedAt     time.Time
 }
 
 // Scope is the structured slice of the fleet a report summarizes: an

--- a/specs/api/reports.spec.yaml
+++ b/specs/api/reports.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-reports
   title: Reports library - point-in-time Fleet Compliance Executive Summary artifacts (list / generate / fetch)
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -80,7 +80,8 @@ spec:
         - The Templates gallery (the six prototype templates beyond the one executive kind)
         - Retention sweeps (rows are kept; no expiry or purge in the MVP)
         - Report kinds other than executive (attestation, remediation, exceptions)
-        - PDF/OSCAL faces, signing, and the snapshot/faces model (Phase A2+)
+        - Rendered faces in report_faces - the table exists (v1.3.0) but gets its first writer with the PDF face in A3b; the executive JSON is the canonical snapshot content, not a face row
+        - Ed25519 signing - the signature + signing_key_id columns are reserved (nullable, unset) in v1.3.0; signing lands in A4
         - A period dimension on the scope (applies to the trend, which arrives with the PDF face in A3) and an explicit host-set scope
 
   constraints:
@@ -124,7 +125,8 @@ spec:
         IS NULL) host count; top_failing_rules lists the rules failing on
         the most hosts, ordered by failing host count then rule id. The row
         is write-once - data_as_of is the sampling instant, generated_by is
-        the supplied actor, and the row is never recomputed thereafter.
+        the supplied actor, and the row is never recomputed thereafter. The
+        row lives in report_snapshots (v1.3.0; renamed from reports).
       type: technical
       enforcement: error
     - id: C-05
@@ -181,6 +183,22 @@ spec:
         host_liveness.reachability_status is 'unreachable' (a host with no
         liveness row is unknown, NOT unreachable). Coverage respects the
         group scope (C-07) the same way the posture counts do.
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: >-
+        v1.3.0 - Snapshots are content-addressed. Generate stores a
+        content_sha256 on the report_snapshots row: the hex SHA-256 of the
+        canonical (service-marshaled) content - the exact bytes stored in
+        content. Identical content yields an identical hash (content
+        addressing), so two snapshots of an unchanged fleet share a
+        content_sha256 while remaining distinct rows (distinct ids); a
+        posture change changes the hash. content_sha256 is the stable
+        identity a later Ed25519 signature (A4) signs over; the signature
+        and signing_key_id columns are reserved (nullable, unset) until
+        then. The report_faces table is created for later rendered
+        projections (PDF/CSV/OSCAL) but the executive JSON remains the
+        canonical snapshot content, not a face row.
       type: technical
       enforcement: error
 
@@ -289,3 +307,12 @@ spec:
         all-unscanned fleet reads hosts_fresh 0 / hosts_stale == hosts_total.
       priority: high
       references_constraints: [C-08]
+    - id: AC-11
+      description: >-
+        v1.3.0 - Generate stores a content-addressed snapshot:
+        content_sha256 is a 64-char hex string; two generations over an
+        unchanged fleet share the same content_sha256 while being distinct
+        rows (distinct ids); seeding a new failing rule (a posture change)
+        before a third generation yields a different content_sha256.
+      priority: high
+      references_constraints: [C-09]


### PR DESCRIPTION
Reports **A3a** (`docs/engineering/reports_design.md` §11). The structural half of A3, split out (per your call) as a **pure storage refactor with no API or frontend change**, ahead of the PDF face (A3b).

## What
- **Migration 0042** RENAMES `reports` → `report_snapshots` (preserving every row + the 0041 `scope` column, **no data copy, no downtime**), adds `content_sha256` (backfilled for existing rows), reserves nullable `signature` + `signing_key_id` columns for A4, and creates the **`report_faces`** table that later rendered projections (PDF in A3b, CSV/OSCAL later) hang off.
- **content addressing:** the service stores `content_sha256` = hex SHA-256 of the canonical marshaled content, so identical content → identical hash (the stable identity A4 will sign over). A code + migration note flags the verification caveat (recompute over the canonical bytes, **not** the jsonb column, since Postgres normalizes jsonb) — that contract is settled when signing lands.
- **`report_faces` is created but unwritten here:** the executive JSON is the *canonical snapshot content*, not duplicated into a json face row. PDF is its first writer (A3b).

## Deliberately NOT in this PR
- No API change — `content_sha256` is internal-only for now (it becomes wire-visible with signing in A4).
- No frontend change.
- No new dependency (the PDF library decision is isolated to A3b).

## SDD
`api-reports` **v1.3.0** — C-04 now names `report_snapshots`; **C-09** (content addressing) + **AC-11** (64-char hex; identical posture → identical hash across distinct rows; posture change → different hash).

## Validation
- gofmt/vet/build clean; `specter check` 111 structural; **api-reports 11/11, 100%**; `specter check --test` 0 errors.
- report Go suite green on isolated PG (the migration applies cleanly in the dbtest template, exercising the rename + backfill).

Next: **A3b** adds the bounded pure-Go PDF face + `report_faces` writer + export endpoint (the dependency decision lives there).