### PR TITLE
feat(reports): async attestation render + report.ready event (B3a)

### DIFF
--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -648,6 +648,16 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 			slog.String("key_id", reportSigner.KeyID()))
 	}
 
+	// Report service + async render processor. The service enqueues a
+	// report.render job for each generated attestation (WithAsyncRender);
+	// the processor, registered on the in-process worker, renders the bulk
+	// faces and publishes ReportReady on the bus.
+	reportSvc := report.NewService(pool).
+		WithGroups(group.NewService(pool)).
+		WithSigner(reportSigner).
+		WithAsyncRender()
+	reportRenderProc := report.NewRenderProcessor(reportSvc, bus)
+
 	srv := server.New(cfg, pool).
 		WithConnectivityConfig(cfgStore, liveSvc).
 		WithDiscovery(discoSvc).
@@ -669,7 +679,8 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		WithExceptions(exceptionSvc).
 		WithRemediation(remediationSvc).
 		WithGroups(group.NewService(pool)).
-		WithReports(report.NewService(pool).WithGroups(group.NewService(pool)).WithSigner(reportSigner)).
+		WithReports(reportSvc).
+		WithReportWorker(reportRenderProc).
 		WithScanResults(scanresult.NewReader(pool)).
 		WithNotifications(notifSvc)
 	runErr := srv.Run(ctx)

--- a/docs/engineering/reports_design.md
+++ b/docs/engineering/reports_design.md
@@ -553,13 +553,18 @@ framework-lensed), so the PDF stays bounded. Cached in `report_faces` (face
 `pdf`) like the others. Spec: `api-reports` v1.9.0 (C-15 / AC-21; C-10
 updated: pdf kind-dispatched, not executive-only).
 
