### PR TITLE
feat(reports): scheduled reports + email delivery (Phase C3)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2539,6 +2539,132 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/reports/schedules:
+    get:
+      operationId: getReportSchedules
+      summary: List the report delivery schedules
+      description: |
+        Returns every scheduled report (daily/weekly/monthly cadence that
+        generates a report and emails its PDF through a notification
+        channel), newest first. RBAC: host:read. Spec system-report-schedule.
+      responses:
+        '200':
+          description: The schedules
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ReportScheduleList'}
+        '401':
+          description: Caller is not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks host:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    post:
+      operationId: createReportSchedule
+      summary: Create a report delivery schedule
+      description: |
+        Schedules a report to generate on a daily/weekly/monthly cadence and
+        email its PDF through an email notification channel. RBAC:
+        host:write. Spec system-report-schedule.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CreateReportScheduleRequest'}
+      responses:
+        '201':
+          description: The created schedule
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ReportSchedule'}
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '401':
+          description: Caller is not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks host:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/reports/schedules/{id}:
+    patch:
+      operationId: updateReportSchedule
+      summary: Enable or disable a report schedule
+      description: |
+        Toggles a schedule's enabled flag. Re-enabling recomputes the next
+        run from now. RBAC: host:write. Spec system-report-schedule.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/UpdateReportScheduleRequest'}
+      responses:
+        '200':
+          description: The updated schedule
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ReportSchedule'}
+        '401':
+          description: Caller is not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks host:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    delete:
+      operationId: deleteReportSchedule
+      summary: Delete a report schedule
+      description: |
+        Removes a schedule (does not delete reports it already generated).
+        RBAC: host:write. Spec system-report-schedule.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      responses:
+        '204':
+          description: Deleted
+        '401':
+          description: Caller is not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks host:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Schedule not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/reports/signing-key:
     get:
       operationId: getReportSigningKey
@@ -5488,6 +5614,64 @@ components:
         frameworks:
           type: array
           items: {$ref: '#/components/schemas/ReportFramework'}
+
+    ReportSchedule:
+      type: object
+      required: [id, name, kind, frequency, hour, channel_id, enabled, next_run_at, created_at]
+      properties:
+        id: {type: string, format: uuid}
+        name: {type: string}
+        kind:
+          type: string
+          enum: [executive, attestation, exception, remediation]
+        group_id: {type: string, format: uuid, description: Optional group scope.}
+        framework: {type: string, description: Optional framework lens.}
+        period_days: {type: integer, description: Period window for the remediation kind.}
+        frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+        hour: {type: integer, description: Hour of day (UTC) to run (0-23).}
+        weekday: {type: integer, description: 0=Sunday..6=Saturday, for weekly.}
+        day_of_month: {type: integer, description: 1-28, for monthly.}
+        channel_id: {type: string, format: uuid, description: The email channel used for delivery.}
+        enabled: {type: boolean}
+        next_run_at: {type: string, format: date-time}
+        last_run_at: {type: string, format: date-time}
+        last_status: {type: string}
+        created_at: {type: string, format: date-time}
+
+    ReportScheduleList:
+      type: object
+      required: [schedules]
+      properties:
+        schedules:
+          type: array
+          items: {$ref: '#/components/schemas/ReportSchedule'}
+
+    CreateReportScheduleRequest:
+      type: object
+      required: [name, kind, frequency, channel_id]
+      properties:
+        name: {type: string}
+        kind:
+          type: string
+          enum: [executive, attestation, exception, remediation]
+        group_id: {type: string, format: uuid}
+        framework: {type: string}
+        period_days: {type: integer, minimum: 1, maximum: 365}
+        frequency:
+          type: string
+          enum: [daily, weekly, monthly]
+        hour: {type: integer, minimum: 0, maximum: 23, description: Defaults to 6.}
+        weekday: {type: integer, minimum: 0, maximum: 6, description: Required for weekly.}
+        day_of_month: {type: integer, minimum: 1, maximum: 28, description: Required for monthly.}
+        channel_id: {type: string, format: uuid, description: An email notification channel.}
+
+    UpdateReportScheduleRequest:
+      type: object
+      required: [enabled]
+      properties:
+        enabled: {type: boolean}
 
     ReportListResponse:
       type: object

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/connprofile"
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/cron"
 	"github.com/Hanalyx/openwatch/internal/knownhosts"
 	"github.com/google/uuid"
 
@@ -53,6 +54,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/posture"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/report"
+	"github.com/Hanalyx/openwatch/internal/reportschedule"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	compsched "github.com/Hanalyx/openwatch/internal/scheduler"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
@@ -65,6 +67,11 @@ import (
 	"github.com/Hanalyx/openwatch/internal/version"
 	"github.com/Hanalyx/openwatch/internal/worker"
 )
+
+// reportScheduleTickInterval is how often the scheduled-report dispatcher
+// checks for due schedules. A minute is fine: schedule cadences are
+// daily/weekly/monthly, so sub-minute precision is unnecessary.
+const reportScheduleTickInterval = time.Minute
 
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
@@ -658,6 +665,14 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		WithAsyncRender()
 	reportRenderProc := report.NewRenderProcessor(reportSvc, bus)
 
+	// Scheduled reports: a cron dispatcher generates due schedules and
+	// emails the rendered PDF through an email notification channel.
+	reportScheduleSvc := reportschedule.NewService(pool)
+	reportScheduleCron := cron.New(reportScheduleTickInterval,
+		reportschedule.NewDispatcher(reportScheduleSvc, reportSvc, notifSvc).Tick)
+	reportScheduleCron.Start(ctx)
+	defer reportScheduleCron.Stop()
+
 	srv := server.New(cfg, pool).
 		WithConnectivityConfig(cfgStore, liveSvc).
 		WithDiscovery(discoSvc).
@@ -680,6 +695,7 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		WithRemediation(remediationSvc).
 		WithGroups(group.NewService(pool)).
 		WithReports(reportSvc).
+		WithReportSchedules(reportScheduleSvc).
 		WithReportWorker(reportRenderProc).
 		WithScanResults(scanresult.NewReader(pool)).
 		WithNotifications(notifSvc)

--- a/docs/engineering/reports_design.md
+++ b/docs/engineering/reports_design.md
@@ -354,10 +354,18 @@ feel instant.** Build them aware of each other.
   selector for the kind. Migration 0045 admits `kind='remediation'`. Spec:
   `api-reports` v1.13.0 (C-18 / AC-24), `frontend-reports` v1.10.0
   (C-13 / AC-14).
