### PR TITLE
fix(reports): release hardening for rc.13 (claim, audit, channel validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,50 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.2.0-rc.13] Eyrie — 2026-06-22
+
+The Reports surface is now a complete compliance-artifact platform, spanning
+the executive summary, an auditor/GRC bulk path, two new GRC read-model
+kinds, and recurring email delivery.
+
+### Added
+- **Framework Attestation report kind** (auditor/GRC): a point-in-time,
+  signed attestation that freezes the latest completed scan per in-scope
+  host. Faces: a fleet **OSCAL 1.0.6 assessment-results (SAR)** with
+  evidence referenced by content hash, a per-(host, rule) **CSV** evidence
+  extract, a bounded one-page **PDF cover**, and the canonical **JSON**.
+  A frozen, signed compliance rollup (compliance %, pass/fail, top-failing)
+  is shown in-app and on the PDF cover.
+- **Exception Register report kind** (Compliance/GRC): a point-in-time
+  read-model of compliance waivers — counts by state (active, pending,
+  expiring-soon) plus the register rows — with CSV + PDF + JSON faces.
+- **Remediation Activity report kind** (Operations): a read-model of
+  remediation requests over a look-back window (last 7/30/90 days), with
+  an outcome summary and CSV + PDF + JSON faces.
+- **Scheduled reports + email delivery**: a daily/weekly/monthly schedule
+  generates a report and emails its rendered PDF (MIME attachment) through
+  an email notification channel. Managed from a live **Scheduled** tab
+  (create / pause-resume / delete). Endpoints under
+  `/api/v1/reports/schedules`.
+- **Asynchronous report rendering** + a new `report.ready` event on the
+  event bus — the first producer of the in-app **notification bell**.
+- **Ed25519 report signing** with an in-browser **offline Verify**, a
+  fleet **framework catalog** endpoint, and a kind selector + scope/period
+  pickers on the Library tab.
+- Report kinds are admitted by `report_snapshots.kind` (migrations
+  0043–0045); `report_schedules` lands in migration 0046.
+
+### Audit
+- Report generation and report-schedule create/delete/enable-disable now
+  emit audit events (`report.generated`, `report.schedule.*`).
+
+### Security / hardening
+- The scheduled-report dispatcher claims due schedules with
+  `FOR UPDATE SKIP LOCKED`, so concurrent dispatchers never double-send.
+- Report-email subjects are CRLF-sanitized (header-injection defense).
+
+---
+
 ## [0.2.0-rc.12] Eyrie — 2026-06-20
 
 The fleet activity stream and audit trail are now readable end to end: every

--- a/audit/events.yaml
+++ b/audit/events.yaml
@@ -759,6 +759,44 @@ events:
     severity: warning
 
   # =========================================================================
+  # reports — generation + scheduled delivery
+  # =========================================================================
+  - code: report.generated
+    severity: info
+    detail_schema:
+      type: object
+      properties:
+        kind: {type: string}
+        scope_label: {type: string}
+        report_id: {type: string}
+
+  - code: report.schedule.created
+    severity: info
+    detail_schema:
+      type: object
+      properties:
+        schedule_id: {type: string}
+        name: {type: string}
+        kind: {type: string}
+        frequency: {type: string}
+        channel_id: {type: string}
+
+  - code: report.schedule.deleted
+    severity: warning
+    detail_schema:
+      type: object
+      properties:
+        schedule_id: {type: string}
+
+  - code: report.schedule.toggled
+    severity: info
+    detail_schema:
+      type: object
+      properties:
+        schedule_id: {type: string}
+        enabled: {type: boolean}
+
+  # =========================================================================
   # integration — external systems
   # =========================================================================
   - code: integration.webhook.delivered

--- a/frontend/src/pages/reports/ReportsPage.tsx
+++ b/frontend/src/pages/reports/ReportsPage.tsx
@@ -1905,9 +1905,10 @@ function ComingSoon({ what }: { what: string }) {
             lineHeight: 1.5,
           }}
         >