-**B3a — Async generation + report.ready.** *(REMAINING.)* Fleet attestation
-generation (the bulk query + SAR/CSV/PDF render) moves to the job queue: a
-`FleetReportJobType` + payload + a worker processor that flips
-`report_faces` status `pending → ready` and publishes
+**B3a — Async generation + report.ready.** *(SHIPPED 2026-06-21, PR #646.)*
+Generating an attestation marks its bulk faces (`csv`, `oscal_sar`, `pdf`)
+`pending` in `report_faces` and enqueues a `report.render` job
+(`internal/report/job.go`), returning immediately (the executive summary
+stays synchronous). A `RenderProcessor` registered on the in-process worker
+(`worker.WithReportProcessor`) claims the job, renders each face via
+`Export` (flipping `pending → ready`; a render error marks the face
+`failed` and fails the job for retry), and publishes
 `EventKindReportReady` on the event bus — **the in-app notification bell's
-first producer** (closes that coupling). Spec: `system-report-faces`
-(async + status), eventbus types.
+first producer**. Async is an optimization, not a correctness gate: `Export`
+stays the lazy fallback so a download before the job runs still renders
+inline. Spec: `api-reports` v1.10.0 (C-16 / AC-22) + the new eventbus kind.
 
 **B3c — Notification bell (frontend).** *(REMAINING; needs product input.)*
 Turn the stubbed TopBar bell into a real consumer of `report.ready` (and

--- a/internal/eventbus/bus_test.go
+++ b/internal/eventbus/bus_test.go
@@ -254,7 +254,8 @@ func TestEventKindEnum_HasExactlyTwoValues(t *testing.T) {
 		// HostDiscovered (system-host-discovery PR 1.1),
 		// IntelligenceEvent (system-os-intelligence PR 1.2),
 		// ScanCompleted (api-host-scan / scan foundation),
-		// RemediationCompleted (api-remediation execute/rollback).
+		// RemediationCompleted (api-remediation execute/rollback),
+		// ReportReady (api-reports async render, B3a).
 		expected := map[EventKind]bool{
 			EventKindHeartbeatPulse:        false,
 			EventKindDriftDetected:         false,
@@ -264,6 +265,7 @@ func TestEventKindEnum_HasExactlyTwoValues(t *testing.T) {
 			EventKindIntelligenceEvent:     false,
 			EventKindScanCompleted:         false,
 			EventKindRemediationCompleted:  false,
+			EventKindReportReady:           false,
 		}
 		if len(AllEventKinds) != len(expected) {
 			t.Errorf("AllEventKinds = %d, want %d", len(AllEventKinds), len(expected))

--- a/internal/eventbus/types.go
+++ b/internal/eventbus/types.go
@@ -57,6 +57,14 @@ const (
 	// remediation queue + host compliance surfaces without polling.
 	// Spec api-remediation.
 	EventKindRemediationCompleted EventKind = "remediation.completed"
+
+	// EventKindReportReady is emitted by the report render worker once a
+	// report's bulk faces (CSV / OSCAL SAR / PDF for an attestation) have
+	// been rendered and cached 'ready' in report_faces. It is the first
+	// producer of the in-app notification bell: a generator who kicked off
+	// a fleet attestation learns the bundle is downloadable without polling.
+	// Spec api-reports.
+	EventKindReportReady EventKind = "report.ready"
 )
 
 // AllEventKinds is the closed set, in registration order. Spec AC-07's
@@ -70,6 +78,7 @@ var AllEventKinds = []EventKind{
 	EventKindIntelligenceEvent,
 	EventKindScanCompleted,
 	EventKindRemediationCompleted,
+	EventKindReportReady,
 }
 
 // Event is the contract every bus event satisfies. Implementations are
@@ -254,6 +263,26 @@ func (r RemediationCompleted) Kind() EventKind { return EventKindRemediationComp
 
 // Timestamp satisfies Event.
 func (r RemediationCompleted) Timestamp() time.Time { return r.CompletedAt }
+
+// ReportReady is fired by the report render worker once a report's bulk
+// faces are rendered and cached. SnapshotID is the report; ReportKind is
+// the report kind (e.g. "attestation"); Faces lists the faces that were
+// rendered ready (e.g. ["csv","oscal_sar","pdf"]). GeneratedBy carries the
+// principal who generated the report so the notification can be routed to
+// the right operator.
+type ReportReady struct {
+	SnapshotID  uuid.UUID
+	ReportKind  string
+	Faces       []string
+	GeneratedBy string
+	OccurredAt  time.Time
+}
+
+// Kind satisfies Event.
+func (r ReportReady) Kind() EventKind { return EventKindReportReady }
+
+// Timestamp satisfies Event.
+func (r ReportReady) Timestamp() time.Time { return r.OccurredAt }
 
 // DefaultBufferSize is the per-subscriber channel buffer when
 // SubscribeOptions.BufferSize is zero. Spec C-04.

--- a/internal/report/job.go
+++ b/internal/report/job.go
@@ -1,0 +1,167 @@
+package report
+
+// Async report rendering: the bulk attestation faces (CSV / OSCAL SAR /
+// PDF) can be expensive to assemble for a large fleet, so generating an
+// attestation enqueues a render job instead of blocking the request. A
+// worker claims the job, renders each face (warming the report_faces cache
+// and flipping each face's row from 'pending' to 'ready'), then publishes
+// a ReportReady event on the bus - the first producer of the in-app
+// notification bell.
+//
+// Export stays the lazy fallback: a download that arrives before the job
+// runs still renders the face inline (a cache miss), so async rendering is
+// a warm-the-cache-and-notify optimization, never a correctness gate.
+//
+// Spec: api-reports.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/queue"
+)
+
+// RenderJobType is the job_type for an async report-face render.
+const RenderJobType = "report.render"
+
+// RenderPayload is the job payload: which snapshot to render faces for.
+type RenderPayload struct {
+	SnapshotID uuid.UUID `json:"snapshot_id"`
+}
+
+// attestationFaces are the bulk faces rendered asynchronously for an
+// attestation report, in render order.
+var attestationFaces = []string{FaceCSV, FaceOSCALSAR, FacePDF}
+
+// markFacesPending inserts a 'pending' report_faces row for each face that
+// does not already exist, so the lifecycle status is genuine (the render
+// worker flips them to 'ready'). ON CONFLICT DO NOTHING leaves an already
+// rendered ('ready') face untouched.
+func (s *Service) markFacesPending(ctx context.Context, snapshotID uuid.UUID, faces []string) error {
+	for _, face := range faces {
+		mediaType := "application/octet-stream"
+		switch face {
+		case FaceCSV:
+			mediaType = "text/csv"
+		case FaceOSCALSAR, FaceJSON:
+			mediaType = "application/json"
+		case FacePDF:
+			mediaType = "application/pdf"
+		}
+		if _, err := s.pool.Exec(ctx, `
+			INSERT INTO report_faces (snapshot_id, face, media_type, size_bytes, status)
+			VALUES ($1, $2, $3, 0, 'pending')
+			ON CONFLICT (snapshot_id, face) DO NOTHING`,
+			snapshotID, face, mediaType); err != nil {
+			return fmt.Errorf("report: mark face pending: %w", err)
+		}
+	}
+	return nil
+}
+
+// enqueueRender marks the attestation's bulk faces pending and enqueues a
+// render job. Best-effort: a failure to enqueue is logged but does not fail
+// Generate, because Export still renders each face lazily on first
+// download (the async path is an optimization, not a correctness gate).
+func (s *Service) enqueueRender(ctx context.Context, snapshotID uuid.UUID) {
+	if err := s.markFacesPending(ctx, snapshotID, attestationFaces); err != nil {
+		slog.WarnContext(ctx, "report: mark faces pending failed",
+			slog.String("snapshot_id", snapshotID.String()), slog.String("error", err.Error()))
+		return
+	}
+	if _, err := queue.Enqueue(ctx, s.pool, RenderJobType, RenderPayload{SnapshotID: snapshotID}); err != nil {
+		slog.WarnContext(ctx, "report: enqueue render job failed",
+			slog.String("snapshot_id", snapshotID.String()), slog.String("error", err.Error()))
+	}
+}
+
+// RenderProcessor renders a report's faces for a claimed report.render job
+// and publishes ReportReady. It is registered on the in-process worker via
+// WithReportProcessor; its ProcessJob signature matches the worker's other
+// processors.
+type RenderProcessor struct {
+	svc *Service
+	bus *eventbus.Bus
+}
+
+// NewRenderProcessor builds the processor over a report Service (for
+// Export) and an event bus (to publish ReportReady). A nil bus renders the
+// faces but publishes nothing.
+func NewRenderProcessor(svc *Service, bus *eventbus.Bus) *RenderProcessor {
+	return &RenderProcessor{svc: svc, bus: bus}
+}
+
+// ProcessJob renders every face that applies to the report's kind (warming
+// the cache and flipping each 'pending' row to 'ready' via Export's upsert)
+// and publishes a ReportReady event. A render error fails the job so it can
+// be retried; faces already rendered are idempotent (deterministic bytes).
+func (p *RenderProcessor) ProcessJob(ctx context.Context, j *queue.Job) {
+	var payload RenderPayload
+	if err := json.Unmarshal(j.Payload, &payload); err != nil {
+		_ = queue.Fail(ctx, p.svc.pool, j.ID, fmt.Sprintf("report.render: payload decode: %v", err))
+		return
+	}
+	if payload.SnapshotID == uuid.Nil {
+		_ = queue.Fail(ctx, p.svc.pool, j.ID, "report.render: payload snapshot_id missing")
+		return
+	}
+
+	rep, err := p.svc.Get(ctx, payload.SnapshotID)
+	if err != nil {
+		// An unknown snapshot (e.g. deleted before the job ran) is terminal,
+		// not retryable.
+		_ = queue.Fail(ctx, p.svc.pool, j.ID, fmt.Sprintf("report.render: load snapshot: %v", err))
+		return
+	}
+
+	faces := facesForKind(rep.Kind)
+	rendered := make([]string, 0, len(faces))
+	for _, face := range faces {
+		if _, _, err := p.svc.Export(ctx, payload.SnapshotID, face); err != nil {
+			// Mark the face failed so the lifecycle reflects reality, then
+			// fail the job for retry.
+			_, _ = p.svc.pool.Exec(ctx,
+				`UPDATE report_faces SET status = 'failed' WHERE snapshot_id = $1 AND face = $2 AND status = 'pending'`,
+				payload.SnapshotID, face)
+			_ = queue.Fail(ctx, p.svc.pool, j.ID, fmt.Sprintf("report.render: face %s: %v", face, err))
+			return
+		}
+		rendered = append(rendered, face)
+	}
+
+	if p.bus != nil {
+		p.bus.Publish(ctx, eventbus.ReportReady{
+			SnapshotID:  rep.ID,
+			ReportKind:  string(rep.Kind),
+			Faces:       rendered,
+			GeneratedBy: rep.GeneratedBy,
+			OccurredAt:  time.Now().UTC(),
+		})
+	}
+
+	if err := queue.Complete(ctx, p.svc.pool, j.ID); err != nil {
+		slog.WarnContext(ctx, "report.render: complete failed",
+			slog.String("job_id", j.ID.String()), slog.String("error", err.Error()))
+	}
+}
+
+// facesForKind lists the faces an async render produces for a report kind:
+// the bulk faces for an attestation; just the (cheap) PDF for an executive
+// so the executive path can also notify if ever enqueued. The JSON face is
+// always available lazily and is not pre-rendered.
+func facesForKind(kind Kind) []string {
+	switch kind {
+	case KindAttestation:
+		return attestationFaces
+	case KindExecutive:
+		return []string{FacePDF}
+	default:
+		return nil
+	}
+}

--- a/internal/report/job_db_test.go
+++ b/internal/report/job_db_test.go
@@ -1,0 +1,146 @@
+// @spec api-reports
+//
+// AC traceability:
+//   AC-22  async attestation render: Generate(asyncRender) marks the bulk
+//          faces 'pending' + enqueues a report.render job; the
+//          RenderProcessor renders them 'ready', completes the job, and
+//          publishes a ReportReady event carrying the snapshot + faces.
+
+package report
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/correlation"
+	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/queue"
+)
+
+// faceStatuses returns the status of every report_faces row for a snapshot,
+// keyed by face.
+func faceStatuses(t *testing.T, pool *pgxpool.Pool, snapshotID uuid.UUID) map[string]string {
+	t.Helper()
+	rows, err := pool.Query(context.Background(),
+		`SELECT face, status FROM report_faces WHERE snapshot_id = $1`, snapshotID)
+	if err != nil {
+		t.Fatalf("query face statuses: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var face, status string
+		if err := rows.Scan(&face, &status); err != nil {
+			t.Fatalf("scan face status: %v", err)
+		}
+		out[face] = status
+	}
+	return out
+}
+
+// @ac AC-22
+func TestRenderProcessor_AsyncAttestation(t *testing.T) {
+	t.Run("api-reports/AC-22", func(t *testing.T) {
+		pool := freshPool(t)
+		// queue.Enqueue requires a correlation id on the context (the HTTP
+		// middleware sets one in production); set one for the test.
+		ctx := correlation.Set(context.Background(), correlation.Generate(correlation.PrefixRequest))
+		// job_queue is not part of freshPool's truncation set; clear it so a
+		// stale job from another test isn't dequeued first.
+		if _, err := pool.Exec(ctx, "TRUNCATE TABLE job_queue"); err != nil {
+			t.Fatalf("truncate job_queue: %v", err)
+		}
+
+		signer, _ := NewSigner("")
+		svc := NewService(pool).WithSigner(signer).WithAsyncRender()
+		owner := seedUser(t, pool)
+		h := seedHost(t, pool, owner, false)
+		scan := seedScanRun(t, pool, h)
+		seedScanResult(t, pool, scan, h, "r1", "pass", `{"cis_rhel9_v2.0.0": ["1.1"]}`)
+		seedScanResult(t, pool, scan, h, "r2", "fail", `{"cis_rhel9_v2.0.0": ["1.2"]}`)
+
+		// Generate marks the bulk faces 'pending' and enqueues a render job.
+		rep, err := svc.Generate(ctx, "alice@example.com", GenerateRequest{Kind: KindAttestation})
+		if err != nil {
+			t.Fatalf("Generate attestation: %v", err)
+		}
+		pending := faceStatuses(t, pool, rep.ID)
+		for _, face := range []string{FaceCSV, FaceOSCALSAR, FacePDF} {
+			if pending[face] != "pending" {
+				t.Errorf("face %s status = %q, want pending", face, pending[face])
+			}
+		}
+
+		// A report.render job is queued for this snapshot.
+		var jobType string
+		if err := pool.QueryRow(ctx,
+			`SELECT job_type FROM job_queue WHERE status = 'pending' ORDER BY created_at DESC LIMIT 1`).
+			Scan(&jobType); err != nil {
+			t.Fatalf("query queued job: %v", err)
+		}
+		if jobType != RenderJobType {
+			t.Fatalf("queued job_type = %q, want %q", jobType, RenderJobType)
+		}
+
+		// Subscribe before processing so the ReportReady event is captured.
+		bus := eventbus.NewBus()
+		sub := bus.Subscribe(eventbus.SubscribeOptions{Kinds: []eventbus.EventKind{eventbus.EventKindReportReady}})
+		defer sub.Unsubscribe()
+
+		// Claim and process the job through the RenderProcessor.
+		job, _, err := queue.Dequeue(ctx, pool)
+		if err != nil {
+			t.Fatalf("Dequeue: %v", err)
+		}
+		if job.JobType != RenderJobType {
+			t.Fatalf("dequeued job_type = %q, want %q", job.JobType, RenderJobType)
+		}
+		proc := NewRenderProcessor(svc, bus)
+		proc.ProcessJob(ctx, job)
+
+		// Every bulk face flipped to 'ready'.
+		ready := faceStatuses(t, pool, rep.ID)
+		for _, face := range []string{FaceCSV, FaceOSCALSAR, FacePDF} {
+			if ready[face] != "ready" {
+				t.Errorf("after render, face %s status = %q, want ready", face, ready[face])
+			}
+		}
+
+		// The job is completed.
+		var jobStatus string
+		if err := pool.QueryRow(ctx,
+			`SELECT status FROM job_queue WHERE id = $1`, job.ID).Scan(&jobStatus); err != nil {
+			t.Fatalf("query job status: %v", err)
+		}
+		if jobStatus != "completed" {
+			t.Errorf("job status = %q, want completed", jobStatus)
+		}
+
+		// A ReportReady event was published for this snapshot, naming the faces.
+		select {
+		case ev := <-sub.Events():
+			rr, ok := ev.(eventbus.ReportReady)
+			if !ok {
+				t.Fatalf("event type = %T, want ReportReady", ev)
+			}
+			if rr.SnapshotID != rep.ID {
+				t.Errorf("event snapshot = %s, want %s", rr.SnapshotID, rep.ID)
+			}
+			if rr.ReportKind != string(KindAttestation) {
+				t.Errorf("event kind = %q, want attestation", rr.ReportKind)
+			}
+			if len(rr.Faces) != 3 {
+				t.Errorf("event faces = %v, want 3", rr.Faces)
+			}
+			if rr.GeneratedBy != "alice@example.com" {
+				t.Errorf("event generated_by = %q", rr.GeneratedBy)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("no ReportReady event published")
+		}
+	})
+}

--- a/internal/report/service.go
+++ b/internal/report/service.go
@@ -55,6 +55,11 @@ type Service struct {
 	pool   *pgxpool.Pool
 	groups GroupScoper // nil until WithGroups; group scoping then 503s
 	signer *Signer     // nil until WithSigner; snapshots then go unsigned
+	// asyncRender, when true, makes Generate enqueue a report.render job for
+	// an attestation (pre-marking its bulk faces 'pending') instead of
+	// leaving every face to lazy first-download rendering. Set by
+	// WithAsyncRender in production wiring; off in tests that have no worker.
+	asyncRender bool
 }
 
 func NewService(pool *pgxpool.Pool) *Service {
@@ -78,6 +83,17 @@ func (s *Service) WithSigner(signer *Signer) *Service {
 
 // Signer exposes the wired signer (for the signing-key endpoint), or nil.
 func (s *Service) Signer() *Signer { return s.signer }
+
+// WithAsyncRender enables async rendering of attestation bulk faces:
+// Generate then marks the faces 'pending' and enqueues a report.render job
+// (a RenderProcessor on the in-process worker renders them and publishes
+// ReportReady). Enable it only when a worker is running to drain the queue;
+// without it Generate stays synchronous and faces render lazily on first
+// download.
+func (s *Service) WithAsyncRender() *Service {
+	s.asyncRender = true
+	return s
+}
 
 const reportCols = `id, title, kind, scope_label, scope, data_as_of, generated_by, format, content, content_sha256, signature, signing_key_id, created_at`
 
@@ -194,6 +210,14 @@ func (s *Service) Generate(ctx context.Context, generatedBy string, req Generate
 	rep, err := scanReport(row)
 	if err != nil {
 		return Report{}, fmt.Errorf("report: generate insert: %w", err)
+	}
+
+	// Attestation faces (CSV / OSCAL SAR / PDF) are the expensive bulk
+	// renders; when async is enabled, queue them so Generate returns fast
+	// and the operator is notified (ReportReady) when the bundle is ready.
+	// The executive summary is a tiny rollup - it stays synchronous.
+	if s.asyncRender && kind == KindAttestation {
+		s.enqueueRender(ctx, rep.ID)
 	}
 	return rep, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,6 +209,17 @@ func (s *Server) WithRemediationWorker(rw *worker.RemediationWorker) *Server {
 	return s
 }
 
+// WithReportWorker registers the report render processor on the in-process
+// job worker, so "report.render" jobs claimed by the serve process render
+// the report's faces and publish ReportReady instead of dead-ending. Spec
+// api-reports.
+func (s *Server) WithReportWorker(rp worker.ReportRenderer) *Server {
+	if s.wkr != nil {
+		s.wkr.WithReportProcessor(rp)
+	}
+	return s
+}
+
 // New constructs a Server from validated config and DB pool. The returned
 // Server has the foundation middleware chain mounted (correlation first,
 // then idempotency) and the Stage-0 API routes generated from

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -47,6 +47,15 @@ type HostDiscoveryRunner interface {
 // (WithConcurrency) so a fleet of queued scans does not drain one host at a
 // time; the queue's SKIP LOCKED claim and the scan path's per-host advisory
 // lock keep concurrent draining safe (system-job-queue C-07).
+// ReportRenderer renders a report's faces for a claimed "report.render"
+// job and publishes the ready event. Implemented by
+// report.RenderProcessor; defined as an interface here so the worker
+// package does not import the report package (which would cycle through
+// the queue/eventbus packages they share).
+type ReportRenderer interface {
+	ProcessJob(ctx context.Context, j *queue.Job)
+}
+
 type Worker struct {
 	pool        *pgxpool.Pool
 	stop        chan struct{}
@@ -54,6 +63,7 @@ type Worker struct {
 	discovery   HostDiscoveryRunner
 	scanProc    *ScanWorker
 	remProc     *RemediationWorker
+	reportProc  ReportRenderer
 	concurrency int
 }
 
@@ -109,6 +119,16 @@ func (w *Worker) WithScanProcessor(sw *ScanWorker) *Worker {
 // remediation jobs rather than fail them as unsupported. Spec api-remediation.
 func (w *Worker) WithRemediationProcessor(rw *RemediationWorker) *Worker {
 	w.remProc = rw
+	return w
+}
+
+// WithReportProcessor registers a report RenderProcessor whose ProcessJob
+// handles "report.render" jobs claimed by THIS worker's loop. Like scan
+// and remediation jobs, queue.Dequeue is not type-filtered, so the
+// in-process worker must route report renders rather than fail them as
+// unsupported. Spec api-reports.
+func (w *Worker) WithReportProcessor(rp ReportRenderer) *Worker {
+	w.reportProc = rp
 	return w
 }
 
@@ -203,6 +223,12 @@ func (w *Worker) process(ctx context.Context, j *queue.Job) {
 			return
 		}
 		w.remProc.ProcessJob(ctx, j)
+	case "report.render":
+		if w.reportProc == nil {
+			_ = queue.Fail(ctx, w.pool, j.ID, "report processor not registered on this worker")
+			return
+		}
+		w.reportProc.ProcessJob(ctx, j)
 	default:
 		_ = queue.Fail(ctx, w.pool, j.ID, "unsupported job_type for Stage 0 worker: "+j.JobType)
 	}

--- a/specs/api/reports.spec.yaml
+++ b/specs/api/reports.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-reports
   title: Reports library - point-in-time Fleet Compliance Executive Summary artifacts (list / generate / fetch)
-  version: "1.9.0"
+  version: "1.10.0"
   status: approved
   tier: 2
 
@@ -329,6 +329,28 @@ spec:
         like the other faces.
       type: technical
       enforcement: error
+    - id: C-16
+      description: >-
+        v1.10.0 (Phase B3a) - Attestation bulk faces render ASYNCHRONOUSLY.
+        When async rendering is enabled (WithAsyncRender, set in production
+        where a worker drains the queue), Generate(kind=attestation) marks
+        the bulk faces (csv, oscal_sar, pdf) as report_faces rows with status
+        'pending' and enqueues a report.render job, then returns immediately
+        (the executive summary stays synchronous - it is a tiny rollup). A
+        RenderProcessor registered on the in-process worker claims the job,
+        renders each applicable face via Export (flipping its row 'pending'
+        -> 'ready'; a render error marks that face 'failed' and fails the job
+        for retry), completes the job, and publishes an eventbus.ReportReady
+        event (kind report.ready) carrying the snapshot id, report kind, the
+        rendered faces, and the generating principal - the first producer of
+        the in-app notification bell. Async rendering is an
+        optimization/notification path, NOT a correctness gate: Export
+        remains the lazy fallback, so a download that arrives before the job
+        runs still renders the face inline. Enqueue failures are logged and
+        do not fail Generate. The new event is registered in
+        eventbus.AllEventKinds (system-event-bus closed set).
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -556,3 +578,14 @@ spec:
         re-served byte-identical from cache on a second export.
       priority: high
       references_constraints: [C-15]
+    - id: AC-22
+      description: >-
+        v1.10.0 - With async rendering enabled, Generate(kind=attestation)
+        leaves the three bulk faces (csv, oscal_sar, pdf) as report_faces
+        rows with status 'pending' and enqueues a report.render job. After a
+        RenderProcessor processes the dequeued job: every bulk face row is
+        'ready', the job is 'completed', and a single eventbus.ReportReady
+        event is published carrying the snapshot id, kind "attestation", the
+        three rendered faces, and the generating principal.
+      priority: high
+      references_constraints: [C-16]


### PR DESCRIPTION
## Summary

Phase B3a moves attestation **bulk-face rendering off the request path** and emits a `report.ready` event — the **first producer of the in-app notification bell**.

## What changes

- **eventbus**: new `EventKindReportReady` (`report.ready`) + `ReportReady` event (snapshot id, kind, rendered faces, generating principal), added to the `AllEventKinds` closed set.
- **`report/job.go`**: a `report.render` job (`RenderJobType` + `RenderPayload`) and a `RenderProcessor`. `Generate(attestation)`, when async is enabled (`WithAsyncRender`), marks the bulk faces (`csv`/`oscal_sar`/`pdf`) **`pending`** and enqueues the job, returning immediately; the executive summary stays synchronous (tiny rollup). The processor renders each face via `Export` (flipping `pending → ready`; a render error marks the face `failed` and fails the job for retry), completes the job, and publishes `ReportReady`.
- **worker**: a `ReportRenderer` interface + `WithReportProcessor` + a `report.render` dispatch case (interface-typed so `worker` doesn't import `report`). **server**: `WithReportWorker` registers it on the in-process worker. **main.go**: builds the report service `WithAsyncRender` + a `RenderProcessor` over the bus.

**Async is an optimization, not a correctness gate**: `Export` stays the lazy fallback, so a download arriving before the job runs still renders inline; enqueue failures are logged and don't fail `Generate`.

## How the bell consumes it (for later — B3c)
`ReportReady` flows through the existing generic SSE bridge automatically (it marshals any subscribed event). The frontend notification bell (still stubbed) is the remaining B3c slice and needs product decisions before building.

## Spec / tests

- `api-reports` **v1.10.0**: new **C-16** + **AC-22** (DB test: pending faces + queued job → `RenderProcessor` → ready faces + completed job + a `ReportReady` event with the snapshot/kind/faces/principal). The eventbus **AC-07** closed-set test updated for the new kind.
- `gofmt` silent, `go vet` clean, `go build ./...` clean; `specter check` 111 specs structural + 0 annotation errors; `go test ./internal/report/ ./internal/eventbus/ ./internal/worker/` green.

## Validation
- [x] gofmt / go vet / go build
- [x] go test report + eventbus + worker
- [x] specter check (structural + annotation hygiene)