-- **C3 — Scheduled dispatcher.** *(REMAINING.)* **Scheduled** reports +
-  **email delivery** (notification-channel dispatch); activates the
-  Scheduled tab. Spec: `system-report-schedule`, `frontend-reports`
-  Scheduled tab.
+- **C3 — Scheduled dispatcher.** *(SHIPPED 2026-06-22, PR #659.)* A
+  `report_schedules` row (migration 0046) recurs a report on a
+  daily/weekly/monthly cadence and emails its PDF through an email
+  notification channel. A cron dispatcher (`internal/reportschedule`,
+  ticking each minute) claims due schedules, generates the report, renders
+  the PDF, emails it as a MIME-multipart attachment
+  (`notification.Service.SendReportEmail`), records last_run/last_status,
+  and advances next_run_at. The Scheduled tab is live (create form +
+  pause/resume + delete over the host:read/host:write CRUD endpoints). Spec:
+  `system-report-schedule` v1.0.0, `frontend-reports` v1.11.0 (C-14 /
+  AC-15). Chosen design: daily/weekly/monthly cadence (not cron),
+  email-with-PDF-attached delivery, recipients from the email channel's To.
 
 ### Phase D — GRC depth
 - **POA&M** (OSCAL) — open findings → milestones → target dates,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1601,6 +1601,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/reports/schedules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the report delivery schedules
+         * @description Returns every scheduled report (daily/weekly/monthly cadence that
+         *     generates a report and emails its PDF through a notification
+         *     channel), newest first. RBAC: host:read. Spec system-report-schedule.
+         */
+        get: operations["getReportSchedules"];
+        put?: never;
+        /**
+         * Create a report delivery schedule
+         * @description Schedules a report to generate on a daily/weekly/monthly cadence and
+         *     email its PDF through an email notification channel. RBAC:
+         *     host:write. Spec system-report-schedule.
+         */
+        post: operations["createReportSchedule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/reports/schedules/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete a report schedule
+         * @description Removes a schedule (does not delete reports it already generated).
+         *     RBAC: host:write. Spec system-report-schedule.
+         */
+        delete: operations["deleteReportSchedule"];
+        options?: never;
+        head?: never;
+        /**
+         * Enable or disable a report schedule
+         * @description Toggles a schedule's enabled flag. Re-enabling recomputes the next
+         *     run from now. RBAC: host:write. Spec system-report-schedule.
+         */
+        patch: operations["updateReportSchedule"];
+        trace?: never;
+    };
     "/api/v1/reports/signing-key": {
         parameters: {
             query?: never;
@@ -3658,6 +3712,71 @@ export interface components {
         };
         ReportFrameworksResponse: {
             frameworks: components["schemas"]["ReportFramework"][];
+        };
+        ReportSchedule: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** @enum {string} */
+            kind: "executive" | "attestation" | "exception" | "remediation";
+            /**
+             * Format: uuid
+             * @description Optional group scope.
+             */
+            group_id?: string;
+            /** @description Optional framework lens. */
+            framework?: string;
+            /** @description Period window for the remediation kind. */
+            period_days?: number;
+            /** @enum {string} */
+            frequency: "daily" | "weekly" | "monthly";
+            /** @description Hour of day (UTC) to run (0-23). */
+            hour: number;
+            /** @description 0=Sunday..6=Saturday */
+            weekday?: number;
+            /** @description 1-28 */
+            day_of_month?: number;
+            /**
+             * Format: uuid
+             * @description The email channel used for delivery.
+             */
+            channel_id: string;
+            enabled: boolean;
+            /** Format: date-time */
+            next_run_at: string;
+            /** Format: date-time */
+            last_run_at?: string;
+            last_status?: string;
+            /** Format: date-time */
+            created_at: string;
+        };
+        ReportScheduleList: {
+            schedules: components["schemas"]["ReportSchedule"][];
+        };
+        CreateReportScheduleRequest: {
+            name: string;
+            /** @enum {string} */
+            kind: "executive" | "attestation" | "exception" | "remediation";
+            /** Format: uuid */
+            group_id?: string;
+            framework?: string;
+            period_days?: number;
+            /** @enum {string} */
+            frequency: "daily" | "weekly" | "monthly";
+            /** @description Defaults to 6. */
+            hour?: number;
+            /** @description Required for weekly. */
+            weekday?: number;
+            /** @description Required for monthly. */
+            day_of_month?: number;
+            /**
+             * Format: uuid
+             * @description An email notification channel.
+             */
+            channel_id: string;
+        };
+        UpdateReportScheduleRequest: {
+            enabled: boolean;
         };
         ReportListResponse: {
             reports: components["schemas"]["Report"][];
@@ -7687,6 +7806,195 @@ export interface operations {
             };
             /** @description Caller lacks host:read permission */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getReportSchedules: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The schedules */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReportScheduleList"];
+                };
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    createReportSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateReportScheduleRequest"];
+            };
+        };
+        responses: {
+            /** @description The created schedule */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReportSchedule"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    deleteReportSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Schedule not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    updateReportSchedule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateReportScheduleRequest"];
+            };
+        };
+        responses: {
+            /** @description The updated schedule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReportSchedule"];
+                };
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Schedule not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/pages/reports/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ReportsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/api/client';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
@@ -526,7 +526,7 @@ export function ReportsPage() {
         />
       )}
       {tab === 'templates' && <ComingSoon what="Templates" />}
-      {tab === 'scheduled' && <ComingSoon what="Scheduled" />}
+      {tab === 'scheduled' && <SchedulesTab canGenerate={canGenerate} />}
 
       {selectedId && (
         <ReportDetail
@@ -1565,6 +1565,328 @@ function RemediationBody({ content }: { content: RemediationContent }) {
     </div>
   );
 }
+
+type ReportScheduleRow = components['schemas']['ReportSchedule'];
+
+// SchedulesTab manages report delivery schedules: a list with enable/disable
+// + delete, and a create form. Delivery is by email through an email
+// notification channel; the channel picker lists the email channels.
+function SchedulesTab({ canGenerate }: { canGenerate: boolean }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<'executive' | 'attestation' | 'exception' | 'remediation'>(
+    'attestation',
+  );
+  const [frequency, setFrequency] = useState<'daily' | 'weekly' | 'monthly'>('weekly');
+  const [weekday, setWeekday] = useState(1);
+  const [dayOfMonth, setDayOfMonth] = useState(1);
+  const [channelId, setChannelId] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const schedulesQ = useQuery({
+    queryKey: ['report-schedules'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/reports/schedules', {});
+      if (error || !response.ok)
+        throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
+      return data!;
+    },
+  });
+
+  // Email channels back the delivery picker (only email can carry a PDF).
+  const channelsQ = useQuery({
+    queryKey: ['notification-channels'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/notifications/channels', {});
+      if (error || !response.ok)
+        throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
+      return data!;
+    },
+    enabled: canGenerate,
+  });
+  const emailChannels = (channelsQ.data?.channels ?? []).filter((c) => c.type === 'email');
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const body: {
+        name: string;
+        kind: typeof kind;
+        frequency: typeof frequency;
+        channel_id: string;
+        weekday?: number;
+        day_of_month?: number;
+      } = { name, kind, frequency, channel_id: channelId };
+      if (frequency === 'weekly') body.weekday = weekday;
+      if (frequency === 'monthly') body.day_of_month = dayOfMonth;
+      const { data, error, response } = await api.POST('/api/v1/reports/schedules', { body });
+      if (error || !response.ok)
+        throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
+      return data!;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['report-schedules'] });
+      setName('');
+      setFormError(null);
+    },
+    onError: (e) => setFormError(e instanceof Error ? e.message : 'Failed to create schedule'),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
+      const { error, response } = await api.PATCH('/api/v1/reports/schedules/{id}', {
+        params: { path: { id } },
+        body: { enabled },
+      });
+      if (error || !response.ok)
+        throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['report-schedules'] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const { error, response } = await api.DELETE('/api/v1/reports/schedules/{id}', {
+        params: { path: { id } },
+      });
+      if (error || !response.ok)
+        throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['report-schedules'] }),
+  });
+
+  const schedules = schedulesQ.data?.schedules ?? [];
+  const canSubmit = canGenerate && name.trim() !== '' && channelId !== '';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      {canGenerate && (
+        <Panel>
+          <div style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--ow-fg-1)' }}>
+              New schedule
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'center' }}>
+              <input
+                aria-label="Schedule name"
+                placeholder="Schedule name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                style={scheduleInputStyle}
+              />
+              <select
+                aria-label="Schedule kind"
+                value={kind}
+                onChange={(e) => setKind(e.target.value as typeof kind)}
+                style={scheduleInputStyle}
+              >
+                <option value="executive">Executive</option>
+                <option value="attestation">Attestation</option>
+                <option value="exception">Exception Register</option>
+                <option value="remediation">Remediation Activity</option>
+              </select>
+              <select
+                aria-label="Schedule frequency"
+                value={frequency}
+                onChange={(e) => setFrequency(e.target.value as typeof frequency)}
+                style={scheduleInputStyle}
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+              {frequency === 'weekly' && (
+                <select
+                  aria-label="Weekday"
+                  value={weekday}
+                  onChange={(e) => setWeekday(Number(e.target.value))}
+                  style={scheduleInputStyle}
+                >
+                  {[
+                    'Sunday',
+                    'Monday',
+                    'Tuesday',
+                    'Wednesday',
+                    'Thursday',
+                    'Friday',
+                    'Saturday',
+                  ].map((d, i) => (
+                    <option key={d} value={i}>
+                      {d}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {frequency === 'monthly' && (
+                <select
+                  aria-label="Day of month"
+                  value={dayOfMonth}
+                  onChange={(e) => setDayOfMonth(Number(e.target.value))}
+                  style={scheduleInputStyle}
+                >
+                  {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
+                    <option key={d} value={d}>
+                      Day {d}
+                    </option>
+                  ))}
+                </select>
+              )}
+              <select
+                aria-label="Delivery channel"
+                value={channelId}
+                onChange={(e) => setChannelId(e.target.value)}
+                style={scheduleInputStyle}
+              >
+                <option value="">Select email channel</option>
+                {emailChannels.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                disabled={!canSubmit || createMutation.isPending}
+                onClick={() => createMutation.mutate()}
+                style={{
+                  height: 34,
+                  padding: '0 16px',
+                  borderRadius: 6,
+                  border: '1px solid var(--ow-info)',
+                  background: canSubmit ? 'var(--ow-info)' : 'var(--ow-bg-2)',
+                  color: canSubmit ? '#0a1424' : 'var(--ow-fg-3)',
+                  fontFamily: 'inherit',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: canSubmit ? 'pointer' : 'default',
+                }}
+              >
+                {createMutation.isPending ? 'Saving…' : 'Create schedule'}
+              </button>
+            </div>
+            {emailChannels.length === 0 && (
+              <div style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>
+                No email notification channels yet. Add one in Settings to deliver scheduled
+                reports.
+              </div>
+            )}
+            {formError && (
+              <div style={{ fontSize: 12.5, color: 'var(--ow-crit)' }}>{formError}</div>
+            )}
+          </div>
+        </Panel>
+      )}
+
+      {schedulesQ.isPending ? (
+        <State kind="loading" text="Loading schedules" />
+      ) : schedulesQ.isError ? (
+        <State kind="error" text={apiErrorMessage(schedulesQ.error, 'Failed to load schedules')} />
+      ) : schedules.length === 0 ? (
+        <State kind="empty" text="No schedules yet." />
+      ) : (
+        <Panel>
+          <Row head cols="1.4fr 1fr 1fr 100px 90px">
+            <span>Schedule</span>
+            <span>Cadence</span>
+            <span>Next run</span>
+            <span>Status</span>
+            <span />
+          </Row>
+          {schedules.map((s, i) => (
+            <ScheduleRow
+              key={s.id}
+              schedule={s}
+              first={i === 0}
+              canGenerate={canGenerate}
+              onToggle={(enabled) => toggleMutation.mutate({ id: s.id, enabled })}
+              onDelete={() => deleteMutation.mutate(s.id)}
+            />
+          ))}
+        </Panel>
+      )}
+    </div>
+  );
+}
+
+function ScheduleRow({
+  schedule,
+  first,
+  canGenerate,
+  onToggle,
+  onDelete,
+}: {
+  schedule: ReportScheduleRow;
+  first: boolean;
+  canGenerate: boolean;
+  onToggle: (enabled: boolean) => void;
+  onDelete: () => void;
+}) {
+  const cadence =
+    schedule.frequency === 'weekly'
+      ? `Weekly (day ${schedule.weekday ?? 0})`
+      : schedule.frequency === 'monthly'
+        ? `Monthly (day ${schedule.day_of_month ?? 1})`
+        : 'Daily';
+  return (
+    <Row cols="1.4fr 1fr 1fr 100px 90px" first={first}>
+      <span style={{ display: 'flex', flexDirection: 'column' }}>
+        <span style={{ fontSize: 13, color: 'var(--ow-fg-1)' }}>{schedule.name}</span>
+        <span style={{ fontSize: 11, color: 'var(--ow-fg-3)' }}>{kindLabel(schedule.kind)}</span>
+      </span>
+      <span style={{ fontSize: 12.5, color: 'var(--ow-fg-2)' }}>{cadence}</span>
+      <span style={{ fontSize: 12.5, color: 'var(--ow-fg-2)' }}>
+        {formatDate(schedule.next_run_at)}
+      </span>
+      <span style={{ fontSize: 12, color: schedule.enabled ? 'var(--ow-ok)' : 'var(--ow-fg-3)' }}>
+        {schedule.enabled ? 'Active' : 'Paused'}
+      </span>
+      <span style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+        {canGenerate && (
+          <>
+            <button
+              type="button"
+              onClick={() => onToggle(!schedule.enabled)}
+              title={schedule.enabled ? 'Pause' : 'Resume'}
+              style={scheduleActionStyle}
+            >
+              {schedule.enabled ? 'Pause' : 'Resume'}
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              title="Delete schedule"
+              style={{ ...scheduleActionStyle, color: 'var(--ow-crit)' }}
+            >
+              Delete
+            </button>
+          </>
+        )}
+      </span>
+    </Row>
+  );
+}
+
+const scheduleInputStyle: CSSProperties = {
+  height: 34,
+  padding: '0 10px',
+  borderRadius: 'var(--ow-radius-sm, 6px)',
+  border: '1px solid var(--ow-line)',
+  background: 'var(--ow-bg-2)',
+  color: 'var(--ow-fg-0)',
+  fontFamily: 'inherit',
+  fontSize: 13,
+};
+
+const scheduleActionStyle: CSSProperties = {
+  height: 26,
+  padding: '0 8px',
+  borderRadius: 5,
+  border: '1px solid var(--ow-line)',
+  background: 'var(--ow-bg-1)',
+  color: 'var(--ow-fg-2)',
+  fontFamily: 'inherit',
+  fontSize: 11,
+  cursor: 'pointer',
+};
 
 function ComingSoon({ what }: { what: string }) {
   return (

--- a/frontend/tests/pages/reports.test.ts
+++ b/frontend/tests/pages/reports.test.ts
@@ -19,6 +19,7 @@
 //          for attestation, ExecutiveBody(asExecutiveContent) otherwise
 //   AC-13  exception register kind: selector option + ExceptionBody(asExceptionContent)
 //   AC-14  remediation activity kind: period selector + RemediationBody(asRemediationContent)
+//   AC-15  Scheduled tab manages schedules (list/create/toggle/delete)
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -75,11 +76,11 @@ describe('frontend-reports — reports library page', () => {
   });
 
   // @ac AC-03
-  test('frontend-reports/AC-03 — deferred Templates/Scheduled + honest states', () => {
-    // Templates and Scheduled tabs render the deferred ComingSoon state.
+  test('frontend-reports/AC-03 — deferred Templates + honest states', () => {
+    // The Templates tab renders the deferred ComingSoon state (the Scheduled
+    // tab is now live, see AC-15).
     expect(PAGE_SRC).toContain('ComingSoon');
     expect(PAGE_SRC).toContain('what="Templates"');
-    expect(PAGE_SRC).toContain('what="Scheduled"');
     expect(PAGE_SRC.toLowerCase()).toContain('coming soon');
     // Honest loading / empty / error states wired off the query.
     expect(PAGE_SRC).toContain('reportsQ.isPending');
@@ -273,13 +274,34 @@ describe('frontend-reports — reports library page', () => {
     expect(PAGE_SRC).toMatch(/s\.rolled_back/);
   });
 
+  // @ac AC-15
+  test('frontend-reports/AC-15 — Scheduled tab manages report schedules', () => {
+    // The Scheduled tab renders the SchedulesTab (not ComingSoon).
+    expect(PAGE_SRC).toMatch(/tab === 'scheduled' && <SchedulesTab/);
+    expect(PAGE_SRC).toContain('function SchedulesTab');
+    // It queries the schedules + the notification channels (email picker).
+    expect(PAGE_SRC).toContain("queryKey: ['report-schedules']");
+    expect(PAGE_SRC).toContain("api.GET('/api/v1/reports/schedules'");
+    expect(PAGE_SRC).toContain("queryKey: ['notification-channels']");
+    expect(PAGE_SRC).toMatch(/filter\(\(c\) => c\.type === 'email'\)/);
+    // Create / toggle / delete mutations over the schedule endpoints.
+    expect(PAGE_SRC).toContain("api.POST('/api/v1/reports/schedules'");
+    expect(PAGE_SRC).toContain("api.PATCH('/api/v1/reports/schedules/{id}'");
+    expect(PAGE_SRC).toContain("api.DELETE('/api/v1/reports/schedules/{id}'");
+    // Mutations invalidate the schedules query; create is host:write gated.
+    expect(PAGE_SRC).toContain("invalidateQueries({ queryKey: ['report-schedules'] })");
+    expect(PAGE_SRC).toMatch(/canSubmit = canGenerate/);
+  });
+
   // @ac AC-04
   test('frontend-reports/AC-04 — generate is the only mutation, tokens, no em-dash', () => {
-    // The only mutating call is the generate POST; no PUT/DELETE.
+    // The Library generate is a POST; the Scheduled tab also mutates schedules
+    // (create POST, toggle PATCH, delete DELETE) - the assertion below is
+    // scoped to the report-generation surface, not the schedule CRUD.
     expect(PAGE_SRC.includes('api.PUT')).toBe(false);
-    expect(PAGE_SRC.includes('api.DELETE')).toBe(false);
+    // Two POSTs: the Library generate and the Scheduled-tab schedule create.
     const posts = PAGE_SRC.split('api.POST(').length - 1;
-    expect(posts).toBe(1);
+    expect(posts).toBe(2);
     // Chrome is styled with --ow-* tokens, not raw hex literals.
     expect(PAGE_SRC).toContain('var(--ow-bg-1)');
     expect(PAGE_SRC).toContain('var(--ow-line)');

--- a/internal/db/migrations/0046_report_schedules.sql
+++ b/internal/db/migrations/0046_report_schedules.sql
@@ -1,0 +1,41 @@
+-- 0046_report_schedules.sql
+--
+-- Reports C3: scheduled reports. A report_schedules row recurs a report
+-- generation on a daily/weekly/monthly cadence and delivers the rendered
+-- PDF by email through an existing email notification channel. The cron
+-- dispatcher claims due schedules (next_run_at <= now), generates the
+-- report, renders its PDF, emails it, and advances next_run_at.
+--
+-- Spec: system-report-schedule v1.0.0.
+
+-- +goose Up
+CREATE TABLE report_schedules (
+    id            UUID PRIMARY KEY,
+    name          TEXT NOT NULL,
+    kind          TEXT NOT NULL
+                  CHECK (kind IN ('executive', 'attestation', 'exception', 'remediation')),
+    -- scope mirrors a GenerateRequest: {group_id, framework, period_days}.
+    scope         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    frequency     TEXT NOT NULL CHECK (frequency IN ('daily', 'weekly', 'monthly')),
+    -- hour of day (UTC) to run; weekday (0=Sun..6=Sat) for weekly;
+    -- day_of_month (1..28) for monthly.
+    hour          INTEGER NOT NULL DEFAULT 6 CHECK (hour >= 0 AND hour <= 23),
+    weekday       INTEGER CHECK (weekday >= 0 AND weekday <= 6),
+    day_of_month  INTEGER CHECK (day_of_month >= 1 AND day_of_month <= 28),
+    -- the email notification channel that provides SMTP transport + recipients.
+    channel_id    UUID NOT NULL REFERENCES notification_channels(id) ON DELETE RESTRICT,
+    enabled       BOOLEAN NOT NULL DEFAULT true,
+    next_run_at   TIMESTAMPTZ NOT NULL,
+    last_run_at   TIMESTAMPTZ,
+    last_status   TEXT,
+    created_by    UUID REFERENCES users(id),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- The dispatcher scans for due schedules; this index serves it.
+CREATE INDEX idx_report_schedules_due ON report_schedules (next_run_at)
+    WHERE enabled;
+
+-- +goose Down
+DROP TABLE IF EXISTS report_schedules;

--- a/internal/notification/report_email.go
+++ b/internal/notification/report_email.go
@@ -1,0 +1,100 @@
+package notification
+
+// Report email delivery: a MIME-multipart email carrying a rendered report
+// PDF as an attachment, sent through an existing EMAIL channel's SMTP
+// config to that channel's configured recipients. The scheduled-report
+// dispatcher (internal/reportschedule) uses this; the alert path
+// (delivery.go) stays plain-text. Only email channels can carry an
+// attachment, so a non-email channel is rejected.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"mime/multipart"
+	"net"
+	"net/smtp"
+	"net/textproto"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// ErrNotEmailChannel is returned when a report email is requested for a
+// non-email channel (only email channels carry attachments).
+var ErrNotEmailChannel = errors.New("notification: channel is not an email channel")
+
+// SendReportEmail delivers a report PDF as a MIME-multipart attachment
+// through the email channel's SMTP config, to the channel's recipients.
+func (s *Service) SendReportEmail(ctx context.Context, channelID uuid.UUID, subject, body, filename string, attachment []byte) error {
+	ch, err := s.getDecrypted(ctx, channelID)
+	if err != nil {
+		return err
+	}
+	if ch.Type != TypeEmail {
+		return ErrNotEmailChannel
+	}
+	cfg := ch.Config
+	if len(cfg.To) == 0 {
+		return fmt.Errorf("notification: email channel %q has no recipients", ch.Name)
+	}
+	msg := buildReportEmail(cfg.From, cfg.To, subject, body, filename, attachment)
+	addr := net.JoinHostPort(cfg.SMTPHost, strconv.Itoa(cfg.SMTPPort))
+	var auth smtp.Auth
+	if cfg.Username != "" {
+		auth = smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.SMTPHost)
+	}
+	if err := smtp.SendMail(addr, auth, cfg.From, cfg.To, msg); err != nil {
+		return fmt.Errorf("notification: report email via %q: %w", ch.Name, err)
+	}
+	return nil
+}
+
+// buildReportEmail assembles a multipart/mixed RFC 5322 message: a
+// text/plain body part and a base64-encoded application/pdf attachment.
+func buildReportEmail(from string, to []string, subject, body, filename string, attachment []byte) []byte {
+	var parts bytes.Buffer
+	w := multipart.NewWriter(&parts)
+
+	textHdr := textproto.MIMEHeader{}
+	textHdr.Set("Content-Type", "text/plain; charset=utf-8")
+	if tw, err := w.CreatePart(textHdr); err == nil {
+		_, _ = tw.Write([]byte(body))
+	}
+
+	attHdr := textproto.MIMEHeader{}
+	attHdr.Set("Content-Type", "application/pdf")
+	attHdr.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	attHdr.Set("Content-Transfer-Encoding", "base64")
+	if aw, err := w.CreatePart(attHdr); err == nil {
+		_, _ = aw.Write([]byte(wrap76(base64.StdEncoding.EncodeToString(attachment))))
+	}
+	_ = w.Close()
+
+	var msg bytes.Buffer
+	fmt.Fprintf(&msg, "From: %s\r\n", from)
+	fmt.Fprintf(&msg, "To: %s\r\n", strings.Join(to, ", "))
+	fmt.Fprintf(&msg, "Subject: %s\r\n", subject)
+	msg.WriteString("MIME-Version: 1.0\r\n")
+	fmt.Fprintf(&msg, "Content-Type: multipart/mixed; boundary=%s\r\n", w.Boundary())
+	msg.WriteString("\r\n")
+	msg.Write(parts.Bytes())
+	return msg.Bytes()
+}
+
+// wrap76 breaks a base64 string into 76-character CRLF-terminated lines
+// (RFC 2045).
+func wrap76(s string) string {
+	var b strings.Builder
+	for len(s) > 76 {
+		b.WriteString(s[:76])
+		b.WriteString("\r\n")
+		s = s[76:]
+	}
+	b.WriteString(s)
+	b.WriteString("\r\n")
+	return b.String()
+}

--- a/internal/notification/report_email_test.go
+++ b/internal/notification/report_email_test.go
@@ -1,0 +1,52 @@
+// @spec system-report-schedule
+//
+// AC traceability:
+//   AC-03  buildReportEmail produces a multipart/mixed message with a
+//          text body part and a base64 application/pdf attachment
+
+package notification
+
+import (
+	"strings"
+	"testing"
+)
+
+// @ac AC-03
+func TestBuildReportEmail_MultipartAttachment(t *testing.T) {
+	t.Run("system-report-schedule/AC-03", testBuildReportEmail)
+}
+
+func testBuildReportEmail(t *testing.T) {
+	msg := string(buildReportEmail(
+		"openwatch@corp.com", []string{"auditor@corp.com"},
+		"Framework Attestation - 2026-06-22",
+		"Your scheduled report is attached.",
+		"openwatch-attestation-2026-06-22.pdf",
+		[]byte("%PDF-1.4 fake pdf bytes"),
+	))
+
+	if !strings.Contains(msg, "To: auditor@corp.com") {
+		t.Errorf("missing To header")
+	}
+	if !strings.Contains(msg, "Subject: Framework Attestation - 2026-06-22") {
+		t.Errorf("missing Subject header")
+	}
+	if !strings.Contains(msg, "Content-Type: multipart/mixed; boundary=") {
+		t.Errorf("not multipart/mixed: %q", msg[:200])
+	}
+	// Text body part.
+	if !strings.Contains(msg, "Content-Type: text/plain; charset=utf-8") ||
+		!strings.Contains(msg, "Your scheduled report is attached.") {
+		t.Errorf("missing text body part")
+	}
+	// PDF attachment part: application/pdf, base64, filename.
+	if !strings.Contains(msg, "Content-Type: application/pdf") {
+		t.Errorf("missing pdf content-type")
+	}
+	if !strings.Contains(msg, "Content-Transfer-Encoding: base64") {
+		t.Errorf("missing base64 encoding")
+	}
+	if !strings.Contains(msg, `filename="openwatch-attestation-2026-06-22.pdf"`) {
+		t.Errorf("missing attachment filename")
+	}
+}

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -25,7 +25,11 @@ func freshService(t *testing.T) (*Service, *pgxpool.Pool) {
 	}
 	t.Cleanup(secretkey.Reset)
 	ctx := context.Background()
-	_, _ = pool.Exec(ctx, "TRUNCATE TABLE notification_channels")
+	// CASCADE because report_schedules (migration 0046) references
+	// notification_channels; a plain TRUNCATE would fail on the FK and
+	// (since the error is ignored) leave stale rows encrypted with a prior
+	// ephemeral key, breaking decrypt in later tests.
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE notification_channels CASCADE")
 	return NewService(pool), pool
 }
 

--- a/internal/reportschedule/dispatcher.go
+++ b/internal/reportschedule/dispatcher.go
@@ -1,0 +1,91 @@
+package reportschedule
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/report"
+)
+
+// Generator generates a report and renders a face. Satisfied by
+// *report.Service; an interface so the dispatcher is testable without a
+// real report service.
+type Generator interface {
+	Generate(ctx context.Context, generatedBy string, req report.GenerateRequest) (report.Report, error)
+	Export(ctx context.Context, id uuid.UUID, face string) ([]byte, string, error)
+}
+
+// Deliverer sends a report PDF as an email attachment through a channel.
+// Satisfied by *notification.Service (SendReportEmail).
+type Deliverer interface {
+	SendReportEmail(ctx context.Context, channelID uuid.UUID, subject, body, filename string, attachment []byte) error
+}
+
+// Dispatcher runs due schedules: generate -> render PDF -> email -> advance.
+type Dispatcher struct {
+	svc     *Service
+	gen     Generator
+	deliver Deliverer
+}
+
+// NewDispatcher wires the dispatcher over the schedule service, a report
+// generator, and an email deliverer.
+func NewDispatcher(svc *Service, gen Generator, deliver Deliverer) *Dispatcher {
+	return &Dispatcher{svc: svc, gen: gen, deliver: deliver}
+}
+
+// Tick processes every due schedule once. It is the cron TickFunc; an error
+// from one schedule is recorded on that schedule (last_status) and does not
+// abort the others. The return error is non-nil only on a query failure.
+func (d *Dispatcher) Tick(ctx context.Context) error {
+	now := time.Now().UTC()
+	due, err := d.svc.Due(ctx, now)
+	if err != nil {
+		return err
+	}
+	for _, sch := range due {
+		status := "ok"
+		if rerr := d.run(ctx, sch); rerr != nil {
+			status = "failed: " + rerr.Error()
+			slog.WarnContext(ctx, "report schedule run failed",
+				slog.String("schedule_id", sch.ID.String()), slog.String("error", rerr.Error()))
+		}
+		// Advance from now so a slow/failed run does not immediately re-fire.
+		next := ComputeNextRun(sch.Frequency, sch.Hour, sch.Weekday, sch.DayOfMonth, time.Now().UTC())
+		if merr := d.svc.MarkRun(ctx, sch.ID, next, status); merr != nil {
+			slog.WarnContext(ctx, "report schedule mark-run failed",
+				slog.String("schedule_id", sch.ID.String()), slog.String("error", merr.Error()))
+		}
+	}
+	return nil
+}
+
+// run generates the scheduled report, renders its PDF face, and emails it.
+func (d *Dispatcher) run(ctx context.Context, sch Schedule) error {
+	req := report.GenerateRequest{
+		Kind:       report.Kind(sch.Kind),
+		GroupID:    sch.Scope.GroupID,
+		Framework:  sch.Scope.Framework,
+		PeriodDays: sch.Scope.PeriodDays,
+	}
+	rep, err := d.gen.Generate(ctx, "scheduler", req)
+	if err != nil {
+		return fmt.Errorf("generate: %w", err)
+	}
+	pdf, _, err := d.gen.Export(ctx, rep.ID, report.FacePDF)
+	if err != nil {
+		return fmt.Errorf("render pdf: %w", err)
+	}
+	filename := report.ExportFilename(rep, report.FacePDF)
+	subject := fmt.Sprintf("%s - %s", rep.Title, rep.DataAsOf.Format("2006-01-02"))
+	body := fmt.Sprintf("Your scheduled OpenWatch report is attached.\n\n%s\nScope: %s\nData as of: %s\n",
+		rep.Title, rep.ScopeLabel, rep.DataAsOf.Format("2006-01-02 15:04 MST"))
+	if err := d.deliver.SendReportEmail(ctx, sch.ChannelID, subject, body, filename, pdf); err != nil {
+		return fmt.Errorf("deliver: %w", err)
+	}
+	return nil
+}

--- a/internal/reportschedule/schedule_db_test.go
+++ b/internal/reportschedule/schedule_db_test.go
@@ -1,0 +1,179 @@
+// @spec system-report-schedule
+//
+// AC traceability:
+//   AC-01  ComputeNextRun honours daily/weekly/monthly cadence at the hour
+//   AC-02  Create computes a future next_run; Due returns past-due enabled
+//          schedules; the dispatcher generates + renders + delivers + advances
+
+package reportschedule
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+	"github.com/Hanalyx/openwatch/internal/report"
+)
+
+func intp(i int) *int { return &i }
+
+// @ac AC-01
+func TestComputeNextRun(t *testing.T) {
+	t.Run("system-report-schedule/AC-01", testComputeNextRun)
+}
+
+func testComputeNextRun(t *testing.T) {
+	// Daily: 06:00 the next day when after today's 06:00.
+	from := time.Date(2026, 6, 22, 9, 0, 0, 0, time.UTC) // 09:00, past 06:00
+	next := ComputeNextRun(Daily, 6, nil, nil, from)
+	if next.Hour() != 6 || next.Day() != 23 {
+		t.Errorf("daily next = %v, want 2026-06-23 06:00", next)
+	}
+	// Daily: today's 06:00 when still before it.
+	from2 := time.Date(2026, 6, 22, 3, 0, 0, 0, time.UTC)
+	if n := ComputeNextRun(Daily, 6, nil, nil, from2); n.Day() != 22 || n.Hour() != 6 {
+		t.Errorf("daily (before hour) next = %v, want same-day 06:00", n)
+	}
+	// Weekly: next Monday (weekday 1). 2026-06-22 is a Monday; from 09:00
+	// it should advance to the following Monday (06-29).
+	wk := ComputeNextRun(Weekly, 6, intp(1), nil, from)
+	if wk.Weekday() != time.Monday || wk.Day() != 29 {
+		t.Errorf("weekly next = %v, want Monday 2026-06-29", wk)
+	}
+	// Monthly: day 1 next month (today is the 22nd).
+	mo := ComputeNextRun(Monthly, 6, nil, intp(1), from)
+	if mo.Day() != 1 || mo.Month() != time.July {
+		t.Errorf("monthly next = %v, want 2026-07-01", mo)
+	}
+}
+
+// fakeGen returns a fixed report + PDF bytes without touching the DB.
+type fakeGen struct{ exported bool }
+
+func (f *fakeGen) Generate(ctx context.Context, by string, req report.GenerateRequest) (report.Report, error) {
+	return report.Report{
+		ID:         uuid.New(),
+		Title:      "Framework Attestation",
+		Kind:       report.KindAttestation,
+		ScopeLabel: "All hosts",
+		DataAsOf:   time.Now().UTC(),
+	}, nil
+}
+
+func (f *fakeGen) Export(ctx context.Context, id uuid.UUID, face string) ([]byte, string, error) {
+	f.exported = true
+	return []byte("%PDF-1.4 fake"), "application/pdf", nil
+}
+
+// fakeDeliver records the delivery call.
+type fakeDeliver struct {
+	called    bool
+	channelID uuid.UUID
+	filename  string
+	attach    []byte
+}
+
+func (d *fakeDeliver) SendReportEmail(ctx context.Context, channelID uuid.UUID, subject, body, filename string, attachment []byte) error {
+	d.called = true
+	d.channelID = channelID
+	d.filename = filename
+	d.attach = attachment
+	return nil
+}
+
+func freshPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool := dbtest.Pool(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		"TRUNCATE TABLE report_schedules CASCADE",
+		"TRUNCATE TABLE notification_channels CASCADE",
+	} {
+		if _, err := pool.Exec(ctx, stmt); err != nil {
+			t.Logf("truncate (ok if benign): %v", err)
+		}
+	}
+	return pool
+}
+
+// seedChannel inserts a minimal email channel (the dispatcher's delivery is
+// faked, so the encrypted config is never read; only the FK must resolve).
+func seedChannel(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO notification_channels (id, type, name, enabled, config_ciphertext)
+		 VALUES ($1, 'email', 'auditors', true, $2)`, id, []byte("x"))
+	if err != nil {
+		t.Fatalf("seed channel: %v", err)
+	}
+	return id
+}
+
+// @ac AC-02
+func TestDispatcher_RunsDueSchedule(t *testing.T) {
+	t.Run("system-report-schedule/AC-02", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		svc := NewService(pool)
+		ch := seedChannel(t, pool)
+
+		sch, err := svc.Create(ctx, CreateParams{
+			Name:      "weekly cis attestation",
+			Kind:      "attestation",
+			Scope:     Scope{Framework: "cis_rhel9"},
+			Frequency: Daily,
+			Hour:      6,
+			ChannelID: ch,
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		// Create computes a FUTURE next_run; it should not be due yet.
+		if due, _ := svc.Due(ctx, time.Now().UTC()); len(due) != 0 {
+			t.Fatalf("a fresh schedule should not be due, got %d", len(due))
+		}
+		// Backdate next_run_at so it is now due.
+		if _, err := pool.Exec(ctx,
+			`UPDATE report_schedules SET next_run_at = now() - interval '1 minute' WHERE id = $1`, sch.ID); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+
+		gen := &fakeGen{}
+		del := &fakeDeliver{}
+		disp := NewDispatcher(svc, gen, del)
+		if err := disp.Tick(ctx); err != nil {
+			t.Fatalf("Tick: %v", err)
+		}
+
+		if !gen.exported || !del.called {
+			t.Errorf("dispatcher did not generate+deliver (exported=%v called=%v)", gen.exported, del.called)
+		}
+		if del.channelID != ch {
+			t.Errorf("delivered to channel %s, want %s", del.channelID, ch)
+		}
+		if string(del.attach) != "%PDF-1.4 fake" {
+			t.Errorf("attachment = %q", del.attach)
+		}
+
+		// next_run advanced into the future, last_status ok.
+		after, err := svc.Get(ctx, sch.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if !after.NextRunAt.After(time.Now().UTC()) {
+			t.Errorf("next_run_at = %v, want future", after.NextRunAt)
+		}
+		if after.LastStatus != "ok" {
+			t.Errorf("last_status = %q, want ok", after.LastStatus)
+		}
+		// No longer due.
+		if due, _ := svc.Due(ctx, time.Now().UTC()); len(due) != 0 {
+			t.Errorf("schedule still due after run, got %d", len(due))
+		}
+	})
+}

--- a/internal/reportschedule/service.go
+++ b/internal/reportschedule/service.go
@@ -1,0 +1,181 @@
+package reportschedule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ErrNotFound is returned when a schedule id does not exist.
+var ErrNotFound = errors.New("reportschedule: not found")
+
+// Service owns CRUD over report_schedules.
+type Service struct {
+	pool *pgxpool.Pool
+}
+
+func NewService(pool *pgxpool.Pool) *Service { return &Service{pool: pool} }
+
+const scheduleCols = `id, name, kind, scope, frequency, hour, weekday, day_of_month,
+	channel_id, enabled, next_run_at, last_run_at, COALESCE(last_status, ''), created_by, created_at, updated_at`
+
+func scanSchedule(row pgx.Row) (Schedule, error) {
+	var s Schedule
+	var scopeRaw []byte
+	if err := row.Scan(&s.ID, &s.Name, &s.Kind, &scopeRaw, &s.Frequency, &s.Hour,
+		&s.Weekday, &s.DayOfMonth, &s.ChannelID, &s.Enabled, &s.NextRunAt,
+		&s.LastRunAt, &s.LastStatus, &s.CreatedBy, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		return Schedule{}, err
+	}
+	if len(scopeRaw) > 0 {
+		if err := json.Unmarshal(scopeRaw, &s.Scope); err != nil {
+			return Schedule{}, fmt.Errorf("reportschedule: decode scope: %w", err)
+		}
+	}
+	return s, nil
+}
+
+// Create inserts a schedule, computing its first next_run_at from now.
+func (s *Service) Create(ctx context.Context, p CreateParams) (Schedule, error) {
+	scopeRaw, err := json.Marshal(p.Scope)
+	if err != nil {
+		return Schedule{}, fmt.Errorf("reportschedule: marshal scope: %w", err)
+	}
+	next := ComputeNextRun(p.Frequency, p.Hour, p.Weekday, p.DayOfMonth, time.Now().UTC())
+	row := s.pool.QueryRow(ctx, `
+		INSERT INTO report_schedules
+			(id, name, kind, scope, frequency, hour, weekday, day_of_month, channel_id, next_run_at, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING `+scheduleCols,
+		uuid.New(), p.Name, p.Kind, scopeRaw, p.Frequency, p.Hour, p.Weekday, p.DayOfMonth,
+		p.ChannelID, next, p.CreatedBy)
+	return scanSchedule(row)
+}
+
+// List returns all schedules, newest first.
+func (s *Service) List(ctx context.Context) ([]Schedule, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+scheduleCols+` FROM report_schedules ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("reportschedule: list: %w", err)
+	}
+	defer rows.Close()
+	out := []Schedule{}
+	for rows.Next() {
+		sch, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sch)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one schedule by id, or ErrNotFound.
+func (s *Service) Get(ctx context.Context, id uuid.UUID) (Schedule, error) {
+	sch, err := scanSchedule(s.pool.QueryRow(ctx, `SELECT `+scheduleCols+` FROM report_schedules WHERE id = $1`, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Schedule{}, ErrNotFound
+	}
+	return sch, err
+}
+
+// Delete removes a schedule. A missing id is ErrNotFound.
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM report_schedules WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("reportschedule: delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetEnabled toggles a schedule. Re-enabling recomputes next_run_at from now
+// so a long-paused schedule does not fire for every missed run.
+func (s *Service) SetEnabled(ctx context.Context, id uuid.UUID, enabled bool) (Schedule, error) {
+	cur, err := s.Get(ctx, id)
+	if err != nil {
+		return Schedule{}, err
+	}
+	next := cur.NextRunAt
+	if enabled && !cur.Enabled {
+		next = ComputeNextRun(cur.Frequency, cur.Hour, cur.Weekday, cur.DayOfMonth, time.Now().UTC())
+	}
+	row := s.pool.QueryRow(ctx,
+		`UPDATE report_schedules SET enabled = $2, next_run_at = $3, updated_at = now() WHERE id = $1 RETURNING `+scheduleCols,
+		id, enabled, next)
+	return scanSchedule(row)
+}
+
+// Due returns the enabled schedules whose next_run_at has passed.
+func (s *Service) Due(ctx context.Context, now time.Time) ([]Schedule, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+scheduleCols+` FROM report_schedules WHERE enabled AND next_run_at <= $1 ORDER BY next_run_at`, now)
+	if err != nil {
+		return nil, fmt.Errorf("reportschedule: due: %w", err)
+	}
+	defer rows.Close()
+	out := []Schedule{}
+	for rows.Next() {
+		sch, err := scanSchedule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sch)
+	}
+	return out, rows.Err()
+}
+
+// MarkRun records a run outcome and advances next_run_at.
+func (s *Service) MarkRun(ctx context.Context, id uuid.UUID, next time.Time, status string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE report_schedules SET last_run_at = now(), last_status = $2, next_run_at = $3, updated_at = now() WHERE id = $1`,
+		id, status, next)
+	if err != nil {
+		return fmt.Errorf("reportschedule: mark run: %w", err)
+	}
+	return nil
+}
+
+// ComputeNextRun returns the next scheduled run strictly after `from`, at the
+// configured hour (UTC), honouring the cadence (weekday for weekly, day of
+// month for monthly; day_of_month is capped at 28 so every month has it).
+func ComputeNextRun(freq Frequency, hour int, weekday, dom *int, from time.Time) time.Time {
+	from = from.UTC()
+	switch freq {
+	case Weekly:
+		wd := 0
+		if weekday != nil {
+			wd = *weekday
+		}
+		c := time.Date(from.Year(), from.Month(), from.Day(), hour, 0, 0, 0, time.UTC)
+		c = c.AddDate(0, 0, (wd-int(c.Weekday())+7)%7)
+		if !c.After(from) {
+			c = c.AddDate(0, 0, 7)
+		}
+		return c
+	case Monthly:
+		d := 1
+		if dom != nil {
+			d = *dom
+		}
+		c := time.Date(from.Year(), from.Month(), d, hour, 0, 0, 0, time.UTC)
+		if !c.After(from) {
+			c = c.AddDate(0, 1, 0)
+		}
+		return c
+	default: // Daily
+		c := time.Date(from.Year(), from.Month(), from.Day(), hour, 0, 0, 0, time.UTC)
+		if !c.After(from) {
+			c = c.AddDate(0, 0, 1)
+		}
+		return c
+	}
+}

--- a/internal/reportschedule/types.go
+++ b/internal/reportschedule/types.go
@@ -1,0 +1,69 @@
+// Package reportschedule recurs report generation on a daily/weekly/monthly
+// cadence and delivers the rendered PDF by email. A report_schedules row
+// captures the report kind + scope, the cadence, and the email channel; the
+// cron dispatcher (dispatcher.go) claims due schedules, generates the
+// report, renders its PDF, emails it, and advances next_run_at.
+//
+// Spec: system-report-schedule.
+package reportschedule
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Frequency is the recurrence cadence.
+type Frequency string
+
+const (
+	Daily   Frequency = "daily"
+	Weekly  Frequency = "weekly"
+	Monthly Frequency = "monthly"
+)
+
+// IsValid reports whether f is a supported cadence.
+func (f Frequency) IsValid() bool {
+	return f == Daily || f == Weekly || f == Monthly
+}
+
+// Scope mirrors the report GenerateRequest scope (stored as the schedule's
+// scope JSONB): an optional group, framework lens, and period window.
+type Scope struct {
+	GroupID    *uuid.UUID `json:"group_id,omitempty"`
+	Framework  string     `json:"framework,omitempty"`
+	PeriodDays int        `json:"period_days,omitempty"`
+}
+
+// Schedule is one report_schedules row.
+type Schedule struct {
+	ID         uuid.UUID
+	Name       string
+	Kind       string
+	Scope      Scope
+	Frequency  Frequency
+	Hour       int  // hour of day (UTC) to run
+	Weekday    *int // 0=Sun..6=Sat, for weekly
+	DayOfMonth *int // 1..28, for monthly
+	ChannelID  uuid.UUID
+	Enabled    bool
+	NextRunAt  time.Time
+	LastRunAt  *time.Time
+	LastStatus string
+	CreatedBy  *uuid.UUID
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// CreateParams is the input to Create.
+type CreateParams struct {
+	Name       string
+	Kind       string
+	Scope      Scope
+	Frequency  Frequency
+	Hour       int
+	Weekday    *int
+	DayOfMonth *int
+	ChannelID  uuid.UUID
+	CreatedBy  *uuid.UUID
+}

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -150,6 +150,51 @@ func (e ConnectivityCheckResultNewReachabilityStatus) Valid() bool {
 	}
 }
 
+// Defines values for CreateReportScheduleRequestFrequency.
+const (
+	CreateReportScheduleRequestFrequencyDaily   CreateReportScheduleRequestFrequency = "daily"
+	CreateReportScheduleRequestFrequencyMonthly CreateReportScheduleRequestFrequency = "monthly"
+	CreateReportScheduleRequestFrequencyWeekly  CreateReportScheduleRequestFrequency = "weekly"
+)
+
+// Valid indicates whether the value is a known member of the CreateReportScheduleRequestFrequency enum.
+func (e CreateReportScheduleRequestFrequency) Valid() bool {
+	switch e {
+	case CreateReportScheduleRequestFrequencyDaily:
+		return true
+	case CreateReportScheduleRequestFrequencyMonthly:
+		return true
+	case CreateReportScheduleRequestFrequencyWeekly:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for CreateReportScheduleRequestKind.
+const (
+	CreateReportScheduleRequestKindAttestation CreateReportScheduleRequestKind = "attestation"
+	CreateReportScheduleRequestKindException   CreateReportScheduleRequestKind = "exception"
+	CreateReportScheduleRequestKindExecutive   CreateReportScheduleRequestKind = "executive"
+	CreateReportScheduleRequestKindRemediation CreateReportScheduleRequestKind = "remediation"
+)
+
+// Valid indicates whether the value is a known member of the CreateReportScheduleRequestKind enum.
+func (e CreateReportScheduleRequestKind) Valid() bool {
+	switch e {
+	case CreateReportScheduleRequestKindAttestation:
+		return true
+	case CreateReportScheduleRequestKindException:
+		return true
+	case CreateReportScheduleRequestKindExecutive:
+		return true
+	case CreateReportScheduleRequestKindRemediation:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CredentialCloneRequestScope.
 const (
 	CredentialCloneRequestScopeHost   CredentialCloneRequestScope = "host"
@@ -903,6 +948,51 @@ func (e ReportKind) Valid() bool {
 	}
 }
 
+// Defines values for ReportScheduleFrequency.
+const (
+	ReportScheduleFrequencyDaily   ReportScheduleFrequency = "daily"
+	ReportScheduleFrequencyMonthly ReportScheduleFrequency = "monthly"
+	ReportScheduleFrequencyWeekly  ReportScheduleFrequency = "weekly"
+)
+
+// Valid indicates whether the value is a known member of the ReportScheduleFrequency enum.
+func (e ReportScheduleFrequency) Valid() bool {
+	switch e {
+	case ReportScheduleFrequencyDaily:
+		return true
+	case ReportScheduleFrequencyMonthly:
+		return true
+	case ReportScheduleFrequencyWeekly:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ReportScheduleKind.
+const (
+	ReportScheduleKindAttestation ReportScheduleKind = "attestation"
+	ReportScheduleKindException   ReportScheduleKind = "exception"
+	ReportScheduleKindExecutive   ReportScheduleKind = "executive"
+	ReportScheduleKindRemediation ReportScheduleKind = "remediation"
+)
+
+// Valid indicates whether the value is a known member of the ReportScheduleKind enum.
+func (e ReportScheduleKind) Valid() bool {
+	switch e {
+	case ReportScheduleKindAttestation:
+		return true
+	case ReportScheduleKindException:
+		return true
+	case ReportScheduleKindExecutive:
+		return true
+	case ReportScheduleKindRemediation:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ReportSigningKeyAlgorithm.
 const (
 	Ed25519 ReportSigningKeyAlgorithm = "ed25519"
@@ -1575,6 +1665,33 @@ type ConnectivityStatus struct {
 	ProbeSuccessCount    int64 `json:"probe_success_count"`
 	StateTransitionCount int64 `json:"state_transition_count"`
 }
+
+// CreateReportScheduleRequest defines model for CreateReportScheduleRequest.
+type CreateReportScheduleRequest struct {
+	// ChannelId An email notification channel.
+	ChannelId openapi_types.UUID `json:"channel_id"`
+
+	// DayOfMonth Required for monthly.
+	DayOfMonth *int                                 `json:"day_of_month,omitempty"`
+	Framework  *string                              `json:"framework,omitempty"`
+	Frequency  CreateReportScheduleRequestFrequency `json:"frequency"`
+	GroupId    *openapi_types.UUID                  `json:"group_id,omitempty"`
+
+	// Hour Defaults to 6.
+	Hour       *int                            `json:"hour,omitempty"`
+	Kind       CreateReportScheduleRequestKind `json:"kind"`
+	Name       string                          `json:"name"`
+	PeriodDays *int                            `json:"period_days,omitempty"`
+
+	// Weekday Required for weekly.
+	Weekday *int `json:"weekday,omitempty"`
+}
+
+// CreateReportScheduleRequestFrequency defines model for CreateReportScheduleRequest.Frequency.
+type CreateReportScheduleRequestFrequency string
+
+// CreateReportScheduleRequestKind defines model for CreateReportScheduleRequest.Kind.
+type CreateReportScheduleRequestKind string
 
 // CredentialCloneRequest defines model for CredentialCloneRequest.
 type CredentialCloneRequest struct {
@@ -2738,6 +2855,50 @@ type ReportListResponse struct {
 	Reports []Report `json:"reports"`
 }
 
+// ReportSchedule defines model for ReportSchedule.
+type ReportSchedule struct {
+	// ChannelId The email channel used for delivery.
+	ChannelId openapi_types.UUID `json:"channel_id"`
+	CreatedAt time.Time          `json:"created_at"`
+
+	// DayOfMonth 1-28
+	DayOfMonth *int `json:"day_of_month,omitempty"`
+	Enabled    bool `json:"enabled"`
+
+	// Framework Optional framework lens.
+	Framework *string                 `json:"framework,omitempty"`
+	Frequency ReportScheduleFrequency `json:"frequency"`
+
+	// GroupId Optional group scope.
+	GroupId *openapi_types.UUID `json:"group_id,omitempty"`
+
+	// Hour Hour of day (UTC) to run (0-23).
+	Hour       int                `json:"hour"`
+	Id         openapi_types.UUID `json:"id"`
+	Kind       ReportScheduleKind `json:"kind"`
+	LastRunAt  *time.Time         `json:"last_run_at,omitempty"`
+	LastStatus *string            `json:"last_status,omitempty"`
+	Name       string             `json:"name"`
+	NextRunAt  time.Time          `json:"next_run_at"`
+
+	// PeriodDays Period window for the remediation kind.
+	PeriodDays *int `json:"period_days,omitempty"`
+
+	// Weekday 0=Sunday..6=Saturday
+	Weekday *int `json:"weekday,omitempty"`
+}
+
+// ReportScheduleFrequency defines model for ReportSchedule.Frequency.
+type ReportScheduleFrequency string
+
+// ReportScheduleKind defines model for ReportSchedule.Kind.
+type ReportScheduleKind string
+
+// ReportScheduleList defines model for ReportScheduleList.
+type ReportScheduleList struct {
+	Schedules []ReportSchedule `json:"schedules"`
+}
+
 // ReportScope The structured slice of the fleet a report summarizes: an optional
 // group and/or framework lens. An empty object is the all-hosts,
 // all-frameworks scope. Echoed so a caller can see and reproduce
@@ -3083,6 +3244,11 @@ type ScanVariablesResponse struct {
 		// Value Effective value (override when set, else the default)
 		Value string `json:"value"`
 	} `json:"variables"`
+}
+
+// UpdateReportScheduleRequest defines model for UpdateReportScheduleRequest.
+type UpdateReportScheduleRequest struct {
+	Enabled bool `json:"enabled"`
 }
 
 // UserCreateRequest defines model for UserCreateRequest.
@@ -3536,6 +3702,12 @@ type ApproveRemediationJSONRequestBody = RemediationReview
 // RejectRemediationJSONRequestBody defines body for RejectRemediation for application/json ContentType.
 type RejectRemediationJSONRequestBody = RemediationReview
 
+// CreateReportScheduleJSONRequestBody defines body for CreateReportSchedule for application/json ContentType.
+type CreateReportScheduleJSONRequestBody = CreateReportScheduleRequest
+
+// UpdateReportScheduleJSONRequestBody defines body for UpdateReportSchedule for application/json ContentType.
+type UpdateReportScheduleJSONRequestBody = UpdateReportScheduleRequest
+
 // PostReportGenerateJSONRequestBody defines body for PostReportGenerate for application/json ContentType.
 type PostReportGenerateJSONRequestBody = GenerateReportRequest
 
@@ -3877,6 +4049,18 @@ type ServerInterface interface {
 	// List the framework lenses available across the fleet
 	// (GET /api/v1/reports/frameworks)
 	GetReportFrameworks(w http.ResponseWriter, r *http.Request)
+	// List the report delivery schedules
+	// (GET /api/v1/reports/schedules)
+	GetReportSchedules(w http.ResponseWriter, r *http.Request)
+	// Create a report delivery schedule
+	// (POST /api/v1/reports/schedules)
+	CreateReportSchedule(w http.ResponseWriter, r *http.Request)
+	// Delete a report schedule
+	// (DELETE /api/v1/reports/schedules/{id})
+	DeleteReportSchedule(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Enable or disable a report schedule
+	// (PATCH /api/v1/reports/schedules/{id})
+	UpdateReportSchedule(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// The public key for verifying report signatures
 	// (GET /api/v1/reports/signing-key)
 	GetReportSigningKey(w http.ResponseWriter, r *http.Request)
@@ -4606,6 +4790,30 @@ func (_ Unimplemented) GetReports(w http.ResponseWriter, r *http.Request) {
 // List the framework lenses available across the fleet
 // (GET /api/v1/reports/frameworks)
 func (_ Unimplemented) GetReportFrameworks(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List the report delivery schedules
+// (GET /api/v1/reports/schedules)
+func (_ Unimplemented) GetReportSchedules(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create a report delivery schedule
+// (POST /api/v1/reports/schedules)
+func (_ Unimplemented) CreateReportSchedule(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete a report schedule
+// (DELETE /api/v1/reports/schedules/{id})
+func (_ Unimplemented) DeleteReportSchedule(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Enable or disable a report schedule
+// (PATCH /api/v1/reports/schedules/{id})
+func (_ Unimplemented) UpdateReportSchedule(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -8056,6 +8264,86 @@ func (siw *ServerInterfaceWrapper) GetReportFrameworks(w http.ResponseWriter, r 
 	handler.ServeHTTP(w, r)
 }
 
+// GetReportSchedules operation middleware
+func (siw *ServerInterfaceWrapper) GetReportSchedules(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReportSchedules(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateReportSchedule operation middleware
+func (siw *ServerInterfaceWrapper) CreateReportSchedule(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateReportSchedule(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteReportSchedule operation middleware
+func (siw *ServerInterfaceWrapper) DeleteReportSchedule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteReportSchedule(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateReportSchedule operation middleware
+func (siw *ServerInterfaceWrapper) UpdateReportSchedule(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateReportSchedule(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetReportSigningKey operation middleware
 func (siw *ServerInterfaceWrapper) GetReportSigningKey(w http.ResponseWriter, r *http.Request) {
 
@@ -9391,6 +9679,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/reports/frameworks", wrapper.GetReportFrameworks)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/reports/schedules", wrapper.GetReportSchedules)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/reports/schedules", wrapper.CreateReportSchedule)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/api/v1/reports/schedules/{id}", wrapper.DeleteReportSchedule)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/api/v1/reports/schedules/{id}", wrapper.UpdateReportSchedule)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/reports/signing-key", wrapper.GetReportSigningKey)
 	})
 	r.Group(func(r chi.Router) {
@@ -9537,521 +9837,534 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7P3rkhs3ligKv8oKfjvC5CeSVbp521IoJuSS1Na0LGmqZPfZp+nDBjNBEq4kkA0gq8Ru+8T+tR9gYp6w",
-	"n+QEFoBMZBJJJllXe/Sn2yoicVlYd6zLP3uJWOWCU65V79k/e5KqXHBF8R/fkfSU/r2gSpt/JYJryvE/",
-	"SZ5nLCGaCX70ixLc/E0lS7oi5r/+h6Tz3rPe/++omvrI/qqOXksp5Gt+QTOR095vv/027KVUJZLlZrLe",
-	"s95PJGMpzjyEnCwYd/8tJLCUrnKhKU/WQM08vd+GvTdCzliaUn57WzwhWUYlZCQ5V6CXFCT9e8EkTSGn",
-	"csWUMsN+G/Z+oHop0vdCv8wycUnT29vhX6TgC/j+06ePsMJNmO28F/qNKPgtbuOUKlHIhAIXGua49m/D",
-	"3hmVFyyhP3JyQVhGZhm9vR19R5Jzxheg7B5wY5d4dYLjVZofqOyZL92kZs2XiWYXTK/Nf+dS5FRqZklk",
-	"KZSeMoTpXMgV0b1nvaJgaW/Y40XmTqdlQYc9vc5p71lPacn4wgAi/tnGMJEkhZQ0nRJdG58STUearWjs",
-	"I0UvqHQ7prxY9Z79tcf4XPSGvUxc9oa9FU1ZseoNe0u2WPaGvUQyzRKS9X6OzYbXGM5FMiq1WVgSrkiC",
-	"4B32GNc0y9iC8sTsihQpM4NWgjMtcLLo7MVqRSRudeM3zbTFj8Yvvw17nurwaAZybpfB4f33dSBWexCz",
-	"X2iizTr+hj+SBY3cMnKYaSIKi6ErxtnKAOK4nMocfUGRJTFNV/hZ+R/bcLbErd/KuYiUBP/N6Wc9TQqp",
-	"hDTT7MCoJkxw9WF989GzpyvGT0VG1anj/psQkObnzmcyk73mWkYO1diknTe6K8SwjY2Q5JyLy4ymi+0U",
-	"sZP6ahPN1gdRMFLB1P45grwzkcaxOpGU6D0pOqVpkU/PaXzGlCkjea4Ik2qWAwFyX9mhpEpkF1eETjnJ",
-	"gcCRRUYdcG6aX7PMsOCDd1p+X3DNssMhpjTRdbFhmB2KhoD6etWCvQrKvQAdo4fUZGE5QpoyI39I9rHG",
-	"KTY/aLKYNuEy7BV5uieBxgRSRbI1VhEVUBZUHQSVmecdm9NknWQ0UM/ris6H3IIEDA+CuZDw8cPZJ8j8",
-	"h0B5mgvGtRqDAz6QJKG5VkA4CP85IsBzIFnmfgYCkhIlOE5qVCaU8pBSTVg27g2bggMHo9Akn99RvtDL",
-	"3rNHT7+OXOiVkO23NlipuEjfU0ijMLoZCR295Zx9EufWqKlf7MuPb0Gbn4xmT1KiyRg+oeKaSKqBKXj/",
-	"+qfXp8B4khUpTTdv5BDhQz/nTFJ1JfbZkb9nROlpcVVJxskqTtm5pHP2eROu7wUfORimTOUZWYMdCn06",
-	"XoxBXJ5PycPZo+Rx+mQQFzEX4vyqEkaUEqK+O3PD5ke4XApFAzvTGqAWIRIipbnjTrwJAVSCo1q6ppxs",
-	"Q80THBYwoDqWXQfG+Etsco4V4/7fD/eBolFLA3iRxDA7Bf1VoTTMKBAwQokjpAc7wegg6FfbDau2eyWX",
-	"bkNMgVqaDXx4f/J6CMyYpEyBvRDwrhkQPFuP4UwLSYFp4OLyufn/hHBjzs7MSC0ZvaApkAVhfJMFkJxN",
-	"tecvW/me50OG9cUZkj+CJZ4xnOEJBE/oeCcI7ZTDYD/boPiOxRANv9uDk4cn2maZuHmjGzIS7/WFc1c0",
-	"7RMLl3/GLA4tpEPMDuaJGZyRGc32GN9qiiRCSpqhT6VNBbUSvF2jqi1cAaMjW19RpZwgvi6VPhEy3fuj",
-	"1F5QHWHaVMVSzEvnyep6e+V4fyG7VeXAAOjAvhv3OeyVPpgAETpokyUmX4+aVBHGbl2pqbCSvxcU7M/P",
-	"IScKefO/2T+8AC1gTnWyRP5tZoLcbHh4oFMk3EscMHr5TiwYbxVwQucN2VSXTDEN15zqUsj0AKFWKCoP",
-	"kocNAJTzBLvZAYA2n5AxCJSqBMkmzc/JlHIpsmxFuZ5W29iQIbIwqg3lcCnkucpJQiEXGUvW3reu4Ic3",
-	"L2FWaLx/cwhYEoX+W7sCTb0ejHoRylLNsgyYUgVNoa/E3IydC5lQs53Bc5wqyRjlGlAFwN9woWrXMKNz",
-	"I2gJX+sl4wugmQol20yIjBJuiX4uqVpuAYjZ924a0ssfaAn15v3VgN5c063Qdp8/vHn5Gg/Wfqe5FBfM",
-	"AJDxxbSQbDc72vhiy+o/Ucnm62skqcZezASty9OPldbcDgCWUq6jrv4WscnUlHDB1ytRhLIkxAvR2YWN",
-	"Qxtzxg4UGAD7CLKNJd1Z6xO2Q7AdbHTldIdDzb4WINUZXwcIBvzN7slN3Xaoj44JniwJX7SbMyhGuZ7W",
-	"OPh2js3pZffhjaNsLNeYrvU0yDQ3GexfPFsdXbKUAin00ly9fWRzrDbmu8EdTVdzEpnSsGsUuWBUl7Vl",
-	"yshHl+QiZKOe+44c902BaMiMbBnEGanj4VMyUyIrNJ0adU4UeqpoIniqIl4RNxIdXGY0JCQHSRdEphlV",
-	"CsQciHtoQcPKzRSsHzzg+PVZmnVY+y33M8Ml46m4HMPLUgw5M9gacivC135lIHNNJTCtICNKG+jFN7O/",
-	"K7L65iD3b/OFJkCCHaDpcHO182zH4h9xYKuH85TmGUmodYBcLo1p7/AYvhOFgXC/xDf7qjtSLKWDZ2D2",
-	"Do+Pj8fjb75+cnwMagh+v/D4a/P3R0+/fXTc+GVSHB8/pi/w652kchhOr8hn+6zo1h9WD41mX4egajkl",
-	"HjWcMDbfjV59222fWhWmlfXuUqs2Nh0Ojy16QjRdCLm2L5Qb69XQrFWgdXL/VxNF9yE4p451fCcpOU/F",
-	"JY+IHv/Ss0ECBZeUJEtDy/AAEiOZk0KzCzqdE5YVkipE2uRxb1gxAcb110+inCalC0nSmH7eaRn64mHH",
-	"ddwx62tsmbfj/rmRQ9NcilnsDFwAvk5m7IJyIxKkuAT6mSmtuk0veMY43R84L467zN/UZO1iwaUET34O",
-	"hI0T70KxkyVNzk+pKrKYu1bKwH1UP6BOck/MQ3NCnFHwqaTzQtF0CDPCOZXTFVMropMlBmuZj3DS52Dk",
-	"DQgOqkDbpZPnl15OHVxZxvR6qjTRRUT4fhRKj5ZrpamkCm0+Mw76iqwoXJCssA7fnEomUpZAJkQOl6LI",
-	"UriUTKOb1z9OlhdppBSv/wsdw9FnSAv9Pb1Qfuq4veC0bAT6dBU59bEBp8OvXgc2Xp1kY+7wAO1w34lb",
-	"gs/Zop13GSEQuTyzMphtywuS4YNiyNIMuSqY0UxcWq/90jB2kaXQ/9oL78EYXtE5KTINDx8dQ//Rytxo",
-	"q9T7+ngb4+u8y+YeL5lebmWM8R0/Pj6G/tODdiwueefd2j0SbciSzMQF7QTNb8zmHh8fsrsVMf/ghCd0",
-	"usjELCa7AvMBEdBSpmbJuUI3D/5RgePaKmonhOvEgUGlYkrT1LCoNAYVxiGYpeWavjag+Pp4NRjDe6Fh",
-	"TbWxoMQIAxVp+hy0JMk5Tcsn8ZzKkZm/NrfKGEan7QlMKwmuHzVfHMdP+6057MODsFISTacZW7GIuv4D",
-	"+Wy24QxbODv7PhAlCtLCMEeYZ5RqUJeU5gr6D8fjR8fHtY08qm3jYWwXgd4ZxYiRxbdPJx9HVnCB+yKw",
-	"C3Htx/WlH+9cOWBe05K8NvdwUt2GZ+LKuxnLCf71f/4z5IVmPw/r+3m4Yz9RjQKh0uB4wzqbDrjLJonV",
-	"wdt25BoqRPlBN4HS7m9KSoGzzZcaEVHI7hHT1SFfN/009s/BnLsOdlYqMvUDYdgDYqZTJRrkY7iJpImh",
-	"HRw1UppIjajrNCwMn0H2M2dSaeSloea519N7eGUuaGtzT8zod6qkY3O8qYXIOHLlMQ5uD1zG1XbQwu0X",
-	"jmwO+NIpoXt9ibFZUwx1xnfRPT7edJaX543vKH7C1j1EbyqKg5Kit5dkJ5ng7Y5OpqYOl2M8XJ67kAQz",
-	"BxDrfFFG/V6B+wz6gmdro3uz1L7pqETk9IUdNYiigffv1pdzEkmBFvCVtWR9PgFZUataQR+3MvjKLiVW",
-	"TGs0lvZ8XsM9hpGKdrs9G9IaD7I0n8TjTHw+SHB8nGZ4RV+c3eWO690el0MKvZy6pJDwuGrpAhUDl/NM",
-	"6GX06A0XSQDrh8ePngyjjyQBVrUjwJ63FrrXI4YZuzA00xYyHfyOjvV8KYmKv0FcETv2jr+9rsdeu+8y",
-	"2Ct4GwnRYDs+vWNKb5HD5bjuUQLV3NUr546XqnCZ7dvd8lx9HZh/SPCk/ybujd9FXIc+qDEVCO5NiutK",
-	"kXdOC+5+pjOmwyfOUDy7EYlYrVxMVussc8YXVOaS7RjXGkh10HPMfk+Y3ai2doXhdW+nj41XlfsnHurC",
-	"9IxqbUxDgx4gOBCvb1Q8AYgWK2O/ZGtI6Upo9yqUS3rBRKEaGspWFeQKEqipBIwoT+TaRtSnIMP3KqUF",
-	"5ou6r62iwAUf0VWu189RjzFqzzmluQ1TcXazjbLsDXeKu/03c07X17yPhlg9DD72++vY2VWk6iZFFUqL",
-	"1anI6A6Fq50YuuCXZZo50ZpKA7X/569k9I+fzf8cj76d/vzPh8OvH//2P6L30DVEZMX4W/vjw53xIo1X",
-	"rd1xIxWY2gXzQQ9uyDRmBcv0lPG4CLuuIJmNQ4cr7wbBK6YScUFlq5M8pZomeir4FA13Y0JrkuitPlPM",
-	"5jkiOTu6eHjkHLyFFiPK/17Qgiog6P8bp35x+EXMSv8kp5f4c+V10oXkhss+On44BlxnTjJFh+VQfFpZ",
-	"A9H2X2Ohpn5ulIbw/sd37wIfhFH20iKjEnLm8uRXUOTog+Zgjk+0kJBk+OspHcmCQ7nbKIv2fs52zx6e",
-	"KSEppjP963//l4PCV6qaGWY0ESuqIEVxgjngl/0BjNrORT8nlKaRCI6xCxb4+vjJN8fHlQPVBhX0Hz1Z",
-	"1tx1dliHJ/09ved1YDe86CU6cGEQwHJa84U57MglFizM/8zoklxQjLllc2hBSWDK4kU8/nGH+3cTIZXf",
-	"IJZOCI5hToA+z6c13/Sjp2Vwh14WPKWGgkdLKlOrGVj3sV4aLGVaWZzcuFHFVkWmCaeiUNk6vKOnx/v5",
-	"VGsY2XB6tlF1Z3dog29c1RfaZEN7OEI3Pj3IC1rOcnZJab4llNChRMxxXnANYh7FpLx661lbYsVnhDH8",
-	"31QKg7jE+aSUpiRd40sxhb6NXUPGQTKJv1TYgi/ZFqlQ7UCC3pL734BLeZIYOF4nS9GqNATZEhva8z4O",
-	"AD9P+wbareWU6Sm9oLwtofuQHBOaLAXtED/jxm3MGT2HhfInqvS/i9k2Mtm5vV/ErNthG9t133Xbbq1G",
-	"STwQI7b59LYTe0p7zBuBNlQeQ72wSMqwZwPuesMe/Wz005Zs9GWxIny6LQFIUi3XbQERG8wmNeLHW3LV",
-	"p82FNoHfRDIEdfSOLkhWEE0x7beVSFUiJK0F2T2syY/dDMLOEN3B54SWGvH1Z1ZuqdMQHxv30H8vlDa/",
-	"DCEXeZERbQvpZAwfq1wlKegj78QIIMYXGR1JcRlkoksMSVLRpNquweNlknnkJ7y9vSN0/FcdnXaSXjB6",
-	"OeVCt2G4+f3KBSjcJDdRgKJ8l6zCoRwMMEEzl+LC1WcwOOr+E1Oeez4/PFanIWZNeeyrdlReYbmRxh00",
-	"LnIrycTzRKn/ubujuiLCXUZiMPnWrXVMl26p5YCD1u65d0UJVzaonTq7q7qPQ/GrnYxaUacZbNa80R3w",
-	"MBi9CQ5PRy2AcIQgAcd18te8MVrciVjlGTOK95nR/iLP8Kr8e2NpToFyLddoqDTmAcYhI2lKJQiZUvkc",
-	"/kGlGOELrdUzVVmPoRfUh4qUEitfllteoWvyuIoH5fggbDeFb8hEaoa/rITS2br2Y/jf7ZGNTVHl6pME",
-	"u4zd7FYqccD9eff1fJLUFqpreErIeufdpGRtg54UJ7laCq2GILKUKm3jItovgFwspiiRp3kS3gEvVjN7",
-	"BWWcjI1Ji15T6m6pRoIxkTEnLDP/GZ2ldYEGSN3k9a37z6s1Nra+990h6FtvzigCb1w86gZc3SamyBr2",
-	"ibvorqU0NlsJmMjarYd45yLDI+yoEVneYe+1GN8O4z0hdh293/xbIoLjkc4dYssRZqcYkmST59RV08dx",
-	"xk9BRcGdvtnWAjp2c0VGd2Jlne12udn9RWFkrdZNnyWE/4cxaDe3XPlFOm2Tc8de9kUPt041x5bNihhs",
-	"c6KMqj+dy6ocRsNba0eAgZGCI+i7T+ABOGANgCRSKIW1p6xvFo7H44fjmnojCou3G6xaC02yKbWGnNf6",
-	"triTLIewTiEpLhVcLqksX5VcHDwwZSsTCInbHB+Q2bEBm9heWwH+SeRvLHy+9xLiyhQXMu8rUly1PUN7",
-	"17O9kIqvur2At2y6WJCJTc8Zrz19W++topSXUXh2ZBoUciv/9PMVje0bLYLYsf5gB9vQILHjawYK5yzP",
-	"rR3YcKnsawWWxl94GbvLmPyJcirxETYXNYdNi/1gpoUHNjKvfBST+PEYXnLr7LWl8/pC2n9OuF1vAAu3",
-	"mn2qJlmG705qiP85l2RFsYoF0M8+yttVuB1P+EbiaDk+EvmA26u2BlpYx3b5DWSUK+iX/55KOldwTteD",
-	"cQwBFlIUeTRisXUp/OQrBStqGKvjw5E4xo21PBlFikXZFcyA5z4kA2M8S3iNgWhNDS5gdroUaZFQNeFm",
-	"f2/Ks78MxvRPzn46+nB28vIdzIrsHOYYSSAuqL3azNyWnnC0fKimKaiEcDQXGB9ZNDBHGzyH0pIv1zUz",
-	"THhpssIpXTCljZUn6YqmjGyMhtPqhwn3BX4hEwu7JQKZEOejGUnOXWaaxQxPXSUgjGZfnRL9LN4jYQiq",
-	"XCSemIYzT+M207tyAzZn3ZiwZqSlBraiI/t3muJFKegHyw2e2btwN4mPJQqcg0bBnGU0tdXLqE1uD7Yy",
-	"nvAwrvfx8XNgC47RHrM1YEnKEePIw+zKFjRVFsbXT3c+0W3yB4PFMad6FitF9IoqtuAjV1TPjMHYGFsH",
-	"kPG5GPSuKTKwI7dviiTFbKlQNU1cKnMUAYJ3xniABGZrTudkxbJIzNCHM7A/AeEYXGCZAeBXhrq49+wa",
-	"nFkRXpDMDon7ci0LUUuWh2ex39nYNhE9RnskYjGLJ6y+kZSODFRBFbNRkhmNa86ohP6KrGFGq8e8Gyr8",
-	"6sL1nPTy+xw6hKuBon5NNTTaWSsB0dqGH21B7utDp23YUsa8G2RAbKkO+Rx8hcUmvtw2nnSq6OiuLdhH",
-	"K/C3B0dbYuis7eKMf2F6eSqyrMhjJdSCUvk7ZzpzYze8cO7vQ7+/1tP9UGFme80m3uHNrsUNbBdBMO/V",
-	"WSGqYbdff0vq+PeYoFm2JrApon2bJjeEVFzyITh3yBDG4/FgD7dTuaFy+R3nb4XvlX1grQs7LIu6QZPS",
-	"E+t9oY1wHkqMaPSDvKlutCpOU0/67qXCh25S/3v7W0Tgv+jka3Uesz38pyVd70eWDksjJFmVhdhh+Huf",
-	"bFXawTraGgetNth6c2cVF9j/6tAQxtej4ALrN2UL3e1zWRWna7mKaVwZCfOcS/FTr98evoAw3fZTwXEL",
-	"tdiStotwm/XzNZeO7ThcoPVabGj9PpL4mkRW644CYWKwI8s+zHvP/toB3Xu/DSMdQNw8O7/28muz14f5",
-	"8+Zuf/5t2PuekkwvtwQJz6Yuz7R2x2GFpQ0vxRLnXIdVVGKKg7Fe4rHHkfcr9E7UNlNNELsHI2Wqdy1f",
-	"eiiCJMEvdYL9M+WKQEI0MQakH/ccCu6R9h8+1RDj4N3AoD1VkdHxjheoLvmz1nHZcTT6NA9xPpeAqFYM",
-	"37HsvLsh/Sb0q0Q9/7H64JcKViTPaRrxtdhKCnV/sHcCb56/8sm0eNwCcF51F2aqcftbRfm40ah4j77y",
-	"Vv932w7G3aol1R5S6wu7kx9VmwOigEBOZUK5Jguzg4KndnWjN6Q0YSuSPYdji+fBl0zB8Rg+iksqVVl7",
-	"A91iuAPf1+snRi9HREGyZHndgTXPBNGbLwgNrKxdZw2ucTStjr8Hqm4pS1q5FTvrLW30ENNhLqgkWXbw",
-	"jG3AQuHq5t4Nh3d0W2HWunJwAARK3hur711kB897WmQ0aqslhGPUN/2su8x4lhB+4oZ3N/U2Qdhq94X7",
-	"GQZmYE33sZDodlmtemgZxNqBUdykEOrAhFCe7Mt/7EfIerq9RvoXkhuWnVFO1Hic8dPvx6MQyfdQWk66",
-	"qCvOuh7Hg8m5liKbsjT6cos/AktV8Hzj4gMrUfXc+ZsKjjVg/6384YW5uwW7oLh29zYAjUy1hmGFVVcU",
-	"NUZDQo1cDdWxYKzf1i6VDTwQDcVi148hYFSGT49MljQ5B1HovNDj1l46OOqGngobr0h2W37Axjnx0cX3",
-	"bUCPQHTXbQ6bhtbjAGy2aqU8UzaPA2MJhqibDcGh/9B2jI2/i5V9wOI4jD8/hznJMgX4ZqIFOAgdoHe3",
-	"Ron4VmD1ZMNAHw7ahlUPpQGdbF74bsI+czlXMbO1dCTccuihextuuAxa0v3CEmvzjCzKTq7uYEab3Z5O",
-	"uGK8iAZ9nriUYqNSKhfoab8pJUHBFaU2rDNWkPSznqLYJVH923tcfEKea2lQ2zqsqT44oLdMqJtSbga2",
-	"vMgiXdokLnADEZTx4tzlnDkp1PZuDvXcxJSp3L0deR8T5lbZmuT9lCm7tJBg0+LCu40VDtpQcJqnjex2",
-	"uInXEVSIYGAHUrr36tD900J2Q/U6QoFJGQzcNRb4eqJ4g+vZoZzG49e6BwCHwb/7uU0Oi/rFOzq08EFL",
-	"FRDXd2/aVqNhM5uQXzApuC/6EvYNebIj/OWgzrYH1ghh+ZSkqXSRxY1d7qovIqSupZh9/fTp46c7S2C6",
-	"1qglcu8CTVPR3VYqY/ezk3v5Cs7dhkKvMDVxW85mxasPsYdLW9hVJ+rwcViTKgsiwrt5z80MZRz5bz8P",
-	"W2U+F1BWIrcFSY3wR+1eFtw27lO60mrHG0gag3xDvLnTt0H/DWEZTa9u2gVq/laTzuil2zJc7qXN9/u0",
-	"oe6ZSRM3YrbbLnWE2Y3D27rX7+3eC0gjghM2YLv1HaEMLH/57p0PZ7dOdY+4zk4VSlcBo6M5yzSVQ8gl",
-	"HWEVicEh8eX1ve1y6L1jnTTY8o16+9tJ5HHihfkCy474OUrchn5CFB0xrigWNb2gg46PC18U6i1uvY27",
-	"2nb3bzVdReIIZLJkmibaZc7s1I4speaSCc/VOpepHrYI+X3kbVTkbxG+TYM7+gDWd742GwYxiAjge1EO",
-	"sqk179KSb04tPrhSZU0/jjsxAy/KYa4QGwJu5znwrPdbG6zXFVrV64UE/ptmOaTDQSpUEA3aZXQQaLFz",
-	"eJ4RbbY1tU0K54zKbt85g6mDUbTbCrr5Wp9xc8kdo06729h4u+pTBsJ1Vn1KsbDLOdCeSVzD+1i9qo1u",
-	"FPErQ9KvtybqQOiNQvqH8gsjEny3HAu53XFwllcFSWJX2kMVnLrpge/WIKoZw7aljZFZpfvNbAx3Vexb",
-	"x0t2wTK6oPusEf1mx0ItXaOu1uNJqeUe+26O3rrjeGb2zuZLhsK6hGe3+v2xnO4LQK+4a7bz3Nb2gxdY",
-	"kmdFd3vc/eytOywR+HumdHvLPas+Ill0ZrSWLQRVpXaS056MZI4m4DQjayt6ytxHp4CrZS/AUQODay27",
-	"xLqaFbfOJcT5FvjVmnvY8svXvq3dSkDJObruNdZzbTe7N5TebYXtCbAB/kfuszN1baupqPeOnGoh3oie",
-	"dA11OvwG2866pVBhw1atsznM2fv8zdfTr58MgZixSEU3bNB+sQpv3Cq8U2OnkS/KlJYC3r6CuRQrOKI6",
-	"ORJqJGlGiaIub1QuaTaEYlZwXQxBiuR8PYSEci0wcXxFMsaLz0NI6YwRPgSRU64KRUcZJfkQVEbV4DnY",
-	"EHqfl9k3k8Kv7hv4FcwH8CuQLGcc/0MmS/gVFmYZAb+C0EsqB/Dh/bv/Ze3Ot6/g0hiatqY65oDkko7K",
-	"Uq1jOMtp4urnY7zFqCq7evFw/Hh8DC9PRo8ejTvC8BpMwAiB+5HPaPZtl4389zMSw+DSzZfaQtoCoq09",
-	"zv9CsmyUZCI5Bz/Yx19ZxwpUqfWy4NCfM87U0tZbHgH2KsN/DGqZRqGDDVziudJklSsgM0W5HnfKPmp6",
-	"iOp7D7fStmf7qlLw1t2ND47BsTVSQ8RvdrA1v4P7fRtUa29BG7uLBP+Urq76iiy9Jjgc1MOqdlnVLjcA",
-	"1YrJyIve8rmIJSGrIsNbJlDyMHOeMfhmdd71O7U8bcr4XIA225/wRGTFio/mQo7sf25jf7FiHiTPiVyJ",
-	"WrjVbt1zf2+7yDLMPdqL6aRMnU/nktLpYtZNvcUv7HvSXp8Uiqadv5gzSS9Jlk0VlRcsFurnR6TwKxTz",
-	"S/gV+BxvTMGvwPLyP5E6upBktWTpH9j9zd/TblLr0LzlnROfU8lpNt13vFND9vlkHyG9oqspuSAMR01X",
-	"HS/dfGURq+sXV9C/oqrXeDyO61NHVps6MrrUkdWkjgyFHlkt6sjpUNjkcEOHunZ9iaVdnessnWbsnHYd",
-	"3hmNhJrmkmq93uuTfVCoGj6dFzYL6caeBxRFPbu1n/xrPhcyYXwBv8JH19jlwqjSr3x0quMzwObAhTbq",
-	"srJV0XevfUnyvbC+1VquCYA2Qbmj09ddh+ftCHy7kv35h4+427jwt1zTLGMLyhPa1mdoz/459eBtkl4Y",
-	"W1sBBrWzYDmjV8/WQOYaS1s5b/e8yOC04CdY4r3/+Li1r/rD5dZO449vvkmO3+aObvN7dDevZqy3tWFc",
-	"adtn3rU2D/rtH+/V5nyPRjQd281sYtBVO85EcHKPpjOxrw/qOxNO9PrCMaO9W4Mc2ETDdgHaU1O3XVd8",
-	"y49GbFkmFE1Bk8+Ci9X6GaADxCoc45wk52RBx84n0bvHxSjDCEj/LGBssd6wl2HCzoqmrMC2omyxDN8H",
-	"9q0uGUCzFn0Ybrt+UZ2wSH10705XKXC6iZsR0YAcNymkEl10nM4VUcO1z3Rb5ZIDDM19UMznZewirLYC",
-	"b3atUBrhm8nYz4td4FZlo3o8jpDjM7/srh4xFRqp6pOd6tc7llCuLFS3cFHsjUhla7Oka2j0MqdE+5fq",
-	"7j5NxqcLSRI6tYUbu9ZbcQ1ojfJG8M3OtwUZ9riYZhYomG6FnbiiL4ya1V9b55Jicbqc8kssQJdnmPdI",
-	"jcTLJVM0Ok2BNZZzSS8a/b/bXuRw3SCvsgTclvv9iUo2X7dq2O7A018u9W5Hbzi4w5KtD323hjMt01Q4",
-	"pKb2lqPIo7sabBd44KltEhTdyCXB1pVX2m6Tafq9N9eP3cx7YezPBLWHkyXhnEZ00ZeQ0oyhGyCxY8Zw",
-	"9vrk9PWnMyCSwvvXP70+dX04aYpcy+isZz98+lh2CR6W3RtVRpLzo0s6WwpxDj+evoMHgOVKhzjZpWSa",
-	"jgTP1mN4g/WLCcv8utYF+v7D+5HtlOsTP5mqllcCB9GUaUA2i9VyJR3NWZY9A7XS+dSGsJPMjCVyQfV0",
-	"ybgeDO2vxooaoj9mCFoMwZs34w2f6SGPpYF7dRO1zKKxNtI8RTMGzULo12Ey6GRVdhNp7UW9PGAiu8N7",
-	"FlLvsbG69Tm12QPtcvSfOx6Re9jsDIwha+NM3RZ8vVf/+vACbMtEYob3YgmFFTZEkp4F93hnEcggL/6X",
-	"kBbbsQ5zNKUl6vBPWM6MyeUulkav9nAu5qOFylqphvJ6w56jPSOIzGpxGXTFl8EIivif3SGf24pHvos4",
-	"U+6xxhPyYO/XmQqlyyq2VTJ1eLM1pNuvbG2EYVZFbBuKnpANZqeKPM/WUMgM+kutczWEvJhlLLGIEzI8",
-	"N7TkVkclAR4ZHnGkBfQNR/VAPaoA6UpL0IysgRR6SbmxPTRVgzG8zDLXZFwht3XFOFwzc5oil67fwybX",
-	"q8XluU6Lbe9DcYbmW0jCGylWDb4WL3Nx7S3uESUNeCoU9OvDWQMq8SdKfzUtc9sLsIxi/4m3sFo7ccBw",
-	"DaWgJf30m/857j0zRHONjHaTR+7Fywb7ZSyiJrCl+8GMEkmlVRgwI83TlrnKjgC+El+UEQXpE/IW1GVi",
-	"dI37rHGCjhvdwVARextctRuSNe2HgGd2ZHrxPoVebnX2IcT0z12h++UiHbdalTatw9D+XQGyT8fTjioi",
-	"GcMZ8mDGF1ZvrWmcfcPEN+4Vey5XGubcs/MBSJpn2NeB6ecgVkxrMy/TkFFsXY4r+PRZXKjgri/LVgbc",
-	"znFvgoVuZ4LbOdlNM6QDeEwbdV8h5qmhd8RQ9INKSPZKJIV/XOruO3rJwTYKeTg+Hn8NLw2fVSv02ttG",
-	"tJC6eaH/72cf3g+GQJRv74FNKrAg61cK6GdzLwbLP+Tk7wUFLeBDTvlfjMKMJpy5d2pMNimKxRIuqJwR",
-	"zVbjmNrsXxsFbwuSDzLyN1V5g+ZSFCqO0LvCRVs8UN4psSC6S9du+zZZpXrXC1lVW/x56/GVbbCyLZz5",
-	"gFqQvvpjaxBzXm2g86TNO4tVlhT7pJ6fioy2TBUvk2uLNoZ790tGgSwyljCqTmkmSNoOX1HoRKxcTNOB",
-	"PKXZAsBP2bqv9SuaMIVNYVuLQB/2CLO7AbnbXbxQr41La6nHHQvw695YNw6kXn3RjSW29tb9KIVt0PyO",
-	"zSPq72ul2QobdedUVsUHglrwI1s4N6WZJtAPimJicx41KK2jIqMwz1iOjXywBjF8R5Ue0flcSP0cCMwZ",
-	"zaxZGqReE11V6/hKQUo0MUMKXoYR1cokxOLsEqbqJrUvvNli7FZllbjTuQ74VGm2OOjTmLwNOkRdQ+uH",
-	"30WT9hU1yhhTq7YS52E7rSXhKb6Yp35nYXkZINrXfsGY4ei2ck8I08xRwlZWXiMbpMuZEHpakec/o2lD",
-	"X7rLd6p3kxA+lcXBqfeRDoSUp4wvprYzve0MFG1Sn8o1ruyDnPFZClMzMY3P/rf9SGSZOb61ZG36X/yN",
-	"qmojWavR1jHbK9LucN9e95vso60N1D5MZI8bbHEt4AXYWpyjoFxRweFyKRSFOcNbsw5mT++owlwtqHwT",
-	"uN2gFjfBfSe77mrbJjffpb+Va+zc6G11yA8WPdM01hgozzN2RSbjqDHOTQ8RJJtsf0kUDd4Ly5K1YrVi",
-	"OkbpvpTOz1dicjGaryjdn/vn3YCP46TSND8IIfEud3fmp3kbKnrnw0YImN7b9rbtP3lKJU3BGNeQC6UL",
-	"o206m9v67wnfbJ76zLXvLFsbDaFqpz0E31YZy10NIez7roYTXhZFYkoVZoAW+bQ+yBapwnYFCwp92wQI",
-	"w3WHE27/NZdULe26mNWcUf+PoJbAwGqsG5B0EJuqJXn09OuWSrwuyOQrBW64dwY/gyX9DGffvxw9evp1",
-	"VVycC26OZWBjh/fN339Rgjv3BLZCBUnD/qSKAv1MEg2zNT5phPu9WkNLo8xPiZqKefdv/KhYEqrrtOt1",
-	"kutqoHk9DVaxb+xuSjS3gP11y2+mGZnRuJdMsQUn8VTm74iiXz+B1+mjp08ffgvlyKrNbQNl0JNq8+gm",
-	"fG7JquDmO5qWmDYGG1Jia7eZWc7pGh/uJ/xPrz/BEcnZ0cXDI9vrVR2ZzxlfjM7pugVv3IjpOV1HlYU3",
-	"jC8wdIeX+XhmSTQMSzcb6g7+hNsrHHZ50HRlCH1DzuAS/DXWcLeBeSWOlkTc2yDnGr20M9I37e2eXzb7",
-	"OrvUAt9JF2tlD+09Ma2s/Y3cb7xPV2nDZjYbRrss5YSpqVzS7NvpxaPx8fg4/pC4ravQK6Y044l2nf1b",
-	"+xi5joHlwca7y+BVh6ptoQOwr7exTvMmdwnXYIn2vW6v4uSob88tdlBC7bTt2zrzPC4iq7QsMGcxBZWx",
-	"quMFXicQ3x3aim/2D6qeGQYknIY6sf30jNA9ErKB+kETdrshYM1m6xPe6LaOZDyG18lS2AgmAgnJMiox",
-	"eElRivK9FIQTjiIQk7hIsF3bzHrPTu2YaaAMdeqQutrbs4et1pnbu6GSPdu219eNzHfFJu525bhbyaCA",
-	"n9ilBoF1M82l+AdFH43jokxwdNOMuxoiiHlWjPyZruNru9dhw7sKZQ9rBEaJdk6+GV1QSBDzecY4nXCM",
-	"53OPmzZR2H7wlWpKVMNj60w+mvKbLYRkermq6RdWRke1Bpov6YrKWMJKo3ECla7+n2tONJoJoSGlGPeB",
-	"D1TIuLnAnHzMYDZ/sK+rhi4Hz0EVybI6mIJUYNaajWr0TFhSTNBXNYEe2GWVJN+0tvAWfIxtTGEZUZ6I",
-	"lKal4lJd3O5XdbfyMABzbc0QnFEmVr6n7Mp/6/okxtR0VrBMT1mLEdv2jrTjSTWmttTfz+qPPOE+oicv",
-	"Mtri3dirGLKfJ14RMChq2ygvhh2yrA7g9JeMzaRtOLarBhpucFvPgtqmok0guGFtGbaacs7lInhXcFuB",
-	"mRSXispIUOrWt9YdmFPn99ve0A7sPFXrRgijSXF8/Nhq/75Ael+RFQW1JDkFonzR8KYLvwJoC7KHFlAH",
-	"PAm8DtuLnJeloH+FJVss4Vew2T7wK2Rht54AHnvXZWmzDyLu2wbquretrxQQDCDMidG4FSoUubasFogW",
-	"K5ZAMJc1vSc9+8ukZ9lu1qFxzZbuT2G19OphHaGxgWjNk7VZsHU6Oq3f8ebb0YjxlOaUp0bihG80zjFj",
-	"s+6tGWefcUgKK5HSDPpzkmiFufLPQTJlNKILip3zDBkQLSTYt80hiEtuwyvKEIrBJl2WT4QtBQ1ReBIO",
-	"pNDCvnL2ueCjFeEFwQiiavf0M2vL9CwdjJEE8bS0b4K5qg+8SGWrPKNGRuMA5c0rFM1T1NhcuQtfKmSw",
-	"V4ife5ya0SW5YCJSFslfBaoMFhGfwcQcUo9yIslq0oO+0mRhYG7G2ECpIbh3FffpAISESY8LTs0HRnUg",
-	"ZbkYcDisRm4dwtUllYP4C5ZVMXyVjwhk/S9Ol62gKzFaQZmt+Gn2AFaD1ioMqt1zbIebYI7R0NnZh9f2",
-	"CuPiNpfigqX7NJyvZvzovt15qmqR7VssJ4yq1JhwTLIh8CpK38qQ0mnrmqsRLvh6JQoFmVgwDjlZRFI7",
-	"rpYwEWOSreGVZ2cf2s92dvYBPIRgRTVJiSZjMEdOMoy4dYdlyiXiMJ5kRRqLG7QftKnDB/lMbfz3VIoY",
-	"WzMaLCwk4draOIWiUtnTGFWQpnDBiDXz/BH3zpjpmg6sVBED74e3r07A/gg/nr7bLyfGWKoRZnCWk4SO",
-	"UopJ7DSFDy8LvQQ3eks8cqOmgRRaJCKDvmBpEmVM+ydptOJlmTjhADUMkKU8aeO+w/SKHQ7EAMV3dN6q",
-	"4eiO0FQ31hJAazuaMhD6eSOzobcz9rUDehu1PMRoi+N99yXYl8zB/mjdDV9dvPngGlMmOmL1c6zyyDBC",
-	"imSXZK2ApCndXTfVFwOM4Vn9Qncg0jWKrOuTVX6mjQI2jWtcMQ2100JfSFCUp9Z3ODD88pzSfDMyfAdf",
-	"vxrN+Ed4nzFntmC1GtQ5jXblPu1ALoei/PWj8qEoGb3lhPCTJU3OX5ubjjZ4NVZ8IlYrwtOvVOm3Zcb2",
-	"ou4j6PvMfqvu1maMWQ+JLkj83c2t1JKHz6pqHJFmRJ9zG2sULVNL9VK0RNTolErZ9pModIvxahtppx3i",
-	"jtzi4QlaL6OlZlDZsHe6YlzFkpZG6FzwBWjMlWAL1UHpbCmngBnhKfRteOm3x+iPJzNxQQdjOMnIKqep",
-	"mUfAX58O4dE33xz/3ItXV3ZP+QftCJ3f3iVV+iHCnRWYKPzoGF9P+boa5IKX9tttawH+H4jSVIK6ZDpZ",
-	"lsAiKclt1IMvGjQG9PLb0vzovKpXL9rsqjuGD3yUUoPP6PmxaYoFJ/O5D4qL2Lz7FFTaXk8p0ue3HzT6",
-	"xZYDg/gmGh2jD0e65ky1G/6fx0YyfPPtfjdZa3R9+M5q09S29Qi39WTPbbl+24dvyE1Q28pT3MrXe25l",
-	"V4UsS3slemAIOnx9rAJUMljUXPPhEB4etyzpAoIPOz2qsqMkI0qxOaOpexnrfuSWdhiNbTVZVhSVGhfZ",
-	"RgvD3sYfDin2VbH8qxb5CoTHHsW9wq8OKuplJnhVZoM0H8uV30M35TUh3HpCMWYw4m4zSNRllrL33EZn",
-	"cmIDitTWA8W18Ub5p4aFS5QCouDf7IAXhmzn1EgU5DX0s0bfzHMXB2QdpPTzkhTKSoKO1bqMGNkLoEHn",
-	"3e2RhzhzG0TMtWxXEZ2nfl5kGaSSZdkoFZcccrLOBKkKqfgkfa85FvxS2tCUPCtU5RTatAuMTrnf0euK",
-	"bfQxxyNu/TyYpzSSlKT4xHBBZcoSbR+hP+vWJjibE/nIoapIrY00N4Zm2S7yNp6tNi61a1PczR/PWT5t",
-	"zaMKMwQaoDAE8ivGg8Kv4EJ94dc2MLR2si1D9YMXGXePQ48kGzDchtanZYRyK1K7Z/0SETCGD1W6MbwX",
-	"wLCLDuDiIAqdF3r7S2bjEa7Rxxn69XbAk561NBZCsn/QdNIbdGhEUl9CcDqye3RrBT+DmNvQmzKXzEKx",
-	"0U7afVnEqxne/VNr7DV1SdSUtnItHUR5MBfGtyTKs6jwOs01IFNDVSRelfSgLtPbH2DhV5j0Jj1/BSru",
-	"qbglimztZY3c0oIPR1TvkB7b+tH+1oMr9q+OMIKNh9gaBrRzAf4fBS2scVin2r/j3/crqNnW7sFn7qgx",
-	"S+HFC8C54RcxA/vv4NFYjat2DLtLN27kZNld7y7QWS1SArM6cBu0zpyN8FG2ZMTMiuSc6gjCPXoCrr3U",
-	"EASnaHUsRSEtwnBx+RzSwoXSGq5kzRSbsITKlzdPUuxb4bqmM66MNYthy2a28Emy2V6Fbut6bz6eivlc",
-	"xXyJ34tCqnKj0D+GF96pYuxq8+2g16FyeLXEMNhPDNYb7LCgUy4u47EB28BkeBrJjDaz9oUQ+t72Q5rM",
-	"xGIQt7TtbC39XM6E4FTp6Jru9d2++ZeWkL3RWk8TUdqcttkzemYP7vHisPcXMVNb6M+u5GpEZ2tw5BK1",
-	"pAuOMfR7zug+240Q/lLrW2+sOyxJqpUmq3bdm0pMbZeoiFvd5atK3UYXoEt6t/SnIrHsVf+ew/PODu3K",
-	"sW9bsg7FAA7g7RgRNy2V/Ri+mAFzZ1W0/W6ocNvvQTv7SK/D9s7ZMdEg9RVvrE19sOCDXz2yw69B/yKr",
-	"VsR1RS3ZYkHlVIlCxvQywafOafpryRx2P8VVsiwoFeylWmPJ8O5jRR2qS6rdaPN66vjQRps/EckMgD9c",
-	"UClZSiOCSYQ/HVg10i+Dsd9Gy/KTwgXJCjqGjz9+qio3YXi84cIrku+svVxtb9cZt+R3XPghkVLqQuaF",
-	"GmH0eDkMlDCoCzMbzd4u1a03XU3LcNrm5E6bSHAVFwor6ZxKyhNfEMsvG3/o8IHc01j8/Qe5IJz9A0Ok",
-	"RiqnCZuzBBDOS5GlVIJ/PzcLleF2aimKLPXPzU6XGkZLBrmyhPHQMgw+HjFersI4UAQJZiiJQmO2h7vC",
-	"vWJC3EcpbYmwduq5igcxhSBG44Clauhuda8YO8TfSAEVPCS7cAgO/RLhL8tsDOrfahxwBl1f9D3Q/eo1",
-	"YAwbOBdAooEsu/W6xvIVlcQ+/VHtDDmx1f62Py8/3lEZbcun3+yo7LfXo3bj7OU8vmZhsKs2aHx0A06p",
-	"oroVKJxeTjsecOcua3O1bssj/zaWji+Jm0/jie2SkAkZacmAFR1nkvD0UTSpxUj2aZXI678u1MNHGBQg",
-	"Hj3Bxg588ehJfALKVaMbRCJWcyG1Y49GxpNERz+2KdhYIiXgWn6ecgYiUxX9PiO2lkjuykP5L30vmJSo",
-	"5UwQaSuLNFPmwiDXtMB2tI3UgPB9PnpvWx5hDgkodK2qotbTe8FHYTUmCiSxli/Dpznb5KqfEI7BvkHt",
-	"28HB5lHJHA7N38aekR77pzZUeT8FWkSFNEafvX2lgCiXFq1t5XPDE8bwsayXNFu7vBGlgfIUK2FBH/Oj",
-	"MVht8Nz21g0KKq3IGotUAtP7lW+9hYayGyyvjaEYAL1E2LQyOQPaLmFTTR+baK/TYlZW2xNiEeqdX2Vq",
-	"NLZLFtqpY/v6yarq7bsySlFq+7hv4Nrbsw+jb74+foiaU1q1uo2WXsBaJZEU8dnMaGyIkguGjVvts+9m",
-	"5makwPCfBGghsmRJGC/7zRq0njFO5Bq7GKJahxpctI6CUf0iKtFqRtO0TLWifME4hZVA94pfqG/PbQRK",
-	"9CGh7PARC6jzRTUVXV1QCf0snWdkoUaM2zpPuxWsanp/DARSCetheHmbl/8bdkWJ9Zw9w9p4x3BJsnPG",
-	"FyN1TjOqMT1GYu0N+wQpKS05h7JeQ/qZyoRZTXHC56LgqUus0SQ5h37QlWoILKWrXGjKk/UQSJEyo2Ya",
-	"AxCoKwTu63hYb3kAtL7b4sC2s7COid7x+OH4eESyfEnGD/0FkJz1nvUej4/Hj1EN0kvEa18EAhu8ODG9",
-	"iLkrTzEs2Np5OZUja/jC6XcvT0a2TC1NoeDu+UdSo3QANmhS4wk/wXztr7Brmk91hJQmVrlm5v5xPpuX",
-	"K9ms0PQ5LFE7th7NCXfyGZbiElaEr62LzL4KuNnNbrA4PBbZLrtd/Ph2wm2eHAaATXrv4YIpDDg8gh/c",
-	"MpOea/FJcjby4LCAtyYWE/xtaoiN6pceWhjbQVZUI8/66z97zDky8EHB8u1e6SOwTKvWV8e3Wqg89dhF",
-	"p+p6ZGwDgxMYN8KZFkgDMUd8y+LVW8bm8oe35YovFjhKyrV2qACt+2a8AbNuEfzx2QquWXZts7mQjXC6",
-	"jl/6YJ7qw1KtfXq8V5fAnzHoxGokZp5Hx8fN4k15nrl0+KNf3FNete42oerRG/ugIYNsCCv3OwagGAbz",
-	"xC4em7Pc5NF3JA1KqD05fnxt+31tuKXvmhDdcJnUZFkFyhDlXdy9H7kNEivPNadGU/7x/dsP723FAKRT",
-	"BQ9qT2rwAEJKhQeWe8MDqCh1gEuVXDZdMX7kai8/s6n6qGu4GuF1RvNRKP3SfFHrEFUVEfxOpOtrg2G0",
-	"8dVvdVlrjIDfbhDv4p2wIvf5U1jqwcZeQd+1JwUhwVBLig7jQtJB47ZfyfVIFhywDxTRFAj8+18+gbuV",
-	"0seFHT2zzBaij9xi7iouP7NJjB2usV6juXeDgGypBh2B5EcqRwZaLhUTymLOt02iVkOAjCTnymUOe8jW",
-	"r8+eCZxVZ0fCnGVUBWECZaEMSJnExoCGbj6PPC6PKj2k96y3uVx51Uj3O5Uixx5c7Ln7F3onUEe8lExr",
-	"yp2tOeGuiTiOG0lRaCqNYqSY0shIyIry1Napv3holLnBGE5Q5kx4ThaMuxonHIJOl/Dq9dnJGFWgZ3YL",
-	"zyQlqVVqJhy1GtxYm05jj9pNo8GmklGFxjcKJMk5F5cZTRfonFUsM0dzWC8yW8w1ZcrcQktkwc3rGLep",
-	"G31RaO5QoUHcblVnLL3+XpSZGqesCD0wrRoc8x1TuuQvqWdPfcdJaDoEa8BhicsI+zv6J0t/62QY4ngM",
-	"CujbPGt8DTP74iTDSFWqkCN6HgBHE14yAddzi2UZIJbZkpstHA26MbTv1m9ftfA0YwNXiGyrutZUnX04",
-	"zI1jbyvi3kv8M1t6cov6PeIdFxrQ19LA/zMse++Qc7YGlrYh+bNAaoUKXX01K+PKkNFQ0tWxFbt1bqLr",
-	"BrKihmh+exksf1tIe/2mBB7lnW8wENgSv90FkdhcY8f27gOxIFbcK2ox6397e+u/tU2irS2Nz5gY/+6C",
-	"3ayYaJBwQBhYBMhSoLvSFlp2cqWdjl/yNcYTVgIIly4Ju/z7Fan6ldvIF4r+QtFfKNp7YSxRIDXj7vte",
-	"T2xVQZ85rXGXZP41lMi/esuzJGuve16Rqk/dZr5Q9Req/kLVpXMOiaKk6lZSdlS5FymXFOxJegxV51uR",
-	"rsfoFAEXMUnVhFcVd+0XQDOSK6qeA94pX8CKEq6A8ZTOGUcO8JEoDTjThEtn2z45Pu7ELSKGaMkvztyJ",
-	"v/CLG+MXvzu/zRcWsz+LcXRUKQ6W6kkVd4PFoiqSztYNjaJImT6yoQmBV2vTf2TGvbbDOnnFy/f7vb2o",
-	"QTxI07XdcQaSaCF9U8mtXzdbdmQaO4a7WA2X9WV0pEImFGeElav5YkudTtAFP+kNDK9k0ratKD9gqU9m",
-	"tl4X/8NXyr2OaklYhnFzkWPU1r3ek7C0cQ5i28//+OPbV4MxfFrnLCEZFgU2XLdxLLP8zk0fdnVfHgbu",
-	"8GGgovG21wHzd2wngNjr2MYh4mbTJx9OCX0L61Hgluf0kioNcyaVbudhR7YdVKuD/pW45LbMLrroKyK0",
-	"9FB2cCcr6h4CsO7IRlQsdssmcHL2Ewhpe3wRrUmytC+V79+efYJvjo9HTx/Dyx9H/9OthJHTyNgf+AYO",
-	"Ve+IwdiOsg5k7EU9hh95xs6pK2DkYGF3gtNVrw2XSywx6YPPFMVUFcHxb3QIiS0DQjQ8PD4+PrbxYham",
-	"I4Qp9AlkRC6oYWI8FZfAVLCmLb/agMJgjBBIRFasuHoWvsAOwUqAIbiGxEPwL4z4k2PQ/r+xS5H/B0uH",
-	"dWYzDDnXEOoSou3Fo8Lm1xYnNuRWI/zS1iKwHGIMr1xdHsNEE3XRxu/KlkkR2u4l6gJLn7pIf/zXLyra",
-	"Z2uLLDtQjnaXglcWPn9UQXBVbtspartC1GjMtqaf9ZFBndrMzZ1uKrOWnbrmeCyj0I8zq4Hl3w9vXfdn",
-	"WDevlnuR3rEdUrLfhoCyDMSmdXoOW5NXKAxSJ1sw1CUEtgH/loibxrKVWNPLkY3G2a6Z66VtLN+7Ud2g",
-	"XCUGRWeiuN1Wl7hdIXgj5Mzm/NXB/ROjl1aoCXmucmIMnApLjPjM/YHbYGqjip6Zz6YuA9kCeNjLi1hc",
-	"WtEE5A24DMoF6iV/bzmwcPtV2l/AZedczZVw2O2f2izq60cAdDBskNgRlvbfEbFY6OU7HHZzmIHz3yFK",
-	"uPXboyNxAGBgKU1p+hy0OKdc2RLj6a1LEe8tSSRNDWKQDKNdf3jzEkrAIWLRpLDVof76cy3O2SWHHfmE",
-	"O9fjAU1d374PPn349DGKMq5w8U6cMeM2bu5JJL+GIuaCpBfinG7GeZq/lvkdtrZ2Fd5U25zNytomLn6g",
-	"Ny0qfqDbMOktXphe3zrOvBc20NkDzyDMjBK5EQRv47hq8GblpjcBftTohrYd+B9rHc5u+B6CxXaEPrth",
-	"aOE19Z+yGECYslRWvt4NoTl5RrkUWbabZn548/K1HXrTsPELbYWL79dgDvjj6duyI0RVyroSTEICyfMm",
-	"7HCNGqAKZdRfjszFMKw4wDplRNhz3GgyRG2NvQRUhM0Z9mx7U96ByDCLG5AzJzqw01KekfUGv8WivXKF",
-	"Hdq5baOPksU1YJitXWtJc5sEyi7KEJUWXsA8sxndu2/Ul104seNvUButLXTVu/WzRZTHW2Lv9BJKaS6p",
-	"zZk1lxXaJbdp6HqzyO/pUgqXsxugGsJ+gz98pcrPIhhVceFnki6Ycq0/t9qIoSBwn9xk1s3mctv4bLml",
-	"OnDeFFlmE1n9MaHvi7VSNQzF0bCq1YNlEAabYJN0Lqla7ibAUzfw5ijPrXCf9X1DTaji4yPQXan5DlBu",
-	"J45zD4F+zg2ohpaHY22rfkJUQlLqVGhwVcloOthqB5wKjHO03fiCtZ7DinENBDi9BILZdA/8AAOQVvQa",
-	"JUKcsy3RHKfUvz98r3X+gWdr+FuZtz91s/wN7DRDkMKmCmDBDp5Sma1t58Jgs0PcrHK7ddrtEOsOnlE9",
-	"OsGpFMyEthXT7ZxpOYldy7YqAfunYEtuvr+N4UdVVQlxXWXh5ce3vr+ceynBB+ycSFube/Tk+KFRm+Qa",
-	"lkKcg/Ld3dDSIpAZvdJvxD09pIJ/pWFhRK0oMGBNC7CWOggO9ILKNTDuM9PxuVsUujXmpKI4C4q7tX/8",
-	"dbhbeF5qzlW/sbsiM4cILiJouI3gxvCdQSeD+u4z24ElyYxFlY73pboABwPK85Za36PbPBOXEd6ulMBg",
-	"qiMjRGckOd8lD8/OPpz4obcQhtQa7JAe9LqymXTY8UNffrr9w+ajx+PjRzEeZnNJbfMQtIPyvEw7xn6q",
-	"FcVaQueu9HUjguXsA0g32QhLWP/rf/8X0M9WV3YlLURKh1YAGRZXsjf/nartYgtulK6+HYjhfX13hRWW",
-	"DUyxFvp1XZQDUMlq8qCRnQuz2u6vfS/0m0hC0XfUXLG5RsUW3KhfNqfNX41b9236EVmFkK6YY/mIXLsv",
-	"3/YloUf0c0LxFO0px28ySjWUA9F1MSydd9m6eq2ZrX1viL5T6Wg6nHCSGzBQfG+25sLQe+BKljcYw/sg",
-	"9iB4Sp/wp1UsZLmLZl5edaRRdaSWR+uTcuzr6vSds5BtvfaN5N3ywL1hzx8YsfYX3yfLOx2xyxticvcH",
-	"6i2xLRjOcqshLCXU3jEVDZSswFqPKLnbh8c67rQnr76p2otVWBXgP9bdrdNT5R3fxvdOgmE3eD3VMrWy",
-	"ZzHwlCOrKtrWMXmX91RBM/ZKjGFM4XNEv9y64Nl6sOW1amPi4RYLtXlZ12+hVivU66F2MlMf3sA2OqKK",
-	"KyN5646nn2z1FFvBzDkXsaPo0IZVljHFqD77EWdn38M5Xd96nPEPRaZZnlGwb6RQdiBrOKYQmEAClO6G",
-	"wZvvrAFRlPnzKc2oppsY/gr/Xl3q3SWtR1ycdnMp9Jma2qSMF1hndnDrweoB1remeou5HlkwH3CL7n5+",
-	"G3YQGn+EwgJ7MxvP3O/j1b/B3njhpQftKPaUQ/FilR9dO03r68eYYF41fnY5ydV0Y0A/l42golmqwDdv",
-	"c3WCZiJdgzX6nmNBWUNmbiiRFDI6x+wGUSRLatRr+xKzIppKs4++95YPIZfsgmg6Pafr2j+wtG6+lETR",
-	"ATAFko7Khu9BDzmCedC2O5etfc4U1lHMGLWd9nB79unHPQhVva99eyuWL6nU9LMeghKVDpMQDjMKNMV2",
-	"/768Fu7EHMSFH5/TtREU/khjK0zAdroVOcbvG6Cw1arAykoGHnZLTPni0C+wA5cwB3KMvroOIFqsXIh/",
-	"SlfC+xdzSS+YKFRDNET9agYv7ogF3KTGc6exWd2YkM/2StqY0Z2oPr7EHPRdW1i096e2O/ewTDL0wHSk",
-	"cz8kJzbBdk2cVCU2bz8HrEm+icgyllJV+dDK3vo1Cm0WcczTpu5mGC0G1l2XEvcsyQTf8sxxInLm2Iqr",
-	"j1uTRhXrVQ1WfkHljGi2sl496waW4tKCAN8XiFxQbVnhkWeIjceJIjsHtrLRz5m4BDMTxjwboCyFojyE",
-	"jaarPEOHtABqBnF6ma3dBK5jcsitcylWOV6DDwNpHKLtJSKwrBB6fwSOiSe53yai2eGdWYdvd1qEFxtM",
-	"9Na54lmTRP+4zNFiQ4M3lpzGqlp9N8O//s9/2gsT0v6//8PgUDaaMrLgQmmWqGc0WYrt0QivqtGvzeA4",
-	"v1hSklJZcYy3VRX10Z/peiv7qHVrebqzW0vLiv/X6KRKyhq9TXc/XFw/RzIAuiO9zS7dzoDM71Xo9MFR",
-	"9U93f/IDqlvvhX6ZZeLyDoi0gXs+OgNJNGVzbNyj0dxrBkoaGNkHYTyyTxx8XnYQUGF7AF9hup24OLrD",
-	"R5oqPfpFzLoTmv3wE1X638Vs0x/+6PqAWVtpGwL9u5hhEEqO8QKXQp5jniZ2gyes+U6AnRBGx64HrjHw",
-	"noMDB8aIiJHIsTVuLkViuwM4vYnxkfubW6QdvMY2Jprach/dges+e+mK/d8IIwjXuCOOYPNoXtGE1Xqp",
-	"tGfcpG5oy1XmfhTepTtgUGh0qpeSqqVA14rP7onfXC7pihWr0V7S56P96F4Iof+e8sPz8ke3x8tdDXpI",
-	"BbXJmraQLfqJDDZMA7SCOSUaNdfGoxhOMcJ8djAo99y7ANTWaWrqlf/js17kk1ZEd5+PjL42Qn9mV2w/",
-	"tV9+L5Q+pVie/gvG3wXGQ9/2qADL2MxFomN6cLfvwOU+Wpg1RixbVl3ievlN+LzfbkPUl9iJ3dbOOAC9",
-	"/4IffsHv+4PfeJX3AcEr23UPDN+o4rUDxbcbyB7HJV3RlFnjkn6mSbE/sp9WU7x2M3zB+v/uekyAV1OL",
-	"V2XhubsivWBLzzyqt9PgA9+pp0GLkVmgbz4YwIOo2tV3Ew32UbzaabvtFJ7Iq0jIo39+xmLzNjCx/Tmh",
-	"jGKsas27WMYx2IbYF4xeUgmrQmnnaSib4Ey4/1xCX1FD9tp150sLjalET46/HWzGcro1xhO+fzyn4UNl",
-	"vOFLd74uDv/P99PjX57l1LZTv+Fil+VyMZL5tKzuv7qu+xLF6XZ2l8UsS+jdYUHL96IM76ioFzMXXBqJ",
-	"o1imamOaKQKOdIAEswRXvo2r2BjnfZiKj4rel6lsZx9B36nD2MepPcgX7nFt3KPMD/7CPf7Q3MNSzmHM",
-	"40Kcb6vK7eVPxTswjSKWEYIZqf2U8AWVolCD6+AIuLsvHOEaOQJe3/1jCA59vvCDsqmkp7x42X2EVtUZ",
-	"p8qPmdG5kBSYVja5q/5GMs8o1WEGmu3R1pp99oFTjEvKqYQqcesME1sZh4ykKZUgpPnfvm+SOJxwLvjU",
-	"r6KHkNtI2iGshNLZOvwp+E8XUzeY8DIMCluBGxMGM6iXQpV1nrEtZHWQqYFxWmRGY7F1XRGOxNUUH8OZ",
-	"zTDHmf9BpXCTVS3oMuyWN+Guh7gLNlWgNM1zKhUEHcWJmXWWUVDs88isl5G1zc0uTSjX81MlhI9se9KW",
-	"fDhMeGrA9kYzlOILtvSKtR2SMCwE70LdE6/0jgSycMeIvEEuWUVQrVShzT23EoWBS0rWgJ8BWSwkXSBy",
-	"YetoVx2AYZkTl+vfd1E68Ph4wlOyVkNIMrLKaQoPx+NvjwfPgFxQSRYUVGLIlyRSKAWKk1wthfbxeWo4",
-	"4dXJhqCFJhnGU2HYaZEZK59wNxgSIiUWUvCUOeFzxlOD1mP4KC4NVpvt4uhRbpZ32wgENqQ006TFO4CA",
-	"6obYnxCmOwoUf2oAjnEw4HpeggujmP76cAjfHv/cUq7YfBBP1nx827maURBEcPwVYZnHJ0wYVkMQWXpP",
-	"Ujc7EF14gAB1tDvwJqlxTl1hi6OZpOQ8FZe8vaI5lcyIwjzGkMrw1JJj/+v//CecJYRjQTOjtz76esKr",
-	"Fu3Y+HUM3xGeKrNZaq3dvyUGBZLCyNOpC1FUf5vwpWHkkiqmnoHgGeP0haQkWRr+/8B+8+J4CCldSJLS",
-	"dONHqzi/eDiccE+GLwoeHZU8HmKF3Re1Lx8PgdMLKqe5FDOavuDCiOTxhJ/Y86tihaG/VhOoIBPkZyPU",
-	"RyHURyXUt1Nv9cV35TXdZHJAdMGtsuk+iCVXiXU7jTwpN1ydEcprgL5FriOPSEceW47Mz0chCgwiJGUU",
-	"JE7V1hRovNN3fuBN871yoehrhf0NpMiyIr/1WjAv66V2q2qq9x6Lvg8432wNjo+wzCCTK5CwiRySJpTr",
-	"kSs4shNFTnH4iRu9Q2RXfViwJpIt5u+19Ln58FLI86mkc8NtuSYM2zkwhSlgZcP7tt4DfoJDm8PUNmU+",
-	"SHS2xroIRmoQbrdy+ubk8ePH31Y9hVq2c70l+7v2THl4fKdNUyI4ES2vZAaE8L5ah/Uv3KADN9gEuoK+",
-	"EzP2qgbNIiAbzAFNVFtWo00Bc5qGmIMZPJUFV7a7inNW4NcpWh6ysHqXdSyMJ/yTbwffR8WQapoeGfWK",
-	"pgPAiYwJTj/jY3U6BhfKoKyh0yw0g4FAlYK5TXcxGuB/4KlumjSqlSJ3+h8R0CSE/16s6bMSOSCluV6C",
-	"yjOG1WEz3xiw1aBGU3ansDnDUZ2FDPp9jKU7tWiOaHirwubnm8cnIaOXZ10bFqxfeGRXHhmvKGT9LJhS",
-	"z/jiCD0pMb1ai3zkHCzIfXZrT59E/sZ+8D2O/x2h9h9AT2lCP6apEH7uE169of9FTblpo0VVyc0rD/nS",
-	"awl9swRF3+QuKsQP9qDCUxz/hQrvhgot9Nup0ED6CxXejrGAlBanQvtg0EqFCymKvP2Z8DTo0vgnHGpf",
-	"E/788S249VEDxto4hXtsM+aEnXfC+4ppqnz1SQNg+HAGVRn0wdDWLMDNM41+27zQNIUVXc2onHDrSPJx",
-	"CTHbwa7VYjLYXd+kqYAr7KoJeOaAlWeFcsBxjWnxeOpLI7u9XwIRiiUWPnCFte1fS3Sq3JAthT58oTiD",
-	"p9BfEV5gRRqDe2rJcqwGTEKkXftRE24YfiZI6hY1Iwst3L/O6RpLM4FQ0zlZsWztY+ycBdxsPd+Oxh+F",
-	"snh8QzmnOLeFxG3XwLDHaglqcUUvLEDvrPSFvU7XhLwMYPlCqm1JM7cdW/OSh2Tni31gOQ3/hki0IWBL",
-	"hW2VIh2SbcjGSNHHpoxciQuXzmz30Hf8A1xXh0FNegV0b2Po2gnflmz0pH+vykh+oYIOVHCLUW6IJK01",
-	"FV/5SpolK20tjaiTJRh0GoIqZq7NNU8hEZmQY/gz49bnWYlIIJJOeFDOL47ru2ScWfh2Mf2GBKmtX3bb",
-	"2WtbBalranXHgrRwgPnCOH4/jKMsxoeo85WClKk8I2tX3rRNXh459tAegP5SKbbgCoh112EJK6d9OyFa",
-	"CXUFKQYKGRHL5IR78YpvLzZEHj01qPU/OT4+WN6WivYPuMLvnRPZU1y57SHOAiRN76D+3AnhSLVpavDD",
-	"7sTgSqjzfeEovyeO8hKvMk70u9jJ0T/RidtRIXerYBBgfZ1r0Mdvj0MMo5M6QNy8vu/IXyJQv6j9u2it",
-	"EcWxssmfbYjYhvDPVoSZExGebEniOqPamp3BaJhnZAG2PbSYz68uCYON/N7FYXWUOyoxsa+S/oXOfh8y",
-	"7ZNYLLJQS24SZI3Ol5RkerntofN7O+IGMdGusPXFgsoLlmADAbthbPby9DbxINiCD542bK3g5IKwjMwy",
-	"urVPYxmL/AAkJSnD/8ZAa+gTLvh6JYpGq92dgSAtkR/RboX8gknBVwZOB7wKa7K4s2glc8pdL1oYr3z3",
-	"ba3ayplhQ6ulu60Ohcq2Na3yl34Tkul7W1j97hpV2TqBO+757ptTVR0aZsSG+FgnJcuHkAuph0B1Mh7c",
-	"+uvD924nzYcHxiFkAC2PDuYc+1cZQ7SubKGwu8EzSZXILnZUGPu+3ont1H3TRb+7GbvjtruQuBNvaUPy",
-	"5DaTw2vdbbxsw7crX799a1F4dxqbWB00hlgSbesszyhgIWsz406kizUKbMO8pplSRKwUVI4YX4RK0XQl",
-	"UuoK4ZNCUYWS5KORzZ+wQQb2XlXnLC/zWKve2aqYKcMruQbNknNb7Qa3lFXZR5gqXm+8hN2MJFXFqrEb",
-	"yJkRJUVelseBjCgNkiZCpj5VfwwXD8ePx8dRc6lAmtrXWLo2YroZuXT3BtMu4eS7CSFK3zbdfl9rhtGg",
-	"yY8GrY8Q2yiUeInap3J0qBg3VsP1yIAqDfZoyZQWcr0zqKvIDZH9DcMP/4ZRYyObT2aJqZpx6ma0IZNm",
-	"80EhvTG8JskSKS4huS6kb8dF5Sgja2pbgWFmCJpCzmNRZJr531El98S2jcycAv5DubPv3VFvi9iuGMH5",
-	"9E4DOKOg26r6hdduk41GQdr6fSG1Twa1vJgwxnd5xlENcfsYGOlQHM8x2LuIsSO7Tn1AzabvZwdQ1wRn",
-	"SjSou2hjtvU6660/u3DH3e0+b/Mq2nJWw5o2LmjxGqLSH42PB2MoXR1MQcHJfG7rAN7bdChzH6+oJizb",
-	"aXqmOAz6ruytqoTpgwhI7xku+16mZQ+2+O6BcsmSpXMVdfNW+PidSBjNrTOem1E/77SbZSe3iHPZ3wO3",
-	"yP1Cexc14iLC3OuXDRg5VNFFP0dJMO0lnKT4hSZahfoAJiY0+WwiZF6YYVIUiyUQPuECJyFZxXgho1yN",
-	"bW40gvWzxtpLvjdkRjRVesLLBOh6GnVZwQYB0OdFlinbpxeLfky4Gc1pOhiXYeyuAIQzdLHsg80ZIDax",
-	"cZonesLr2Y1AzM85lUaxIQs6BMEp9uRZkWwIx3ZJO5SpCTcCo8rA8CE22AiSrJwEmq3hnHJFzECSiUUZ",
-	"/T7h/YL7r/9BUzu5r/BmTGxsOunTT169PjvBtI8JL+PnX56djF12WIa+stc/vT79XwiwfmkrHBnjP6fp",
-	"ETWYOBhOuDJAYXo9wqp0NLXZJHilLDWTDi2HNRclRTZl2KhZ2EqpE+7voiqlWV1z33ZMFnpJ5SVTdGB9",
-	"CrYf8oQbUwbTmZIlTc5BFDovND6VmS0B/ZwL5avumrGuVA8imAH4zJCI0bv+36ePv7UnR0hZSc4U3lfB",
-	"c7JgHM1ZlNfjCT/daMDRnjIPNkVti9lU1au6SzVIi710HMJTf4suPwhvF1iqntdSkAKMJtKaky6TqMDS",
-	"frZ9t9nC/VaLqlt6R7na2hm0unvDp6Dv6g9YPvUgSI0JYPPA4d99TPK5V/6bio4bUDbEaiA9hBXh64CL",
-	"XDB6GXtPbAovVyVjI9817qWJGwjI6AopKddTKyZeWA+L5XI2xWgInlXO1uDZZ1XOE1zp3yVbLP1/r2jK",
-	"ipX/VyYu3X9OeMGNqWiZbkaUniIztEak4fJj+MS04ekNYkzEik546VhlfLSiKyMGrHyxfNUKmedOUi3L",
-	"vyD7DN57h6DNIjAnRpTOSHKOpYAMWzfzMMeEvSQ36/rbsbQPktpaQa7OCX5tGFGMHRnBXvIj2mRHyjrY",
-	"y0++qjGnCceKhoEwGlsRPPWi0dV+zgV6VczmhpBLOkJnklkaS73tIwK28P43iHItGdO3wPx/IJ+dyJeI",
-	"10ZcnrjSj67w48Pj45+f+xcOeHjcxqa3ONsexupA3rwgut8CJbj6bdLkTb3YaFPb+iIvtssLjDcg3uRw",
-	"rDlb++IGoRiRLnN+p5jw6NMuJF5hz+hEN9H3nK6VrzUbWEINWYIllYPEcV5gqKeYO1JdkdzRJyXJMpQm",
-	"IWM1TPc16s8l90bBuSReQZ5RysHZOuMJ/w6vFO0nI1BzlpybVYNPQ62W0cs9i0ftowm/qWB8J17am9Id",
-	"q3NtpflylEUCY7xUF2uv31k+97aq1b1jAmhoVIANyA8habW4FTEmt+jABXz981Ye8ClYQFxWT9gkJTlW",
-	"jvUzyGcb1bKHE86NseCHpE6zdfwLjBSVFyQbllUeclIoG9OoJrxfWrvha/oD60vwq9oKTZQb/S0NIwZQ",
-	"vZqzxWAMLysPqSg0Ojvs13gk6VRhCzrna3DF5AnwIsvAnGKKzheiYeT4DuGA3oODyrfX6enM38IfikuU",
-	"p4oFX/obcEoPOhsDf9YXXtD70WIiCAnuRc1BpsYUPvCSPj1JIvpVON5/WWhh/6ZZRruYkN0K2RvbopC0",
-	"LDd/tUr2pQNyCM7/OPR+PlexfgyvyFpZynR07FZGnwyZKXx6LTmUlGT9HNwj7YSTJClWBTpVq0EpViC3",
-	"dTxgIcyW50JeEpm29KHZVrq+jv4tletvwRz6g5XDj4G1tRr+76UO/r1kJhaEgRj3JI5YjwxacFp9GeUi",
-	"VZnyZ+jEac8wOkE/S/k0wPgolyKp4uhXJFkyTuXah/wwkbIEMiFyKJTR1/tVOOFoLimFTycfRzNjCqDK",
-	"nwup4dGjwdB8rPA1QAur5ZfRfEOX6FuVoppLqpYYypfpMTSa3NrWdoZQN02EoE4+nrwt9ckidDX6BMF0",
-	"i8l+19TI9+Gjbzo18r2Fqv8IwlO8smjdfxcEZn8/sFrcF8vk7lpcvXQsweqIzAIFmCoD4xmHecYWyyZL",
-	"O1vzZCkFF4UCwUcpXVlyD+rfVzPXoyZbOFzKVGIUnfUzWfB25vYhp9y+vZ2dfQ+K4rUBWRDGnRmHRygU",
-	"emu1Ahdbn054xdSGttY1+qwzoWg6UlS7Dc+wmEpfqJGkGSWKDqHArAUsYcD4XAwhnQ+DbIYF1ZTPhUzo",
-	"EAgZWc/+0MhIekmybIAdt5CvmgXtQ6QaQpErKrXz71gLZ2qmhweQUm5YToZvtQijsVDT/7+xvbJixTFR",
-	"oQRqUG58CHkxy5hamsXoBeV6Vqgxxu046NLUMma6YsF7+7gE/rh8FZ9wUqRMA07jmLKzw5AvV59sYcd+",
-	"2fVpwb9w4kM0tDME+Vs+F1HlzMPXMWH41//+L/cUg1G9Kdjv35BEq98nh77zLNJNFv30NlvJ25ilqkUR",
-	"XrHhfSkjmVE8g+QRx+vAvlXeeupnhY3KJYEasF0aMvOeYvPDRsfUuDD5cAZzxhdU5pJxDSW/6S5Squam",
-	"W41uFBhVz0ashuqdJsFzvSYzeAB/MeIBh9i2T9+ty9cvr+yKnHIXvFzFrTwoe0gOnsO/OesZk2mM6ms/",
-	"tAFEZt5IQ1eSHtTC1dnPrytQ3CIbbhi/yzLwP2L/zkmmaDnVTIiMEn7DDLaEyjum9NY2pKrZuOO+NGr9",
-	"Pdi/jWe2IIK2wsrWYq9nxQx1lWg/5SA57oEsMjqGD5wiAU54QHxmkKe+4GPUczNxaZvZVbM8BzLhaWGh",
-	"Rku6fnL8rW/S7ruwu3CAWuUFY0PL8YRvkjB+Fdi3e/VhrlHx7zhIOGjCfCep0x26Mkfadv/ONKcNrLuX",
-	"TOL2a86iaK4YQLTurLeCbZOgbLPbswUoiTIy6ON74SVhF1QOjNZDtqooKiF8S8E9m3NuA4kJN1Yr9O07",
-	"nY9YzsRiJsS50RoG1rLj2CBI2Yiy7394eTJSbMHdKyH8ImbIsi6FPMcwWJoUZoULRuDPlCsyBh/E9uj4",
-	"UdD8Gb9maWlh2H9rRbM5MlJVKXHPwVmRTPAJz7C1J+PNQIajWp8ss3UzDeei4EmpMDozFowdaxiwDVcg",
-	"CIlWp4VrgCXkhLsuTxv+RqjcjfVgLVtuKXh7RGPXHHYbYz5LyH8b+/b6bB8DtdPCdutK48+ZDul9UXGD",
-	"JQaDHZKnX0za36fXEZnHbvr1TdoaLPi1vX0gPDAXa92kCO9uJTqnFuNz0amlRpiQuuG7CxNIFuzC6KHo",
-	"YIOPIsdHUhvWG/OjQT9goYYfT/jHD2efoNVJimqt+cZMWYveGIwn/MnxE+c65EJP8aKBzaFPBpWXFBMP",
-	"UTgPoT8bVEHI5hdVpXSmQ7NWPwk+dSJzVmgozf4Jx/AxoZFm19S6oyzHFLZnv/nR+lmrWSiGlRgBhNhA",
-	"eYqvjc2HoOCethi6gb/sDxD1sd379w4zmaA+8Eu8R9R/ZlXQD6fABQReU3Fp8HRDxSNpkCoWjJ+TxOmJ",
-	"0QdbxjXNMrYwGH2Eiku3Lj22O6h1tdu/fDiDt8FkkIgso4lGlcYXODHExelltka11hixQmo1hJwk52Th",
-	"axNiWDB64ybcd3aydZfgpJBKSHApTEZ7FRxSqjH5qkoRsKHXEz5bgyvHMLRbnSYipVXU8RCwIe9RwTXL",
-	"QmeVUKMQMi3UG573tYVdp5JtVYmIKzuoqlP1WjSmr5/sUphapvZAqk1MebHqPftrj1l2lYnL3rBnszl6",
-	"w96SLQyn8pkfvZ+7L3atjZHxPq9ttgSR7iZbrj2604Idm2j8ERsvR5yLltyv1Jf5Hjd8Qq/fBh8LOV07",
-	"77QGYq1w9P56WThjlYdVZVuhfmbfP6FFW4poSkaGsPmEc9E4GXbfNQpQXqp6mONkRQz0Sz1owrcoQrCh",
-	"Bw2uxkrPsB/wH6FK3OapojqR0mUA4xf1J6b+lOGdm5oPQg9T72u4XX7RqvlkLKFcbe0v/c4NuUEMcUsg",
-	"cmxLoXDjgl7ZFQj+RG0YiY+mz8Kx0NeMyiHMKdFWkfp7ITQxOhZGfdSjgLnQbO5Ooo4M6+M021qp9n3w",
-	"xYkff4MAi6zX9hTmfm5Wj90urt4IOWNpSnnwFr39C1c++MdmueC6WAkhCx6w0Fc0kRRjflJidNhtpaLC",
-	"KTqUk41A6oaKy0ZWups2f7Ejb0EM76NztxBcwpWUm1tHsLLOawzJuiLUZkmUODPoWJUsjn33sLfc3VxZ",
-	"2SntKle2uyDZvbmF4zui8cPu2Ok72794L/SbKr7qOpDCl/GK4USESe0rKbaU8rpLPLkVeXQ33fI64qov",
-	"L9t+1bclj+4I8cv2b7cmwJ5pavWmuP70iSp9nyXYJ3zPz6jUkNKMXVSlE/64SHJGeQoE1JrrJdUsAV0B",
-	"wddX867pPdBG04ZhKOmKpsySu+NO23zi5WAfhmMfA+vRd8OyVky2diViXIEDH3tf+qnxDRGLjT2HxFZG",
-	"IMamWzFdZU8+qroPTniw4WbJguCnmOPFNt8oh5z603byYtudR73DOeUp44upDWEj5i58NBvShi2W1hv2",
-	"UrmeyoJPfQx/b9iz8R2GFvx/249EltF0OiOYIOXChbv7l6/R5e5u55r9wegCvlW37+bFtxnSESS/V9Gl",
-	"TQLY4eGVkeNAf47d/oUsyXObgtVcsUswaJMoYvtoRocC4al/P3N1nHypwUYVjbB+GJvrKqzUTz3hW4JH",
-	"oWPsqE0IigSPwqclU/D+9U+vT21Ro7A4ZgunagaX7mBWDkkDZLwhd8YmYdyNN2NzH20BoN6REcOovsM7",
-	"8Hg3+N093UTQ5kt0aBUdGrv1q8WJhjP25+zzwPGleVC8K4gUNXwSU+9GPoLgryGHHJfxyUZgd2OpHt23",
-	"q2VH/5Rb39ownr2jehR7lYpQYBcLQN5j90l3phJBq3ss5m+ZB8T0/rZyTX+iTZqSJTJ1VzA6kcKR0jTf",
-	"njtmRti46TAPF34RheQkg/6JzcM8epnn2frIlQCnRydihfUiRaETsaJq4KuxYaxFWPIYmPJB2in0S3Xe",
-	"ZZ5M+IeccsxJe+BfqlKzk/+Pva9rbhvH0v4rKL8XliqS7KSTVI9T70UmSc9mKx27rKT3YtjlgkhIwpoC",
-	"uABoWTPb/30L5wAkSJGU/CHZTnzVHYskvs4XcHCeJ74s+NSbNRbTyTfb0YxhOn4gnbUDagvTYbADqLS2",
-	"a4c4es8qexuVdfVfDTp7qJvVBhSvf/8afeI2zu0VF2v7iqGD1fVbbh/GX3G2ZIoscm1IwqdTpgr4IwQz",
-	"wSi/p5lVF7xdNyVJbjjTA7sfaFRQ10pYgLBBR9/jG9VAfk8auuPdgp1iK3t/PQoP7gXgcbty18tHbBr2",
-	"HNd/lcYacYQ6quk2winCIaHXZ1fRWShwzZQ5bSsPIFojka4Qvji+2zKC91ZrSyOXqNWwE0Tlv2SeJsQh",
-	"K3kw7nIzwwDgaTmn9t/O/eHFPT3wcI82fsjSFdRW/aYYcHMw0gt77cKW/oh8xctGhC+ylC2YMCx5549G",
-	"IvHm+OX25xYfAUvkQaxdYIEeh667Ca7p+pt9MtB/RFED/a6tcD1H756s7Ycz1Lxtfb0b8raa4B9v1QQb",
-	"l3timCm/rgAa9zCu7wzh+4PIlaIVmPbB6LDIMlCQE193qKvHd34le1ivhPC9Cyry2sEmMv1HwoX6wxk1",
-	"wEQTnCxiRDJh3ugdemNziObuHclkmkbiH5++kdp0FaUjfsPxv5gZIG6bsr2WfsIPPLSaumLFOqYD7KGk",
-	"cHVmOCGkbT5qc/F4PH2z9v/Env683DGL0ukXYVvTZU8np87NuecCFawe3Xkt7m908EWq7c+dmDXM+d1i",
-	"E+OThTfdxGzartwg7WA78LxZ2f1xo8trPW9Wft7NCirb496rKJmmcA2h1ZidM6B001Vcu0yxoZuR7eKv",
-	"SFQDsOppmutFVyQViUNv1g89ufzWZs99/1EGRL5zJMRUeBRnnL5jz/ahM8Qp8gNNIY5dXSTdoqJ88raB",
-	"TXhxaNv0o9fwqkWAYuWtCvvO8VmS8omianXicPJmTFgVY/7Awt+hiQRcovHhShP3jGu9pXrOtXewU0du",
-	"m8D0SnuZEtqiyuBR4l7uXTmdwFXuqjyNCtS6mGjSC+9a9ZvEchsWp1BCky5Gp0wxYFCgYrWcM1W6E7wj",
-	"1XOMTzV0pP4A+JtKnicg84EUgmssEnXCJ24GUAU7LCtQnSqU7E3ucE/HMmORQBqnQ73Gnns33akQNO1Y",
-	"ibYjTbKqhPMdXPJCusJnlbqpSlXIkkBgmCbFReOQwgymvFHDNJ8JLmbDS7baSsU+Ja/evHn5NwS4jpFJ",
-	"H3SDG6T640mf5BoVwX7c7l9R1D2PCrD3UhLjkGMqyBVTfLqCI0n76KGGN6G0E0hXIuFJA4Gyc05fvXlL",
-	"5HSacsHuqiNjnACP1rVTHQna6nQzxK1KMMvP2rGpnHuvEMtfUbit/AIPVq7WDtqB0LrUkqlUTs5xB1is",
-	"M1YwNyrnv7fBXCjAtdw3J1YHB4SLOM1ht2kKNm7yn+PTr0jMCmDyd9Ocv68+f3zqdXc4km5tfFa9R4Wk",
-	"gEvWeskFyw2lKPShdE+BEnjqn36r3h2xa1j8NvUbG8XoAvGQBVJ7TmnMbGQYxHfUPpDIpUglTaxXjgQ1",
-	"hsbzBSggiv7/z5JpUQXTd99Dd+vZ76Vgw4zOGDn7+NsgEgnXUPiIMHaXXCQnwQ4UeAsdf3mPkim/BlAq",
-	"5DqapDK+HOCVd0DTsl+N6RWjpiQqNDIryFdTrk2fuIxUEW7AOJgNkaGoDajRepQsmJnLRKZytrIrxAZ4",
-	"9j+bKTajJmjxRciCigRlA2vK6CJLIXiodgC7Rn0MMJxTPY8E4LIgGzFMVp5ewiLofkFjCJ3O05R4tsUj",
-	"+z82Yo8Eu+IJoLf4dbCSWuFKiqmQAui+p0r+i4liFl0/ItGjAhegPyK/SaBNDCfGb4ldA7G+Cr8fCduZ",
-	"HtKN2z71ie8TYddG0RhvAri3pY5peqGpKr5BI+GM/+n4w/sv5OXoePSWUK2Z1lbChkhHoUki49z+ARnY",
-	"5UQzdYU9tAvB8Vgys2sYdGZQ9kaxKVMMAGEnK+IiMC4iMaHx5XBhh6wG7izERmUJ8FKCQgDRdyKZs2Zw",
-	"iwEXzIeGhxpmEKAnyevj4xH5ZLdc8DbXpX5Jgfuo8j64SCIRU9AD7if7AiTABZmKZQyaRw0kcFqJilu6",
-	"xUhMVobdebf1CQ3Gg1DiWSmHyZZuukbkI9oToGnPkmkrzza21Vi+dZAl04NBWQAH/wJzPjiI9ZWdCi+S",
-	"TVVrd3XcNEk41heeKTvnhtvv4GS5tuQEMnDWiIffsj2tfKqY0QkXFIa/NqcHhl2bIzusypv151oChcAF",
-	"DNatPimNflCnst/CDjcFz8HMEwpmPnq71RBl0CLAsTEBRDUD8mH8B6Sm0B2M3583Bjgn/jCuA/FcLrIc",
-	"Ic/Byw65AIDBNVpUTFR7lKaEGhqJXu0QDShPj6w/d1zY5AXxcIoDz1qeCzOwfh/hMQs2fURTd6knjhGV",
-	"IHyxyA1oFg4JE0a+HDkSE5ms8HDNGXoXDhnrFGZK5tmhJgsGlO2AN2dbObL+O4xLUib0Ozivh6IA+ChE",
-	"MFBzWL5o/xW8V/UkiGS+lSs5k9r5kn/4BdpNxtx/HhsLcti7rfzr2mvVz4f3bid/p6k1kTbCseuMsZxH",
-	"bAORueAJytSzEd2Ao16rFMKVJZT8Bke/AZnTp2LDMnbPV8yVTFknTts5PLDD84H3yYILaKXrVNs+UAdk",
-	"e4icrUxZWYVROyye5Dy1VpwoN2etOcPKVypLcYIlue0II2DA7JOutng31utDro1c2HawmQdisCm70SUb",
-	"+BTMuq9o3rtpOyvW1xu0/WfM7fh5Qgy9ZKIN6S0u52qTgK7j4kC0sPG0FHPWeKMYKWL86VBA9RmcTPh9",
-	"r44EnkCEGXs3hEFxYdd+cehSxGSi5FIjUzPyy4wice6/B5ESksjEUmW5Bqh/Qw2P+4MSTCVOud3Ga56w",
-	"Am/Afmttf2oH37Y7zXdsJG0DbeV739ysPCfO69a6WMYtsnyBvHrp6hUnW/Bnl0Ttur9fNFhRm4L5aGPq",
-	"ryQ7cgSCFRjaOjTQhMaXXMzwoNG+OvRvJYqn6dBujwk1TjVIj11nqGCwHTCSaMasXqK86/7IgwnhkZBn",
-	"DVrHzp944pILagr6tyad8TrZpDNjmJUb4t7fO1FjJ7JOgLT+ciPS+tqJUTFF/sA6pcilWYAsaMYE6Z3/",
-	"9uGXX375W/8dkQuO62KoMnbl7Fu45i1HSw0Q81sh1u8y4WMXtstWOXJEoK7xAnsnZPhnU9dm6h6YbGk7",
-	"akxnnapXlW5lY7fO5sZUOAlEa7tghkK0kKV5QU6bp+xQkyRXmFS6YirhsefLpQYFuOdx2EpqkEpoowdA",
-	"FXThj/l9BRNdknjO4ktHkm4l6uvpN3+0T+ZMsXdkCok2biCJgU4IMfNZkMQoOIQazTCCH2yywz9CntmO",
-	"4yMzlKdthgcWLHGPPBuOR2Q4gP2uzXCcCuY1ttDTF8TnGInPv/WEdOpTKMddzMgR5F06jAlmkKkgdiGV",
-	"ky4aXBYJ84Xvi3whOcf+RqKaMPQZwheV1KHX+/6AKBZLoY3KodhlquQCAz9noLB9OMQtGS4PNcEcO1MF",
-	"myXeeV5ykchlJKgyfErrZq3FmGwV08Gwn7oxObWL/9EtUJPEdi8upAqebczTsTHvyXIu00CJxQb1LdL9",
-	"dzExcKRw9G/7n8/JX0febG2MYODqTSU8KeMBRwZpmwZ1d2FLJNDxDVxS3poRrC5iahjLBRJL2ohEk577",
-	"96CoQQL4piw3A8KuuSFIhsauMyi8O6KxyWnaxwsk1ejH4Tt6AMhMSTklEzbn7haM6x18TGq4gJCuSG5t",
-	"K6lMGF5EmBW0koVE9XwR+xAHGB59Gzqxe6mVLi+iDKeKsf4NzNl5nrJPfmH2yHtbq44CEdmW7PbVm7c3",
-	"J7s9vmey22DaOg6trIcqHnu2l4/NXjpQ6c7YzC0jHJQ1mCHU0OBEKqOrVNKkf4+Wc7tYLTCb7p6iQ3tw",
-	"YZuhIqGpfSqw/ZHoMP4doVt/gPi71ZCN3CBiu9PJmtW/vUViP4DNeg74fnoDFhqDHYZ/Wh5lSlo7qToT",
-	"7+Px6Vnx3C69ddlO26mt//3WjGjrB4Hj8SkppoH0io29jf/euZwccXQmeM0YL+R2w6vTZMHFidbywn+7",
-	"m+osGPuOEulBCw+aSQ9H2rXC6/nzXXKCNOaoRUU4brjabZp2xIT1ucm2GvfJPb5bxXOttOmd+zlUFJ6Q",
-	"F8Q6WNCUfpNquZHWVMznzzWfiSEXBOthSY8KKVYLWSd0rE7edtRtVW36ASjbbkhY00jUVpVm0oupjmkC",
-	"Fy01scGy4YYzTV4gpIG+uXnbQpyf/Nn+dtZr/6v8B2dL2FdUF7nizm7hsPImf5U/yIru1CUif9eNXOLe",
-	"hYrkyLL2WGmyGgnR6lYHbhZgVHXhoiojySVjmStqA6SFmRXl/h087kobtjhyaKv8ipvVERbvdrpdeOtD",
-	"8NIHfGeHa7/eWvcFQ7x6j2MhL0jiC390Phn6ApkH3XDBHG6463Ruf8XrcOXohwspuIFtkoDqg2KQE3rJ",
-	"Ehsq+NEGpmnt8qMGuhB3X8V9Y4DF1yn+nYthpmTMtCYpv2LC/o9G7rZIGEnOWSppgofIDKiPcFAj/NgI",
-	"YXmTEfm7lXtNqGLkykGUJpFwt2XmVCR2WqCqk6oVpL1kboZyOlRAyH9F0xwwsex2AmrhAgRybHIYTlBj",
-	"FUHeLbU7uJC73tCezWVbD1ooKVGKqvT0T4g6yCnUhnv3ztxuoU8b7aRjxbuRnRx7Jr29LLprramugxnF",
-	"Y11b7SdsCwNbtXBje0EWlNuxQGZpmtLGJU24huqlBr/XfuszQ/PJEvLRv44KRnpS+SLT4ieynDMRCSHh",
-	"KiHyNPXJ2ZfvY6zQrlvtwEcRjVXc3z9HIqbCFbwRSiIrQRgT+NeiA0KnU6kSGK+DQieUKGtYh0bxbBSJ",
-	"37ldGR2aTjtHacpnkGxzVuDq5ajJyhaT5Z5rO86Gp2tTs0uhrzX1M0UGp2NSrAqxDSZ5ynYRG5Ae4Apc",
-	"0dTGo+SXt8fHo9Hb49e/Hh8PiKKGXcDN3Ei8HI3e2L8lzLDYXEhxATcELxxZIJlImTIqBqF6XsxSOcEa",
-	"RfgROIdaIwqPLajpghEw+JEIqFrwwl5gEcppybid4TwrxoaxRRGMGJkROcXSB3ZtiOHxJQQkQpK5NEMF",
-	"IY+LkohgLGHJLfWkiEia9OT+w5F6K3uORRqb/6EDERzGlvHIVlrc7b70krGsvXb5VLChnE49cD88jZhk",
-	"kxWIfnRwDlwJy6ofkQ4QcMyM3W9quPg9Ip+QWQCLHUdl3/9bTvDkUkgxdJyJA+v7xDD0xlglvJxL7f5/",
-	"JPWF/wpewf88Jl+/f/kyisR/YEmxu4JfPgUbiq+n34hiQ+aZDvDSHNxgIdQ6TRPPh3mGOBzUdi2Gctrh",
-	"lIsZU5nCm7ghvokDM4wEDKb4cuGKAZ4NlkRhetiZnVvaAanrhmAMS7kPbYSWutwlPEBKaJ0npFpORN0N",
-	"9qqMInsC/AtKa6DgzYobqcthk9KFEdPtwsbPwRfWI8fw10jY6JHcIXiMhBPZWwSPkQiiR9IQPIbBeFvU",
-	"2BBgdgaO65OzS11Yb+0nCx/DCdhrBGkDyF/fvm6IH1/Zv62Hh6QWHUZiy/CQ1KPDSNwkPCSV6BCBNyE8",
-	"jFdxym4RH26pEUWI2KIR9x8lNjS050CxrQfPsWIQK26lsk2eS8dU3M5jjWMq1j0V3NgJHFQkbnm8YR1U",
-	"JO58vAFFQ/wa7kgjyo43OXj8DNFaQjOEA/QTd6iJ4UxFIqUJJF/gnl+WQvFRzAEj4P+9PnGr5Y/KMaDM",
-	"ZMrjFZnylPUbNB2KfLfweeX0Huz4nu/P5+OKBa+VMAaac39ObkS+oBAtuECsKMXIhy/vfz/79NEKo4zE",
-	"P98MyKtffz3+ExkNC9cHP5N/vhyQl8fHf9of5gDWCKEbUuZEoodAmrh6hMVz6dlHUrrIWOJcVv8dpmTu",
-	"3UUqNlVMz32jOG9rpyeRAP/49ljDEUp4DXYrvSg8X00vdpDbLhvYdza71nKzh+u5de3/lL7uRurb6vD8",
-	"g0NH6Njh+mgyhIKWTEmrcY4ZGeAMyuYv/AcBiN0ZgGsTiVevyVzmSpPe19NvhBJHdlrsn/snDnI1VyTJ",
-	"mQd+cze9gkOWogFtHZsrAZJSAMMLuzZFD5ILO8IBvl7QMMyrJyY5K1FsU/R81DEMkoRlZn5HxzV2nTlz",
-	"07tjpak313iT2M1fuY5PwGO9ej23srCkKqkJINraZvFvFfsrqjiddAEAnQpGmDBqBWWr/nmX/NfGDiBx",
-	"UCqIx4OFY+nKhmoeBIj0LgGJRc95pslCKlbiahWRA3ixEtgnErlm+h3JRY41ZM5R2pgqhYCz7wBvsXsx",
-	"VcpRoUai/nVUD5RPqUAnFU8YxqWaud9BORCwiCcawCKnU8dDl6dMlypSoNdfLDBvSBZUIW6LVDMq+L9A",
-	"XoY6YzGf8thGijGby9S6/SJcFT2lVzqVswvFFtKwC83UFVMDEs+VFKsLYbKLTMp0QCZUCKYuDLs2fajo",
-	"jYQfjCZ6DnzINF3SlXbsajd2pxVt/aMQix3radFQZ7AJ8jAEMSgElmipXN0gXIx7/KpboBLFwXguC4Si",
-	"oWGLLLUerRwjnDkWCmKFz0tuR9D5/RtRDOQNA7Df4MzSS/yCZqRHJ0DpYycOBIYpU2BLrylmf0Q8Fm6h",
-	"/vhmz+pikCCw8aA3CTjIPqhsweYI43l9fGzf9xQLcjpFer9IXLLVu3KEhP1PTtMSpLzaLfhwoiSQB1l9",
-	"cCEqX7DOxCBm/nD3Rs2c4HGMK2UN7VjBXLRgalaRPEeyDOErFNbf2DVWYteqsu0mfPVtnJbis/9ItqUT",
-	"6zWkAaRcRW4BymBJdXnm8GNHuOeoxlXfVehgYAoC726kNSldV47en33+hg/tEgA049BIK2aU/fEeS4/e",
-	"n30mOPS1uiO8GqtvUHEEH3JVXl2VRn4md6S4fg4ftMao2omkfS1dkdE7BHSkS1/oxUsKOThRABg6dzZh",
-	"F+hhq5IKucGK5rLPXk6IFDEbAHbTxov/KDfrEJsomFsW3ARC9Tiqbc7ZlbxkCenxhC0yaUWqf+cVwI9W",
-	"VmDjxLp5C2c21xsKLr/rHVdaQgObmDDtQ48A6NjOVivQce5mqm0Ngpe7bGI54fdvEO23H9QY2g5sXOeH",
-	"Qiv+A+/Nw3GAKpIOlKe5Yo9A7kqz2IBgbJ/YJHvrdhVE9mjBjrLyqKH1IOOMKbvlUuT7Z5KFRxNsNBuB",
-	"0zrCM7GZ4snwSg+RJ8HTS43ImKXTIeDY4xUiKlbV8nxf+bciVk2wGFAuxTsiJIGDAJoGsZ7dVWlmkGTV",
-	"bmY0X2Tpiri9GUIcY8n0lKapRhJkoEnV4d4Mth5u22HHNwwH9wI2JfU/t+z/QXV/Z2fBZO7YcIZNtewF",
-	"kO6yRPcIl3rf0AxfJRanEM0QFVwqMmFUNTDXQx2Kcf23W127Boe6JnxgSqmJ5w08aXOapnI5hN2ny7Ri",
-	"eVaCIgOZINM9Q5g9CpK1bi+L8HojcipSvNlXYfp1iR+gc7CC6XbOCGVrfPu4sTeUC7upDpSjccNrB9ki",
-	"X7vxE2uitb+97paS7dZiTaAfjLvj8erT73aqCCUZVcZaUazerKpAh5KtuYztInG7jg8Horqp7n2PoCsQ",
-	"1rSBrYzl1LhrvFs6ch/HDzqj9h8BvnabePFxrSbSgG63jmswOKVyOd4TqjWfiW7eE5gj+/R7fPjp1sD7",
-	"keBAbrRFadp2y5QRnMAH2Ez4E3+F/CN1ZE3oFtysShmSg20QGCAfceLQKTK5uJHQfPePP4tNIDaKLeTV",
-	"2pFNLUS1j/glBBi7e1jEk4Rru21qLzL5napL7Uoi8DKCeyU5IdwQxHMlqRQzpirbK9JL5YwLgB31CaV+",
-	"kZB1np/GeG0P4wkfpOL5FV8gAw1LVyPyXkQCgA9si9YYul7Yj3FFgGTD9a+XyvhS5sbGFFe2N1IMyOvj",
-	"v/ULLD9EULBduFhQAcUvRUII5qatqMMu/Uc3Yz+4q7MRr19plLMHPZJYW7KHBLWre+Q9c0x9qGrASuYV",
-	"BahjILnH0FoUD1mrgSjkoCRWhBFZZGQfG/mlP/hzExBJsCZtRgbBsDpIOFNGHRF4IXJwScPdJYaOAyh0",
-	"aF/ojHKBaV9gs2R6TtDk9Ap74m3Jcs7T4OPa0BVJGE36BdvUnWwCYoT9DCYB6vKejcJNw/RzP22EVq3q",
-	"tvrokfPuQx3hHv4wo1ovpUra1XLMjHZm41AT/zyRAieea4MZbquVUnGzIkMbCziO3EgUb5Q0Vt/cxery",
-	"pxxOupTMZ3h7w8YsQ7qkikXCnYm/IBPFaDwnOlaMCcxYGqpmzGwIIbSEeyIrssiBTn0YGhDPr3AnzT+3",
-	"c3nmp/JpB7V+GDCmu8a1Z+Xia2Zqa1Ys1pKVq7X3PdPXiiD6O0+Tlc/F9IyURM+lMkc2vj1CKWRJ/9nq",
-	"bWf1gFV2iGU/63akZ2MWoB+WZm5/6m8ygv7VC/jk7W3hFVP4XHse+g/3yA7drWuiy+O6R0rKHbxWzjVJ",
-	"WJbKlcPJHhxoFufWAh+c/PPPcAX+nvM08eMtP1MFHIX31ZW3WdUufJExTUnCQAQc2HKu0oOTg7kxmT45",
-	"OkrtE0CQ/Ovr178c/PXnX/8XAAD//w==",
+	"7P3rkhs3ligKv8oKfjvC5GeSVbpuWwrFhFyS2pqWJU2V7D77dPmwwUyQhCsJZAPIothtn9i/9gNMzBP2",
+	"k5zAApCJTCLJJOtqj/50y0UkLgvrjnX5Zy8Ry1xwyrXqPftnT1KVC64o/sd3JD2lfy+o0ua/EsE15fhP",
+	"kucZS4hmgh/9ogQ3f1PJgi6J+df/kHTWe9b7/x1VUx/ZX9XRaymFfM0vaSZy2vvtt9+GvZSqRLLcTNZ7",
+	"1vuJZCzFmYeQkznj7t9CAkvpMhea8mQN1MzT+23YeyPklKUp5be3xROSZVRCRpILBXpBQdK/F0zSFHIq",
+	"l0wpM+y3Ye8HqhcifS/0yywTK5re3g7/IgWfw/efPn2EJW7CbOe90G9EwW9xG6dUiUImFLjQMMO1fxv2",
+	"zqi8ZAn9kZNLwjIyzejt7eg7klwwPgdl94AbW+HVCY5XaX6gsme+dJOaNV8mml0yvTb/zqXIqdTMkshC",
+	"KD1hCNOZkEuie896RcHS3rDHi8ydTsuCDnt6ndPes57SkvG5AUT8s41hIkkKKWk6Ibo2PiWajjRb0thH",
+	"il5S6XZMebHsPftrj/GZ6A17mVj1hr0lTVmx7A17CzZf9Ia9RDLNEpL1fo7NhtcYzkUyKrVZWBKuSILg",
+	"HfYY1zTL2JzyxOyKFCkzg5aCMy1wsujsxXJJJG514zfNtMWPxi+/DXue6vBoBnJul8Hh/fd1IFZ7ENNf",
+	"aKLNOv6GP5I5jdwycphJIgqLoUvG2dIA4ricyhx9TpElMU2X+Fn5j204W+LWb+VcREqC/83pZz1JCqmE",
+	"NNPswKgmTHD1YX3z0bOnS8ZPRUbVqeP+mxCQ5ufOZzKTveZaRg7V2KSdN7orxLCNjZDkgotVRtP5dorY",
+	"SX21iabrgygYqWBi/xxB3qlI41idSEr0nhSd0rTIJxc0PmPKlJE8V4RJNcuBALmv7FBSJbLLK0KnnORA",
+	"4Mgiow44N82vWWZY8ME7Lb8vuGbZ4RBTmui62DDMDkVDQH29asFeBeVegI7RQ2oytxwhTZmRPyT7WOMU",
+	"mx80WUybcBn2ijzdk0BjAqki2RqriAooC6oOgsrM847NaLJOMhqo53VF50NuQQKGB8FMSPj44ewTZP5D",
+	"oDzNBeNajcEBH0iS0FwrIByE/xwR4DmQLHM/AwFJiRIcJzUqE0p5SKkmLBv3hk3BgYNRaJLP7yif60Xv",
+	"2cMnTyMXeiVk+60NViou0vcU0iiMbkZCR285Z5/EhTVq6hf78uNb0OYno9mTlGgyhk+ouCaSamAK3r/+",
+	"6fUpMJ5kRUrTzRs5RPjQzzmTVF2JfXbk7xlRelJcVZJxsoxTdi7pjH3ehOt7wUcOhilTeUbWYIdCn47n",
+	"YxCriwl5MH2YPEofD+Ii5lJcXFXCiFJC1Hdnbtj8CKuFUDSwM60BahEiIVKaO+7EmxBAJTiqpWvKyTbU",
+	"PMFhAQOqY9l1YIy/xCbnWDLu//vBPlA0amkAL5IYZqegvyyUhikFAkYocYT0YCcYHQT9arth1XavZOU2",
+	"xBSohdnAh/cnr4fAjEnKFNgLAe+aAcGz9RjOtJAUmAYuVs/N/yeEG3N2akZqyeglTYHMCeObLIDkbKI9",
+	"f9nK9zwfMqwvzpD8ESzxjOEMTyB4Qsc7QWinHAb72QbFdyyGaPjdHpw8PNE2y8TNG92QkXivL527ommf",
+	"WLj8M2ZxaCEdYnYwT8zgjExptsf4VlMkEVLSDH0qbSqoleDtGlVt4QoYHdn6kirlBPF1qfSJkOneH6X2",
+	"guoI06YqlmJeOk9W19srx/sL2a0qBwZAB/bduM9hr/TBBIjQQZssMfl61KSKMHbrSk2Flfy9oGB/fg45",
+	"Ucib/83+4QVoATOqkwXybzMT5GbDwwOdIuFe4oDRi3diznirgBM6b8imumSKabjmVCsh0wOEWqGoPEge",
+	"NgBQzhPsZgcA2nxCxiBQqhIkmzQ/IxPKpciyJeV6Um1jQ4bIwqg2lMNKyAuVk4RCLjKWrL1vXcEPb17C",
+	"tNB4/+YQsCAK/bd2BZp6PRj1IpSlmmUZMKUKmkJfiZkZOxMyoWY7g+c4VZIxyjWgCoC/4ULVrmFKZ0bQ",
+	"Er7WC8bnQDMVSrapEBkl3BL9TFK12AIQs+/dNKQXP9AS6s37qwG9uaZboe0+f3jz8jUerP1OcykumQEg",
+	"4/NJIdludrTxxZbVf6KSzdbXSFKNvZgJWpenHyutuR0ALKVcR139LWKTqQnhgq+XoghlSYgXorMLG4c2",
+	"5owdKDAA9hFkG0u6s9YnbIdgO9jo0ukOh5p9LUCqM74OEAz4m92Tm7rtUB8dEzxZED5vN2dQjHI9qXHw",
+	"7Ryb01X34Y2jbCzXmK71NMg0NxnsXzxbHa1YSoEUemGu3j6yOVYb893gjibLGYlMadg1ilwwqsvaMmXk",
+	"owtyGbJRz31HjvumQDRkRrYM4ozU8fAJmSqRFZpOjDonCj1RNBE8VRGviBuJDi4zGhKSg6RzItOMKgVi",
+	"BsQ9tKBh5WYK1g8ecPz6LM06rP2W+5lhxXgqVmN4WYohZwZbQ25J+NqvDGSmqQSmFWREaQO9+Gb2d0VW",
+	"3xzk/m2+0ARIsAM0HW6udp7tWPwjDmz1cJ7SPCMJtQ6Q1cKY9g6P4TtRGAj3S3yzr7ojxVI6eAZm7/Do",
+	"+Hg8/ubp4+NjUEPw+4VHT83fHz759uFx45fz4vj4EX2BX+8klcNwekk+22dFt/6wemg0+zoEVcsp8ajh",
+	"hLH5bvTq22771Kowrax3l1q1selweGzRE6LpXMi1faHcWK+GZq0CrZP7v5ooug/BOXWs4ztJyUUqVjwi",
+	"evxLzwYJFFxSkiwMLcPXkBjJnBSaXdLJjLCskFQh0iaPesOKCTCunz6OcpqUziVJY/p5p2Xoiwcd13HH",
+	"rK+xZd6O++dGDk1yKaaxM3AB+DqZsUvKjUiQYgX0M1NadZte8Ixxuj9wXhx3mb+pydrFgksJnvwcCBsn",
+	"3oViJwuaXJxSVWQxd62UgfuofkCd5J6Yh+aEOKPgE0lnhaLpEKaEcyonS6aWRCcLDNYyH+Gkz8HIGxAc",
+	"VIG2SyfPL11NHFxZxvR6ojTRRUT4fhRKjxZrpamkCm0+Mw76iiwpXJKssA7fnEomUpZAJkQOK1FkKawk",
+	"0+jm9Y+T5UUaKcXr/4WO4egzpIX+nl4oP3XcXnBaNgJ9soyc+tiA0+FXrwMbr06yMXd4gHa478QtwWds",
+	"3s67jBCIXJ5ZGcy25SXJ8EExZGmGXBVMaSZW1mu/MIxdZCn0n3rhPRjDKzojRabhwcNj6D9cmhttlXpP",
+	"j7cxvs67bO5xxfRiK2OM7/jR8TH0nxy0Y7HinXdr90i0IUsyFZe0EzS/MZt7dHzI7pbE/AcnPKGTeSam",
+	"MdkVmA+IgJYyNUsuFLp58I8KHNdWUTshXCcODCoVU5qmhkWlMagwDsEsLdf01IDi6fFyMIb3QsOaamNB",
+	"iREGKtL0OWhJkgualk/iOZUjM39tbpUxjE7bE5hWElw/ar44jp/2W3PYBwdhpSSaTjK2ZBF1/Qfy2WzD",
+	"GbZwdvZ9IEoUpIVhjjDLKNWgVpTmCvoPxuOHx8e1jTysbeNBbBeB3hnFiJHFt08nH0dWcIH7IrALce1H",
+	"9aUf7Vw5YF6Tkrw293BS3YZn4sq7GcsJ/vV//jPkhWY/D+r7ebBjP1GNAqHS4HjDOpsOuMsmidXB23bk",
+	"GipE+UE3gdLub0pKgbPNlxoRUcjuEdPVIV83/TT2z8Gcuw52Vioy9QNh2ANiplMlGuRjuImkiaEdHDVS",
+	"mkiNqOs0LAyfQfYzY1Jp5KWh5rnX03t4ZS5oa3NPzOh3qqRjc7yJhcg4cuUxDm4PXMbVdtDC7ReObA74",
+	"0imhe32JsVkTDHXGd9E9Pt50lpfnje8ofsLWPURvKoqDLlwjF1KfJQuaFtkWb+fCMMYsGkTxkgM6VoEL",
+	"zWbehei+GIcI1+bqTcl6ImaTpeB6EfPruGQKI81wTIauyUoEfLOLD88kWdKVkBdR+31mLoTypBZrmRKW",
+	"rXvD3orSC/yHWzmq8s+lKPJJR8f2QhSR504nbRVoAU/rx3s03BFffsFsEoffO/3spElv2CNaU4Mq9i2Y",
+	"fk5o7v4t6ZKmjDS8EV0iptB2mqRkXfcoPXr6ZNdFGGimZL3jki3Ma0B4uh0G8UgchEt4v8MQkVuIAp9A",
+	"SHaSCd5OD0xNHIOPKTbywsXpmDmAWI+kMjbpEtxn0Bc8WxuDlKX2oVMlIqcv7KhBlDf6C2lHnK+se8cn",
+	"2ZAltfYG9HErg6/sUmLJtEYPwp5vzrjHENPsdns2zjseeWw+iQdf+SsPjo/TDK/ooLa73HG924PVSKEX",
+	"E5cpFR5XLVz0bvAOMxV6ET16w28YwPrB8cPHw+jLYYBV7Qiw562Fb04RbwW7NIKkLY8g+B1fm/KFJCrO",
+	"F66IHXsHpV9XBITddxkBGTwYhmiwHZ/eMaW3KKfluO6hM9Xc1dP/jufbcJnt290Sw3EdmH9IRLH/Jv5E",
+	"tYu4Dn1lZirQZjcpritF3jktuPuZTJkO3/1DndWNSMRy6QIVW2eZMT6nMpdsx7jW6MKD3ij3e9fvRrW1",
+	"Kwyvezt9bDw13j/xUBemZ1RrxufoQAPBgXh9o+IJQLRYGqM+W0NKl0K7p9Jc0ksmCtXQULaqIFeQQE0l",
+	"YER5Itc2zSQFGT7iKi0widp9bRUFLviILnO9fo56jFF7LijNbeyWcybZ0OPecKe4238zF3R9zftoiNXD",
+	"4GO/v46dXUWqblJUobRYnoqM7lC42omhC35ZppkbW0caqP0/fyWjf/xs/ud49O3k538+GD599Nv/iN5D",
+	"17ipJeNv7Y8PdgZRNZ56dwdTVWBqF8wHvUIj05gWLNMTxuMi7LoixzYOHa68GwSvmErEJZWtL0cp1TTR",
+	"E8En6M2aJIJrkuitDwmY4nZEcnZ0+eDIvXoUWowo/3tBC6qAoFN8nPrF4RcxLZ32nK7w58oVqwvJDZd9",
+	"ePxgDLjOjGSKDsuh+N64BqLtf42Fmvi5URrC+x/fvQscc8o5XiTkzBWPWEKR48MMB3N8ooWEJMNfT+lI",
+	"FhzK3UZZtHf+t7u78UwJSTHH71//+78cFL5S1cwwpYlYUgUpihMsjLDqD2DUdi76OaE0jYQ1jV0EzdPj",
+	"x98cH1evCjbSpv/w8aLmw7bDOsS57PmkVAd242mpRAcuDAJYTmu+MIcduWybufmfKV2QS4qB6GwGLSgJ",
+	"TFm8iAcF73gT2URI5TeI9USCY5gT4EPAk9qDzcMnZcSTXhQ8pYaCRwsqU6sZ2DcVvTBYyrSyOLlxo4ot",
+	"i0wTTkWhrAPM39GT4/0eGmoY2XgJaKPqzm8EDb5x1QeCJhva43Vg49ODngbKWc5WlOZb4msdSsRekwqu",
+	"QcyimJRXD6BrS6z4tjaG/5tKYRCXOJ+U0pSkawyfoNC3AZ3IOEgm8ZcKWzC8wyIVqh1I0N2ddeVJYuB4",
+	"nSxEq9IQpBBtaM/7OAD8PO0baLeWU6Yn9JJy3dX92yHxiiYLQTsElblxG3NGz2Gh/Ikq/e9iuo1Mdm7v",
+	"FzHtdtjGdt133bZbK9wTj06KbT697Wy30h7zRqDNH8H4R6wcNOzZKFT0vhv9tKVEw6JYEj7ZlhUnqZbr",
+	"tiihDWaTGvHjLbnq0+ZCm8BvIhmCOnpHlyQriKaYC99KpCoRktbeCR7U5MduBmFniO6gfM64kXTjLcVL",
+	"4mPjHvrvhdLmlyHkIi8yom11qYzhC64rrwZ95J0YFsf4PKMjKVZBeQaJcXoqmmneNaOirLwQ+Qlvb++w",
+	"Nf9VR6edpJeMriZc6DYMN79fuSqLm+QmqrKUj/VVjKCDAWYt51JcuqIlBkfdP7EOQM8XTYgVL4lZUx77",
+	"qh2VV1hupHEHjYvcSjLx5OnygbC7o7oiwl1GYjD51q11rCHQUuAEB61dDMSSEq5spgd1dld1H4fiVzsZ",
+	"taJOMwKzeaM74GEwehMcno5aAOEIQQKO6+SveWO0uBOxzDNmFO8zo/1FYlNU+ffG0pwC5Vqu0VBpzAOM",
+	"Q0bSlEoQMqXyOfyDSjHCsAWrZ6qySEkvKJoWqa9Xhlu0hGbU5HEVJM0xSsJuCgMriNQMf1kKpbN17cfw",
+	"3+3hvk1R5Yr2BLuM3exWKnHA/Xn39XyS1D78Nzwl7mF+292kZG0jARUnuVoIrYYgspQqbYOF2i+AXM4n",
+	"KJEneRLeAS+WU3sFZfCYDdSMXlPqbqlGgjGRMSMsM/+MztK6QAOkbvL61v3n1RobW9/77hD0rTdnFIE3",
+	"Lkh7A65uExNkDfsEI3XXUhqbrQRMZO3WQ7xz6RIRdtRIt+iw91rge4fxnhC7jt5v/i1h8vHw/w4JFwiz",
+	"U4zTsxml6qo1FXDGT0GZzZ2+2daqUnZzRUZ3YmWd7Xa52f1FYWSt1k2fJYT/hzFoN7dc+UU6bZNzx172",
+	"RQ+3TjXHls2KGGxzooyqP5nJqkZMw1trR4CBkYIj6LtP4GtwwBoASaRQCguyWd8sHI/HD2pxd6koLN5u",
+	"sGotNMkm1BpyXuvb4k6yHMI6haRYKVgtqCxflVxyCDBly3UIidscH5DutAGb2F5bAf5J5G8sfL73EuLK",
+	"FBcy7ytSXLU9Q3vXs72Qiq+6vYC3RCNB53TSDDm03ltFKS9DU+3INKhuWP7p5ysa2zdaGbRjUc4OtqFB",
+	"YsfXDBQuWJ5bO7DhUtnXCiyNv/Aydtf2+RPlVJYxv7srRZpp4WsbmVc+ikn8eAwY9Zvrta0n2RfS/uc5",
+	"t+sNYO5Ws0/VJMvw3UkN8Z9lQK6CMlgVXNnn8TnfyKauBfA2Ih9we9XWQAvr2C6/gYxyBf3yvyeSzhRc",
+	"0PVg3NsRzNtxKfzkKwVLahir48NdIp89GUUqqNkVzIDnPiQDYzxLeI0hiO2FXIq0SKg652Z/b8qzvwzG",
+	"9E/Ofjr6cHby8h1Mi+wCZhhJIC6pvdrM3JY+52j5UE1TUAnhaC4wPrJoYI42eA6lJV+ua2Y456XJCqd0",
+	"zpQ2Vl4QZ1wbDafVD+fcV72GTMztlghkQlyMpiS5cOmaFjOuN8q5Ecxcv4h35QZsIQdjwpqRlhrYko7s",
+	"32mKF6WgHyw3eGbvwt0kPpYocA4aBTOW0dSW9KO24kOwlfE5D+N6Hx0/BzbnGO0xXQPWaR0xjjzMrmxB",
+	"0z0UO2b8/8lgccypnolowLpicz5ylSbNGIyNscUxGZ+JQe+aIgM7cvumSFLM1s9Vk8Tl90cRIHhnjAdI",
+	"YArzZEaWLIvEDH04A/sTEI7BBZYZAH5lqIt7zy6mLxBekMwOiftyLQtRC5aHZ7Hf2dg2sV+0viqm8Szu",
+	"N5LSkYEqqGI6SjKjcc0YldBfkjVMafWYd0PVkOtR+n6fQ4dwNVDUr6mGRjsLiCBa2/CjLch9fei0DVtq",
+	"aQ6ILdUhn4MvO9rEl9vGk05lTt21BftoBf724GhLDJ21XZzxL0wvTkWWFXmsrmDQP2LnTGdu7IYXzv19",
+	"6PfXerofKsxsL2TGO7zZtbiB7SII5r3ajUQ17Pbrb6mn8D1mLZf9OmzedN/mjg4hFSs+BOcOGcJ4PB7s",
+	"4XYqN1Quv+P8rfC9sg+sdWGHZVE3aFJ6Yr0vtBHOQ4kRjX6QN9WNVsVp6knfvVT40E3qf29/iwj8F518",
+	"rc5jtof/tKTr/cjSYWmEJKtaKTsMf++TreqdWEdb46DVBltv7qziAvtfHRrC+HoUXGD9pmz1x30uq+J0",
+	"LVcxiSsjYfJ/KX7qTQ3CFxCm234qOG6hFlvSdhFus36+5tKxHYcLtF6LDa3fRxJfk8hq3VEgTAx2ZNmH",
+	"We/ZXzuge++3YaQtjptn59defm02wDF/3tztz78Ne99TkunFliDh6cQlX9fuOCw7tuGlWOCc67C0UExx",
+	"MNZLPPY48n6F3onaZqoJYvdgpEz1ruXrcUWQJPilTrB/plwRSIgmxoD0455DwT3S/sOnGmIcvBsY9Gwr",
+	"Mjre8QLVJancOi47jkaf5iHO5xIQ1YrhO5addzek34R+lajnP1Y0f6VgSfKcphFfiy0vUvcHeyfwlsTs",
+	"No9bAM6r7sJMNW5/qygfNxptINBX3ur/btvBuFsJsdpDan1hd/KjanNAFBDIqUwo12RudlDw1K5u9IaU",
+	"JmxJsudwbPE8+JIpOB7DR7GiUpUFadAthjvwze5+YnQ1IgqSBcvrDqxZJojefEFoYGXtOmtwjaNpdfw9",
+	"UHVLrd7KrdhZb2mjh5gOc0klybKDZ2wDFgpXN/duOLyj26oV15WDAyBQ8t5Y0fsiO3je0yKjUVstIRyj",
+	"vuln3WXGs4TwEze8u6m3CcJWuy/czzAwA2u6j4VEt8tq1UPLINYOjOImhVAHJoTyZF/+Yz9C1tPtNdK/",
+	"kNyw7IxyosbjjJ9+Px6FSL6H0nLSRV1x1vU4HkzOtRTZhKXRl1v8EViqgucbFx9Yiarnzt9UcCyM/G/l",
+	"Dy/M3c3ZJcW1u/fGaGSqNQwrLEWkqDEaEmrkaqiOBWP9tnapbOCBaCgWW+EMAaMyfHpksqDJBYhC54Ue",
+	"tzaYwlE39FTYeEWy2/IDNs6Jjy6+mQl6BKK7bnPYNLQeB2CzVSvlmbJ5HBhLMETdbAgO/Ye2jXL8Xaxs",
+	"jhfHYfz5OcxIlinANxMtwEHoAL27NUrE98erJxsG+nDQS696KA3oZPPCdxO2L5AUM1tLR8Ithx66t+GG",
+	"y6Al3S+sOzjLyLxsb+wOZrTZ7emES8aLaNDniUspNiqlcoGe9ptSEhRcUWrDOmNVej/rCYpdEtW/vcfF",
+	"J+S5Ph+1rcOa6oMDesuEugnlZmDLiyzSpU3iAjcQQRmvWF/OmZNCbW9xUs9NTJnK3duR9zFhbpUt1N9P",
+	"mbJLCwk2LS6821jhoA0Fp3nayG6Hm3gdQYUIBnYgpXuvDt0/LWQ3VK8jFJiUwcBdY4GvJ4o3uJ4dymk8",
+	"fq17AHAY/Luf2+SwqF+8o0MLH7RUAXHNKCdtNRo2swn5JZOC+6IvYTOdx3vWsuuUMXVgjRCWT0iaShdZ",
+	"3NjlrvoiQupaitnTJ08e7SxG5/sFl8i9CzRNRXdbqYzdz07u5Ss4dxsKvcLUxG05mxWvPsQeLm1hV52o",
+	"w8dhTaosiAjv5j03M5Rx5L/9PGyV+VxAWZ7fVuk1wh+1e1lw281S6UqrHW8gaQzyDfHmTt8G/TeEZTS9",
+	"umkXqPlbTTqjl27LcLmXNt/v04a6ZyZN3IjZbrvUEWY3Dm/xHe7v3gtII4ITNmC79R2hDCx/+e6dD2e3",
+	"TnWPuM5OFUpXAaOjGcs0lUPIJR1hFYnBIfHl9b3tcui9Y5002PKNevvbSeRx4oX5AsuO+DlK3IZ+QhQd",
+	"Ma4oVvq9pIOOjwtfFOotbr2Nu9p29281XUbiCGSyYJom2mXO7NSOLKXmkgnP1TrXbh+2CPl95G1U5G8R",
+	"vk2DO/oA1ne+NhsGMYgI4HtRDrKpNe/Skm9OLT64UmVNP447MQMvymGuEBsCbuc58Kz3Wxus1xVa1uuF",
+	"BP6bZjmkw0EqVBAN2mV0EGixc3ieEW22NbGdO2fMxgju/s4ZTB2Mot1W0M3X+oybS+4YddrdxsbbVZ8y",
+	"EK6z6lOKhV3OgfZM4hrex+pVbbRoiV8Zkn69X1cHQm90lziUXxiR4FtIWcjtjoOzvCpIErvSHqrg1E0P",
+	"fLeuac0Yti29vcwq3W9mY7hr7dA6XrJLltE53WeN6Dc7FmpppXa1xmdKLfbYd3P01h3HM7N3diQzFNYl",
+	"PLvV74/ldF8AesVdB6rntrYfvMCSPEu62+PuZ2/dYYnA3zOl2/tQWvURyaIzo7VsIagqtZOc9mQkMzQB",
+	"JxlZW9FT5j46BVwtegGOGhhca9kl1tWsuHUuIS62wK/W8caWX772be1WAkrO0XWvsUaEu9m9ofRuK2xP",
+	"gA3wP3KfnalrW01FvXfkVAvxRvSka6jT4TfYdtYthQobtmqdzWHO3udvnk6ePh4CMWORim7YoP1iFd64",
+	"VXinxk4jX5QpLQW8fQUzKZZwRHVyJNRI0owSRV3eqFzQbAjFtOC6GIIUycV6CAnlWmDi+JJkjBefh5DS",
+	"KSN8CCKnXBWKjjJK8iGojKrBc7Ah9D4vs28mhV/dN/ArmA/gVyBZzjj+QyYL+BXmZhkBv4LQCyoH8OH9",
+	"u/9l7c63r2BlDE1bUx1zQHJJR2Wp1jGc5TRx9fMx3mJUlV29fDB+ND6Glyejhw/HHWF4DSZghMD9yGc0",
+	"+7bLRv77GYlhcOnmS20hbQHR1sb/fyFZNkoykVyAH+zjr6xjBarUellw6M8YZ2ph6y2PABv44X8MaplG",
+	"oYMNXOK50mSZKyBTRbked8o+anqI6nsPt9K2Z/uqUvDW3Y0PjsGxNVJDxG+2dTa/g/t9G1Rrb0Ebu4sE",
+	"/5SurvqKLL0mOBzUw6p2WdUuNwDVisnIi97ymYglIasiw1smUPIwc54x+A6O3vU7sTxtwvhMgDbbP+eJ",
+	"yIolH82EHNl/bmN/sWIeJM+JXIpauNVu3XN/b7vIMsw92ovppExdTGaS0sl82k29xS/se9JenxSKpp2/",
+	"mDFJVyTLJorKSxYL9fMjUvgVitkKfgU+wxtT8CuwvPwnUkcXkqyWLP0Du7/5e9pNah2at7xz4gsqOc0m",
+	"+453asg+n+wjpJd0OSGXhOGoybLjpZuvLGJ1/eIK+ldU9RqPx3F96shqU0dGlzqymtSRodAjq0UdOR0K",
+	"mxxu6FDXri+xtKtznaWTjF3QrsM7o5FQk1xSrdd7fbIPClXDJ7PCZiHd2POAoqhnT9pizF/zmZAJ43P4",
+	"FT66xi6XRpV+5aNTHZ8BNgMutFGXla2KvnvtFcn3wvpWa7kmANoE5Y5OX3cdnrcj8O1K9ucfPuJu48Lf",
+	"ck2zjM0pT2hbn6E9++fUg7dJemlsbQUY1M6C5YxePV0DmWksbeW83bMig9OCn2CJ9/6j40j7/UdPsf/+",
+	"Ymv7/Uc33yTHb7MMBVAHtbcJWv5XM9bb2jCuNCYq+H7/FTAeHO/V+3+PRjQd281sYtBVO85EcHKPpjOx",
+	"rw/qOxNO9PrSMaO9W4Mc2ETDdgHaU1O3XVd8y49GbFkmFE1Bk8+Ci+X6GaADxCoc45wkF2ROx84n0bvH",
+	"xSjDCEj/LGBssd6wl2HCzpKmrMC2omy+CN8H9q0uGUCzFn0Ybrt+UZ2wSH10705XKXC6iZsR0YAcNymk",
+	"El10nM4VUcO1z3Rb5ZIDDM19UMznZewirLYCb3atUBrhm8nYz4td4JbO9nfHEXJ85pfd1SOmQiNVfbJT",
+	"/XrHEsqVheoWLoq9EalsbZZ0DY1eZpRo/1Ld3afJ+GQuSUIntnBj13orrgGtUd4Ivtn5tiDDHheTzAIF",
+	"062wE1f0hVGz+mvrTFIsTpdTvsICdHmGeY/USLxcMkWj0xRYYzmX9LLR/7vtRQ7XDfIqS8Btud+fqGSz",
+	"dauG7Q48+WWldzt6w8Edlmx96Ls1nGmZpsIhNbG3HEUe3dVgu8QDT2yToOhGVgRbV15pu02m6ffeXD92",
+	"M++FsT8T1B5OFoRzGtFFX0JKM4ZugMSOGcPZ65PT15/OgEgK71//9PrU9eGkKXIto7Oe/fDpY9kleFh2",
+	"b1QZSS6OVnS6EOICfjx9B18Dlisd4mQryTQdCZ6tx/AG6xcTlvl1rQv0/Yf3I9sp1yd+MlUtrwQOoinT",
+	"gGwWq+VKOpqxLHsGaqnziQ1hJ5kZS+Sc6smCcT0Y2l+NFTVEf8wQtBiCN2/GGz7TQx5LA/fqJmqZRWNt",
+	"pHmKZgyahdCvw2TQyarsJtLai3p5wER2h/cspN5jY3Xrc2KzB9rl6D93PCL3sNkZGEPWxpm6Lfh6r/71",
+	"4QXYlonEDO/FEgorbIgkPQvu8c4ikEFe/JeQFtuxDnM0pSXq8E9YzozJ5S6WRq/2cC7mo4XKWqmG8nrD",
+	"nqM9I4jManEZdMWXwQiK+J/dIZ/bike+izhT7rHGE/Jg79eZCqXLKrZVMnV4szWk269sbYRhVkVsG4qe",
+	"kA1mp4o8z9ZQyAz6C61zNYS8mGYssYgTMjw3tORWRyUBHhkecaQF9A1H9UA9qgDpSkvQjKyBFHpBubE9",
+	"NFWDMbzMMtdkXCG3dcU4XDNzmiKXrt/DJterxeW5Tott70NxhuZbSMIbKZYNvhYvc3HtLe4RJQ14KhT0",
+	"68NZAyrxJ0p/NS1z2wuwjGL/ibewWjtxwHANpaAl/eSb/znuPTNEc42MdpNH7sXLBvtlLKImsKX7wZQS",
+	"SaVVGDAjzdOWucqOAL4SX5QRBekT8hbUZWJ0jfuscYKOG93BUBF7G1y1G5I17YeAZ3ZkevE+hV5udfYh",
+	"xPTPXaH75SIdt1qVNq3D0P5dAbJPx9OOKiIZwxnyYMbnVm+taZx9w8Q37hV7Llca5syz8wFImmfY14Hp",
+	"5yCWTGszL9OQUWxdjiv49FlcqOCuL8tWBtzOcW+ChW5ngts52U0zpAN4TBt1XyHmqaF3xFD0g0pI9kok",
+	"hX9c6u47esnBNgp5MD4eP4WXhs+qJXrtbSNaSN280P/3sw/vB0Mgyrf3wCYVWJD1KwX0s7kXg+UfcvL3",
+	"goIW8CGn/C9GYUYTztw7NSabFMV8AZdUTolmy3FMbfavjYK3BckHGfmbqrxBcykKFUfoXeGiLR4o75SY",
+	"E92la7d9m6xSveuFrKot/rz1+Mo2WNkWznxALUhf/bE1iDmvNtB50uadxSpLin1Sz09FRlumipfJtUUb",
+	"w737JaNAFhlLGFWnNBMkbYevKHQili6m6UCe0mwB4Kds3df6FU2YwqawrUWgD3uE2d2A3O0uXqjXxqW1",
+	"1OOOBfh1b6wbB1KvvujGElt7636UwjZofsdmEfX3tdJsiY26cyqr4gNBLfiRLZyb0kwT6AdFMbE5jxqU",
+	"1lGRUZhlLMdGPliDGL6jSo/obCakfg4EZoxm1iwNUq+Jrqp1fKUgJZqYIQUvw4hqZRJicXYJU3WT2hfe",
+	"bDF2q7JK3OlcB3yqNJsf9GlM3gYdoq6h9cPvokn7khpljKllW4nzsJ3WgvAUX8xTv7OwvAwQ7Wu/YMxw",
+	"dFu5J4RJ5ihhKyuvkQ3S5VQIPanI85/RtKEv3eU71btJCJ/I4uDU+0gHQspTxucT25nedgaKNqlP5RpX",
+	"9kHO+CyFqZmYxmf/bT8SWWaOby1Zm/4Xf6Oq2kjWarR1zPaKtDvct9f9JvtoawO1DxPZ4wZbXAt4AbYW",
+	"5ygoV1RwWC2EojBjeGvWwezpHVWYqwWVbwK3G9TiJrjvZNddbdvk5rv0t3KNnRu9rQ75waJnmsYaA+V5",
+	"xq7IZBw1xrnpIYJkk+0viKLBe2FZslYsl0zHKN2X0vn5SkwuRvMVpftz/7wb8HGcVJrmByEk3uXuzvw0",
+	"b0NF73zYCAHTe9vetv0nT6mkKRjjGnKhdGG0TWdzW/894ZvNU5+59p1la6MhVO20h+DbKmO5qyGEfd/V",
+	"8JyXRZGYUoUZoEU+qQ+yRaqwXcGcQt82AcJw3eE5t/81k1Qt7LqY1ZxR/x9BLYGB1Vg3IOkgNlEL8vDJ",
+	"05ZKvC7I5CsFbrh3Bj+DBf0MZ9+/HD188rQqLs4FN8cysLHD++bvvyjBnXsCW6GCpGF/UkWBfiaJhuka",
+	"nzTC/V6toaVR5idETcSs+zd+VCwJ1XXa9TrJdTXQvJ4Gq9g3djclmlvA/rrlN5OMTGncS6bYnJN4KvN3",
+	"RNGnj+F1+vDJkwffQjmyanPbQBn0pNo8unM+s2RVcPMdTUtMG4MNKbG128wsF3SND/fn/E+vP8ERydnR",
+	"5YMj2+tVHZnPGZ+PLui6BW/ciMkFXUeVhTeMzzF0h5f5eGZJNAxLNxvqDv6E2yscdnnQdGUIfUPO4BL8",
+	"NdZwt4F5JY6WRNzbIOcavbQz0jft7Z5fNvs6u9QC30kXa2UP7T0xraz9jdxvvE9XacNmNhtGuyzlhKmJ",
+	"XNDs28nlw/Hx+Dj+kLitq9ArpjTjiXad/Vv7GLmOgeXBxrvL4FWHqm2hA7Cvt7FO8yZ3Cddgifa9bq/i",
+	"5Khvzy12UELttO3b2tIewL4MRUnc4FgtCgMK5VrD+jCoTk3EDxNB64mYTZaC68Xmzh6MHn5jVwYcka23",
+	"vPbueCNqJbFSC68TdLwHGxoCPKkFQqeEZWt8TaUX+A+316gYau/qXu7DNm5GRtcJ7gtRyJgjqcB2YSlZ",
+	"Q//HTycDWzSWQ/949PDRIN6B7E4ltC3iVfC9EKis4VWo/Zo2Ypz2vqtt7dL+EX/0LdqrqseVn8zALQ54",
+	"gzspiaRLHr84K3hK1uPx0xdnRr6aUZYkLL61UsTuVtcVNjskGoZ8IowlCoHVUXZ6XtRiILlf92WSJYfb",
+	"aSOVC2zboog1JEfVXssCU7xTUBmrGgSh9APim+lba4f9g6pnRl8TjoTPbftRY6McCdlkLPCSu+g8uyFg",
+	"VrKSLMOcLmMBmX9XksgxA3idLIQN+CSQkCyjEmM9FaVoDpV2wzlHiwFzXkmwXdv7P+aj38IfMTFLGWVG",
+	"h8qI1Xr6m8rJwKE9rsjc3o1SEeWo7fywvm5kPquk4ARfKdfF2Bp4ndimXTnuhTco4Cd2mZRgvfIzKf5B",
+	"0aXtlE5D14ZdjLv6bRDzrNb9Z7qOr+2CaYyqh7JYC9SvS7Rz5oAxnYXh8rOMcXrOMfzZxYLYugr2g69U",
+	"0wAxKmldJ45WSMjmQjK9WNaYvTVpoiyc5gu6pDKW39foM0OlK5fqermNpkJoSCmGyeF7Puq5XGAJEyz4",
+	"YP5gg1EMXQ6egyqSRXUwBanAJF8bBO51Vkmxnomq2T+BZlAZPpvcHm/BpyTE7LsR5YlIaVraedXF7Q5C",
+	"cisPAzDX1gzBGWVi5fPzrnThrhEETE2mBcv0hLX4/Nqe3XdEoMREUT3coP4mHu4jevJWubJf7Xg/T7yA",
+	"alADvFGNERsKWpPJmXsZm0rbn3FXyUjc4LYWL7VNRXvmcMPaMuzM597iiuAZ1m0FplKsFJWRGP6toSk7",
+	"MKfO77eFHBzYqK/WvBVG58Xx8SPrLPH9JPqKLCmoBckpEOV7LDRfPCuAtiB7qI52wJPASbu9J0RZOf9X",
+	"WLD5An4FmxwJv0IWNjcL4LF3Gas2d0rktauBui4U4CsFBOOtc6IXRqoahSLXltUC0WLJEgjmsp7K8579",
+	"5bxn2W7Woc/XlmZ5YXOJKg4JobGBaM2TtZkTdTo6rd/x5lP7iPGU5pSnRuKEqrrzY9siJdbrZV+9SQpL",
+	"kdIM+jOSaIWlRZ6DZMpoRJcUG40aMiBaSLChIEMQK26j0cqIs8EmXZYRFS31X1F4Eg6k0MIGhfS54KMl",
+	"4QXBgMtq9/Qza0uML99jIhZMWrqDgrmqD7xIZcs8o0ZG4wDlvVEomieosbnqQL6y0mCviGj3lj+lC3LJ",
+	"RMS09VeBKoNFxGdwbg6pRzmRZHneg77SZG5gbsbYuNIhuGdo9+kAhITzHhecmg+M6kDK6lrgcFiN3DqE",
+	"qxWVg/iDv1UxfFGkCGT9LxsmocTgLmW24qfZA1gNWqswqHbPsR1ugjlGQ2dnH17bK4yL21yKS5ZS2V3k",
+	"VjN+dN/uPFW1yPYtlhNGVWqsz0CyIfAqqcnKkPKNy/WiJFzw9VIUCjIxZxxyMo9kwl0tv6zVOG85YvvZ",
+	"zs4+gIcQLKkmKdFkDObISYYJCu6wTLm8RcaTrEhjYdb2gzZ1+CD/nk2XmUgRY2tGg4W5JFxbG6dQVCp7",
+	"GqMK0hQuGbFmnj/i3gmGXasnKFXEwPvh7asTsD/Cj6fv9kshNJZqhBmc5SSho5RizQ+awoeXhV6AG70l",
+	"faPhbpJCi0Rk0BcsTaKMaf+cti1OIxfd6AA1DJClPGnjvkMP0g6fUYDiOxoV1nB0RyS/G2sJoLV7V5k3",
+	"8ryRCNbbmSrQAb2NWh5itMXxvvsSbODHYH+07oavLj1ncI0ZZh2x+jkWxWUYUEqyFVkrIGlKd5eZ9rVT",
+	"Y3hWv9AdiHSNIuv6ZJWfaaPeV+Mal0xD7bTQFxIU5an1HaI7/4LSfDORZgdfvxrN+FcKn2BstmC1GtQ5",
+	"jXblPu1ALoei/PWj8qEoGb3lhPCTBU0uXpubjvbDNlZ8IpZLwtOvVOm3Zcb2ou4j6PtCKFbdrc0Ysx4S",
+	"XZB4mIJbqaVsCauKF0Ue1T7nNjQzWtWb6oVoCUDUKZWy7SdR6BbjteBJI3ulza50i4cnaL2MlhJrZX/z",
+	"yZJxFcvxHKFzwdfrMleCHacHpbOlnAKmhKfQt9H43x6jP55MxSUdjOEkI8ucpmYeAX99MoSH33xz/HMv",
+	"XozeRT4dtCN0fnuXVOmHCHdWYF2Fh8cYbMLX1SAX67nfblv7lfxAlKYS1IrpZFECi6Qkt0FivsbaGNDL",
+	"bzuZoPOqXuxtswn5GD7wUUoNPqPnx2Z1F5zMZj6GOGLz7lN/bnv5uUhb9H7QFx07tAzim2g02D8c6Zoz",
+	"1W74fx4byfDNt/vdJBf8OnZWm6a2rYe4rcd7bisnUrNDqcFWW8AJalt5glt5uudWdhUUtLRXogdm7MDT",
+	"YxWgksGi5poPhvDguGVJlz9x2OlRlR0lGVGKzRhN3ctY9yO3dA9qbKvJsqKo1LjINloY9jb+cEhtxIrl",
+	"X7UmYiA89qiFGH51UA1EM8GrMnmuGVuk/B66Ka8J4dYTiiHWEXebQaIus5StOjde2omN7lBbDxTXxhvV",
+	"8hoWLlEKiIJ/swNeGLKdUSNRkNfQzxp9M89d2KR1kNLPC1IoKwk6Fjc0YmQvgAaNyncEIZiZ2yBirmW7",
+	"iug89bMiyyCVLMtGqVhxyMk6E6SqO+VrmnjNseAraSP58qxQlVNo0y4wOuV+R68rttHHHI+49fNgWudI",
+	"UpLiE8MllSlLtH2E/qxbe4ZtTuQDLaua3jb8xxiaZXfd23i22rjUrj3EN3+8YPmkNe00TKhqgMIQyK8Y",
+	"Pg+/gsuMgF/bwNDa+LvMbApeZNw9Dj2SbMBwG1qflgkdrUjtnvVLRMCQZ1TpxvBeAMOmY4CLgyh0Xujt",
+	"L5mNR7hG23vo17unn/espTEXkv2Dpue9QYe+TfUlBKcju0e3VvAziJkNvSlTby0UG9333ZdFvPjr3T+1",
+	"xl5TF0RNaCvX0kGUB3NRzwuiPIsKr9NcAzI1VEXiRZwPasq//QEWfoXz3nnPX4GKeypuiSJbW/8jt7Tg",
+	"wxHVO6THtgZCO1ANrtjuP8IINh5iaxjQzgX4fxS0sMZhnWr/jn/fr/5wW3ccn+ioxiyFFy8A54ZfxBTs",
+	"fwePxmpcda/ZXel2I4XV7np3PeNqkRKY1YHboOXDGj/KlgTCaZFcUB1BuIePwXXjG4LgFK2OhSikRRgu",
+	"Vs8hLVzmgeFK1kyx+Z2ofHnzJMU2P2CxinFlrFnM8nCRoSWPaXajCpILNk0Y8/FEzGYq5kv8XhRSlRuF",
+	"/jG88E4VY1ebbwe9Do0WqiWGwX5isN5ghwWdcLGKxwZsA5PhaSQz2sza143pe9sPaTIT80Hc0raztbS/",
+	"OhOCU6Wja7rXd/vmX1pC9kZrLaBEaXPa3vjomT24JZbD3l/EVG2hP7uSK6mfrcGRS9SSLjimHO05o/ts",
+	"N0L4S61vvbHusCSpVpp0Sn5UiantEhVxq7t8Vanb6AJ0NUIs/alI6k/V7uzwNN1Dmxjt28WxQ+2UA3g7",
+	"RsRNSmU/hi9mwMxZFW2/Gyrc9rvPG443ga7kSxfRIPUVb6xNfbDgg189ssOvQbs3q1bEdUUt2XxO5USJ",
+	"Qsb0MsEnzmn6a8kcdj/FVbIsqKzupVpjyfDuYzVwqkuq3Wjzeur40EabPxHJDIA/XFIpWUojgkmEPx1Y",
+	"ZNcvg7HfRsvyk8IlyQo6ho8/fqoK3WF4vOHCS5LvLFVfbW/XGbekw136IZHOE0LmhRph9Hg5DJQwqAtT",
+	"G83eLtWtN11NynDa5uROm0hwFRcKK+mMSsoTXz/QLxt/6PCB3JNY/P0HOSec/QNDpEYqpwmbsQQQzguR",
+	"pVSCfz83C5Xhdmohiiz1z81OlxpGK6y5Kq7x0DIMPh4xXq7COFAECSZ0ikJjtoe7wr1iQtxHKW2JsHbq",
+	"uYoHMYUgRuOApWrobnWvGDvE30i9KTwku3QIDv0S4VdlNgb1bzUOOIOuL/oe6H71GjCGDZwLINFAlt16",
+	"XWP5ikpin/qH+DC7qEuD/is02/9R7YxysfVYt79oP9pRu3LLp9/sqL261zt64+TlPL6qbLCrNmh8dANO",
+	"qaK6FSicriYdD7hzl7W5Wrfl6W2bFMHHy83X+MT2scmEjDTNwZq7U0l4+jCaR2NQclKVWvBfF+rBQ4xD",
+	"EA8fY+sdPn/4OD4B5arRrycRy5mQ2nFko1aQREc/tkUysIhVwCj9POUMRKaqJZHTVnvKXQE//6Xv1pUS",
+	"tZgKIm3tp2ZScxhXmxbYMLyRjRDSXPTetrz7HBLD6JoJRg2294KPwnp5FEhijW2Gr4G2DWE/IRzji4Pq",
+	"5IODLbKSORxaYQOTZj32T2x09H46u4jqBRjw9vaVAqJc4Qpte1MYnjCGj2VFu+napaooDZSnWKsQ+ljB",
+	"AuPjBs9t9/Og5N2SrLGMMDC9X4HtW2j5vcHy2hiKAdBLhE0rkzOg7RKp1XTrifZKWmZltb1kAUK980NQ",
+	"jcZ2iV87dWxfP1nroH1XRg9LJ3hJG7j29uzD6Junxw9QWUurZuTRygRYTSpSxGM6NUoiouScYWtt+9K8",
+	"mSwaKQH/JwFaiCxZEMbLjuAGraeME7nGPrOoSaLSGM2jN9pmRAtbTmmaltldlM8Zp7AU6NHxC/XtuY1A",
+	"ib5dlD2YYjF8vuyxostLKqGfpbOMzNWIcVuJb7dOV03vj4FAKmE9DC9v8/J/w75Vsa7gZ1i99BhWJLtg",
+	"fD5SFzSjGjNyJFZHsq+ektKScyjrqKSfqUyYVU7P+UwUPHW5PJokF9AP+gYOgaV0mQtNebIeAilSZjRb",
+	"Y3MCda0afKUl66APgNZ3WxzYhkPKJeqPH4yPRyTLF2T8wF8AyVnvWe/R+Hj8CNUgvUC89mV6sAWXE9Pz",
+	"mIf0FCORrWmZUzmytjacfvfyZGQLidMUCu5enCQ1SgdgCz01PucnmCL+Ffa19NmVkNLE6vPM3D/OZ1OB",
+	"JZsWmj6HBSrk1ol6zp18hoVYwZLwtfXK2YcIN7vZDbbvwDYIZT+iH9+ec5uahzFn5733cMkUxjgewQ9u",
+	"mfOea8JMcjby4LCAt1YdE/xtaoiN6pceWhhOQpZUI8/66z97zPlO8A3D8u1e6ZawTKvW+cw3w6keB7DP",
+	"WdWXzpgjBidsMQ+mBdJAzPffsnj1fLK5/OGNE+OLBb6Zcq0dKkDrvhlvwKxb0kB8toJrll3bbC5KJJyu",
+	"45c+fqj6sFRrnxzv1cf1Z4xzsRqJmefh8XGzvF6eZy4D/+gX93pYrbtNqHr0xk6VyCAbwsr9jjEvhsE8",
+	"tovH5iw3efQdSYMil4+PH13bfl8bbun72kQ3XOZRWVaBMkR5r3rvR27j0spzzajRlH98//bDe1ukAOlU",
+	"wde1Vzz4GkJKha8t94avoaLUAS5Vctl0yfiRq47/zFYHQF3DdXGoM5qPQumX5otaD7+qzOt3Il1fGwyj",
+	"rQl/q8taYwT8doN4F+9VGLnPn8LqEjbcC/qugTQICYZaUvRRF5IOGrf9Sq5HsuCAnfqIpkDg3//yCdyt",
+	"lG417LmcZbZVSOQWc1cT/5nNm+xwjfUq+r0bBGRLvf4IJD9SOTLQctmfUJbbv20StRoCZCS5UC5Z2UO2",
+	"fn32TOCsOjsSZiyjKohMKGtzQMoktm41dPN55HF5VOkhvWe9zeXKq0a636kUOfbgwt3df6F3AnXElWRa",
+	"U+5szXNuuy6PcNxIikJTaRQjxZRGRkKWlKe2k8jlA6PMDcZwgjLnnOdkzrgrq8Ih6EUMr16fnYxRBXpm",
+	"t/BMUpJapeaco1aDG2vTaexRu2k02PY3qtD4Vq4kueBildF0jv5gxTJzNIf1IrPltlOmzC20BDPcvI5x",
+	"m7rRF4XmDhUaxO1WdcbS6+9FmalxyorQA9OqwTHfMaVL/pJ69tR3nISmQ7AGHBYhjrC/o3+y9LdOhiGO",
+	"xziEvk3txgc4sy9OMgyOpQo5oucBcHTOSybguiKyLAPEMlsUuYWjQTeG9t367asWnmZs4AqRbd3tmqqz",
+	"D4e5cextRdx7iX9mS49vUb9HvONCA/paGvh/ho1JHHJO18DSNiR/FkitUKGrr2ZlXBmlGkq6OrZiP+VN",
+	"dN1AVtQQzW8vg+VvC2mv35TAo7zzLWACW+K3uyAS+6rq2N59IBbEintFLWb9b29v/be2jb+1pfEZE0Pu",
+	"XXydFRMNEg4IA+sOWQp0V9pCy06utNPxS77GEMZKAOHSJWGXf78iVb9yG/lC0V8o+gtFey+MJQqkZtx9",
+	"3+uJrSroM6c17pLMv4YS+VdveZZk7XXPK1L1qdvMF6r+QtVfqLp0ziFRlFTdSsqOKvci5ZKCPUmPoepN",
+	"LtL1GJ0i4II0qTrnVZFf+wXQjOSKqueAd8rnsKSEK2A8pTPGkQN8JEoDznTOpbNtHx8fd+IWEUO05Bdn",
+	"7sRf+MWN8Yvfnd/mC4vZn8U4OqoUB0v1pIq7wfpUFUln64ZGUaRMH9nQhMCrtek/MuNe22GdvOLl+/3e",
+	"XtQgHqTp2u44A0m0kL7t79avm02VMk0laOFiNVyimdGRCplQnBGWrsyMra56ji74897A8EombWOh8gOW",
+	"+vxp63XxP3yl3OuoloRlGDcXOUZt3es9CUsb5yCYrwY//vj21WAMn9Y5S0iGdYgN120cyyy/c9OHXd2X",
+	"h4E7fBioaLztdcD8HTsYIPY6tnGIuNn0yYdTQt/CehS45TldUaVhxqTS7TzsyDbsa3XQvxIrbiv7oou+",
+	"IkJLDz5HBkuZ24cALHWyERU7NH8lcHL2EwhpuzASrUmysC+V79+efYJvjo9HTx7Byx9H/9OthJHTyNi/",
+	"9j0jqnYVg7EdZR3Ic3PqMfzIM3ZBXc0kBwu7E5yuem1YLbCqpQ8+UxSzYwTHv9EhJLbyCNHw4Pj4+NjG",
+	"i1mYjhCm0CeQETmn0rfKYSpY01Z8bUBhMEYIJCIrllw9C19gh2AlwBBcy/gh+BdG/MkxaP9v7CPn/4Ol",
+	"wzqzGYacawh1CdH24lFh82uLExtyqxF+acsfWA4xhleuFJBhoom6bON3ZVO7CG33EnWJ1VZdpD/+1y8q",
+	"2mdpiyw7UI52l4JXFj5/VEFwVW7bKWq7QtRozLamn/WRQZ3azM2dbiqzlp269qUso9CPM6uB5d8Pbl33",
+	"Z1iqr5Z7kd6xHVKy34aAsgzEZpJ6DluTVygMUidbMNQlBLYB/5aIm8aylVjTi5GNxtmumevFRzvqRnWD",
+	"cpUYFJ2J4nZbXeJ2heCNkFObZlgH90+MrqxQE/JC5cQYOBWWGPGZ+wO3wdRGFT0zn01c0rMF8LCXF7G4",
+	"tKIJyBtwGZQL1KsM33Jg4fartL+Ay865mivhsNs/tYnb148A6GDYILEj7CawI2Kx0It3OOzmMAPnv0OU",
+	"cOu3R0fiAMDAUprS9DlocUG5slXN01uXIt5bkkiaGsQgGUa7/vDmJZSAQ8SiSWELUv3151qcs0sOO/IJ",
+	"d66tBJq6vmMgfPrw6WMUZVyt5J04Y8Zt3NzjSH4NRcwFSS/FBd2M8zR/LfM7bDnvKryptjmblbVNXPxA",
+	"b1pU/EC3YdJbvDC9vnWceS9soLMHnkGYKSVyIwjexnHV4M3KTW8C/KjRgG078D/Wmqrd8D0Ei+0IfXbD",
+	"0MJr6j9l/YEwZakstr0bQjPyjHIpsmw3zfzw5uVrO/SmYeMX2goX3yLCHPDH07dlE4qqenYlmIQEkudN",
+	"2OEaNUAVyqi/HJmLYVhxgHXKiLDnuNFkiNoaewmoCJsz7Nm2w7wDkWEWNyBnTnRgc6c8I+sNfot1guUS",
+	"CAeLtzRFyeJ6PkzXrpuluU0CZZ97iEoLL2Ce2Yzu3Tfqyy6c2PE3qI3WFrrq3frZIsrjLbF3uoJSmktq",
+	"c2bNZYV2yW0aut4s8ntaSeFydgNUQ9hv8IevVPlZBKMqLvxM0jlTrtvoVhsxFATuk5vMutlcbhufLbdU",
+	"B86bIstsIqs/JvR9fViqhqE4GlblgbAMwmATbJLOJFWL3QR46gbeHOW5Fe6zvm+oCVV8fAS6KzXfAcrt",
+	"xHHuIdDPuQHV0PJwLKfVT4hKSEqdCg2uEBpNB1vtgFOBcY62AWCw1nNYMq6BAKcrIJhN97UfYADSil6j",
+	"RIgLtiWa45T694fvtc4/8GwNfyvz9idulr+BnWYIUthUASzYwVMqs7VtlhhsdoibVW63TrsdYqnDM6pH",
+	"JziVgqnQtki7nTMtJ7Fr2e4oYP8UbMnN97cx/KiqKiGukS28/PjWt7RzLyX4gJ0TacuBjx4fPzBqk1zD",
+	"QogLUL6hHFpaBDKjV/qNuKeHVPCvNMyNqBUFBqxpAdZSB8GBXlK5BsZ9Zjo+d4tCt8acVBRnQXG39o+/",
+	"DncLz0vNuWpxdldk5hDBRQQNtxHcGL4z6GRQ331mm74kmbGo0vG+VBfgYEB53lLre3SbZWIV4e1KCQym",
+	"OjJCdEqSi13y8Ozsw4kfegthSK3BDulBryubSYcdP/QVr9s/bD56PDp+GONhNpfU9itBOyjPy7RjbOFa",
+	"UawldO6qbTciWM4+gHSTjbBq9r/+938B/Wx1ZVfSQqR0aAWQYXEle/PfqdoutuBG6erbgRje13dXWGHZ",
+	"wATLr1/XRTkAlawmD3rnuTCr7f7a90K/iSQUfUfNFZtrVGzOjfplc9r81bh136YfkVUI6epHlo/Itfvy",
+	"nWYSekQ/JxRP0Z5y/CajVEM5EF0Xw9J5l62r15rp2rej6DuVjqbDc05yAwaK783WXBh6D1zJ8gZjeB/E",
+	"HgRP6ef8SRULWe6imZdXHWlUHanl0fqkHPu6On3nLGRbIn4jebc8cG/Y8wdGrP3Ft+byTkdsLIeY3P2B",
+	"ektsC4az3GoISwm1d0xFAyUrsNYjSu724bGOO+3Jq2+qjmYVVgX4j6V+6/RUece38b2TYNgNXk+1TK3s",
+	"WQw85ciqcLd1TN7lPVXQjL0SYxhT+BzRL7cueLYebHmt2ph4uMVCbV7W9Vuo1Qr1eqidzNQHN7CNjqji",
+	"ykjeuuPpJ1s9xVYwc85FbGI6tGGVZUwxqs9+xNnZ93BB17ceZ/xDkWmWZxTsGymUTc8ajikEJpAApbth",
+	"8OY7a0AUZf58SjOq6SaGv8K/V5d6d0nrERen3VwKfaYmNinjBdaZHdx6sHqA9a2p3mKmRxbMB9yiu5/f",
+	"hh2Exh+hsMDezMYz9/t49W+wHV946UEHjD3lULxY5UfXwdP6+jEmmFe9pl1OcjXdGNDPZSOoaJYq8P3i",
+	"XJ2gqUjXYI2+51hQ1pCZG0okhYzOMLtBFMmCGvXavsQsiabS7KPvveVDyCW7JJpOLui69h9YWjdfSKLo",
+	"AJgCSUdlj/mgbR3BPGjbEMyWW2cK6yhmjNrmfrg9+/TjHoSqdtu+oxbLF1Rq+lkPQYlKh0kIhykFmjLt",
+	"wupFoe1OzEFc+PEFXRtB4Y80tsIEbHNdkWP8vgEKWy4LrKxk4GG3xJQvDv0Cm34JcyDH6KvrAKLF0oX4",
+	"p3QpvH8xl/SSiUI1REPUr2bw4o5YwE1qPHcam9WNCflsr6SNGd2J6uNLzEHfdaJFe39iG4IPyyRDD0xH",
+	"OvdDcmLfbdc3SlVi8/ZzwJrkm4gsYylVlQ+tbOdfo9BmEcc8bepuhtFiYN11KXHPkkzwLc8cJyJnjq24",
+	"+rg1aVSxXtVg5ZdUTolmS+vVs25gKVYWBPi+QOScassKjzxDbDxOFNkFsKWNfs7ECsxMGPNsgLIQivIQ",
+	"Npou8wwd0gKoGcTpKlu7CVyT5pBb51Isc7wGHwbSOETbS0RgWSH0/ggcE09yv01Es8M7sw7f7rQILzeY",
+	"6K1zxbMmif5xmaPFhgZvLDmNVbX6boZ//Z//tBcmpP1//4fBoWw0ZWTOhdIsUc9oshDboxFeVaNfm8Fx",
+	"frGgJKWy4hhvqyrqoz/T9Vb2UevW8mRnt5aWFf+v0UmVlDV6m+5+uLh+jmQAdEd6m126nQGZ36vQ6YOj",
+	"6p/s/uQHVLfeC/0yy8TqDoi0gXs+OgNJNGUzbNyj0dxrBkoaGNkHYTyyTxx8XnYQUGF7AF9hup24OLrD",
+	"R5oqPfpFTLsTmv3wE1X638V00x/+8PqAWVtpGwL9u5hiEEqO8QIrIS8wTxMb0BPWfCfATgijY9d21xh4",
+	"z8GBA2NExEjk2I03lyKx3QGc3sT4yP3NLdIOXmMbE01tuY/uwHWfvXTF/m+EEYRr3BFHsHk0r2jCar1U",
+	"2jNuUje05SpzPwrv0h0wKDQ60QtJ1UKga8Vn98RvLpd0yYrlaC/p89F+dC+E0H9P+eF5+cPb4+WuBj2k",
+	"gtpkTVvIFv1EBhsmAVrBjBKNmmvjUQynGGE+OxiUe+5dAGrrNDX1yv/xWS/ySSuiu89HRl8boT+zK7af",
+	"2i+/F0qfUixP/wXj7wLjoW97VIBlbOYi0TE9uNt34HIfLcwaI5Ytqy5xvfwmfN5vtyHqS+zEbmtnHIDe",
+	"f8EPv+D3/cFvvMr7gOCV7boHhm9U8dqB4tsNZI/jki5pyqxxST/TpNgf2U+rKV67Gb5g/X93PSbAq4nF",
+	"q7Lw3F2RXrClZx7V22nwa9+pp0GLkVmgbz4YwNdRtavvJhrso3i103bbKTyRV5GQR//8jMXmbWBi+3NC",
+	"GcVY1Zp3sYxjsD24LxldUQnLQmnnaSib4Jxz/7mEvqKG7LXrzpcWGlOJHh9/O9iM5XRrjM/5/vGchg+V",
+	"8YYv3fm6OPw/30+Pf3mWU9vB/YaLXZbLxUjm06K6/+q67ksUp9vZXRazLKF3hwUt34syvKOiXsxccGkk",
+	"jmKZqo1ppgg40gESzBJc+TauYmOc92EqPip6X6aynX0EfacOYx+n9iBfuMe1cY8yP/gL9/hDcw9LOYcx",
+	"j0txsa0qt5c/Fe/ANIpYRghmpPZTwudUikINroMj4O6+cIRr5Ah4ffePITj0+cIPyqaSnvLiZfcRWlVn",
+	"nCo/ZkpnQlJgWtnkrvobySyjVIcZaLZHW2v22QdOMS4ppxKqxK0zTGxlHDKSplSCkOZ/+75J4vCcc8En",
+	"fhU9hNxG0g5hKZTO1uFPwT9dTN3gnJdhUNgK3JgwmEG9EKqs84xtIauDTAyM0yIzGout64pwJK6m+BjO",
+	"bIY5zvwPKoWbrGpBl2G3vHPueoi7YFMFStM8p1JB0FGcmFmnGQXFPo/MehlZ29zs0oRyPT9VQvjItidt",
+	"yYfDhKcGbG80Qym+YEuvWNshCcNC8C7UPfFK70ggC3eMyBvkklUE1UoV2txzK1EYuKRkDfgZkPlc0jki",
+	"F7aOdtUBGJY5cbn+fRelA4+Oz3lK1moISUaWOU3hwXj87fHgGZBLKsmcgkoM+ZJECqVAcZKrhdA+Pk8N",
+	"z3l1siFooUmG8VQYdlpkxson3A2GhEiJhRQ8ZZ7zGeOpQesxfBQrg9Vmuzh6lJvl3TYCgQ0pzTRp8Q4g",
+	"oLoh9ieE6Y4CxZ8agGMcDLiel+DCKKa/PhjCt8c/t5QrNh/EkzUf3XauZhQEERx/RVjm8QkThtUQRJbe",
+	"k9TNDkQXHiBAHe0OvElqnFNX2OJoKim5SMWKt1c0p5IZUZjHGFIZnlpy7H/9n/+Es4RwLGhm9NaHT895",
+	"1aIdG7+O4TvCU2U2S621+7fEoEBSGHk6cSGK6m/nfGEYuaSKqWcgeMY4fSEpSRaG/39tv3lxPISUziVJ",
+	"abrxo1WcXzwYnnNPhi8KHh2VPBpihd0XtS8fDYHTSyonuRRTmr7gwojk8Tk/sedXxRJDf60mUEEmyM9G",
+	"qI9CqI9KqG+n3uqL78prusnkgOiCW2XTfRBLrhLrdhp5XG64OiOU1wB9i1xHHpGOPLYcmZ+PQhQYREjK",
+	"KEicqq0p0Hin7/zAm+Z75ULR1wr7G0iRZUV+67VgXtZL7VbVVO89Fn0fcL7pGhwfYZlBJlcgYRM5JE0o",
+	"1yNXcGQnipzi8BM3eofIrvqwYE0kW8zfa+kz8+FKyIuJpDPDbbkmDNs5MIUpYGXD+7beA36CQ5vD1DZl",
+	"Pkh0tsa6CEZqEG63cvrm5NGjR99WPYVatnO9Jfu79kx5cHynTVMiOBEtr2QGhPC+Wof1L9ygAzfYBLqC",
+	"vhMz9qoGzSIgG8wBTVRbVqNNAXOahpiBGTyRBVe2u4pzVuDXKVoesrB6l3UsjM/5J98Ovo+KIdU0PTLq",
+	"FU0HgBMZE5x+xsfqdAwulEFZQ6dZaAYDgSoFc5vuYjTA/8BT3TRpVCtF7vQ/IqBJCP+9WNNnJXJASnO9",
+	"AJVnDKvDZr4xYKtBjabsTmFzhqM6Cxn0+xhLd2LRHNHwVoXNzzePT0JGL8+6NixYv/DIrjwyXlHI+lkw",
+	"pZ7x+RF6UmJ6tRb5yDlYkPvs1p4+ifyN/eB7HP87Qu0/gJ7ShH5MUyH8wie8ekP/i5py00aLqpKblx7y",
+	"pdcS+mYJir7JXVSIH+xBhac4/gsV3g0VWui3U6GB9BcqvB1jASktToX2waCVCudSFHn7M+Fp0KXxTzjU",
+	"vib8+eNbcOujBoy1cQr32GbMCTvvOe8rpqny1ScNgOHDGVRl0AdDW7MAN880+m3zQtMUlnQ5pfKcW0eS",
+	"j0uI2Q52rRaTwe76Jk0FXGFXTcAzB6w8K5QDjmtMi8dTXxrZ7f0SiFAssfBrV1jb/rVEp8oN2VLowxeK",
+	"M3gK/SXhBVakMbinFizHasAkRNq1H3XODcPPBEndomZkoYX7rwu6xtJMINRkRpYsW/sYO2cBN1vPt6Px",
+	"R6EsHt9QzinObSFx2zUw7LFaglpc0QsL0DsrfWGv0zUhLwNYvpBqW9LMbcfWvOQh2fliH1hOw78hEm0I",
+	"2FJhW6VIh2QbsjFS9LEpI5fi0qUz2z30Hf8A19VhUJNeAd3bGLp2wrclGz3p36sykl+ooAMV3GKUGyJJ",
+	"a03FV76SZslKW0sj6mQBBp2GoIqpa3PNU0hEJuQY/sy49XlWIhKIpOc8KOcXx/VdMs4sfLuYfkOC1NYv",
+	"u+3sta2C1DW1umNBWjjAfGEcvx/GURbjQ9T5SkHKVJ6RtStv2iYvjxx7aA9Af6kUm3MFxLrrsISV076d",
+	"EK2EuoIUA4WMiGXynHvxim8vNkQePTWo9T8+Pj5Y3paK9g+4wu+dE9lTXLntIc4CJE3voP7cCeFItWlq",
+	"8MPuxOBKqPN94Si/J47yEq8yTvS72MnRP9GJ21Ehd6tgEGB9nWvQx2+PQwyjkzpA3Ly+78hfIlC/qP27",
+	"aK0RxbG0yZ9tiNiG8M+WhJkTEZ5sSeI6o9qancFomGVkDrY9tJjNri4Jg4383sVhdZQ7KjGxr5L+hc5+",
+	"HzLtk5jPs1BLbhJkjc4XlGR6se2h83s74gYx0a6w9cWCykuWYAMBu2Fs9vLkNvEg2IIPnjZsreDkkrCM",
+	"TDO6tU9jGYv8NUhKUob/xkBr6BMu+Hopikar3Z2BIC2RH9FuhfySScGXBk4HvAprMr+zaCVzyl0vWhiv",
+	"fPdtrdrKmWFDq4W7rQ6FyrY1rfKXfhOS6XtbWP3uGlXZOoE77vnum1NVHRqmxIb4WCcly4eQC6mHQHUy",
+	"Htz668P3bifNhwfGIWQALY8O5hz7VxlDtK5sobC7wTNJlcgud1QY+77eie3UfdNFv7sZu+O2u5C4E29p",
+	"Q/L4NpPDa91tvGzDtytfv31rUXh3GptYHTSGWBBt6yxPKWAhazPjTqSLNQpsw7ymmVJErBRUjhifh0rR",
+	"ZClS6grhk0JRhZLko5HNn7BBBvZeVRcsL/NYq97Zqpgqwyu5Bs2SC1vtBreUVdlHmCpeb7yE3YwkVcWy",
+	"sRvImRElRV6Wx4GMKA2SJkKmPlV/DJcPxo/Gx1FzqUCa2tdYujZiuhm5dPcG0y7h5LsJIUrfNt1+X2uG",
+	"0aDJjwatjxDbKJR4idqncnSoGDdWw/XIgCoN9mjBlBZyvTOoq8gNkf0Nww//hlFjI5tPZompmnHiZrQh",
+	"k2bzQSG9MbwmyQIpLiG5LqRvx0XlKCNraluBYWYImkLOY1FkmvnfUSX3xLaNzJwC/kO5s+/dUW+L2K4Y",
+	"wfnkTgM4o6DbqvqF126TjUZB2vp9IbVPBrW8mDDGd3nGUQ1x+xgY6VAczzHYu4ixI7tOfUDNpu9nB1DX",
+	"BGdCNKi7aGO29TrrrT+7cMfd7T5v8yraclbDmjYuaPEaotIfjo8HYyhdHUxBwclsZusA3tt0KHMfr6gm",
+	"LNtpeqY4DPqu7K2qhOnXEZDeM1z2vUzLHmzx3QPlkiUL5yrq5q3w8TuRMJpbZzw3o37eaTfLTm4R57K/",
+	"B26R+4X2LmrERYS51y8bMHKooot+jpJg2ks4SfELTbQK9QFMTGjy2UTIvDDDpCjmCyD8nAuchGQV44WM",
+	"cjW2udEI1s8aay/53pAZ0VTpc14mQNfTqMsKNgiAPi+yTNk+vVj045yb0Zymg3EZxu4KQDhDF8s+2JwB",
+	"YhMbJ3miz3k9uxGI+Tmn0ig2ZE6HIDjFnjxLkg3h2C5phzJ1zo3AqDIwfIgNNoIkSyeBpmu4oFwRM5Bk",
+	"Yl5Gv5/zfsH91/+gqZ3cV3gzJjY2nfTpJ69en51g2sc5L+PnX56djF12WIa+stc/vT79XwiwfmkrHBnj",
+	"P6fpETWYOBiec2WAwvR6hFXpaGqzSfBKWWomHVoOay5KimzCsFGzsJVSz7m/i6qUZnXNfdsxWegFlSum",
+	"6MD6FGw/5HNuTBlMZ0oWNLkAUei80PhUZrYE9HMulK+6a8a6Uj2IYAbgU0MiRu/6f588+taeHCFlJTlT",
+	"eF8Fz8mccTRnUV6Pz/npRgOO9pR5sClqW8ymql7VXapBWuyl4xCe+lt0+UF4u8BS9byWghRgNJHWnHSZ",
+	"RAWW9rPtu80W7rdaVN3SO8rV1s6g1d0bPgV9V3/A8qmvg9SYADZfO/y7j0k+98p/U9FxA8qGWA2kh7Ak",
+	"fB1wkUtGV7H3xKbwclUyNvJd416auIGAjK6QknI9sWLihfWwWC5nU4yG4FnldA2efVblPMGV/l2w+cL/",
+	"e0lTViz9f2Vi5f55zgtuTEXLdDOi9ASZoTUiDZcfwyemDU9vEGMilvScl45VxkdLujRiwMoXy1etkHnu",
+	"JNWi/Auyz+C9dwjaLAIzYkTplCQXWArIsHUzD3NM2Etys66/HUv7IKmtFeTqnODXhhHF2JER7CU/ok12",
+	"pKyDvfzkqxpzOudY0TAQRmMrgideNLraz7lAr4rZ3BBySUfoTDJLY6m3fUTAFt7/BlGuJWP6Fpj/D+Sz",
+	"E/kS8dqIyxNX+tEVfnxwfPzzc//CAQ+O29j0Fmfbg1gdyJsXRPdboARXv02avKkXG21qW1/kxXZ5gfEG",
+	"xJscjjVna1/cIBQj0mXO7xQTHn3ahcQr7Bmd6Cb6XtC18rVmA0uoIUuwpHKQOM4LDPUUM0eqS5I7+qQk",
+	"WYTSJGSshum+Rv255N4oOBfEK8hTSjk4W2d8zr/DK0X7yQjUnCUXZtXg01CrZXS1Z/GofTThNxWM78RL",
+	"e1O6Y3WurTRfjrJIYIyX6mLt9TvL595Wtbp3TAANjQqwAfkhJK0WtyTG5BYduICvf97KAz4FC4hV9YRN",
+	"UpJj5Vg/g3y2US17eM65MRb8kNRpto5/gZGi8pJkw7LKQ04KZWMa1Tnvl9Zu+Jr+tfUl+FVthSbKjf6W",
+	"hhEDqF7N2HwwhpeVh1QUGp0d9ms8knSqsAWd8zW4YvIEeJFlYE4xQecL0TByfIdwQO/BQeXb6/R05m/h",
+	"D8UlylPFgi/9DTilB52NgT/rCy/o/WgxEYQE96LmIFNjCh94SZ+eJBH9Khzvvyy0sH/TLKNdTMhuheyN",
+	"bVFIWpabv1ol+9IBOQTnfxx6P5+rWD+GV2StLGU6OnYro0+GTBU+vZYcSkqyfg7ukfackyQplgU6VatB",
+	"KVYgt3U8YC7MlmdCrohMW/rQbCtdX0f/lsr1t2AO/cHK4cfA2loN//dSB/9eMhMLwkCMexJHrEcGLTit",
+	"voxykapM+TN04rRnGJ2gn6V8GmB8lEuRVHH0S5IsGKdy7UN+mEhZApkQORTK6Ov9KpxwNJOUwqeTj6Op",
+	"MQVQ5c+F1PDw4WBoPlb4GqCF1fLLaL6hS/StSlHNJFULDOXL9BgaTW5taztDqJsmQlAnH0/elvpkEboa",
+	"fYJgusVkv2tq5Pvg4TedGvneQtV/BOEpXlm07r8LArO/H1gt7otlcnctrl46lmB1RGaBAkyVgfGMwyxj",
+	"80WTpZ2tebKQgotCgeCjlC4tuQf176uZ61GTLRwuZSoxis76mSx4O3P7kFNu397Ozr4HRfHagMwJ486M",
+	"wyMUCr21WoGLrU/PecXUhrbWNfqsM6FoOlJUuw1PsZhKX6iRpBklig6hwKwFLGHA+EwMIZ0Ng2yGOdWU",
+	"z4RM6BAIGVnP/tDISLoiWTbAjlvIV82C9iFSDaHIFZXa+XeshTMx08PXkFJuWE6Gb7UIo7FQk/+/sb2y",
+	"YskxUaEEalBufAh5Mc2YWpjF6CXlelqoMcbtOOjS1DJmumTBe/u4BP64fBU/56RImQacxjFlZ4chX64+",
+	"2cKO/bLr04J/4cSHaGhnCPK3fCaiypmHr2PC8K///V/uKQajelOw378hiVa/Tw5951mkmyz6yW22krcx",
+	"S1WLIrxiw/tSRjKjeAbJI47XgX2rvPXUzwoblUsCNWBbGTLznmLzw0bH1Lgw+XAGM8bnVOaScQ0lv+ku",
+	"UqrmpluNbhQYVc9GrIbqnSbBc70mU/ga/mLEAw6xbZ++W5evX17ZFTnlLni5ilv5uuwhOXgO/+asZ0ym",
+	"Maqv/dAGEJl5Iw1dSXpQC1dnP7+uQHGLbLhh/C7KwP+I/TsjmaLlVFMhMkr4DTPYEirvmNJb25CqZuOO",
+	"+9Ko9fdg/zae2YII2gorW4u9nhVT1FWi/ZSD5LivZZHRMXzgFAnwnAfEZwZ56gs+Rj03EyvbzK6a5TmQ",
+	"c54WFmq0pOvHx9/6Ju2+C7sLB6hVXjA2tByf800Sxq8C+3avPsw1Kv4dBwkHTZjvJHW6Q1fmSNvu35nm",
+	"tIF195JJ3H7NWRTNFQOI1p31VrBtEpRtdnu2ACVRRgZ9fC9cEXZJ5cBoPWSriqISwrcU3LM55zaQmHBj",
+	"tULfvtP5iOVMzKdCXBitYWAtO44NgpSNKPv+h5cnI8Xm3L0Swi9iiixrJeQFhsHSpDArXDICf6ZckTH4",
+	"ILaHxw+D5s/4NUtLC8P+t1Y0myEjVZUS9xycFckEP+cZtvZkvBnIcFTrk2W2bqbhXBQ8KRVGZ8aCsWMN",
+	"A7bhCgQh0eq0cA2whDznrsvThr8RKndjPVjLllsK3h7R2DWH3caYzxLy38a+vT7bx0DttLDdutL4c6ZD",
+	"el9U3GCJwWCH5OkXk/b36XVE5rGbfn2TtgYLfm1vHwgPzMVaNynCu1uJzqnF+Ex0aqkRJqRu+O7CBJI5",
+	"uzR6KDrY4KPI8ZHUhvXG/GjQD1io4cfn/OOHs0/Q6iRFtdZ8Y6asRW8Mxuf88fFj5zrkQk/wooHNoE8G",
+	"lZcUEw9ROA+hPx1UQcjmF1WldKZDs1Y/CT51InNaaCjN/nOO4WNCI82uqXVHWY4pbM9+86P1s1azUAwr",
+	"MQIIsYHyFF8bmw9BwT1tMXQDf9kfIOpju/fvHWYyQX3gl3iPqP/MqqAfToELCLymYmXwdEPFI2mQKhaM",
+	"n5HE6YnRB1vGNc0yNjcYfYSKS7cuPbY7qHW12798OIO3wWSQiCyjiUaVxhc4McTF6Spbo1prjFghtRpC",
+	"TpILMve1CTEsGL1x59x3drJ1l+CkkEpIcClMRnsVHFKqMfmqShGwodfnfLoGV45haLc6SURKq6jjIWBD",
+	"3qOCa5aFziqhRiFkWqg3PO9rC7tOJduqEhFXdlBVp+q1aExPH+9SmFqm9kCqTUx5sew9+2uPWXaViVVv",
+	"2LPZHL1hb8HmhlP5zI/ez90Xu9bGyHif1zZbgkh3ky3XHt5pwY5NNP6IjZcjzkVL7lfqy3yPGz6h12+D",
+	"j4Wcrp13WgOxVjh6f70snLHKw6qyrVA/s++f0KItRTQlI0PY7Jxz0TgZdt81ClBeqnqY42RFDPRLPeic",
+	"b1GEYEMPGlyNlZ5hP+A/QpW4zVNFdSKlywDGL+pPTP0pwzs3NR+EHqbe13C7/KJV88lYQrna2l/6nRty",
+	"gxjilkDk2JZC4cYFvbIrEPyJ2jASH02fhWOhrxmVQ5hRoq0i9fdCaGJ0LIz6qEcBc6HZzJ1EHRnWx2m2",
+	"tVLt++CLEz/+BgEWWa/tKcz93Kweu11cvRFyytKU8uAtevsXrnzwj81ywXWxEkIWPGChr2giKcb8pMTo",
+	"sNtKRYVTdCgnG4HUDRWXjax0N23+YkfeghjeR+duIbiEKyk3t45gZZ3XGJJ1RajNkihxZtCxKlkc++5h",
+	"b7m7ubKyU9pVrmx3QbJ7cwvHd0Tjh92x03e2f/Fe6DdVfNV1IIUv4xXDiQiT2ldSbCnldZd4civy6G66",
+	"5XXEVV9etv2qb0se3RHil+3fbk2APdPU6k1x/ekTVfo+S7BP+J6fUakhpRm7rEon/HGR5IzyFAioNdcL",
+	"qlkCugKCr6/mXdN7oI2mDcNQ0iVNmSV3x522+cTLwT4Mxz4G1qPv/j/2rq25bRxL/xWU98FSRZKddJLq",
+	"cWofMrnMZisdu+yk96HZpYJISMKYArgAaFkz2/99C+cA4EUkJduRbCd+6o7FG4Bzw8E53zcIWDHpykHE",
+	"OIADX3sf8tRwhghgY29IjMgI1O7pFtwU3ZMvCvbBSJQ+uA5ZUPqpKfGC5BvhknM/2q2y2PjljdnhjImE",
+	"i9kYS9ioXQtfzQa6gWBpB4ODRK3GKhdjX8N/MDjA+g6rC/7/8SaZpiwZTyg0SLly4e3zy98x5e5W5zvn",
+	"gyEFvNe07/rCt22kG4T8QVWX1hVgQ4ZXNQyH9KbA9i9VUM+uAKv+xm2KQetK0fQd9epQQkXiz88cjpOH",
+	"GqyhaJTxw/jUFGWl/tGR6CgeJVvWjmJDUEPxKPk655p8+fD7h3MENSqDY7ZYqnpx6QZj5YS0JIw7Smes",
+	"K8b9ZDPWv6OtANQnMpokqufkjni56z+6o5sGsXmqDi2qQ5tW/W51ouUn9qb8uu/s0rQE3lWqFLV2Elrv",
+	"hr6C4I+yhRyF+mTrsLczqV7cu8Oyo3+rzrM2qGffMjxqOpVq0MBtdgDqAadPtjcqDWL1gN38nm1AU9zf",
+	"Btf0D1bXKRWEafsAYytVONKGZd29Y/YKrJsu9+GSf8pcCZqS3jvswzx6m2Xp6shBgLOjd3IBeJEyN7Fc",
+	"MN33aGxQa1GGPCZc+yLthPRCOO86TyJxmjEBPWnP/ElVYr8kvgx86s0ai8fJN9vRXMB0/EA6awfUFqbD",
+	"YAfQaW3XDnH0nlT2Nirr+r8adPZQN6sNKF7/+2v0ids4t3dcrO0rhg5W12+5fRh/xdmSKbLItSEJn06Z",
+	"CvBHCGaCUX5PM6suWF03JUluONMDux9oVFD3lnIDwgYdfYt3VAP5PWnojncLdoqt7P31IDy4F4CH7crd",
+	"Vz5g07DnuP6LNNaII9RRTbcRThGShF6fXUdnUOCaKXPaViQgWiORrhA+pO+2jOC91drSyCVqNewEUfkf",
+	"macJcchKHoy72MwwAHhazqn9t3N/WLinBx7u0cYPWbqC3qqPigE3ByO98le7sKU/Il+w2IjwRZayBROG",
+	"JW98aiQSr46fb5+3eA9YIvdi7UoW6GHoupvgmq6/2icD/XsUNdDv2grXz+jdlbX9cIaat62vd0PeVhP8",
+	"5a2aYONyTwwz5dcVQOMexvWdIXx/ELlWtIBpXxodNlmWFOTE9x3qavrOr2QP+5UQvndBRV5LbCLTfyRc",
+	"qD+cUQNMNKXMIkYkE+aN3qE3Nodo7t6QTKZpJP7x4SupTVdoHfEbjv/DkwHitinba+kHfMB9q6lrVqxj",
+	"OsAeSgrXZ4YTQtrmozYXD8fTN2v/T+zpz4sdsyicfgjbmoo9nZw6N+euK6lgNXXntbi/0cGHo7Y/d2LW",
+	"8MzvFpsYf1h4003Mpu3KDY4d7Ac8bVZ2n25051pPm5Wfd7OCyvaw9ypKpimUIbQas3MGlG66imuXKTZ0",
+	"M7Jd/BWJagBWzaa5r+iKpCJx6M36oSeX39rsuec/yIDIfxwpYyo8iByn/7An+9AZ4oTzgaYQx64ukm5R",
+	"UVx528CmXDi07fGj1/CqRYBm5a0a+87xWpLyiaJqdeJw8mZMWBVjPmHha2giAUU0Plxp4p5xb2/pnnPv",
+	"O9ipI7evwOOV9jYltEWVwaPEPd+7cjqBq9SqPI4O1LqYaNIr11r1m8RyGxansoQmXYxOmWLAoEDFajln",
+	"qnAnWCPVc4xPNXSk/gD4mwqeJyDzgSME97JI1AmfuBlAF+yw6EB1qlCwN7nkno5lxiKBNE6Heo099266",
+	"UyFo2rESbUeaZFUJ57tU5IV0hU8qdVOVqpAlgcAwTUKhcZnCDKa8UcM8Vs1mBXO0yoHsyElwDzhGjpaM",
+	"Xaaro4UUZp6uSEwT6Fg1c2oi4XUf0SPhNgS/pjzVgA5+9v5jQSddKZiPhCt97leLM9t0w8HT4GuG/nM7",
+	"1eQizMHOtcS/qu20+2sJPkg/acRtNMIJmOsgWFWns6Wc1V9SyKeRwWNhTVinmENBK4jzujQLlPPGLpBQ",
+	"Q1rCvLupGGMZZ1W8dlRD2vSqe4IPrY13Qwlp4IErikT3I8WfxBVNeVJN+TxpdCsAX3MHcJtKd3u0hp7e",
+	"tT2lvHKonp5NLJEM5wpvCsEqL6pPQyTbD+jCd1Bf7JldU98H2FP8JLYPBTcy0Au2VXqFRuywzSjsX+iY",
+	"rZlLOZulFWU41J54EigrR+ScDeEPmMK0Hw6QtcB+y65hIyTw3EIU2Pl3UA1soLwn1fj+3rNpODfynsd7",
+	"9p656+Ctes8nM/BozMAHUF9o6eAa94TrFqHJhfKZ4GI2vGSrrfIuH5IXr149/xuyHsXA+N6DhIkNhu2/",
+	"eNInucbsiH14JPxneHLNAdGSUBLjLMdUkCum+HQVvvhQw52A9wNMnJHwTPJMmLGe0xevXhM5naZcsLsm",
+	"Ti5wAjyE8261sHhXZ+6RuFUpzfKTQm7C+Nor784XFG4rv0COnKu16iu7nCUtmUrl5Bx9alhnhLVqVM5/",
+	"bwPEFxCX3TMnVgcHhIs4zeEIEnCKjVQsIf99cfoF6KQNMIzdTXP+vvr0/rGDseBIurXxSfUeFLweLlmr",
+	"I0QMGimCPhTuqaQEng+236p3R+waFr9N/S6MYnSBaSSRABzClMaMyGk5NUXtBYlcilTSxLrlSFBjaDxf",
+	"gAKi6P9nlkwDNELfPQ/d7cSOEKgZ2DCjM0bO3n8cRCLhGmJ7xDa/5CI5KR1LApk9TgjpUTLl14BUjAS4",
+	"k1TGlwPsgwaIZfvUmF4xagr2eiOzoe+VTLk2feLKFEMOGsbBtHE5LuDL7lGyYGYuE5nK2cquEBtgQdhs",
+	"ptjMbvDDG59FoshnI2v1wJoyushSCB6qH4CfRn0MMJxTPY8EgHUy5esQJnl6CYug+4HbHj46T1PiKfiP",
+	"7P+oPAWeCw45vbAOVlIrBLoxFVLwmKZ2r/MvJsIsuu+IRI8KXID+iHyUwKVfnhh/TupeEOur8vMjYT+m",
+	"Zz9rAD2pfeK/ibBro2iM2XN3t9QxTceaqvAMGgln/E8v3r39TJ6PjkevCdWaaW0lbIgchZokMs7tH0jP",
+	"aoacaKau8AvtQnCsVcnsGpY+ZlB8jWJTphiwhExWxEVgXERiQuPL4cIOWQ3cAbmNyux0vEWFMHNqSMi1",
+	"YGk7LpgPDQ81zCDwEZCXx8cj8oHGc7yb60K/pMDzgKJJWCSRiCnoAfeTPQYJcEGmYhmD16MGEihhQcUt",
+	"3GIkJivD7nwE9wENxr3wpFsph8mWbrpG5D3aE23/liXTUQs9untXI6bHQZZMDwYFKgr8C8z54CDWV3Yq",
+	"vEg2QZnc1XHTJOEIOnOm7Jwbbp+Dk+XeJSdQlmmNePlZ9ksrjwozOuGCwvDX5vTAsGtzZIdVubN+XUug",
+	"UHIBg3WrTwqjv/e8tO/2d1PwFMw8omDmvbdbDVFG2N/3bEwAUc2AvLv4HeoV0R1cvD1vDHBOfF67gwbL",
+	"p/woAS875AJQ54MHLACKlVwE6N6EGhqJXq2ygmRU6yPrz7GmQpNnxGPsI3IU/n1g/T5yJniUBo0UW64e",
+	"kWNEJQhfLHIDmoVDwipCj1EViYlMVlhx4Qy9C4eMdQozJfPsUJMFW0wcjgywYR1Z/12OS1Im9Bs81svM",
+	"isBDIYIBIJriRvuv0n26NSG6wZWcSe18yT/8Au0mP+kfjy8rZSZ3f47XZkLrRUN7t5O/0dSaSBvh2HXG",
+	"WM7DeIPIjHmCMvVkRG9ytueFjVDyEeqBSgy/H8KG5cJdXzFXslqtsh54yR2XcrxNFlzAW7pKnewFdZTu",
+	"+yjklSkrWvNr9RKTnKfWihPl5qy1kLTylMpSnOAhezvsJBgwe6UDnNpRbUKujVzY9/gqhXupSyg+o0s2",
+	"8CqYdV+jsHfTdhbW1xu0/ZdR2/HzhBh6yVoP/+NirjYJ6DpYqrpBaRu2mSJvqM8OCRsfp/xfNsQqMhN+",
+	"36sjgRmIchm3G8IgdHHaJw5d3TCZKLnUTNltK5KOjiJx7p8HkRIyi8ZSZbkG/jdDDY/7gwJhM0653cZr",
+	"nrBQQGSftbY/tYNv253uvN5tQ5UbzPNTNXXNWodl3KLQrSSvXrp6IbMFf3aVtV1N3eGFFbUJdLgbj/4K",
+	"BlzHKl/hJqnjxU5ofMnFDBON9tahvytRPE2HdntMqHGqQXrsOkMFg+2AkUQzZvUS5V33Rx5hFlNCnkp2",
+	"nVBt4tksx9SEqp0mnfE62aQzFzArNyRD++7s/Z1wqyX6recb6bfWMkZhinzCOqXaAHOSr33SjAnSO//4",
+	"7pdffvlb/w2RC47rYqgyduWwGGSJHW1b8o5tRWO2ywMfu7Bdtsox5gOfqRfYO9GFPZm6NlN3zwy8TXhZ",
+	"bvVrxLZr/Su3srFbn+bGVDgJRGu7YIZCtJCluQ9gFBZtJbnCQ6UrphIeGxeIUIMC3PPg3AVfZCW00QPg",
+	"jx37NL+HtaBLEs9ZfElkbrIcet++nH71qX0yZ4q9IVM4aOMGDjHQCSGRGisdYgRi2UYzjIh4m+zwj3DO",
+	"bMfxnhnK0/ZWAApMoHDJk+F4QIYDKNHbDMepYF5jg54+I/6Mkfjzt56QTn2CctzFjBzBuUuHMcETZCqI",
+	"XUjlpIuWikXK54Vvw3khOcfvjUT1wNCfED6rHB16ve8PoEZUaKNyQECYKrnAwM8ZKHw/JHHBSEA8e6gJ",
+	"nrEzBcS6iMydcDNccpHIZSSoMnxK62atxZhsFdPBsB+7MTm1i//eLVCTxHYvLhwVPNmYx2Nj3pLlXKYl",
+	"JRYb1Dcc99/FxChsrLD/+ZT8deTN1sYIBkpvKuFJEQ8gCje8GtTdhS2RQMc3cIfy1owg5ARTw1guFnZn",
+	"CBGJJj3370EApgBM3yw3A8KuuSHIkM2uM0BjOaKxyWnaxwKSavTjQP89K0CmpJySCZtzVwXjvg4eJjUU",
+	"IKQrklvbSioThoUIgAwG5RFBonoe2WyIAyynvg2d2L3USheFKMOpYqx/A3N2nqfsg1+Y/RQeNEFmgIh0",
+	"PrjE5/3i1etNhN67jsQq09aRtLIeKlz2ZC8fmr10TEOdsZlbRkiUNZgh1NBSRiqjq1TSpP8dLed2sVrJ",
+	"bLo6RQcB6MI2Q0VCU3tVyfZHosP4d4Ru/QGSslRDNnKDiO1OmTWrf3uLxH4Am/UU8P30BqxsDHYY/ml5",
+	"lClp7aTqPHi/uDg9C9ft0lsX72nL2vrfb02TvZ4IvLg4JWEaSC9s7G3898adyRHHcYllxliQ2825RZMF",
+	"Fyday7F/djf/dWnsOzpIL73hXk/SyyPtWuH18/NdEkU2nlGLinDccLXbNO3INd9uq3Ef3OW7VTz3lja9",
+	"cz+XFYUn5BmxDhY0pd+kWr7NuKpi/vxc85kYckEQJIn0qJBitZB1lv/q5G3H513Vph+Ax/uGLKaNTeNV",
+	"aSa9mOqYJgyBemywbLjhTJNniHOnb27ethDnR5/b38567X+Vf+dsCfuK6iJX3NktHFbe5K/ye1nRnbpE",
+	"38R/L23727pE17j/ULmTG1my61YHKgswqhq7qMpIcslY5praAH5vZkW5fwePC2AUR46Cg19xszrC5t1O",
+	"twt3vSvd9A7v2eHar7+tu8AQS+9xLOQZSXzjj84nQ98gc68bLpjDDbVO5/ZXLIcrRj9cSMENbJMEdB+E",
+	"QU7oJUtsqOBHWzJNa8WPGjgkXb2Ke8YAm69T/DsXw0zJmGlNUn7FhP0fjYTekTCSnLNU0mTgsOygmRQG",
+	"NcKHjZCrJRmRv1u514QqRq4cb0USCVctM6cisdMCXZ1UreDYS+ZmKKdDZR9g78kBKNluJ6AXrkRL5eBU",
+	"yhPU2EWQd0vtDgpy11+0Z3PZ9gW1ViiHcuKkyLewPDo+WadQG+runbndQp822klHlX4jO3nh6dX3suju",
+	"bU19HcwoHuvaaj9iW1iyVQs3tmdkQbkdC5wsTVPauKQJ19C91OD32qs+MzSfLCHv/e2oYKQnlW8yDT+R",
+	"5ZyJSAgJpYRI3tsnZ5+/XWCHdt1ql3wU0djF/e1TJGIqXMMboSSyEoQxgb8tOiB0OpUqgfE6fixCibKG",
+	"dWgUz0aR+I3bldFl02nnKE35DA7bnBW4ej5qsrJhstx1belsuLo2NbsU+tqrfqbI4PSChFUJqEa7iA1I",
+	"D3AFrmhq41Hyy+vj49Ho9fHLX4+PB0RRw8ZQmRuJ56PRK/u3hBkWm7EUY6gQHDsGeTKRMmVUDMrqOZ6l",
+	"coI9ivAjENG2RhQecF7TBSNg8CNR4u/Egr2SRSimJeN2hvMsjA1jixCMGJkROcXWB3ZtiOHxJQQkQpK5",
+	"NEMFIY+LkohgLGHJLfUkRCRNevL9w5H6W/YcizS+/ocORHAYW8YjW2lxt/vSS8ay9t7lU8GGcjr1bG5w",
+	"NWKSTVYg+tHBORDoLat+RDqU+Atm7H5TQ+H3iHxAujlsdhwV3/5POcHMpZBi6Ij0B9b3iWHZG2OX8HIu",
+	"tfv/kdRj/xQswf90Qb58+/x5FIn/wpZiV4JfXAUbii+nX4liQ+bp77BoDipYCLVO08TzYZ4hDge1nxZD",
+	"O+1wysWMqUxhJW4Z38Qh3EcCBhOeHFwxwLPBkig8HnZm55Z2QOq6IbiApdyHNsKbutwlXEAKaJ1HpFpO",
+	"RF0Fe1VGkVIP/gWtNdDwZsWN1OWwSenKEdPtwsZPpSesR47lXyNho0dyh+AxEk5kbxE8RqIUPZKG4LEc",
+	"jLdFjQ0BZmfguD45u9SF9bf9ZOFjeQL2GkHaAPLX1y8b4scX9m/r4SGpRYeR2DI8JPXoMBI3CQ9JJTpE",
+	"4E0ID+NVnLJbxIdbakQIEVs04vtHiQ0v2nOg2PYFT7FiKVbcSmWbPJeOqbidx7qIqVj3VFCxU3JQkbhl",
+	"esM6qEjcOb0BTUP8GmqkEWXHmxxMP0O0ltAM4QD9xB1qYjhTkUhpAocvUOeXpdB8FHPACPiPlydutXyq",
+	"HAPKTKY8XpEpT1m/QdOhyXcLn1dM78GO63x/Ph8XFrzWwljSnO/n5EbkMwrRggvEilKMvPv89rezD++t",
+	"MMpI/PFqQF78+uvxn0hzH1wf/Ez+eD4gz4+P/7Q/zAGsEUI35FGNRA+BNHH1CIvn0lNSpnSRscS5rP4b",
+	"PJL57i5Ssalieu5fivO2lj2JBPjH18caUijlMtit9CJ4vppe7OBsu3jBvk+za29u9nA9t679n9LX3Uh9",
+	"Wx2ev3DoWP47XB9NhtDQkilpNc5afjlFlIXi9ePAlyI9nCoSQLx4SeYyV5r0vpx+JZQkajVUuQj75/6J",
+	"g1zNFUly5oHfXKVXKckSXqCtY3MtQFIKoP1k1yZ8QTK2Ixzg7YGbb17NmOSsQLFN0fNRRztPEpaZ+R0d",
+	"lwfiP3PTu2Olqb+uixqgWMdH4LFevJxbWVhSldQEEG1ts/i3iv0VVZxOugCATgUjTBi1grZVf707/NfG",
+	"DiBxUCqIx4ONY+nKhmoeBIj0LgGJRc95pslCKlbgaoXIAbxYAewTiVwz/YbkIsceMucobUyVQsDZd4C3",
+	"+HkxVYozhw9cfzqqB8qnVKCTiicM41LN3O+gHAhYxBMNYJHTqSMnz1OmCxUJ6PXjBZ4bkgVViNsi1YwK",
+	"/i+Ql6HOWMynPLaRYszmMrVuP4Sroqf0SqdyNlZsIQ0ba6aumBqQeK6kWI2FycaZlOmATKgQTI0NuzZ9",
+	"xxjoB6OJnss8TQhNl3SlHeX2jd1pRVt/D2KxYz0NL+oMNkEehiAGQWCJlsr1DUJh3MNX3YBKFJfGcxkQ",
+	"ioaGLbLUerRijJBzDApihc9LbkfQ+e0rUQzkDQOwj5Cz9BK/oBnp0QnwvNqJA4FhSOfXqDq6PyIeCzeo",
+	"P97Zs7pYOiCw8aA3CTjIPqhsoPiH8bw8Prb3e4oFOZ0i53skLtnqTTFCwv43p2kBUl79LHhwoiQwylp9",
+	"cCEqX7DOg0E8+cPdGzVzgukY18patmOBznbB1KwieXjegekdaKy/sWusxK5VZdtN+OrfcVqIz/4j2ZaP",
+	"WO8hLUHKVeQWoAyWVBc5hx87wj1HNa76rqCDJVNQ8u5GWpPSVXL09uzTV7xolwCgGYeXtGJG2R+/Y+vR",
+	"27NPBIe+1neEpbH6Bh1H8CDX5dXVaeRnckeK6+fwXnuMqh+RtK+lazJ6g4COdOkbvXjBKw4ZBYChc7kJ",
+	"u0D325UU5AY7motv9nJCpIjZALCbNhb+o9ysQ2yiYG7ZcFMSqofRbXPOruQlS0iPJ2yRSStS/TuvAD60",
+	"sgIbJ9bNW3lmc72h4fKb3nGnJbzAmqCuCNZe9ACAju1stQId526m2tagdHOXTSwmfAf0kPqeGy7tB2xc",
+	"5/tCK/4d6+YhHaDCoQPlaa7YA5C7wiw2IBjbKzbJ3rpdBZE9WrCjrEg1tCYyzpiyWy5Fvn0iWTk1wUaz",
+	"ETitI8yJzRRPhld6iDwJnl5qRC5YOh0Cjj2WEFGxqrbn+86/FbFqgs2AcineECEJJAJoWor17K5KM0Mu",
+	"2QoTG5ovsnRF3N4MIY6xZXpK01QDMqzdDdnHlvZmZcZYO75heXDPYFNS/3PL/h9U9zd2VprMHRvO8qva",
+	"+MlBkAp0j/JS7xua4YvE5hSiGaKCS0UmjCrXMVX2btCHYtz3262uXYNDXRO+DrLhizlNU7kcwu7TnbRi",
+	"e1aCIgMnQaZ7hvD0qHRY6/ayCK83Iqcixco+eGIlTGNI52AF0+2cEcrW+Pfjxt5QLuymuqQcjRteO8gW",
+	"+dqNn1gTrf3tdbeUbLcWawJ9b9wdD1effrNTRSjJqDLWimL3ZlUFOpRszWVsF4nbdbw/ENVNfe97BF2B",
+	"sKYNbOVCTo0r493Skfs4ftAZtf8I8LXbxIsPazWRBnS7dVyDwSmUy/GeUK35THTznsAc2avf4sWPmL3e",
+	"jQQHcqMtStO2W6aM4ATew2bCZ/wV8o/UkTXhs6CyKmVIDrZBYIB8xIlDp8jk4kZC881f/iQ2JbFRbCGv",
+	"1lI2tRDVXuKXEGDsvsMinjgW/fYmk9+outSuJQKLEdwtyQnhhiCeK0mlmDFV2V6RXipnXADsqD9Q6ocD",
+	"Wef5aYxlexhP+CAV81d8gQw0LF2NyFsRCQA+sG+0xtDT/5s544oAyYb7vl4q40uZGxtTXNmvkWJAXh7/",
+	"rR+w/BBBwX7CeEEFNL+EAyGYm7amDrv0792M/eCuzka8fqVRzu41JbG2ZPcJalf3yHvmmHpX1YCVzCsK",
+	"UMdAcpehtQgXWauBKOSgJFaEEVlkZC8b+aU/+HMTEElpTdqMDIJhdZBwpow6IvAgclCk4WqJ4cMBFLps",
+	"X+iMcoHHvsBmyfScoMnpBXvibclyztPSw7WhK5IwmvQD29SdbAJihP0MJgH68p6Mwk3D9HM/bYRWreq2",
+	"+uiR876HOkId/jCjWi+lStrV8oIZ7czGoSb+eiIFTjzXBk+4rVZKxc2KDG0s4DhyIxHuKGisvrrC6uKn",
+	"HDJdSuYzrN6wMcuQLqlikXA58WdkohiN50THijGBJ5aGqhkzG0IILaFOZEUWOdCpD8sGxPMr3Enzz+1c",
+	"nvmpfNxBrR8GjOmuce1ZsfiamdqahcVasmK19r5n+lIRRF/zNFn5s5iekZLouVTmyMa3RyiFLOk/Wb3t",
+	"rB6wyg6x7WfdjvRszAL0w9LM7U/9TUbQ3zqGR97eFl4xhde1n0P/7i7Zobt1r+jyuO6SgnIHy8q5JgnL",
+	"UrlyONmDA83i3Frgg5M//iyvwN9zniZ+vMVjqoCjcL+68jar+gmfZUxTkjAQAQe2nKv04ORgbkymT46O",
+	"UnsFECT/+vLlLwd//fnX/wcAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/internal/server/api_helpers_test.go
+++ b/internal/server/api_helpers_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/report"
+	"github.com/Hanalyx/openwatch/internal/reportschedule"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	"github.com/Hanalyx/openwatch/internal/scheduler"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
@@ -308,6 +309,8 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	// new snapshots are signed.
 	reportSigner, _ := report.NewSigner("")
 	s.WithReports(report.NewService(pool).WithGroups(group.NewService(pool)).WithSigner(reportSigner))
+	// Spec system-report-schedule: wire the schedule service.
+	s.WithReportSchedules(reportschedule.NewService(pool))
 	// Spec api-scans: wire the durable per-scan results reader so
 	// /api/v1/scans and its sub-routes reach a real handler.
 	s.WithScanResults(scanresult.NewReader(pool))

--- a/internal/server/api_report_schedule_test.go
+++ b/internal/server/api_report_schedule_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+)
+
+// @spec system-report-schedule
+// @ac AC-04
+// The CRUD surface: list (host:read), create/patch/delete (host:write).
+// A host:read caller cannot create; create -> list -> toggle -> delete
+// round-trips; RBAC is enforced.
+func TestAPI_ReportSchedules(t *testing.T) {
+	t.Run("system-report-schedule/AC-04", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+
+		// A real email channel for the schedule's FK + delivery transport.
+		chID := uuid.New()
+		if _, err := pool.Exec(context.Background(),
+			`INSERT INTO notification_channels (id, type, name, enabled, config_ciphertext)
+			 VALUES ($1, 'email', 'auditors', true, $2)`, chID, []byte("x")); err != nil {
+			t.Fatalf("seed channel: %v", err)
+		}
+
+		body := map[string]any{
+			"name":       "weekly cis attestation",
+			"kind":       "attestation",
+			"framework":  "cis_rhel9",
+			"frequency":  "daily",
+			"channel_id": chID.String(),
+		}
+
+		// host:read may not create.
+		ro := doReq(t, asRole(t, "POST", url+"/api/v1/reports/schedules", auth.RoleViewer, body))
+		ro.Body.Close()
+		if ro.StatusCode != http.StatusForbidden {
+			t.Fatalf("create as viewer status = %d, want 403", ro.StatusCode)
+		}
+
+		// host:write creates.
+		cr := doReq(t, asRole(t, "POST", url+"/api/v1/reports/schedules", auth.RoleOpsLead, body))
+		defer cr.Body.Close()
+		if cr.StatusCode != http.StatusCreated {
+			t.Fatalf("create status = %d, want 201", cr.StatusCode)
+		}
+		var created struct {
+			ID        string `json:"id"`
+			Enabled   bool   `json:"enabled"`
+			NextRunAt string `json:"next_run_at"`
+		}
+		if err := json.NewDecoder(cr.Body).Decode(&created); err != nil {
+			t.Fatalf("decode created: %v", err)
+		}
+		if created.ID == "" || !created.Enabled || created.NextRunAt == "" {
+			t.Fatalf("created schedule malformed: %+v", created)
+		}
+
+		// list (host:read) returns it.
+		lr := doReq(t, asRole(t, "GET", url+"/api/v1/reports/schedules", auth.RoleViewer, nil))
+		defer lr.Body.Close()
+		if lr.StatusCode != http.StatusOK {
+			t.Fatalf("list status = %d, want 200", lr.StatusCode)
+		}
+		var list struct {
+			Schedules []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"schedules"`
+		}
+		if err := json.NewDecoder(lr.Body).Decode(&list); err != nil {
+			t.Fatalf("decode list: %v", err)
+		}
+		if len(list.Schedules) != 1 || list.Schedules[0].ID != created.ID {
+			t.Fatalf("list = %+v, want the created schedule", list.Schedules)
+		}
+
+		// toggle disabled (host:write).
+		pr := doReq(t, asRole(t, "PATCH", url+"/api/v1/reports/schedules/"+created.ID, auth.RoleOpsLead, map[string]any{"enabled": false}))
+		defer pr.Body.Close()
+		if pr.StatusCode != http.StatusOK {
+			t.Fatalf("patch status = %d, want 200", pr.StatusCode)
+		}
+		var patched struct {
+			Enabled bool `json:"enabled"`
+		}
+		_ = json.NewDecoder(pr.Body).Decode(&patched)
+		if patched.Enabled {
+			t.Errorf("schedule should be disabled after patch")
+		}
+
+		// delete (host:write).
+		dr := doReq(t, asRole(t, "DELETE", url+"/api/v1/reports/schedules/"+created.ID, auth.RoleOpsLead, nil))
+		dr.Body.Close()
+		if dr.StatusCode != http.StatusNoContent {
+			t.Fatalf("delete status = %d, want 204", dr.StatusCode)
+		}
+
+		// gone.
+		lr2 := doReq(t, asRole(t, "GET", url+"/api/v1/reports/schedules", auth.RoleViewer, nil))
+		defer lr2.Body.Close()
+		var list2 struct {
+			Schedules []json.RawMessage `json:"schedules"`
+		}
+		_ = json.NewDecoder(lr2.Body).Decode(&list2)
+		if len(list2.Schedules) != 0 {
+			t.Errorf("schedules after delete = %d, want 0", len(list2.Schedules))
+		}
+	})
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/queue"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/report"
+	"github.com/Hanalyx/openwatch/internal/reportschedule"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	"github.com/Hanalyx/openwatch/internal/server/api"
 	"github.com/Hanalyx/openwatch/internal/sso"
@@ -105,6 +106,10 @@ type handlers struct {
 	// Reports library service. Set via (*Server).WithReports; nil makes
 	// the report endpoints 503. Spec api-reports.
 	reportSvc *report.Service
+
+	// Report schedule service. Set via (*Server).WithReportSchedules; nil
+	// makes the schedule endpoints 503. Spec system-report-schedule.
+	reportScheduleSvc *reportschedule.Service
 
 	// Durable per-scan results reader. Set via (*Server).WithScanResults;
 	// nil makes the /api/v1/scans endpoints 503. Spec api-scans.

--- a/internal/server/report_schedule_handlers.go
+++ b/internal/server/report_schedule_handlers.go
@@ -1,0 +1,199 @@
+// Report schedule HTTP surface: CRUD over report_schedules (list, create,
+// toggle, delete). Thin handlers over internal/reportschedule with RBAC
+// (host:read for list, host:write for mutations) and wire-shaping. Spec:
+// system-report-schedule.
+
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	openapitypes "github.com/oapi-codegen/runtime/types"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/reportschedule"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// toAPISchedule maps a service schedule to the wire shape.
+func toAPISchedule(s reportschedule.Schedule) api.ReportSchedule {
+	out := api.ReportSchedule{
+		Id:         openapitypes.UUID(s.ID),
+		Name:       s.Name,
+		Kind:       api.ReportScheduleKind(s.Kind),
+		Frequency:  api.ReportScheduleFrequency(s.Frequency),
+		Hour:       s.Hour,
+		Weekday:    s.Weekday,
+		DayOfMonth: s.DayOfMonth,
+		ChannelId:  openapitypes.UUID(s.ChannelID),
+		Enabled:    s.Enabled,
+		NextRunAt:  s.NextRunAt,
+		LastRunAt:  s.LastRunAt,
+		CreatedAt:  s.CreatedAt,
+	}
+	if s.Scope.GroupID != nil {
+		gid := openapitypes.UUID(*s.Scope.GroupID)
+		out.GroupId = &gid
+	}
+	if s.Scope.Framework != "" {
+		out.Framework = &s.Scope.Framework
+	}
+	if s.Scope.PeriodDays != 0 {
+		pd := s.Scope.PeriodDays
+		out.PeriodDays = &pd
+	}
+	if s.LastStatus != "" {
+		ls := s.LastStatus
+		out.LastStatus = &ls
+	}
+	return out
+}
+
+func (h *handlers) reportScheduleReady(w http.ResponseWriter) bool {
+	if h.reportScheduleSvc == nil {
+		writeError(w, http.StatusServiceUnavailable, "server.unavailable", "server",
+			"report schedule service not wired", true)
+		return false
+	}
+	return true
+}
+
+// GetReportSchedules implements api.ServerInterface.
+// Spec system-report-schedule.
+func (h *handlers) GetReportSchedules(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.HostRead); denied {
+		return
+	}
+	if !h.reportScheduleReady(w) {
+		return
+	}
+	list, err := h.reportScheduleSvc.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule list failed", true)
+		return
+	}
+	resp := api.ReportScheduleList{Schedules: []api.ReportSchedule{}}
+	for _, s := range list {
+		resp.Schedules = append(resp.Schedules, toAPISchedule(s))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// CreateReportSchedule implements api.ServerInterface.
+// Spec system-report-schedule.
+func (h *handlers) CreateReportSchedule(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.HostWrite); denied {
+		return
+	}
+	if !h.reportScheduleReady(w) {
+		return
+	}
+	var body api.CreateReportScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "malformed request body", false)
+		return
+	}
+	if body.Name == "" {
+		writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "name is required", false)
+		return
+	}
+	freq := reportschedule.Frequency(body.Frequency)
+	if !freq.IsValid() {
+		writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "frequency must be daily, weekly, or monthly", false)
+		return
+	}
+	if freq == reportschedule.Weekly && body.Weekday == nil {
+		writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "weekly schedule requires weekday", false)
+		return
+	}
+	if freq == reportschedule.Monthly && body.DayOfMonth == nil {
+		writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "monthly schedule requires day_of_month", false)
+		return
+	}
+
+	p := reportschedule.CreateParams{
+		Name:       body.Name,
+		Kind:       string(body.Kind),
+		Frequency:  freq,
+		Hour:       6,
+		Weekday:    body.Weekday,
+		DayOfMonth: body.DayOfMonth,
+		ChannelID:  uuid.UUID(body.ChannelId),
+	}
+	if body.Hour != nil {
+		p.Hour = *body.Hour
+	}
+	if body.GroupId != nil {
+		gid := uuid.UUID(*body.GroupId)
+		p.Scope.GroupID = &gid
+	}
+	if body.Framework != nil {
+		p.Scope.Framework = *body.Framework
+	}
+	if body.PeriodDays != nil {
+		p.Scope.PeriodDays = *body.PeriodDays
+	}
+	if id := auth.FromContext(r.Context()); !id.IsAnonymous && id.ID != "" {
+		if u, err := uuid.Parse(id.ID); err == nil {
+			p.CreatedBy = &u
+		}
+	}
+
+	sch, err := h.reportScheduleSvc.Create(r.Context(), p)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule create failed", true)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toAPISchedule(sch))
+}
+
+// UpdateReportSchedule implements api.ServerInterface (enable/disable).
+// Spec system-report-schedule.
+func (h *handlers) UpdateReportSchedule(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.HostWrite); denied {
+		return
+	}
+	if !h.reportScheduleReady(w) {
+		return
+	}
+	var body api.UpdateReportScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "malformed request body", false)
+		return
+	}
+	sch, err := h.reportScheduleSvc.SetEnabled(r.Context(), uuid.UUID(id), body.Enabled)
+	if errors.Is(err, reportschedule.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "schedule.not_found", "client", "schedule not found", false)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule update failed", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPISchedule(sch))
+}
+
+// DeleteReportSchedule implements api.ServerInterface.
+// Spec system-report-schedule.
+func (h *handlers) DeleteReportSchedule(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.HostWrite); denied {
+		return
+	}
+	if !h.reportScheduleReady(w) {
+		return
+	}
+	err := h.reportScheduleSvc.Delete(r.Context(), uuid.UUID(id))
+	if errors.Is(err, reportschedule.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "schedule.not_found", "client", "schedule not found", false)
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule delete failed", true)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/report"
+	"github.com/Hanalyx/openwatch/internal/reportschedule"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	"github.com/Hanalyx/openwatch/internal/server/api"
 	"github.com/Hanalyx/openwatch/internal/sso"
@@ -153,6 +154,13 @@ func (s *Server) WithRemediation(rm *remediation.Service) *Server {
 // routable. Nil makes the group endpoints 503. Spec api-groups.
 func (s *Server) WithGroups(g *group.Service) *Server {
 	s.handlers.groupSvc = g
+	return s
+}
+
+// WithReportSchedules wires the report schedule service for the
+// /api/v1/reports/schedules endpoints. Spec system-report-schedule.
+func (s *Server) WithReportSchedules(svc *reportschedule.Service) *Server {
+	s.handlers.reportScheduleSvc = svc
 	return s
 }
 

--- a/specs/frontend/reports.spec.yaml
+++ b/specs/frontend/reports.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-reports
   title: Reports page - Library table, Generate action, deferred Templates and Scheduled tabs
-  version: "1.10.0"
+  version: "1.11.0"
   status: approved
   tier: 2
 
@@ -239,13 +239,30 @@ spec:
       enforcement: error
     - id: C-03
       description: >-
-        The Templates and Scheduled tabs render an explicit deferred state
-        (a "coming soon" message) and call no endpoint, so the page never
-        fakes a signed artifact, a PDF, an OSCAL document, or a schedule.
+        The Templates tab renders an explicit deferred state (a "coming soon"
+        message) and calls no endpoint, so the page never fakes a template
+        gallery. (The Scheduled tab is live as of v1.11.0 - see C-14.)
         Loading, empty, and error states are honest: apiErrorMessage drives
         the error text rather than a crash, and an empty Library renders an
         empty state rather than a blank table. Prose UI copy carries no
         em-dashes.
+      type: technical
+      enforcement: error
+    - id: C-14
+      description: >-
+        v1.11.0 (Phase C3) - The Scheduled tab is live: it renders a
+        SchedulesTab over the report-schedule endpoints. It issues a
+        ["report-schedules"] query against GET /api/v1/reports/schedules and
+        a ["notification-channels"] query against GET
+        /api/v1/notifications/channels, filtered to email channels for the
+        delivery picker. A host:write caller sees a create form (name, kind,
+        frequency with a weekday picker for weekly / day-of-month for
+        monthly, and an email channel) that POSTs /api/v1/reports/schedules;
+        each schedule row offers pause/resume (PATCH
+        /api/v1/reports/schedules/{id} {enabled}) and delete (DELETE), all
+        invalidating ["report-schedules"]. The create form is gated on
+        canGenerate (host:write). Loading/empty/error states are honest. UI
+        copy carries no em-dash.
       type: technical
       enforcement: error
 
@@ -406,3 +423,16 @@ spec:
         copy contains no em-dash.
       priority: high
       references_constraints: [C-13]
+    - id: AC-15
+      description: >-
+        v1.11.0 - Source inspection: the Scheduled tab renders <SchedulesTab>
+        (not ComingSoon). SchedulesTab queries ["report-schedules"] against
+        GET /api/v1/reports/schedules and ["notification-channels"] against
+        GET /api/v1/notifications/channels (filtered to c.type === 'email'),
+        and mutates via api.POST /api/v1/reports/schedules,
+        api.PATCH /api/v1/reports/schedules/{id}, and api.DELETE
+        /api/v1/reports/schedules/{id}, each invalidating ["report-schedules"].
+        The create form is gated on canGenerate (canSubmit = canGenerate
+        && ...). The added copy contains no em-dash.
+      priority: high
+      references_constraints: [C-14]

--- a/specs/system/report-schedule.spec.yaml
+++ b/specs/system/report-schedule.spec.yaml
@@ -1,0 +1,150 @@
+spec:
+  id: system-report-schedule
+  title: Scheduled reports - recurring generation + email delivery of the rendered PDF
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch-go
+    feature: A daily/weekly/monthly schedule that generates a report and emails its PDF through an email notification channel
+    description: >
+      A report_schedules row (migration 0046) recurs a report generation on
+      a daily, weekly, or monthly cadence and delivers the rendered PDF by
+      email. The schedule captures the report kind + scope (group, framework
+      lens, period window), the cadence (hour of day UTC; weekday for
+      weekly; day-of-month 1..28 for monthly), and the email notification
+      channel that provides SMTP transport + recipients.
+
+      A cron dispatcher (internal/cron.Scheduler ticking each minute) claims
+      due schedules (enabled AND next_run_at <= now), generates the report
+      via report.Service.Generate, renders its PDF face, emails it as a
+      MIME-multipart attachment through the channel, records the outcome
+      (last_run_at, last_status), and advances next_run_at to the next
+      occurrence. A failure on one schedule is recorded on that schedule and
+      does not abort the others.
+
+      Delivery reuses the existing email notification channel: the new
+      notification.Service.SendReportEmail builds a multipart/mixed message
+      (text body + base64 application/pdf attachment) and sends it via the
+      channel's decrypted SMTP config to its configured recipients. Only
+      email channels can carry an attachment.
+
+      The HTTP surface is CRUD over the schedules: list (host:read), create,
+      enable/disable, and delete (host:write). Re-enabling a paused schedule
+      recomputes next_run_at from now so it does not fire for every missed
+      run.
+
+    related_specs:
+      - api-reports
+      - api-notifications
+      - system-notifications
+      - system-job-queue
+
+  objective:
+    summary: >
+      Recurring report delivery: a schedule model with a correct
+      daily/weekly/monthly next-run computation, a cron dispatcher that
+      generates + renders + emails + advances, email delivery of the PDF as
+      a multipart attachment, and a host:read/host:write CRUD surface.
+    scope:
+      includes:
+        - 'report_schedules table (migration 0046) + internal/reportschedule service'
+        - 'Daily/weekly/monthly next-run computation (ComputeNextRun)'
+        - 'The cron dispatcher: due detection, generate + render PDF + deliver, advance, last_status'
+        - 'Email delivery of the PDF as a MIME-multipart attachment via an email channel'
+        - 'CRUD endpoints (list/create/patch-enable/delete) with host:read / host:write RBAC'
+      excludes:
+        - 'Cron-expression recurrence (only daily/weekly/monthly cadences)'
+        - 'Delivery via non-email channels (slack/webhook cannot carry an attachment)'
+        - 'Per-schedule recipient lists (recipients come from the email channel To)'
+        - 'Retries / dead-lettering of a failed delivery (recorded in last_status, retried next cadence)'
+
+  constraints:
+    - id: C-01
+      description: >-
+        A report_schedules row captures: name, kind (executive | attestation
+        | exception | remediation), scope JSONB ({group_id, framework,
+        period_days}), frequency (daily | weekly | monthly), hour (0..23 UTC),
+        weekday (0..6, weekly), day_of_month (1..28, monthly), channel_id (FK
+        notification_channels), enabled, next_run_at, last_run_at,
+        last_status, created_by. The kind CHECK + the frequency/hour/weekday/
+        day_of_month CHECKs enforce the domains. Create computes the first
+        next_run_at from now.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: >-
+        ComputeNextRun returns the next run strictly after the given instant,
+        at the configured hour (UTC), honouring the cadence: daily = the next
+        day's hour (or today's if still before it); weekly = the next
+        occurrence of weekday at hour; monthly = the next occurrence of
+        day_of_month at hour (capped at 28 so every month has it).
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: >-
+        The cron dispatcher (Tick) claims due schedules (enabled AND
+        next_run_at <= now), and for each: generates the report
+        (report.Service.Generate with the schedule's kind + scope, actor
+        "scheduler"), renders its PDF face, delivers it, records last_run_at
+        + last_status ("ok" or "failed: <err>"), and advances next_run_at via
+        ComputeNextRun from now. A per-schedule error is recorded and does
+        not abort the other due schedules.
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: >-
+        Email delivery: notification.Service.SendReportEmail builds a
+        multipart/mixed RFC 5322 message - a text/plain body part and a
+        base64 application/pdf attachment with a Content-Disposition filename
+        - and sends it via the channel's decrypted SMTP config to its
+        recipients. A non-email channel is rejected (ErrNotEmailChannel);
+        only email channels carry attachments.
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: >-
+        The HTTP surface is CRUD over schedules: GET
+        /api/v1/reports/schedules (host:read) lists newest-first; POST
+        (host:write) creates after validating the cadence (weekly requires
+        weekday, monthly requires day_of_month); PATCH /{id} (host:write)
+        toggles enabled (re-enabling recomputes next_run_at); DELETE /{id}
+        (host:write) removes it. A missing id is 404.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: >-
+        ComputeNextRun: a daily 06:00 schedule from 09:00 yields the next
+        day's 06:00 (and from 03:00 yields the same day's 06:00); a weekly
+        Monday schedule from a Monday 09:00 yields the following Monday; a
+        monthly day-1 schedule from the 22nd yields the 1st of next month.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-02
+      description: >-
+        A freshly created schedule is not due (next_run is in the future);
+        after backdating next_run_at, the dispatcher Tick generates the
+        report, renders + delivers the PDF to the schedule's channel, sets
+        last_status "ok", and advances next_run_at into the future so the
+        schedule is no longer due.
+      priority: critical
+      references_constraints: [C-01, C-03]
+    - id: AC-03
+      description: >-
+        buildReportEmail produces a multipart/mixed message with the To /
+        Subject headers, a text/plain body part, and a base64
+        application/pdf attachment carrying the Content-Disposition filename.
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-04
+      description: >-
+        The CRUD surface enforces RBAC and round-trips: a host:read caller
+        cannot POST a schedule (403); a host:write caller creates one (201,
+        enabled, with a future next_run_at); GET (host:read) lists it; PATCH
+        {enabled:false} (host:write) disables it; DELETE (host:write) removes
+        it (204) and the list is then empty.
+      priority: high
+      references_constraints: [C-05]

--- a/specter.yaml
+++ b/specter.yaml
@@ -79,6 +79,7 @@ domains:
             - api-reports
             - frontend-reports
             - frontend-notifications
+            - system-report-schedule
             - system-scan-results-store
             - api-scans
             - frontend-scan-detail


### PR DESCRIPTION
## Summary

Phase **C3** adds recurring report generation with **email delivery of the rendered PDF** — the final Phase C delivery-spine slice. It activates the previously-stubbed Scheduled tab.

**Design choices (per product decision):** daily/weekly/monthly cadence (not cron), **email-with-PDF-attached** delivery, recipients sourced from the email notification channel's `To`.

## Backend

- **Migration 0046** `report_schedules`: kind + scope + daily/weekly/monthly cadence (hour UTC; weekday for weekly; day-of-month 1..28 for monthly) + the email channel + `next_run_at`.
- **`internal/reportschedule`**: the schedule `Service` (CRUD + `ComputeNextRun`) and a cron `Dispatcher` (`Tick`) that claims due schedules (`enabled AND next_run_at <= now`), generates the report, renders its PDF, emails it, records `last_status`, and advances `next_run_at`. A per-schedule failure is recorded and doesn't abort the others.
- **`notification.SendReportEmail`**: a `multipart/mixed` email with a base64 `application/pdf` attachment, sent via the channel's SMTP config (only email channels carry attachments).
- **`main.go`** wires the dispatcher into a `cron.Scheduler` ticking each minute.
- **CRUD API** (`GET`/`POST`/`PATCH`/`DELETE` `/api/v1/reports/schedules`): host:read for list, host:write for mutations.

## Frontend

- The **Scheduled tab** is live: a create form (kind, cadence with weekday / day-of-month, email channel) + per-schedule **pause/resume** + **delete**, over the schedule endpoints; the channel picker lists email channels.

## Fix (latent bug the new FK exposed)
The `report_schedules → notification_channels` FK made the notification tests' `TRUNCATE notification_channels` silently fail, leaving stale channels encrypted with a prior ephemeral key (breaking decrypt). Fixed with `TRUNCATE ... CASCADE`.

## Spec / tests

- New **`system-report-schedule`** v1.0.0 (C-01..C-05, AC-01..AC-04; registered in `specter.yaml`) + **`frontend-reports`** v1.11.0 (C-14 / AC-15).
- Tests: schedule service + dispatcher (with fakes) + the email multipart builder + schedule API CRUD/RBAC + frontend source-inspection.
- `specter check` 113 specs + structural coverage 100%; frontend `vitest` 337; `gofmt`/`vet`/`build` clean.

> Note: the full local server suite flaked on a few auth tests under heavy parallel DB load (single local Postgres, end of a long session) — they pass in isolation. CI's clean environment is the real arbiter.

## Validation
- [x] gofmt / vet / build
- [x] go test reportschedule + notification + report + schedule API (isolated)
- [x] tsc / eslint / prettier / vitest (337)
- [x] specter check + structural coverage (100%)