-          {what === 'Templates'
-            ? 'The report kinds (Fleet Compliance Executive Summary and Framework Attestation) are live in the Library tab, each with signed PDF, CSV, OSCAL, and JSON faces. A gallery for building and saving custom report templates is not built yet.'
-            : 'Scheduled report delivery requires a dispatcher, which is not built yet. For now, generate reports on demand from the Library tab.'}
+          The report kinds (executive, attestation, exception, remediation) are live in the Library
+          tab, each with signed PDF, CSV, OSCAL, and JSON faces, and reports can be delivered on a
+          schedule from the Scheduled tab. A gallery for building and saving custom report templates
+          is not built yet.
         </div>
       </div>
     </Panel>

--- a/internal/audit/events.gen.go
+++ b/internal/audit/events.gen.go
@@ -244,6 +244,14 @@ const (
 	//
 	RemediationRolledBack Code = "remediation.rolled_back"
 	//
+	ReportGenerated Code = "report.generated"
+	//
+	ReportScheduleCreated Code = "report.schedule.created"
+	//
+	ReportScheduleDeleted Code = "report.schedule.deleted"
+	//
+	ReportScheduleToggled Code = "report.schedule.toggled"
+	//
 	IntegrationWebhookDelivered Code = "integration.webhook.delivered"
 	//
 	IntegrationWebhookFailed Code = "integration.webhook.failed"
@@ -1094,6 +1102,34 @@ var Metadata = map[Code]EventMeta{
 		Description: ``,
 		ActorTypes:  nil,
 	},
+	ReportGenerated: {
+		Code:        ReportGenerated,
+		Category:    "report",
+		Severity:    SeverityInfo,
+		Description: ``,
+		ActorTypes:  nil,
+	},
+	ReportScheduleCreated: {
+		Code:        ReportScheduleCreated,
+		Category:    "report",
+		Severity:    SeverityInfo,
+		Description: ``,
+		ActorTypes:  nil,
+	},
+	ReportScheduleDeleted: {
+		Code:        ReportScheduleDeleted,
+		Category:    "report",
+		Severity:    SeverityWarning,
+		Description: ``,
+		ActorTypes:  nil,
+	},
+	ReportScheduleToggled: {
+		Code:        ReportScheduleToggled,
+		Category:    "report",
+		Severity:    SeverityInfo,
+		Description: ``,
+		ActorTypes:  nil,
+	},
 	IntegrationWebhookDelivered: {
 		Code:        IntegrationWebhookDelivered,
 		Category:    "integration",
@@ -1452,6 +1488,10 @@ var codeOrder = []Code{
 	RemediationApproved,
 	RemediationExecuted,
 	RemediationRolledBack,
+	ReportGenerated,
+	ReportScheduleCreated,
+	ReportScheduleDeleted,
+	ReportScheduleToggled,
 	IntegrationWebhookDelivered,
 	IntegrationWebhookFailed,
 	IntegrationWebhookSubscribed,

--- a/internal/notification/report_email.go
+++ b/internal/notification/report_email.go
@@ -56,6 +56,11 @@ func (s *Service) SendReportEmail(ctx context.Context, channelID uuid.UUID, subj
 // buildReportEmail assembles a multipart/mixed RFC 5322 message: a
 // text/plain body part and a base64-encoded application/pdf attachment.
 func buildReportEmail(from string, to []string, subject, body, filename string, attachment []byte) []byte {
+	// Defense-in-depth: strip CR/LF from the subject so a value flowing into
+	// the Subject header can never inject additional headers (CWE-93). Report
+	// titles are fixed today, but this future-proofs the header.
+	subject = stripCRLF(subject)
+	filename = stripCRLF(filename)
 	var parts bytes.Buffer
 	w := multipart.NewWriter(&parts)
 
@@ -83,6 +88,12 @@ func buildReportEmail(from string, to []string, subject, body, filename string, 
 	msg.WriteString("\r\n")
 	msg.Write(parts.Bytes())
 	return msg.Bytes()
+}
+
+// stripCRLF removes carriage returns and newlines so a value cannot inject
+// extra MIME/RFC-5322 headers.
+func stripCRLF(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
 }
 
 // wrap76 breaks a base64 string into 76-character CRLF-terminated lines

--- a/internal/report/types.go
+++ b/internal/report/types.go
@@ -1,15 +1,15 @@
 // Package report implements the Reports library: point-in-time,
-// immutable compliance artifacts. The MVP generates exactly one kind,
-// the Fleet Compliance Executive Summary. Generating it computes a
-// posture snapshot from data that already exists (host_rule_state
-// pass/fail counts + critical, host count, top failing rules) and
-// stores it as a JSON document; the row is then never recomputed.
+// immutable, Ed25519-signed compliance artifacts. It generates four kinds
+// (executive summary, framework attestation, exception register,
+// remediation activity), each computed once from data that already exists
+// and stored as a frozen JSON document; the row is never recomputed. Each
+// kind renders to downloadable faces (PDF / CSV / OSCAL SAR / JSON).
 //
-// DEFERRED (not built here, see the migration + spec excludes): Ed25519
-// signing, PDF/OSCAL rendering, the Scheduled dispatcher, the Templates
-// gallery, retention sweeps.
+// DEFERRED: the Templates gallery and retention sweeps (see the spec
+// excludes). Recurring generation + email delivery lives in
+// internal/reportschedule.
 //
-// Spec: api-reports v1.0.0.
+// Spec: api-reports.
 package report
 
 import (

--- a/internal/reportschedule/dispatcher.go
+++ b/internal/reportschedule/dispatcher.go
@@ -38,26 +38,26 @@ func NewDispatcher(svc *Service, gen Generator, deliver Deliverer) *Dispatcher {
 	return &Dispatcher{svc: svc, gen: gen, deliver: deliver}
 }
 
-// Tick processes every due schedule once. It is the cron TickFunc; an error
-// from one schedule is recorded on that schedule (last_status) and does not
-// abort the others. The return error is non-nil only on a query failure.
+// Tick claims + processes every due schedule once. It is the cron TickFunc.
+// ClaimDue atomically reserves the due schedules (FOR UPDATE SKIP LOCKED +
+// advance), so concurrent dispatchers never double-send. An error from one
+// schedule is recorded on that schedule (last_status) and does not abort the
+// others. The return error is non-nil only on a claim failure.
 func (d *Dispatcher) Tick(ctx context.Context) error {
 	now := time.Now().UTC()
-	due, err := d.svc.Due(ctx, now)
+	claimed, err := d.svc.ClaimDue(ctx, now)
 	if err != nil {
 		return err
 	}
-	for _, sch := range due {
+	for _, sch := range claimed {
 		status := "ok"
 		if rerr := d.run(ctx, sch); rerr != nil {
 			status = "failed: " + rerr.Error()
 			slog.WarnContext(ctx, "report schedule run failed",
 				slog.String("schedule_id", sch.ID.String()), slog.String("error", rerr.Error()))
 		}
-		// Advance from now so a slow/failed run does not immediately re-fire.
-		next := ComputeNextRun(sch.Frequency, sch.Hour, sch.Weekday, sch.DayOfMonth, time.Now().UTC())
-		if merr := d.svc.MarkRun(ctx, sch.ID, next, status); merr != nil {
-			slog.WarnContext(ctx, "report schedule mark-run failed",
+		if merr := d.svc.MarkResult(ctx, sch.ID, status); merr != nil {
+			slog.WarnContext(ctx, "report schedule mark-result failed",
 				slog.String("schedule_id", sch.ID.String()), slog.String("error", merr.Error()))
 		}
 	}

--- a/internal/reportschedule/schedule_db_test.go
+++ b/internal/reportschedule/schedule_db_test.go
@@ -114,6 +114,50 @@ func seedChannel(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
 	return id
 }
 
+// @ac AC-05
+// ClaimDue atomically advances next_run_at under FOR UPDATE SKIP LOCKED, so
+// a second claim at the same instant returns nothing - the property that
+// stops two concurrent dispatchers from double-sending a report.
+func TestClaimDue_NoDoubleClaim(t *testing.T) {
+	t.Run("system-report-schedule/AC-05", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		svc := NewService(pool)
+		ch := seedChannel(t, pool)
+		sch, err := svc.Create(ctx, CreateParams{
+			Name: "daily", Kind: "executive", Frequency: Daily, Hour: 6, ChannelID: ch,
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		// Make it due.
+		if _, err := pool.Exec(ctx,
+			`UPDATE report_schedules SET next_run_at = now() - interval '1 minute' WHERE id = $1`, sch.ID); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+		now := time.Now().UTC()
+
+		first, err := svc.ClaimDue(ctx, now)
+		if err != nil {
+			t.Fatalf("first ClaimDue: %v", err)
+		}
+		if len(first) != 1 {
+			t.Fatalf("first claim = %d schedules, want 1", len(first))
+		}
+		if !first[0].NextRunAt.After(now) {
+			t.Errorf("claim did not advance next_run_at: %v", first[0].NextRunAt)
+		}
+		// A second claim at the same instant must see nothing (already advanced).
+		second, err := svc.ClaimDue(ctx, now)
+		if err != nil {
+			t.Fatalf("second ClaimDue: %v", err)
+		}
+		if len(second) != 0 {
+			t.Errorf("second claim = %d schedules, want 0 (no double-claim)", len(second))
+		}
+	})
+}
+
 // @ac AC-02
 func TestDispatcher_RunsDueSchedule(t *testing.T) {
 	t.Run("system-report-schedule/AC-02", func(t *testing.T) {

--- a/internal/reportschedule/service.go
+++ b/internal/reportschedule/service.go
@@ -133,13 +133,69 @@ func (s *Service) Due(ctx context.Context, now time.Time) ([]Schedule, error) {
 	return out, rows.Err()
 }
 
-// MarkRun records a run outcome and advances next_run_at.
-func (s *Service) MarkRun(ctx context.Context, id uuid.UUID, next time.Time, status string) error {
-	_, err := s.pool.Exec(ctx,
-		`UPDATE report_schedules SET last_run_at = now(), last_status = $2, next_run_at = $3, updated_at = now() WHERE id = $1`,
-		id, status, next)
+// ClaimDue atomically claims the due schedules: in ONE transaction it locks
+// them with FOR UPDATE SKIP LOCKED and advances next_run_at to the next
+// occurrence. A concurrent dispatcher (a second serve process) therefore
+// sees a DISJOINT set and never re-claims the same schedule, so a report is
+// never double-generated or double-emailed. The claimed schedules are
+// returned for processing; record the per-run outcome with MarkResult.
+// next_run advances at claim time, so a crash mid-run simply skips that run
+// rather than re-firing it every tick.
+func (s *Service) ClaimDue(ctx context.Context, now time.Time) ([]Schedule, error) {
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("reportschedule: mark run: %w", err)
+		return nil, fmt.Errorf("reportschedule: claim begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx,
+		`SELECT `+scheduleCols+` FROM report_schedules
+		  WHERE enabled AND next_run_at <= $1
+		  ORDER BY next_run_at
+		  FOR UPDATE SKIP LOCKED`, now)
+	if err != nil {
+		return nil, fmt.Errorf("reportschedule: claim select: %w", err)
+	}
+	var claimed []Schedule
+	for rows.Next() {
+		sch, serr := scanSchedule(rows)
+		if serr != nil {
+			rows.Close()
+			return nil, serr
+		}
+		claimed = append(claimed, sch)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Advance next_run_at within the same locked transaction so the claim is
+	// effective the moment we commit.
+	for i := range claimed {
+		next := ComputeNextRun(claimed[i].Frequency, claimed[i].Hour,
+			claimed[i].Weekday, claimed[i].DayOfMonth, now)
+		if _, err := tx.Exec(ctx,
+			`UPDATE report_schedules SET next_run_at = $2, updated_at = now() WHERE id = $1`,
+			claimed[i].ID, next); err != nil {
+			return nil, fmt.Errorf("reportschedule: claim advance: %w", err)
+		}
+		claimed[i].NextRunAt = next
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("reportschedule: claim commit: %w", err)
+	}
+	return claimed, nil
+}
+
+// MarkResult records the outcome of a claimed run (last_run_at + last_status).
+// next_run_at was already advanced by ClaimDue.
+func (s *Service) MarkResult(ctx context.Context, id uuid.UUID, status string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE report_schedules SET last_run_at = now(), last_status = $2, updated_at = now() WHERE id = $1`,
+		id, status)
+	if err != nil {
+		return fmt.Errorf("reportschedule: mark result: %w", err)
 	}
 	return nil
 }

--- a/internal/server/api_helpers_test.go
+++ b/internal/server/api_helpers_test.go
@@ -177,6 +177,13 @@ func freshAPIServer(t *testing.T) (string, *pgxpool.Pool) {
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE posture_snapshots")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE compliance_exceptions")
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE job_queue")
+	// Reports: schedules FK notification_channels; report_faces FK
+	// report_snapshots. CASCADE so a leftover schedule/snapshot/channel from a
+	// prior test cannot leak (a stale channel encrypted with a prior ephemeral
+	// key would break notification decrypt in a later test).
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE report_schedules CASCADE")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE report_snapshots CASCADE")
+	_, _ = pool.Exec(ctx, "TRUNCATE TABLE notification_channels CASCADE")
 	// SSO config + federation links (cascades to identities + auth states).
 	_, _ = pool.Exec(ctx, "TRUNCATE TABLE sso_providers CASCADE")
 	// TRUNCATE…CASCADE delegates child cleanup to the schema — the

--- a/internal/server/api_report_schedule_test.go
+++ b/internal/server/api_report_schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -57,6 +58,38 @@ func TestAPI_ReportSchedules(t *testing.T) {
 		if err := json.NewDecoder(cr.Body).Decode(&created); err != nil {
 			t.Fatalf("decode created: %v", err)
 		}
+		// The create emits a report.schedule.created audit event. audit.Emit is
+		// async (background writer), so poll briefly for the row to land.
+		var auditCount int
+		for i := 0; i < 30; i++ {
+			if err := pool.QueryRow(context.Background(),
+				`SELECT count(*) FROM audit_events WHERE action = 'report.schedule.created' AND resource_id = $1`,
+				created.ID).Scan(&auditCount); err != nil {
+				t.Fatalf("audit query: %v", err)
+			}
+			if auditCount > 0 {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		if auditCount != 1 {
+			t.Errorf("report.schedule.created audit events = %d, want 1", auditCount)
+		}
+
+		// A non-email channel is rejected at create (only email carries the PDF).
+		whID := uuid.New()
+		if _, err := pool.Exec(context.Background(),
+			`INSERT INTO notification_channels (id, type, name, enabled, config_ciphertext)
+			 VALUES ($1, 'webhook', 'ops-hook', true, $2)`, whID, []byte("x")); err != nil {
+			t.Fatalf("seed webhook channel: %v", err)
+		}
+		whBody := map[string]any{"name": "bad", "kind": "executive", "frequency": "daily", "channel_id": whID.String()}
+		wr := doReq(t, asRole(t, "POST", url+"/api/v1/reports/schedules", auth.RoleOpsLead, whBody))
+		wr.Body.Close()
+		if wr.StatusCode != http.StatusBadRequest {
+			t.Errorf("create with webhook channel status = %d, want 400", wr.StatusCode)
+		}
+
 		if created.ID == "" || !created.Enabled || created.NextRunAt == "" {
 			t.Fatalf("created schedule malformed: %+v", created)
 		}

--- a/internal/server/report_handlers.go
+++ b/internal/server/report_handlers.go
@@ -4,9 +4,10 @@
 // mapping, and report.Report -> api.Report wire shaping live here; the
 // posture computation lives in the service.
 //
-// MVP: generate produces exactly one kind, the Fleet Compliance
-// Executive Summary, for all hosts. Signing, PDF/OSCAL rendering, the
-// Scheduled dispatcher and the Templates gallery are deferred.
+// Generate produces one of four kinds (executive, attestation, exception,
+// remediation), signed (Ed25519), with PDF/CSV/OSCAL/JSON faces. Recurring
+// generation + email delivery lives in report_schedule_handlers.go; only
+// the Templates gallery remains deferred.
 //
 // Spec: api-reports.
 
@@ -22,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	openapitypes "github.com/oapi-codegen/runtime/types"
 
+	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/group"
 	"github.com/Hanalyx/openwatch/internal/report"
@@ -241,6 +243,19 @@ func (h *handlers) PostReportGenerate(w http.ResponseWriter, r *http.Request) {
 			"report content decode failed", true)
 		return
 	}
+
+	ident := auth.FromContext(r.Context())
+	detail, _ := json.Marshal(map[string]string{
+		"kind": string(rep.Kind), "scope_label": rep.ScopeLabel, "report_id": rep.ID.String(),
+	})
+	audit.Emit(r.Context(), audit.ReportGenerated, audit.Event{
+		ActorType:    "user",
+		ActorID:      ident.ID,
+		ResourceType: "report",
+		ResourceID:   rep.ID.String(),
+		Detail:       detail,
+	})
+
 	writeJSON(w, http.StatusCreated, out)
 }
 

--- a/internal/server/report_schedule_handlers.go
+++ b/internal/server/report_schedule_handlers.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/notification"
 	"github.com/Hanalyx/openwatch/internal/reportschedule"
 	"github.com/Hanalyx/openwatch/internal/server/api"
 )
@@ -143,11 +145,38 @@ func (h *handlers) CreateReportSchedule(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// The delivery channel must be an EMAIL channel (only email carries the
+	// PDF attachment). Validate up front so a misconfigured schedule fails at
+	// create rather than silently at every dispatch.
+	if h.notificationSvc != nil {
+		ch, cerr := h.notificationSvc.Get(r.Context(), p.ChannelID)
+		if errors.Is(cerr, notification.ErrChannelNotFound) {
+			writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client", "channel not found", false)
+			return
+		}
+		if cerr == nil && ch.Type != notification.TypeEmail {
+			writeError(w, http.StatusBadRequest, "schedule.invalid_request", "client",
+				"channel must be an email channel", false)
+			return
+		}
+	}
+
 	sch, err := h.reportScheduleSvc.Create(r.Context(), p)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule create failed", true)
 		return
 	}
+
+	ident := auth.FromContext(r.Context())
+	detail, _ := json.Marshal(map[string]string{
+		"schedule_id": sch.ID.String(), "name": sch.Name, "kind": sch.Kind,
+		"frequency": string(sch.Frequency), "channel_id": sch.ChannelID.String(),
+	})
+	audit.Emit(r.Context(), audit.ReportScheduleCreated, audit.Event{
+		ActorType: "user", ActorID: ident.ID,
+		ResourceType: "report_schedule", ResourceID: sch.ID.String(), Detail: detail,
+	})
+
 	writeJSON(w, http.StatusCreated, toAPISchedule(sch))
 }
 
@@ -174,6 +203,14 @@ func (h *handlers) UpdateReportSchedule(w http.ResponseWriter, r *http.Request, 
 		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule update failed", true)
 		return
 	}
+
+	ident := auth.FromContext(r.Context())
+	detail, _ := json.Marshal(map[string]any{"schedule_id": sch.ID.String(), "enabled": sch.Enabled})
+	audit.Emit(r.Context(), audit.ReportScheduleToggled, audit.Event{
+		ActorType: "user", ActorID: ident.ID,
+		ResourceType: "report_schedule", ResourceID: sch.ID.String(), Detail: detail,
+	})
+
 	writeJSON(w, http.StatusOK, toAPISchedule(sch))
 }
 
@@ -195,5 +232,13 @@ func (h *handlers) DeleteReportSchedule(w http.ResponseWriter, r *http.Request, 
 		writeError(w, http.StatusInternalServerError, "server.error", "server", "schedule delete failed", true)
 		return
 	}
+
+	ident := auth.FromContext(r.Context())
+	detail, _ := json.Marshal(map[string]string{"schedule_id": uuid.UUID(id).String()})
+	audit.Emit(r.Context(), audit.ReportScheduleDeleted, audit.Event{
+		ActorType: "user", ActorID: ident.ID,
+		ResourceType: "report_schedule", ResourceID: uuid.UUID(id).String(), Detail: detail,
+	})
+
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.12"
+VERSION="0.2.0-rc.13"
 CODENAME="Eyrie"

--- a/specs/api/reports.spec.yaml
+++ b/specs/api/reports.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-reports
   title: Reports library - point-in-time Fleet Compliance Executive Summary artifacts (list / generate / fetch)
-  version: "1.13.0"
+  version: "1.14.0"
   status: approved
   tier: 2
 
@@ -145,7 +145,8 @@ spec:
         with auth.HostRead or auth.HostWrite). A host:read-only caller is
         403 on generate. generated_by records the calling principal's id,
         or 'system' when the request is anonymous, and the wire surfaces no
-        signing, PDF, or OSCAL fields.
+        signing, PDF, or OSCAL fields. A successful generate emits a
+        report.generated audit event (actor, report id, kind, scope_label).
       type: security
       enforcement: error
     - id: C-07

--- a/specs/system/report-schedule.spec.yaml
+++ b/specs/system/report-schedule.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-report-schedule
   title: Scheduled reports - recurring generation + email delivery of the rendered PDF
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -84,13 +84,19 @@ spec:
       enforcement: error
     - id: C-03
       description: >-
-        The cron dispatcher (Tick) claims due schedules (enabled AND
-        next_run_at <= now), and for each: generates the report
+        The cron dispatcher (Tick) claims due schedules atomically:
+        ClaimDue runs ONE transaction that selects enabled AND next_run_at <=
+        now FOR UPDATE SKIP LOCKED and advances next_run_at (ComputeNextRun
+        from now) before commit, so two concurrent dispatchers (a second
+        serve process) see disjoint sets and never double-generate or
+        double-email a report; advancing at claim time also means a crash
+        mid-run skips that run rather than re-firing every tick. For each
+        claimed schedule the dispatcher generates the report
         (report.Service.Generate with the schedule's kind + scope, actor
-        "scheduler"), renders its PDF face, delivers it, records last_run_at
-        + last_status ("ok" or "failed: <err>"), and advances next_run_at via
-        ComputeNextRun from now. A per-schedule error is recorded and does
-        not abort the other due schedules.
+        "scheduler"), renders its PDF face, delivers it, and records the
+        outcome with MarkResult (last_run_at + last_status "ok" or
+        "failed: <err>"). A per-schedule error is recorded and does not abort
+        the other claimed schedules.
       type: technical
       enforcement: error
     - id: C-04
@@ -99,7 +105,9 @@ spec:
         multipart/mixed RFC 5322 message - a text/plain body part and a
         base64 application/pdf attachment with a Content-Disposition filename
         - and sends it via the channel's decrypted SMTP config to its
-        recipients. A non-email channel is rejected (ErrNotEmailChannel);
+        recipients. The subject and attachment filename are stripped of CR/LF
+        before assembly so report-derived values cannot inject extra headers
+        (CWE-93). A non-email channel is rejected (ErrNotEmailChannel);
         only email channels carry attachments.
       type: technical
       enforcement: error
@@ -108,9 +116,13 @@ spec:
         The HTTP surface is CRUD over schedules: GET
         /api/v1/reports/schedules (host:read) lists newest-first; POST
         (host:write) creates after validating the cadence (weekly requires
-        weekday, monthly requires day_of_month); PATCH /{id} (host:write)
-        toggles enabled (re-enabling recomputes next_run_at); DELETE /{id}
-        (host:write) removes it. A missing id is 404.
+        weekday, monthly requires day_of_month) AND that the referenced
+        channel exists and is an email channel (a non-email or unknown
+        channel is rejected 400, since only email channels carry the PDF);
+        PATCH /{id} (host:write) toggles enabled (re-enabling recomputes
+        next_run_at); DELETE /{id} (host:write) removes it. A missing id is
+        404. Create, toggle, and delete each emit an audit event
+        (report.schedule.created / .toggled / .deleted).
       type: technical
       enforcement: error
 
@@ -143,8 +155,19 @@ spec:
       description: >-
         The CRUD surface enforces RBAC and round-trips: a host:read caller
         cannot POST a schedule (403); a host:write caller creates one (201,
-        enabled, with a future next_run_at); GET (host:read) lists it; PATCH
+        enabled, with a future next_run_at) and the create emits a
+        report.schedule.created audit event; a POST referencing a non-email
+        (webhook) channel is rejected 400; GET (host:read) lists it; PATCH
         {enabled:false} (host:write) disables it; DELETE (host:write) removes
         it (204) and the list is then empty.
       priority: high
       references_constraints: [C-05]
+    - id: AC-05
+      description: >-
+        ClaimDue is atomic under FOR UPDATE SKIP LOCKED: for a single due
+        schedule, the first ClaimDue returns it with next_run_at advanced into
+        the future, and a second ClaimDue at the same instant returns nothing,
+        so two concurrent dispatchers never double-claim (and never
+        double-send) the same schedule.
+      priority: high
+      references_constraints: [C-03]


### PR DESCRIPTION
## Summary

Pre-release quality + security pass on the Reports surface ahead of
**v0.2.0-rc.13**, implementing the remediation set chosen from the release
review (Blockers + HIGH + M1 + the quick wins).

### Release (B1, B2)
- Bump `packaging/version.env` to `0.2.0-rc.13` (Eyrie).
- Add the `0.2.0-rc.13` CHANGELOG entry: four report kinds, OSCAL SAR,
  scheduled email delivery, async rendering + `report.ready` notification
  bell, Ed25519 signing, migrations 0043–0046.

### Hardening (H1, H2, M2, L1)
- **H1 – atomic claim:** the scheduled-report dispatcher now claims due
  schedules with `FOR UPDATE SKIP LOCKED`. `ClaimDue` advances `next_run_at`
  inside the locked transaction; `MarkResult` records the per-run outcome. Two
  concurrent dispatchers see disjoint sets, so a scheduled report is never
  double-generated or double-emailed (mirrors the scan/remediation job queue).
- **H2 – audit:** report generate and schedule create / toggle / delete now
  emit audit events (`report.generated`, `report.schedule.created` /
  `.toggled` / `.deleted`).
- **L1 – channel validation:** a non-email (or unknown) delivery channel is
  rejected at schedule create (400) instead of failing silently at every
  dispatch.
- **M2 – CRLF:** report-email subject + attachment filename are CRLF-sanitized
  (header-injection defense, CWE-93).

### Test isolation (M1)
- `freshAPIServer` truncates `report_schedules` / `report_snapshots` /
  `notification_channels` between API tests (closed isolation gap).

### Tests + specs
- New `AC-05` no-double-claim test for `ClaimDue`; the schedule API test
  asserts the create audit event (async, polled) and the non-email-channel
  400.
- `system-report-schedule` → 1.1.0 (C-03 atomic claim, C-04 CRLF, C-05
  channel validation + audit, AC-04 extended, AC-05 added).
- `api-reports` → 1.14.0 (C-06 `report.generated` audit).
- **L4 cleanup:** stale "dispatcher not built" / "MVP one kind" comments and
  the dead `ReportsPage` ComingSoon copy replaced with accurate text.

## Validation
- `gofmt` / `go build ./...` / `go vet` clean
- `reportschedule`, `notification`, `report`, `audit` packages pass
- full `internal/server` API surface passes (`-parallel 2`, 229s)
- `specter check` 0 errors; structural coverage 100% (`--strictness annotation`)
- frontend `tsc` / `eslint` / `prettier` / `vitest` pass

## Deferred (fast-follow, per chosen scope)
M3 (host:write vs a report-specific permission), M4 (remaining AC coverage),
L2 / L3 / L5 from the review were intentionally left out of this PR.
