### PR TITLE
fix(packaging): remediation broken under hardened unit — pin Kensa store to writable tree (PKG-3)

### DIFF
--- a/packaging/common/openwatch.service
+++ b/packaging/common/openwatch.service
@@ -9,6 +9,13 @@ Type=simple
 User=openwatch
 Group=openwatch
 EnvironmentFile=-/etc/openwatch/secrets.env
+# Kensa remediation needs a durable SQLite store for rollback pre-state. Pin it
+# inside the writable state tree: ProtectSystem=strict makes / read-only, and
+# without this the path defaults to `.kensa/remediation.db` under the working
+# dir (systemd defaults that to read-only /), so the store fails to open and
+# remediation silently degrades to "not wired" while scans still work.
+Environment=OPENWATCH_KENSA_STORE_PATH=/var/lib/openwatch/kensa/remediation.db
+WorkingDirectory=/var/lib/openwatch
 ExecStart=/usr/bin/openwatch serve --config /etc/openwatch/openwatch.toml
 Restart=on-failure
 RestartSec=5s

--- a/packaging/tests/package_test.go
+++ b/packaging/tests/package_test.go
@@ -504,6 +504,49 @@ func TestOpenwatch_DependsOnKensaRules(t *testing.T) {
 	})
 }
 
+// @ac AC-23
+// AC-23: the hardened unit pins the Kensa rollback store inside the writable
+// state tree. Backstops the rc.14 regression where ProtectSystem=strict left
+// the store path on the read-only root, so remediation boot-wiring failed and
+// every remediation/rollback returned "not wired" while scans still worked.
+func TestUnit_KensaStorePathIsWritable(t *testing.T) {
+	t.Run("release-package-build/AC-23", func(t *testing.T) {
+		dir := appDir(t)
+		unit, err := os.ReadFile(filepath.Join(dir, "packaging", "common", "openwatch.service"))
+		if err != nil {
+			t.Fatalf("read openwatch.service: %v", err)
+		}
+		u := string(unit)
+
+		// The store path must be set and live under /var/lib/openwatch, which is
+		// the unit's ReadWritePaths entry (so it is writable under
+		// ProtectSystem=strict).
+		storeRe := regexp.MustCompile(`(?m)^Environment=OPENWATCH_KENSA_STORE_PATH=(\S+)`)
+		m := storeRe.FindStringSubmatch(u)
+		if m == nil {
+			t.Fatal("openwatch.service must set Environment=OPENWATCH_KENSA_STORE_PATH (else the Kensa rollback store lands on the read-only root and remediation degrades to \"not wired\")")
+		}
+		if !strings.HasPrefix(m[1], "/var/lib/openwatch/") {
+			t.Errorf("OPENWATCH_KENSA_STORE_PATH=%q must be under /var/lib/openwatch/ (a ReadWritePaths entry)", m[1])
+		}
+
+		// Defense in depth: WorkingDirectory must be writable too, so the store's
+		// default fallback (.kensa/ relative to the working dir) cannot land on
+		// the read-only root if the env var is ever dropped.
+		wdRe := regexp.MustCompile(`(?m)^WorkingDirectory=(\S+)`)
+		if wm := wdRe.FindStringSubmatch(u); wm == nil {
+			t.Error("openwatch.service must set WorkingDirectory to a writable path")
+		} else if !strings.HasPrefix(wm[1], "/var/lib/openwatch") {
+			t.Errorf("WorkingDirectory=%q must be under /var/lib/openwatch", wm[1])
+		}
+
+		// Sanity: the writable path we point at is actually granted by the unit.
+		if !strings.Contains(u, "ReadWritePaths=") || !strings.Contains(u, "/var/lib/openwatch") {
+			t.Error("openwatch.service must grant ReadWritePaths=/var/lib/openwatch")
+		}
+	})
+}
+
 // @ac AC-17
 // AC-17: make packages builds the kensa-rules corpus package too.
 func TestMake_PackagesBuildsKensaRules(t *testing.T) {

--- a/specs/release/package-build.spec.yaml
+++ b/specs/release/package-build.spec.yaml
@@ -138,6 +138,20 @@ spec:
         the tilde form. Source-inspection enforces (AC-21).
       type: technical
       enforcement: error
+    - id: C-13
+      description: >
+        The systemd unit MUST set OPENWATCH_KENSA_STORE_PATH to a path inside
+        the unit's writable state tree (a ReadWritePaths entry, e.g.
+        /var/lib/openwatch). Kensa remediation composes a full engine backed by
+        a durable SQLite transaction store for rollback pre-state; under
+        ProtectSystem=strict the store path MUST resolve to a writable location
+        or the store fails to open and remediation degrades to "not wired"
+        (scans, which compose a store-less engine, are unaffected and mask the
+        failure). The unit MUST also set WorkingDirectory to a writable path so
+        the store's default fallback (.kensa/ relative to the working dir) does
+        not land on the read-only root.
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -247,3 +261,14 @@ spec:
         removes) an operator's replacement certificate, including the transition.
       priority: critical
       references_constraints: [C-05]
