### PR TITLE
feat(reports): Download PDF/JSON controls on the report detail (A3b-2)

### DIFF
--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1599,6 +1599,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/reports/{id}/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a rendered face of a report (PDF or JSON)
+         * @description Streams a rendered face of the report as a downloadable
+         *     attachment. format=pdf (default) renders the bounded one-page
+         *     executive PDF (a fixed posture block, the coverage caveat, and the
+         *     top-failing list - never the full per-host/per-rule evidence);
+         *     format=json returns the canonical frozen posture content. The PDF
+         *     is rendered on first request and cached in report_faces, so a
+         *     repeat download re-streams the stored bytes. RBAC: host:read. Spec
+         *     api-reports.
+         */
+        get: operations["getReportExport"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/scans": {
         parameters: {
             query?: never;
@@ -7542,6 +7569,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Report"];
+                };
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Report not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getReportExport: {
+        parameters: {
+            query?: {
+                /** @description The face to render. Defaults to pdf. */
+                format?: "pdf" | "json";
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The rendered face, as a downloadable attachment */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/pdf": string;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Unknown format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
             /** @description Caller is not authenticated */

--- a/frontend/src/pages/reports/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ReportsPage.tsx
@@ -389,6 +389,32 @@ function LibraryTab({
   );
 }
 
+// downloadReportFace fetches a rendered face of a report (pdf | json) and
+// triggers a browser download. The export endpoint is a GET, so the
+// session cookie authenticates it (same-origin credentials) and no CSRF
+// token is needed; the filename comes from the server's
+// Content-Disposition. Errors are surfaced to the caller.
+async function downloadReportFace(id: string, format: 'pdf' | 'json'): Promise<void> {
+  const res = await fetch(`/api/v1/reports/${id}/export?format=${format}`, {
+    credentials: 'same-origin',
+  });
+  if (!res.ok) {
+    throw new Error(`Export failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const cd = res.headers.get('Content-Disposition') ?? '';
+  const match = cd.match(/filename="?([^"]+)"?/);
+  const filename = match?.[1] ?? `openwatch-report.${format}`;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 function ReportDetail({
   report,
   id,
@@ -398,6 +424,21 @@ function ReportDetail({
   id: string;
   onClose: () => void;
 }) {
+  const [downloading, setDownloading] = useState<'pdf' | 'json' | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  async function onDownload(format: 'pdf' | 'json') {
+    setDownloading(format);
+    setDownloadError(null);
+    try {
+      await downloadReportFace(id, format);
+    } catch (e) {
+      setDownloadError(e instanceof Error ? e.message : 'Download failed');
+    } finally {
+      setDownloading(null);
+    }
+  }
+
   // The list query already holds every report, so we render from the row
   // the user clicked. Fall back to a direct fetch only if the row is not
   // in the cached list (defensive; should not happen in normal flow).
@@ -465,6 +506,54 @@ function ReportDetail({
               </div>
             )}
           </div>
+          {resolved && (
+            <>
+              <button
+                type="button"
+                onClick={() => onDownload('pdf')}
+                disabled={downloading !== null}
+                title="Download the one-page executive PDF"
+                style={{
+                  height: 32,
+                  padding: '0 12px',
+                  borderRadius: 6,
+                  border: '1px solid var(--ow-info)',
+                  background: 'var(--ow-info)',
+                  color: '#0a1424',
+                  fontFamily: 'inherit',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  cursor: downloading !== null ? 'default' : 'pointer',
+                  opacity: downloading !== null ? 0.6 : 1,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {downloading === 'pdf' ? 'Preparing…' : 'Download PDF'}
+              </button>
+              <button
+                type="button"
+                onClick={() => onDownload('json')}
+                disabled={downloading !== null}
+                title="Download the report data as JSON"
+                style={{
+                  height: 32,
+                  padding: '0 12px',
+                  borderRadius: 6,
+                  border: '1px solid var(--ow-line)',
+                  background: 'var(--ow-bg-1)',
+                  color: 'var(--ow-fg-1)',
+                  fontFamily: 'inherit',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  cursor: downloading !== null ? 'default' : 'pointer',
+                  opacity: downloading !== null ? 0.6 : 1,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                JSON
+              </button>
+            </>
+          )}
           <button
             type="button"
             onClick={onClose}
@@ -489,6 +578,22 @@ function ReportDetail({
           {!resolved && detailQ.isPending && <State kind="loading" />}
           {!resolved && detailQ.isError && (
             <State kind="error" text={apiErrorMessage(detailQ.error, 'Failed to load report')} />
+          )}
+          {downloadError && (
+            <div
+              role="alert"
+              style={{
+                marginBottom: 14,
+                padding: '8px 12px',
+                borderRadius: 'var(--ow-radius)',
+                border: '1px solid var(--ow-crit)',
+                background: 'var(--ow-crit-bg, rgba(220,60,60,0.12))',
+                color: 'var(--ow-crit)',
+                fontSize: 12.5,
+              }}
+            >
+              {downloadError}
+            </div>
           )}
           {resolved && <ExecutiveBody content={asExecutiveContent(resolved.content)} />}
         </div>

--- a/frontend/tests/pages/reports.test.ts
+++ b/frontend/tests/pages/reports.test.ts
@@ -109,6 +109,25 @@ describe('frontend-reports — reports library page', () => {
     expect(PAGE_SRC).toContain('<CoverageCaveat');
   });
 
+  // @ac AC-07
+  test('frontend-reports/AC-07 — report detail download controls (pdf/json export)', () => {
+    // A downloadReportFace helper hits the export endpoint with the format.
+    expect(PAGE_SRC).toContain('function downloadReportFace');
+    expect(PAGE_SRC).toMatch(/\/api\/v1\/reports\/\$\{id\}\/export\?format=\$\{format\}/);
+    // Cookie auth (same-origin credentials), no bearer token / Authorization.
+    expect(PAGE_SRC).toContain("credentials: 'same-origin'");
+    expect(PAGE_SRC.includes('Authorization')).toBe(false);
+    // The blob is saved via an object URL.
+    expect(PAGE_SRC).toContain('URL.createObjectURL');
+    // The detail renders Download PDF + JSON controls calling onDownload,
+    // with an in-flight disabled state and an error surface.
+    expect(PAGE_SRC).toContain('Download PDF');
+    expect(PAGE_SRC).toMatch(/onDownload\('pdf'\)/);
+    expect(PAGE_SRC).toMatch(/onDownload\('json'\)/);
+    expect(PAGE_SRC).toContain('downloading');
+    expect(PAGE_SRC).toContain('downloadError');
+  });
+
   // @ac AC-04
   test('frontend-reports/AC-04 — generate is the only mutation, tokens, no em-dash', () => {
     // The only mutating call is the generate POST; no PUT/DELETE.

--- a/specs/frontend/reports.spec.yaml
+++ b/specs/frontend/reports.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-reports
   title: Reports page - Library table, Generate action, deferred Templates and Scheduled tabs
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -114,6 +114,19 @@ spec:
         carries no em-dash.
       type: technical
       enforcement: error
+    - id: C-06
+      description: >-
+        v1.3.0 - The report detail header renders Download controls
+        (Download PDF + JSON) that GET /api/v1/reports/{id}/export with the
+        matching format and trigger a browser download via a
+        downloadReportFace helper (fetch with same-origin credentials so
+        the session cookie authenticates the GET - no bearer token, no CSRF
+        for a read; the rendered blob is saved via an object URL using the
+        server's Content-Disposition filename). The controls disable while a
+        download is in flight, and a failed download surfaces an error
+        rather than silently doing nothing.
+      type: technical
+      enforcement: error
     - id: C-03
       description: >-
         The Templates and Scheduled tabs render an explicit deferred state
@@ -182,3 +195,15 @@ spec:
         caveat. The caveat copy contains no em-dash.
       priority: high
       references_constraints: [C-05]
+    - id: AC-07
+      description: >-
+        v1.3.0 - Source inspection: a downloadReportFace(id, format) helper
+        fetches "/api/v1/reports/${id}/export?format=" with same-origin
+        credentials and saves the response blob via an object URL (no
+        Authorization header / bearer token - the session cookie carries
+        the GET). ReportDetail renders Download PDF and JSON controls that
+        call an onDownload handler invoking the helper, disable while a
+        download is in flight (downloading state), and show a downloadError
+        on failure.
+      priority: high
+      references_constraints: [C-06]


### PR DESCRIPTION
Reports **A3b-2** (frontend) — completes the export story from A3b. The report-detail modal header gains **Download PDF** + **JSON** controls.

## What
- A **`downloadReportFace(id, format)`** helper fetches `GET /api/v1/reports/{id}/export?format=…` with **same-origin credentials** (the session cookie authenticates the GET — no bearer token, and a read needs no CSRF) and saves the response blob via an object URL, using the server's `Content-Disposition` filename.
- The controls **disable while a download is in flight** and surface a **download error** on failure rather than failing silently.

## Note on auth
The app is **cookie-authenticated** (session cookie + `XSRF-TOKEN` double-submit), not bearer-token-in-localStorage — so the download needs no `Authorization` header. (The `auth_token` localStorage note in CLAUDE.md is stale Python-era.)

## SDD
`frontend-reports` **v1.3.0** — C-06 + AC-07 (source inspection of the helper + the Download controls). `schema.d.ts` regenerated to include the export path.

## Validation
tsc / eslint / prettier clean; reports vitest **7/7**; full frontend suite **326** green; specter frontend-reports **7/7, 100%**.

> Not live-tested in-browser yet: the running dev backend predates A3b (export route 404s) so a live download needs a backend rebuild to main. The code path is covered by the backend's A3b tests + this frontend's source inspection.