### PR TITLE
feat(auth): client-side idle-session timeout (AUTH-1 slice 1)

### DIFF
--- a/frontend/src/components/shell/AppFrame.tsx
+++ b/frontend/src/components/shell/AppFrame.tsx
@@ -4,10 +4,11 @@ import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
 import { ErrorBoundary } from './ErrorBoundary';
 import { usePreferencesStore } from '@/store/usePreferencesStore';
+import { useIdleLogout } from '@/hooks/useIdleLogout';
 
 // AppFrame — the persistent shell that wraps every authenticated route.
 //
-// Spec: frontend-foundation C-08, C-09, AC-10.
+// Spec: frontend-foundation C-08, C-09, AC-10; frontend-session-idle.
 
 export function AppFrame() {
   // Reconcile per-user UI preferences with the server once the
@@ -17,6 +18,11 @@ export function AppFrame() {
   useEffect(() => {
     void hydratePreferences();
   }, [hydratePreferences]);
+
+  // Enforce the operator-configured idle timeout against REAL user activity
+  // (background polling slides the server-side window, so a client timer is
+  // what actually terminates an unattended session). Spec frontend-session-idle.
+  useIdleLogout();
 
   return (
     <div

--- a/frontend/src/hooks/useIdleLogout.ts
+++ b/frontend/src/hooks/useIdleLogout.ts
@@ -1,0 +1,148 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api, onAuthFailure } from '@/api/client';
+import { useAuthStore } from '@/store/useAuthStore';
+
+// useIdleLogout — client-side inactivity timeout.
+//
+// WHY this exists (and why the server-side window is not enough): the backend
+// enforces the configured idle window in internal/identity/sessions.go, but it
+// measures "idle" by HTTP request activity. The SPA polls several endpoints
+// every 15-60s and holds a persistent SSE stream, so every background request
+// slides the server's expires_at forward — the session never goes idle even
+// when the human has walked away. This hook measures REAL user activity
+// (pointer / keyboard / touch), so the Authentication-policy "Idle timeout"
+// setting actually terminates an unattended session and returns to /login.
+//
+// It reads the operator-configured window from GET /api/v1/auth-policy and
+// falls back to the backend default (15 min) when that can't be read — failing
+// toward enforcing a timeout rather than leaving the session open forever.
+//
+// Mounted once from AppFrame (the authenticated shell), so it is armed only
+// while a user is signed in.
+//
+// Spec: frontend-session-idle.
+
+// Matches DefaultSessionInactivityWindow in internal/identity/sessions.go.
+const DEFAULT_IDLE_SECONDS = 15 * 60;
+
+// Shared "last user activity" timestamp (epoch ms) across tabs of the same
+// origin. Activity in any tab keeps every tab's session alive; without this a
+// background tab would log the user out while they work in another.
+export const ACTIVITY_STORAGE_KEY = 'ow.session.lastActivity';
+
+// How often we re-check elapsed idle time. This is the granularity of the
+// check, not the timeout itself.
+const CHECK_INTERVAL_MS = 5_000;
+
+// Throttle how often raw activity events rewrite the shared timestamp so a
+// burst of mousemove events is cheap.
+const ACTIVITY_WRITE_THROTTLE_MS = 1_000;
+
+// Real user-input signals only. Deliberately NOT HTTP/visibility driven — the
+// whole point is to ignore background traffic and tab focus.
+const ACTIVITY_EVENTS: readonly string[] = [
+  'mousemove',
+  'mousedown',
+  'keydown',
+  'wheel',
+  'scroll',
+  'touchstart',
+];
+
+function readLastActivity(fallback: number): number {
+  try {
+    const raw = localStorage.getItem(ACTIVITY_STORAGE_KEY);
+    const n = raw ? Number(raw) : NaN;
+    if (Number.isFinite(n)) return n;
+  } catch {
+    /* localStorage unavailable (private mode / SSR) — use the fallback */
+  }
+  return fallback;
+}
+
+export function useIdleLogout(): void {
+  const identity = useAuthStore((s) => s.identity);
+
+  const { data: policy } = useQuery({
+    queryKey: ['auth-policy'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/auth-policy');
+      if (error || !response.ok) throw new Error('failed to load auth policy');
+      return data!;
+    },
+    // The window changes rarely; one fetch per shell mount is plenty. A short
+    // refetch interval would itself be background traffic, which is the very
+    // thing this hook exists to stop counting as activity.
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const idleSeconds = policy?.session_idle_timeout_seconds ?? DEFAULT_IDLE_SECONDS;
+
+  // Hold the latest window in a ref so a policy change does not tear down and
+  // rebuild the listeners/interval.
+  const idleMsRef = useRef(idleSeconds * 1000);
+  idleMsRef.current = idleSeconds * 1000;
+
+  useEffect(() => {
+    // Arm only while authenticated.
+    if (!identity) return;
+
+    let lastWrite = 0;
+    let loggingOut = false;
+
+    const markActivity = (): void => {
+      const t = Date.now();
+      if (t - lastWrite < ACTIVITY_WRITE_THROTTLE_MS) return;
+      lastWrite = t;
+      try {
+        localStorage.setItem(ACTIVITY_STORAGE_KEY, String(t));
+      } catch {
+        /* ignore — readLastActivity falls back to lastWrite via the closure */
+      }
+    };
+
+    const logout = async (): Promise<void> => {
+      if (loggingOut) return;
+      loggingOut = true;
+      // Best-effort server-side revoke so the cookie session is actually dead,
+      // not merely hidden from this tab. Redirect regardless of the result.
+      try {
+        await api.POST('/api/v1/auth/logout');
+      } catch {
+        /* ignore — we still clear the client and redirect */
+      }
+      try {
+        localStorage.removeItem(ACTIVITY_STORAGE_KEY);
+      } catch {
+        /* ignore */
+      }
+      onAuthFailure();
+    };
+
+    const check = (): void => {
+      if (loggingOut) return;
+      const last = readLastActivity(lastWrite || Date.now());
+      if (Date.now() - last >= idleMsRef.current) {
+        void logout();
+      }
+    };
+
+    // Seed an initial timestamp so a freshly-mounted shell is not treated as
+    // already idle.
+    lastWrite = 0;
+    markActivity();
+
+    for (const ev of ACTIVITY_EVENTS) {
+      window.addEventListener(ev, markActivity, { passive: true });
+    }
+    const interval = window.setInterval(check, CHECK_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+      for (const ev of ACTIVITY_EVENTS) {
+        window.removeEventListener(ev, markActivity);
+      }
+    };
+  }, [identity]);
+}

--- a/frontend/tests/hooks/useIdleLogout.test.tsx
+++ b/frontend/tests/hooks/useIdleLogout.test.tsx
@@ -1,0 +1,176 @@
+// @spec frontend-session-idle
+//
+// AC traceability (this file):
+//
+//   AC-01  test('frontend-session-idle/AC-01 — idle past the window logs out (revoke + redirect)')
+//   AC-02  test('frontend-session-idle/AC-02 — user input before the window resets the clock')
+//   AC-03  test('frontend-session-idle/AC-03 — honors the configured window; falls back to 15m default')
+//   AC-04  test('frontend-session-idle/AC-04 — a fresher cross-tab timestamp prevents logout')
+//   AC-05  test('frontend-session-idle/AC-05 — AppFrame mounts the hook; listeners are user-input only')
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ReactNode } from 'react';
+
+import { api, onAuthFailure } from '@/api/client';
+import { ACTIVITY_STORAGE_KEY, useIdleLogout } from '@/hooks/useIdleLogout';
+import { useAuthStore } from '@/store/useAuthStore';
+
+vi.mock('@/api/client', () => ({
+  api: { GET: vi.fn(), POST: vi.fn() },
+  onAuthFailure: vi.fn(),
+}));
+
+const mockedGet = vi.mocked(api.GET);
+const mockedPost = vi.mocked(api.POST);
+const mockedAuthFailure = vi.mocked(onAuthFailure);
+
+const T0 = new Date('2026-01-01T00:00:00Z').getTime();
+
+// Policy GET result helpers (the openapi-fetch result shape).
+function policyOk(idleSeconds: number) {
+  return {
+    data: {
+      require_mfa: false,
+      session_idle_timeout_seconds: idleSeconds,
+      session_absolute_timeout_seconds: 43200,
+      updated_at: '2026-01-01T00:00:00Z',
+    },
+    error: undefined,
+    response: { ok: true } as Response,
+  };
+}
+function policyFail() {
+  return { data: undefined, error: { code: 'x' }, response: { ok: false } as Response };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+// Render the hook and let the auth-policy query settle so idleMsRef is primed.
+async function mount() {
+  const view = renderHook(() => useIdleLogout(), { wrapper });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  return view;
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe('frontend-session-idle — client idle logout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    mockedGet.mockReset();
+    mockedPost.mockReset();
+    mockedAuthFailure.mockReset();
+    mockedPost.mockResolvedValue({ data: {}, error: undefined, response: { ok: true } } as never);
+    try {
+      localStorage.clear();
+    } catch {
+      /* ignore */
+    }
+    useAuthStore.getState().setIdentity({
+      id: 'u1',
+      username: 'alice',
+      email: 'alice@example.com',
+      role: 'admin',
+      permissions: [],
+      mfaEnabled: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    useAuthStore.getState().clear();
+  });
+
+  // @ac AC-01
+  test('frontend-session-idle/AC-01 — idle past the window logs out (revoke + redirect)', async () => {
+    mockedGet.mockResolvedValue(policyOk(60) as never);
+    await mount();
+
+    // No activity for 65s (> 60s window) → revoke + redirect.
+    await advance(65_000);
+
+    expect(mockedPost).toHaveBeenCalledWith('/api/v1/auth/logout');
+    expect(mockedAuthFailure).toHaveBeenCalledTimes(1);
+  });
+
+  // @ac AC-02
+  test('frontend-session-idle/AC-02 — user input before the window resets the clock', async () => {
+    mockedGet.mockResolvedValue(policyOk(60) as never);
+    await mount();
+
+    // Sit idle for 50s, then the user presses a key (resets the clock).
+    await advance(50_000);
+    act(() => {
+      window.dispatchEvent(new Event('keydown'));
+    });
+    // 50s more: 50s since the keypress (< 60s) → still NOT logged out.
+    await advance(50_000);
+
+    expect(mockedAuthFailure).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  // @ac AC-03
+  test('frontend-session-idle/AC-03 — honors the configured window; falls back to 15m default', async () => {
+    // Configured short window: fires at the configured value, not before.
+    mockedGet.mockResolvedValue(policyOk(120) as never);
+    await mount();
+    await advance(100_000); // < 120s
+    expect(mockedAuthFailure).not.toHaveBeenCalled();
+    await advance(30_000); // now > 120s
+    expect(mockedAuthFailure).toHaveBeenCalledTimes(1);
+  });
+
+  // @ac AC-03
+  test('frontend-session-idle/AC-03b — policy unavailable falls back to the 15-minute default', async () => {
+    mockedGet.mockResolvedValue(policyFail() as never);
+    await mount();
+    // 5 minutes idle is well past a short window but under the 15-min default →
+    // must NOT log out (proves the safe default, not a 0/immediate timeout).
+    await advance(5 * 60_000);
+    expect(mockedAuthFailure).not.toHaveBeenCalled();
+  });
+
+  // @ac AC-04
+  test('frontend-session-idle/AC-04 — a fresher cross-tab timestamp prevents logout', async () => {
+    mockedGet.mockResolvedValue(policyOk(60) as never);
+    await mount();
+
+    // This tab sees no local input, but another tab records activity by writing
+    // the shared key. Keep it fresh across the window.
+    for (let i = 0; i < 6; i++) {
+      localStorage.setItem(ACTIVITY_STORAGE_KEY, String(Date.now()));
+      await advance(20_000); // 20s < 60s window each step
+    }
+
+    expect(mockedAuthFailure).not.toHaveBeenCalled();
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  // @ac AC-05
+  test('frontend-session-idle/AC-05 — AppFrame mounts the hook; listeners are user-input only', () => {
+    const appFrame = readFileSync(resolve(__dirname, '../../src/components/shell/AppFrame.tsx'), 'utf8');
+    expect(appFrame).toContain('useIdleLogout');
+
+    const hook = readFileSync(resolve(__dirname, '../../src/hooks/useIdleLogout.ts'), 'utf8');
+    for (const ev of ['mousemove', 'mousedown', 'keydown', 'wheel', 'scroll', 'touchstart']) {
+      expect(hook).toContain(`'${ev}'`);
+    }
+    // Tab focus / visibility and background HTTP must NOT count as activity.
+    expect(hook).not.toContain('visibilitychange');
+  });
+});

--- a/specs/frontend/session-idle.spec.yaml
+++ b/specs/frontend/session-idle.spec.yaml
@@ -1,0 +1,128 @@
+spec:
+  id: frontend-session-idle
+  title: Frontend client-side idle-session timeout
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch-go
+    feature: Browser inactivity timeout that enforces the Authentication-policy "Idle timeout" against real user activity
+    description: >
+      The backend enforces the operator-configured session idle window
+      (system-auth-policy / internal/identity/sessions.go), but it measures
+      "idle" by HTTP request activity and slides expires_at forward on every
+      authenticated request. The SPA polls several endpoints every 15-60s and
+      holds a persistent SSE stream, so the server-side window never elapses
+      even when the human has walked away. The result: the "Idle timeout"
+      setting under /settings/security has no observable effect in the browser.
+
+      This spec adds a client-side idle timer that measures REAL user input
+      (pointer, keyboard, touch) rather than HTTP traffic. When the user is
+      inactive for the configured window, the session is terminated
+      (POST /api/v1/auth/logout) and the app returns to /login. The timer reads
+      the configured window from GET /api/v1/auth-policy and falls back to the
+      backend default (15 minutes) when that cannot be read.
+
+      Tier 1 because session termination is a security control (NIST 800-53
+      AC-11/AC-12) and the frameworks OpenWatch itself scans for require it.
+
+      Scope note: this is slice 1 of AUTH-1. The absolute-timeout ceiling in the
+      cookie-refresh path (PostAuthRefreshCookie re-mints a session on the
+      7-day refresh token, resetting the absolute deadline) and the server-side
+      "slide only on user-initiated requests" hardening are tracked separately.
+    related_specs:
+      - frontend-auth-login
+      - system-auth-policy
+      - api-auth-policy
+
+  objective:
+    summary: >
+      A signed-in user who stops interacting with the page for the configured
+      idle window is logged out and returned to /login, regardless of any
+      background polling or SSE traffic the SPA generates.
+    scope:
+      includes:
+        - Idle timer armed only while authenticated, mounted from the app shell
+        - Idle window read from GET /api/v1/auth-policy with a safe default
+        - User-input activity (pointer/keyboard/touch) resets the idle clock
+        - Cross-tab shared activity clock so one active tab keeps all alive
+        - Server-side session revoke + redirect to /login on expiry
+      excludes:
+        - Absolute-timeout enforcement in the refresh-cookie path (backend)
+        - A pre-expiry warning/countdown dialog (follow-up)
+        - Server-side "slide only on user activity" hardening (backend)
+
+  constraints:
+    - id: C-01
+      description: >
+        The idle timer MUST measure real user input (pointer, keyboard, touch
+        events) and MUST NOT treat background HTTP traffic, SSE messages, or tab
+        focus/visibility changes as activity. It MUST be armed only while a user
+        is authenticated, and mounted from the persistent authenticated shell
+        (AppFrame) so it is active across every authenticated route.
+      type: security
+      enforcement: error
+    - id: C-02
+      description: >
+        The idle window MUST come from session_idle_timeout_seconds in
+        GET /api/v1/auth-policy. When the policy cannot be read the timer MUST
+        fall back to the backend default of 15 minutes (fail toward enforcing a
+        timeout, never leaving the session open indefinitely).
+      type: security
+      enforcement: error
+    - id: C-03
+      description: >
+        On reaching the idle window with no user activity, the timer MUST
+        terminate the session server-side via POST /api/v1/auth/logout (so the
+        cookie session is actually revoked, not merely hidden from the tab) and
+        then clear the client identity and redirect to /login.
+      type: security
+      enforcement: error
+    - id: C-04
+      description: >
+        User activity MUST reset the idle clock. The clock MUST be shared across
+        tabs of the same origin (via localStorage) so activity in one tab keeps
+        every tab's session alive and a background tab does not log the user out
+        while they work in another.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: >-
+        With an idle window W and no user-input events, after W elapses the hook
+        calls POST /api/v1/auth/logout and then the shared auth-failure handler
+        (clear identity + redirect to /login).
+      priority: critical
+      references_constraints: [C-01, C-03]
+    - id: AC-02
+      description: >-
+        A user-input event (e.g. keydown) dispatched before W elapses resets the
+        clock: advancing time to just under W from the last event does NOT log
+        the user out.
+      priority: critical
+      references_constraints: [C-01, C-04]
+    - id: AC-03
+      description: >-
+        The timer honors the configured window: with the auth-policy returning a
+        specific session_idle_timeout_seconds, logout fires at that value, and
+        when the policy is unavailable it falls back to the 15-minute default
+        (not before).
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: >-
+        Cross-tab — a fresher activity timestamp written to the shared
+        localStorage key by another tab prevents logout in this tab even when
+        this tab has seen no local input events.
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-05
+      description: >-
+        Source-inspection — AppFrame (the authenticated shell) mounts
+        useIdleLogout, and the hook's activity listeners are user-input events
+        (mousemove/mousedown/keydown/wheel/scroll/touchstart) with no
+        visibilitychange or HTTP-driven reset.
+      priority: high
+      references_constraints: [C-01]

--- a/specter.yaml
+++ b/specter.yaml
@@ -96,6 +96,7 @@ domains:
             - api-sso
             - api-remediation
             - frontend-remediation-tab
+            - frontend-session-idle
 settings:
     specs_dir: specs
     # Honored by `specter coverage` (not by `specter sync` — CI passes


### PR DESCRIPTION
## Problem

The Authentication-policy **Idle timeout** (`/settings/security`) had no observable effect: a user who walks away stays logged in. The backend *does* enforce the configured window (`internal/identity/sessions.go`), but it measures idle by **HTTP request activity** and slides `expires_at` on every authenticated request. The SPA polls several endpoints every 15-60s + holds a persistent SSE stream, so the server-side window never elapses. (Full diagnosis: BACKLOG **AUTH-1**.)

## This change (slice 1 of AUTH-1)

`useIdleLogout`, mounted from `AppFrame` (the authenticated shell), measures **real user input** (pointer/keyboard/touch) instead of HTTP traffic. On inactivity for the configured window it revokes the session server-side (`POST /api/v1/auth/logout`) and returns to `/login`.

- Window read from `GET /api/v1/auth-policy` (`session_idle_timeout_seconds`), **15-minute safe default** matching the backend when the policy can't be read (fails toward enforcing).
- Activity clock **shared across tabs** via `localStorage` so one active tab keeps all alive (no false logout in a background tab).
- Deliberately ignores background HTTP, SSE, and tab focus/visibility — only genuine input resets the clock.

## Tests / SDD

- New spec **`frontend-session-idle`** (5 ACs) registered in `specter.yaml`; `specter check` 114 specs, coverage **100%**.
- 6 vitest cases (fake timers): idle→logout, activity resets, honors configured value, 15m fallback, cross-tab freshness, source-inspection of the mount + listener set. Full suite 343 green; tsc + eslint clean.

## Not in this PR (tracked under AUTH-1)

- (b) **Absolute-timeout** ceiling in `PostAuthRefreshCookie` — it re-mints a session on the 7-day refresh token, resetting the absolute deadline; needs the original deadline carried in the refresh token and enforced.
- (c) Server-side defense-in-depth: slide the session window only on **user-initiated** requests.
- A pre-expiry warning/countdown dialog (UX follow-up).