+    - id: AC-23
+      description: >-
+        Source-inspection of packaging/common/openwatch.service: the unit sets
+        OPENWATCH_KENSA_STORE_PATH to a path under /var/lib/openwatch (a
+        ReadWritePaths entry), and sets WorkingDirectory to a writable path
+        (not the default read-only /). Backstops the rc.14 regression where the
+        hardened unit left the Kensa rollback store unwritable, so remediation
+        boot-wiring failed ("compose remediation service") and every
+        remediation/rollback returned "not wired" while scans worked.
+      priority: critical
+      references_constraints: [C-13]


### PR DESCRIPTION
## Problem (regressed in rc.14)

On every packaged install, remediation/rollback fails with `kensa: remediate path not wired`; the boot log shows `kensa remediation wiring unavailable` / `error=kensa: compose remediation service: …`. **Scans work**, which masks it.

**Root cause:** `packaging/common/openwatch.service` runs with `ProtectSystem=strict` + `ReadWritePaths=/var/lib/openwatch /var/log/openwatch`, but (a) sets **no `WorkingDirectory`** (systemd defaults it to the read-only `/`) and (b) **never sets `OPENWATCH_KENSA_STORE_PATH`**. So `kensaStorePath()` (`cmd/openwatch/main.go:768`) falls back to `.kensa/remediation.db` → `/.kensa/remediation.db`, and Kensa's `OpenSQLite` `MkdirAll` fails on the read-only root. The remediation path composes the **full** Kensa with a durable SQLite rollback-pre-state store; the scan path composes a **store-less** engine, which is why scans are unaffected.

## Fix

```ini
Environment=OPENWATCH_KENSA_STORE_PATH=/var/lib/openwatch/kensa/remediation.db
WorkingDirectory=/var/lib/openwatch
```

The store path is inside the writable `ReadWritePaths` tree (owned by the `openwatch` user); Kensa's `MkdirAll` creates the `kensa/` subdir. `WorkingDirectory` is belt-and-suspenders so the bare default can't land on the read-only root if the env var is ever dropped.

## Tests

- New spec **C-13 / AC-23** (`specs/release/package-build.spec.yaml`) + source-inspection regression test `TestUnit_KensaStorePathIsWritable` asserting the unit sets the store path under `/var/lib/openwatch` and a writable `WorkingDirectory`.
- `go test ./packaging/tests/` green; `specter check` 113 specs; coverage 100%.

## Operator workaround (no upgrade needed)

`systemctl edit openwatch` → `[Service]\nEnvironment=OPENWATCH_KENSA_STORE_PATH=/var/lib/openwatch/kensa/remediation.db` → `systemctl restart openwatch`.

Worth an **rc.15** — it breaks all remediation on hardened packaged installs.