### PR TITLE
docs: session log + backlog for v0.2.0-rc.14 (Eyrie)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,7 +3,7 @@
 > **Purpose**: Single source of truth for **pending** work in the OpenWatch Go rebuild (repo root).
 > Completed work is removed from this file; provenance lives in the commit history + `SESSION_LOG.md`.
 
-**Last Updated**: 2026-06-21
+**Last Updated**: 2026-06-23
 **Active Tree**: repo root (Go backend `cmd/`+`internal/`, React/TypeScript `frontend/`)
 **Frozen Tree**: the legacy Python/FastAPI backend was archived out of the repo on 2026-06-05 to `~/hanalyx/OWAR/openwatch-python/` (see CLAUDE.md)
 
@@ -140,6 +140,7 @@ Gaps identified comparing `docs/KENSA_OPENWATCH_BOUNDARY.md` against current Ope
 | ID | Item | Priority | Status | Notes |
 |----|------|----------|--------|-------|
 | DOC-1 | CLAUDE.md "Packaging Infrastructure" describes a Python-era layout that doesn't exist in the Go native package | P2 | Open | The section claims package contents include `/opt/openwatch/backend/` (Python backend + requirements.txt), `/opt/openwatch/frontend/` (built SPA), and `/opt/openwatch/backend/kensa/` (rules, mappings, config, 508 rules), plus systemd units `openwatch-api`/`openwatch-worker@`/`openwatch-beat` and an nginx reverse proxy. None of that matches the rc7 Go RPM/DEB: the payload is a single `openwatch` Go binary (with embedded SPA), `openwatch.toml`, `openwatch.service`, and demo TLS certs (`packaging/rpm/openwatch.spec` + `build-rpm.sh`). The Kensa-rules-bundled claim is the same gap tracked in PKG-2. Fix: rewrite the section to match the Go packaging, or banner it as historical Python-era reference like the other frozen sections |
+| DOC-2 | `~539` approximate rule-count bounds not updated to `~538` after Kensa v0.6.0 | P3 | Open | The factual rule counts moved 539->538 with Kensa v0.6.0 (rc.14), but the explicitly-approximate `~539` bounds that justify the unpaginated host-compliance lens were left as-is in `internal/server/host_compliance_lens_handler.go`, `api/openapi.yaml` (+ generated `openapi_embed.yaml` / `frontend/src/api/schema.d.ts`), and specs `host-compliance` / `host-compliance-tab`. Cosmetic only (the `~` already disclaims precision and the bounded->no-pagination claim is unaffected by ±1); updating the openapi source requires `make generate-api` to re-sync the two generated copies |
 
 ---
 

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -6,6 +6,56 @@ and their provenance lives here + in the commit history.
 
 ---
 
+## 2026-06-23 — Opus 4.8 (1M context) — Kensa v0.6.0 + v0.2.0-rc.14 (Eyrie) released
+
+**Done** — Bumped Kensa, landed the open fix backlog, cut and published rc.14,
+and verified the released build live.
+- **Kensa v0.6.0 (#670):** go.mod v0.5.2->v0.6.0 (atomicity engine; +3 indirect
+  deps), all three version pins aligned (go.mod, `internal/kensa` const,
+  `kensa-executor` spec). Corpus 539->538 (one rule removed upstream). Verified
+  by a live end-to-end scan on owas-tst02 (.211, RHEL): completed, **538 rules,
+  0 errors**.
+- **539->538 docs follow-up:** corrected the factual rule-count claims in README
+  (4) + SCANNING/COMPLIANCE_CONTROLS guides + CLAUDE.md. Left version-pinned
+  historical statements (LINUX_DISTRIBUTION_SUPPORT "v0.4.3 = 539",
+  scan_implementation_plan past measurements) and the explicitly-approximate
+  `~539` architectural bounds in the lens handler/openapi/spec unchanged.
+- **Landed the open PR backlog:** #668 (known-hosts TOCTOU fail-closed — the
+  MEDIUM from the 2026-06-22 review), #664 (liveness privilege probe via
+  `internal/ssh`, fixes false "degraded" on hardened/keyboard-interactive
+  hosts), #665 (settings group-maintenance stub removed), #666 (Users "Invite
+  member"->"Add member"), #667 (guide accuracy), #669 (README Go-reality +
+  screenshot). Branch protection requires up-to-date branches, so each was
+  re-synced onto main before merge (sequential, no `--admin`).
+- **Cut + published v0.2.0-rc.14 (Eyrie) (#671):** version.env bump + CHANGELOG
+  `[Unreleased]`->`[0.2.0-rc.14]` with entries for all of the above. Tag
+  `v0.2.0-rc.14` (-> commit `407fb3d8`) triggered `release.yml`: **Release +
+  package-smoke both green**, signed pre-release live with RPM (x86_64+aarch64),
+  DEB (amd64+arm64), `kensa-rules-0.6.0` RPM/DEB, per-artifact CycloneDX SBOMs,
+  GPG-signed `SHA256SUMS.asc`.
+- **Dev server rebuilt from the rc.14 tag** via `make build` (proper ldflags:
+  `openwatch 0.2.0-rc.14 / 407fb3d8`, Kensa v0.6.0). Re-verified live: scan
+  completed (538 rules, 0 errors) and owas-tst02 connectivity **online /
+  reachable, privilege-probe failures 0** — confirming the #664 fix in the
+  shipped build.
+
+**Next** — (1) Optional: update the `~539`->`~538` approximate bounds in
+openapi/spec/lens-handler (DOC-2; cosmetic, drags in `make generate-api`).
+(2) Stage 3 GA fleet-verification gate still pending per
+`docs/runbooks/RELEASING.md` (rc.14 is a pre-release). (3) Remaining licensed
+remediation track + framework rule-count verification unchanged.
+
+**Notes** — `pgrep -f 'dist/openwatch serve'` matches your own shell commands;
+find the real serve PID by listening port (`ss -ltnp 'sport = :8443'`) before
+SIGTERM, or you kill a wrapper and the old server keeps the port (cost a
+"bind: address already in use" restart this session). Dev environ saved at
+`/tmp/ow-serve-env-v60.bin` (KENSA_RULES_DIR -> v0.6.0 rules, 538 files); serve
+is manual (not systemd), logs `.dev/openwatch.log`, restart = SIGTERM + execve
+with `/proc` environ. `.kensa/*.db-wal/shm` show as tracked-modified runtime
+files — `git checkout -- .kensa/` before branch ops.
+
+---
+
 ## 2026-06-22 — Opus 4.8 (1M context) — Release-grade review + operator-guide truthfulness pass
 
 **Done** — Full quality+security review (4 parallel audit agents + live testing


### PR DESCRIPTION
Session-continuity docs for the rc.14 release session (2026-06-23).

- **SESSION_LOG.md** — prepend the `2026-06-23` entry: Kensa v0.6.0 (#670, corpus 539->538, live-scan verified), the six landed fix PRs (#664/#665/#666/#667/#668/#669), the rc.14 cut + signed publish (#671), and the dev-server rebuild from the tag + live re-verification. Includes Next items and the serve-restart / `pgrep` gotchas.
- **BACKLOG.md** — bump *Last Updated* to 2026-06-23; add **DOC-2** (P3) for the deferred `~539`->`~538` approximate-bound cleanup (cosmetic; requires `make generate-api`).

Docs-only; no code or spec changes.