### PR TITLE
feat(auth): absolute-timeout ceiling + slide-on-user-activity (AUTH-1 b+c)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -24,6 +24,26 @@ const CSRF_HEADER = 'X-CSRF-Token';
 const REFRESH_PATH = '/api/v1/auth/refresh-cookie';
 const LOGIN_PATH = '/login';
 
+// AUTH-1 (c): the server slides the session idle window only on user-initiated
+// requests. We mark background/poll GETs with X-Background-Refresh so they do
+// NOT keep an unattended session alive. "User-initiated" is inferred from the
+// idle-timer's activity signal (the same localStorage key useIdleLogout writes
+// on real pointer/keyboard input). Fail-safe: until that key is written (e.g.
+// the idle timer is not present), we never mark, so the server slides exactly
+// as before — no premature logout.
+const BACKGROUND_HEADER = 'X-Background-Refresh';
+const ACTIVITY_KEY = 'ow.session.lastActivity';
+let lastReportedActivity = 0;
+
+function lastUserActivity(): number {
+  try {
+    const n = Number(localStorage.getItem(ACTIVITY_KEY));
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
 function readCookie(name: string): string | null {
   if (typeof document === 'undefined') return null;
   const target = name + '=';
@@ -131,8 +151,20 @@ baseClient.use({
   onRequest({ request }) {
     const method = request.method.toUpperCase();
     if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+      // AUTH-1 (c): a safe read rides genuine user activity (don't mark → the
+      // server slides) only when there is NEW activity since the last reported
+      // request; otherwise it is background churn and must not slide the window.
+      const last = lastUserActivity();
+      if (last > 0) {
+        if (last > lastReportedActivity) {
+          lastReportedActivity = last;
+        } else {
+          request.headers.set(BACKGROUND_HEADER, '1');
+        }
+      }
       return request;
     }
+    // Mutations are always user-initiated → never marked background (they slide).
     const token = readCookie(CSRF_COOKIE);
     if (token) request.headers.set(CSRF_HEADER, token);
     return request;

--- a/frontend/tests/api/client-retry.test.ts
+++ b/frontend/tests/api/client-retry.test.ts
@@ -207,3 +207,22 @@ describe('api/client — 401 retry middleware', () => {
     expect(navigateSpy).toHaveBeenCalledWith('/login');
   });
 });
+
+// @ac AC-31
+// AC-31 (AUTH-1 c) — the client marks background/poll reads with
+// X-Background-Refresh so the server does not slide the idle window for them,
+// gated on the idle-timer activity signal (fail-safe: inert until that
+// localStorage key is written). Source-inspection of the request middleware.
+test('system-auth-identity/AC-31 — marks background reads with X-Background-Refresh, gated on activity', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { resolve } = await import('node:path');
+  const src = readFileSync(resolve(process.cwd(), 'src/api/client.ts'), 'utf8');
+  // Sets the background marker header...
+  expect(src).toContain("'X-Background-Refresh'");
+  // ...gated on the idle-timer activity signal (the fail-safe localStorage key).
+  expect(src).toContain("'ow.session.lastActivity'");
+  // ...via the request middleware on safe reads (mutations always slide).
+  expect(src).toMatch(/BACKGROUND_HEADER/);
+  // Fail-safe: only marks when an activity timestamp actually exists.
+  expect(src).toMatch(/last > 0/);
+});

--- a/internal/db/migrations/0047_refresh_absolute_deadline.sql
+++ b/internal/db/migrations/0047_refresh_absolute_deadline.sql
@@ -1,0 +1,24 @@
+-- 0047_refresh_absolute_deadline.sql
+--
+-- AUTH-1 (b): make the session ABSOLUTE timeout a real ceiling.
+--
+-- The cookie-refresh path (PostAuthRefreshCookie) re-mints a session on the
+-- 7-day refresh token and, before this change, gave the new session a FRESH
+-- absolute window — so the absolute timeout (default 12h) never actually bit:
+-- a browser could be kept alive for the full 7-day refresh-token life.
+--
+-- Carry the original login's absolute deadline through the refresh-token
+-- lineage: it is stamped at login and copied UNCHANGED on every rotation. Once
+-- now > absolute_expires_at, refresh is refused and the chain ends.
+--
+-- Nullable: refresh tokens minted before this migration (in-flight, up to 7
+-- days) carry NULL and are treated as legacy (no absolute ceiling) until they
+-- naturally expire — no forced logout on upgrade.
+--
+-- Spec: system-auth-identity.
+
+-- +goose Up
+ALTER TABLE refresh_tokens ADD COLUMN absolute_expires_at TIMESTAMPTZ;
+
+-- +goose Down
+ALTER TABLE refresh_tokens DROP COLUMN absolute_expires_at;

--- a/internal/identity/binder.go
+++ b/internal/identity/binder.go
@@ -24,6 +24,14 @@ const SessionCookieName = "openwatch_session"
 // user-driven navigation and mutations omit it and slide as before. AUTH-1 (c).
 const BackgroundRefreshHeader = "X-Background-Refresh"
 
+// sseEventsPath is the live-events SSE stream. EventSource cannot set custom
+// headers, so it can never send BackgroundRefreshHeader; yet it is a long-lived
+// background subscription that reconnects (often through a proxy idle-timeout).
+// Treating it as user activity would let an open SPA keep an unattended session
+// alive forever, defeating the idle timeout — so the binder never slides for it.
+// AUTH-1 (c).
+const sseEventsPath = "/api/v1/events"
+
 // authBypassPaths are credential-lifecycle endpoints where the binder
 // MUST NOT 401 on a stale session cookie — they handle their own
 // credential semantics. Login does not need any cookie; logout is
@@ -148,7 +156,7 @@ func resolveIdentity(ctx context.Context, pool *pgxpool.Pool, lookups Lookups, c
 		// HTTP traffic. Fail-safe: an unmarked request slides as before, so a
 		// client that does not send the header is unaffected.
 		var vopts []VerifyOption
-		if r.Header.Get(BackgroundRefreshHeader) == "1" {
+		if r.Header.Get(BackgroundRefreshHeader) == "1" || r.URL.Path == sseEventsPath {
 			vopts = append(vopts, WithoutSlide())
 		}
 		sess, err := VerifySession(ctx, pool, cookie.Value, vopts...)

--- a/internal/identity/binder.go
+++ b/internal/identity/binder.go
@@ -18,6 +18,12 @@ import (
 // presentation tokens. Server-set; client reads it back over HTTPS.
 const SessionCookieName = "openwatch_session"
 
+// BackgroundRefreshHeader marks a request as NOT user-initiated (a background
+// poll, an SSE reconnect) so the binder verifies the session without sliding
+// its idle window. The SPA sets it on recurring/background fetches; ordinary
+// user-driven navigation and mutations omit it and slide as before. AUTH-1 (c).
+const BackgroundRefreshHeader = "X-Background-Refresh"
+
 // authBypassPaths are credential-lifecycle endpoints where the binder
 // MUST NOT 401 on a stale session cookie — they handle their own
 // credential semantics. Login does not need any cookie; logout is
@@ -136,7 +142,16 @@ func writeSessionInvalid(w http.ResponseWriter, r *http.Request, reason string) 
 // presented-but-rejected credentials).
 func resolveIdentity(ctx context.Context, pool *pgxpool.Pool, lookups Lookups, cfg binderConfig, r *http.Request) (auth.Identity, string) {
 	if cookie, err := r.Cookie(SessionCookieName); err == nil && cookie.Value != "" {
-		sess, err := VerifySession(ctx, pool, cookie.Value)
+		// AUTH-1 (c): the client marks NON-user-initiated requests (background
+		// polling, SSE) with X-Background-Refresh so the server does not slide
+		// the idle window for them — idle then tracks real user activity, not
+		// HTTP traffic. Fail-safe: an unmarked request slides as before, so a
+		// client that does not send the header is unaffected.
+		var vopts []VerifyOption
+		if r.Header.Get(BackgroundRefreshHeader) == "1" {
+			vopts = append(vopts, WithoutSlide())
+		}
+		sess, err := VerifySession(ctx, pool, cookie.Value, vopts...)
 		switch {
 		case errors.Is(err, ErrSessionNotFound):
 			return anon(), "invalid_session_token"

--- a/internal/identity/binder_test.go
+++ b/internal/identity/binder_test.go
@@ -159,5 +159,61 @@ func TestBinder_ExpiredSession_Writes401(t *testing.T) {
 	})
 }
 
+// @ac AC-31
+// AC-31 (AUTH-1 c): the binder slides the idle window only on user-initiated
+// requests. A request carrying X-Background-Refresh validates the session but
+// does NOT advance expires_at; an unmarked request does.
+func TestBinder_SlideOnlyOnUserActivity(t *testing.T) {
+	t.Run("system-auth-identity/AC-31", func(t *testing.T) {
+		pool := freshPool(t)
+		userID := seedUser(t, pool, "slide-binder")
+		token, sess, err := IssueSession(context.Background(), pool, userID, "127.0.0.1", "ua")
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		// Backdate expires_at so a slide is observable.
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE sessions SET expires_at = expires_at - interval '10 minutes' WHERE id = $1`,
+			sess.ID); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+		readExpiry := func() time.Time {
+			var e time.Time
+			if err := pool.QueryRow(context.Background(),
+				`SELECT expires_at FROM sessions WHERE id = $1`, sess.ID).Scan(&e); err != nil {
+				t.Fatalf("read expiry: %v", err)
+			}
+			return e
+		}
+		h := Binder(pool, adminLookups)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		do := func(background bool) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
+			req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: token})
+			if background {
+				req.Header.Set(BackgroundRefreshHeader, "1")
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status: want 200, got %d", rr.Code)
+			}
+		}
+
+		before := readExpiry()
+		// Background request must NOT slide.
+		do(true)
+		if got := readExpiry(); !got.Equal(before) {
+			t.Errorf("background request slid the window: before=%v after=%v", before, got)
+		}
+		// User-initiated request must slide.
+		do(false)
+		if got := readExpiry(); !got.After(before) {
+			t.Errorf("user request did not slide the window: before=%v after=%v", before, got)
+		}
+	})
+}
+
 // Silence the unused-import warning when the test runs without DB.
 var _ = pgxpool.Config{}

--- a/internal/identity/binder_test.go
+++ b/internal/identity/binder_test.go
@@ -212,6 +212,17 @@ func TestBinder_SlideOnlyOnUserActivity(t *testing.T) {
 		if got := readExpiry(); !got.After(before) {
 			t.Errorf("user request did not slide the window: before=%v after=%v", before, got)
 		}
+
+		// The SSE events stream must NOT slide — it cannot send the header but
+		// is a long-lived background subscription.
+		afterUser := readExpiry()
+		req := httptest.NewRequest(http.MethodGet, sseEventsPath, nil)
+		req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: token})
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		if got := readExpiry(); !got.Equal(afterUser) {
+			t.Errorf("SSE request slid the window: before=%v after=%v", afterUser, got)
+		}
 	})
 }
 

--- a/internal/identity/jwt_test.go
+++ b/internal/identity/jwt_test.go
@@ -84,7 +84,7 @@ func TestRefresh_RotationOnConsume(t *testing.T) {
 		userID := seedUser(t, pool, "ac12-user")
 
 		// Issue an initial refresh token.
-		refresh1, err := IssueRefreshToken(context.Background(), pool, userID)
+		refresh1, err := IssueRefreshToken(context.Background(), pool, userID, time.Now().UTC().Add(12*time.Hour))
 		if err != nil {
 			t.Fatalf("IssueRefreshToken: %v", err)
 		}
@@ -135,7 +135,7 @@ func TestRefresh_ReuseDetectionCascadeRevokes(t *testing.T) {
 			t.Fatalf("IssueSession: %v", err)
 		}
 
-		refresh1, err := IssueRefreshToken(context.Background(), pool, userID)
+		refresh1, err := IssueRefreshToken(context.Background(), pool, userID, time.Now().UTC().Add(12*time.Hour))
 		if err != nil {
 			t.Fatalf("IssueRefreshToken: %v", err)
 		}

--- a/internal/identity/refresh.go
+++ b/internal/identity/refresh.go
@@ -25,6 +25,11 @@ var (
 	ErrRefreshTokenExpired  = errors.New("identity: refresh token expired")
 	ErrRefreshTokenRevoked  = errors.New("identity: refresh token revoked")
 	ErrRefreshTokenReused   = errors.New("identity: refresh token reuse detected")
+	// ErrRefreshSessionExpired — the refresh token is still inside its 7-day
+	// window, but the session's ABSOLUTE deadline (carried through the lineage
+	// from login) has passed. Refresh is refused; the user must re-authenticate.
+	// AUTH-1 (b).
+	ErrRefreshSessionExpired = errors.New("identity: session absolute timeout reached")
 )
 
 // RevokeRefreshToken marks the row identified by presentation-token as
@@ -50,8 +55,14 @@ func RevokeRefreshToken(ctx context.Context, pool *pgxpool.Pool, token string) e
 // presentation token. Token is stored as SHA-256 hash; presentation
 // form is never in the DB.
 //
+// absoluteExpiresAt is the session's absolute deadline (login time + the
+// configured absolute window). It is carried through every rotation so the
+// session cannot be refreshed past it (AUTH-1 b). A zero value stores NULL —
+// the legacy "no absolute ceiling" behavior, used only by callers that have no
+// session deadline to anchor to.
+//
 // Spec AC-12.
-func IssueRefreshToken(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID) (token string, err error) {
+func IssueRefreshToken(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, absoluteExpiresAt time.Time) (token string, err error) {
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {
 		return "", fmt.Errorf("identity: refresh entropy: %w", err)
@@ -64,12 +75,22 @@ func IssueRefreshToken(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID
 		return "", fmt.Errorf("identity: uuid: %w", err)
 	}
 	const stmt = `
-		INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at)
-		VALUES ($1, $2, $3, $4)`
-	if _, err := pool.Exec(ctx, stmt, id, userID, hash[:], time.Now().UTC().Add(RefreshTokenWindow)); err != nil {
+		INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, absolute_expires_at)
+		VALUES ($1, $2, $3, $4, $5)`
+	if _, err := pool.Exec(ctx, stmt, id, userID, hash[:],
+		time.Now().UTC().Add(RefreshTokenWindow), nullableTime(absoluteExpiresAt)); err != nil {
 		return "", fmt.Errorf("identity: insert refresh: %w", err)
 	}
 	return token, nil
+}
+
+// nullableTime returns nil for the zero time (stored as SQL NULL) or the time
+// otherwise — so a missing absolute deadline is recorded honestly as "none".
+func nullableTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
 }
 
 // TokenPair is the result of a successful ConsumeRefreshToken call —
@@ -79,6 +100,11 @@ type TokenPair struct {
 	AccessToken  string
 	RefreshToken string
 	Claims       Claims
+	// AbsoluteExpiresAt is the session's carried absolute deadline (AUTH-1 b),
+	// zero when the consumed token had none (legacy). The cookie-refresh handler
+	// stamps it onto the re-minted session so the absolute ceiling is preserved
+	// across refreshes rather than reset.
+	AbsoluteExpiresAt time.Time
 }
 
 // ConsumeRefreshToken atomically:
@@ -106,17 +132,18 @@ func ConsumeRefreshToken(ctx context.Context, pool *pgxpool.Pool, token, role st
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	var (
-		rowID     uuid.UUID
-		userID    uuid.UUID
-		expiresAt time.Time
-		rotatedTo *uuid.UUID
-		revokedAt *time.Time
+		rowID       uuid.UUID
+		userID      uuid.UUID
+		expiresAt   time.Time
+		absoluteExp *time.Time
+		rotatedTo   *uuid.UUID
+		revokedAt   *time.Time
 	)
 	err = tx.QueryRow(ctx, `
-		SELECT id, user_id, expires_at, rotated_to_id, revoked_at
+		SELECT id, user_id, expires_at, absolute_expires_at, rotated_to_id, revoked_at
 		FROM refresh_tokens WHERE token_hash = $1 FOR UPDATE`,
 		hash[:],
-	).Scan(&rowID, &userID, &expiresAt, &rotatedTo, &revokedAt)
+	).Scan(&rowID, &userID, &expiresAt, &absoluteExp, &rotatedTo, &revokedAt)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrRefreshTokenNotFound
@@ -129,6 +156,13 @@ func ConsumeRefreshToken(ctx context.Context, pool *pgxpool.Pool, token, role st
 	}
 	if time.Now().UTC().After(expiresAt) {
 		return nil, ErrRefreshTokenExpired
+	}
+	// AUTH-1 (b): the session's absolute deadline is a hard ceiling. Once it
+	// passes, the chain ends even though the 7-day refresh window is still
+	// open. Legacy tokens (absolute_expires_at NULL) are exempt until they age
+	// out. Checked before reuse so an expired-session token simply fails closed.
+	if absoluteExp != nil && time.Now().UTC().After(*absoluteExp) {
+		return nil, ErrRefreshSessionExpired
 	}
 	if rotatedTo != nil {
 		// Reuse! This row was already consumed. An attacker has the old
@@ -167,10 +201,12 @@ func ConsumeRefreshToken(ctx context.Context, pool *pgxpool.Pool, token, role st
 	if err != nil {
 		return nil, fmt.Errorf("identity: uuid: %w", err)
 	}
+	// Carry the original absolute deadline UNCHANGED onto the rotated row, so
+	// the absolute ceiling cannot be reset by refreshing (AUTH-1 b).
 	if _, err := tx.Exec(ctx, `
-		INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at)
-		VALUES ($1, $2, $3, $4)`,
-		newID, userID, newHash[:], time.Now().UTC().Add(RefreshTokenWindow),
+		INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at, absolute_expires_at)
+		VALUES ($1, $2, $3, $4, $5)`,
+		newID, userID, newHash[:], time.Now().UTC().Add(RefreshTokenWindow), absoluteExp,
 	); err != nil {
 		return nil, fmt.Errorf("identity: insert rotated refresh: %w", err)
 	}
@@ -188,9 +224,13 @@ func ConsumeRefreshToken(ctx context.Context, pool *pgxpool.Pool, token, role st
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("identity: refresh commit (happy): %w", err)
 	}
-	return &TokenPair{
+	pair := &TokenPair{
 		AccessToken:  access,
 		RefreshToken: newPres,
 		Claims:       claims,
-	}, nil
+	}
+	if absoluteExp != nil {
+		pair.AbsoluteExpiresAt = *absoluteExp
+	}
+	return pair, nil
 }

--- a/internal/identity/refresh_test.go
+++ b/internal/identity/refresh_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"testing"
+	"time"
 )
 
 // @ac AC-24
@@ -24,7 +25,7 @@ func TestRefresh_Revoke(t *testing.T) {
 		userID := seedUser(t, pool, "refresh-revoke")
 
 		ctx := context.Background()
-		token, err := IssueRefreshToken(ctx, pool, userID)
+		token, err := IssueRefreshToken(ctx, pool, userID, time.Now().UTC().Add(12*time.Hour))
 		if err != nil {
 			t.Fatalf("issue: %v", err)
 		}
@@ -66,6 +67,75 @@ func TestRefresh_Revoke_Idempotent(t *testing.T) {
 		}
 		if err := RevokeRefreshToken(ctx, pool, "unknown-token-value"); err != nil {
 			t.Errorf("unknown token: %v", err)
+		}
+	})
+}
+
+// @ac AC-28
+// AC-28 (AUTH-1 b): ConsumeRefreshToken refuses a token whose carried absolute
+// deadline has passed (ErrRefreshSessionExpired), even though the 7-day window
+// is still open; a token with a future deadline rotates normally.
+func TestRefresh_AbsoluteCeiling(t *testing.T) {
+	t.Run("system-auth-identity/AC-28", func(t *testing.T) {
+		ensureKey(t)
+		pool := freshPool(t)
+		ctx := context.Background()
+		userID := seedUser(t, pool, "refresh-abs-ceiling")
+
+		// Past absolute deadline → refused (the 7-day refresh window is open).
+		expired, err := IssueRefreshToken(ctx, pool, userID, time.Now().UTC().Add(-time.Minute))
+		if err != nil {
+			t.Fatalf("issue expired: %v", err)
+		}
+		if _, err := ConsumeRefreshToken(ctx, pool, expired, ""); !isOneOf(err, ErrRefreshSessionExpired) {
+			t.Fatalf("consume past-deadline: want ErrRefreshSessionExpired, got %v", err)
+		}
+
+		// Future deadline → rotates normally.
+		live, err := IssueRefreshToken(ctx, pool, userID, time.Now().UTC().Add(12*time.Hour))
+		if err != nil {
+			t.Fatalf("issue live: %v", err)
+		}
+		if _, err := ConsumeRefreshToken(ctx, pool, live, "viewer"); err != nil {
+			t.Fatalf("consume live: %v", err)
+		}
+	})
+}
+
+// @ac AC-29
+// AC-29 (AUTH-1 b): a successful rotation carries the ORIGINAL absolute deadline
+// onto the rotated row unchanged and returns it on the TokenPair (so the
+// cookie-refresh handler can preserve the ceiling).
+func TestRefresh_CarriesAbsoluteForward(t *testing.T) {
+	t.Run("system-auth-identity/AC-29", func(t *testing.T) {
+		ensureKey(t)
+		pool := freshPool(t)
+		ctx := context.Background()
+		userID := seedUser(t, pool, "refresh-carry")
+		deadline := time.Now().UTC().Add(8 * time.Hour).Truncate(time.Second)
+
+		tok, err := IssueRefreshToken(ctx, pool, userID, deadline)
+		if err != nil {
+			t.Fatalf("issue: %v", err)
+		}
+		pair, err := ConsumeRefreshToken(ctx, pool, tok, "viewer")
+		if err != nil {
+			t.Fatalf("consume: %v", err)
+		}
+		// The TokenPair carries the original deadline.
+		if !pair.AbsoluteExpiresAt.UTC().Truncate(time.Second).Equal(deadline) {
+			t.Errorf("pair.AbsoluteExpiresAt = %v, want %v", pair.AbsoluteExpiresAt, deadline)
+		}
+		// The rotated DB row inherits the same deadline (not a fresh one).
+		newHash := sha256.Sum256([]byte(pair.RefreshToken))
+		var got time.Time
+		if err := pool.QueryRow(ctx,
+			"SELECT absolute_expires_at FROM refresh_tokens WHERE token_hash = $1",
+			newHash[:]).Scan(&got); err != nil {
+			t.Fatalf("scan new row: %v", err)
+		}
+		if !got.UTC().Truncate(time.Second).Equal(deadline) {
+			t.Errorf("rotated absolute_expires_at = %v, want %v", got, deadline)
 		}
 	})
 }

--- a/internal/identity/sessions.go
+++ b/internal/identity/sessions.go
@@ -130,6 +130,12 @@ func IssueSessionWithAbsolute(ctx context.Context, pool *pgxpool.Pool, userID uu
 	}
 	now := time.Now().UTC()
 	win := CurrentWindows()
+	// Defensive: a zero deadline would otherwise cap the idle expiry to the zero
+	// time and mint an always-expired session. Treat it as "no carried deadline"
+	// and grant a fresh absolute window (the IssueSession default).
+	if absoluteExpiresAt.IsZero() {
+		absoluteExpiresAt = now.Add(win.Absolute)
+	}
 	expires := now.Add(win.Idle)
 	if expires.After(absoluteExpiresAt) {
 		expires = absoluteExpiresAt

--- a/internal/identity/sessions.go
+++ b/internal/identity/sessions.go
@@ -107,6 +107,16 @@ type Session struct {
 //
 // Spec AC-06, C-05, C-06.
 func IssueSession(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, remoteAddr, userAgent string) (token string, sess Session, err error) {
+	return IssueSessionWithAbsolute(ctx, pool, userID, remoteAddr, userAgent,
+		time.Now().UTC().Add(CurrentWindows().Absolute))
+}
+
+// IssueSessionWithAbsolute is IssueSession with an explicit absolute deadline,
+// used by the cookie-refresh path to carry the ORIGINAL login's absolute
+// ceiling onto a re-minted session instead of granting a fresh window (AUTH-1
+// b). The idle expiry is capped at the absolute deadline, so a session minted
+// close to its ceiling expires at the ceiling, not idle+window beyond it.
+func IssueSessionWithAbsolute(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, remoteAddr, userAgent string, absoluteExpiresAt time.Time) (token string, sess Session, err error) {
 	raw := make([]byte, SessionTokenBytes)
 	if _, err := rand.Read(raw); err != nil {
 		return "", Session{}, fmt.Errorf("identity: read session entropy: %w", err)
@@ -120,13 +130,17 @@ func IssueSession(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, rem
 	}
 	now := time.Now().UTC()
 	win := CurrentWindows()
+	expires := now.Add(win.Idle)
+	if expires.After(absoluteExpiresAt) {
+		expires = absoluteExpiresAt
+	}
 	sess = Session{
 		ID:                id,
 		UserID:            userID,
 		CreatedAt:         now,
 		LastSeen:          now,
-		ExpiresAt:         now.Add(win.Idle),
-		AbsoluteExpiresAt: now.Add(win.Absolute),
+		ExpiresAt:         expires,
+		AbsoluteExpiresAt: absoluteExpiresAt,
 		RemoteAddr:        remoteAddr,
 		UserAgent:         userAgent,
 	}
@@ -145,11 +159,29 @@ func IssueSession(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, rem
 	return token, sess, nil
 }
 
+// VerifyOption tunes VerifySession. AUTH-1 (c).
+type VerifyOption func(*verifyOpts)
+
+type verifyOpts struct{ noSlide bool }
+
+// WithoutSlide validates the session and enforces the idle + absolute
+// deadlines, but does NOT advance expires_at/last_seen. The identity binder
+// passes this for requests that are NOT user-initiated (background polling,
+// SSE), so the server-side idle window tracks REAL user activity rather than
+// HTTP traffic — otherwise the SPA's polling keeps every session alive forever.
+// AUTH-1 (c).
+func WithoutSlide() VerifyOption { return func(o *verifyOpts) { o.noSlide = true } }
+
 // VerifySession looks up the session row by token, applies inactivity +
-// absolute timeout rules, and touches last_seen + extends expires_at.
+// absolute timeout rules, and (unless WithoutSlide is passed) touches
+// last_seen + extends expires_at.
 //
 // Spec AC-07, AC-08, AC-10.
-func VerifySession(ctx context.Context, pool *pgxpool.Pool, token string) (Session, error) {
+func VerifySession(ctx context.Context, pool *pgxpool.Pool, token string, opts ...VerifyOption) (Session, error) {
+	var o verifyOpts
+	for _, f := range opts {
+		f(&o)
+	}
 	if token == "" {
 		return Session{}, ErrSessionNotFound
 	}
@@ -181,6 +213,21 @@ func VerifySession(ctx context.Context, pool *pgxpool.Pool, token string) (Sessi
 	}
 	if now.After(s.ExpiresAt) {
 		return Session{}, ErrSessionExpired
+	}
+
+	// AUTH-1 (c): a non-user-initiated request (background poll, SSE) validates
+	// the session but must NOT advance the idle window — otherwise the SPA's
+	// polling keeps an unattended session alive indefinitely. Return the
+	// validated session as-is without touching last_seen/expires_at.
+	if o.noSlide {
+		s.RevokedAt = revokedAt
+		if remoteAddr != nil {
+			s.RemoteAddr = *remoteAddr
+		}
+		if userAgent != nil {
+			s.UserAgent = *userAgent
+		}
+		return s, nil
 	}
 
 	// Touch last_seen and extend expires_at by the inactivity window —

--- a/internal/identity/sessions_test.go
+++ b/internal/identity/sessions_test.go
@@ -213,6 +213,63 @@ func TestSession_AbsoluteTimeout(t *testing.T) {
 	})
 }
 
+// @ac AC-30
+// AC-30 (AUTH-1 c): VerifySession with WithoutSlide validates the session but
+// does NOT advance expires_at/last_seen, while a normal VerifySession on the
+// same session still extends it.
+func TestSession_VerifyNoSlide(t *testing.T) {
+	t.Run("system-auth-identity/AC-30", func(t *testing.T) {
+		pool := freshPool(t)
+		userID := seedUser(t, pool, "ac30-user")
+		token, sess, err := IssueSession(context.Background(), pool, userID, "", "")
+		if err != nil {
+			t.Fatalf("IssueSession: %v", err)
+		}
+		// Roll expires_at + last_seen back 10 min so a slide would be observable.
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE sessions SET expires_at = expires_at - interval '10 minutes',
+			                     last_seen  = last_seen  - interval '10 minutes' WHERE id = $1`,
+			sess.ID); err != nil {
+			t.Fatalf("adjust: %v", err)
+		}
+		var before time.Time
+		if err := pool.QueryRow(context.Background(),
+			`SELECT expires_at FROM sessions WHERE id = $1`, sess.ID).Scan(&before); err != nil {
+			t.Fatalf("read before: %v", err)
+		}
+
+		// WithoutSlide: validates but must NOT extend.
+		got, err := VerifySession(context.Background(), pool, token, WithoutSlide())
+		if err != nil {
+			t.Fatalf("VerifySession(WithoutSlide): %v", err)
+		}
+		if got.ID != sess.ID {
+			t.Errorf("session ID mismatch")
+		}
+		var after time.Time
+		if err := pool.QueryRow(context.Background(),
+			`SELECT expires_at FROM sessions WHERE id = $1`, sess.ID).Scan(&after); err != nil {
+			t.Fatalf("read after: %v", err)
+		}
+		if !after.Equal(before) {
+			t.Errorf("WithoutSlide advanced expires_at: before=%v after=%v", before, after)
+		}
+
+		// Contrast: a normal verify on the same session DOES extend it.
+		if _, err := VerifySession(context.Background(), pool, token); err != nil {
+			t.Fatalf("VerifySession (slide): %v", err)
+		}
+		var extended time.Time
+		if err := pool.QueryRow(context.Background(),
+			`SELECT expires_at FROM sessions WHERE id = $1`, sess.ID).Scan(&extended); err != nil {
+			t.Fatalf("read extended: %v", err)
+		}
+		if !extended.After(before) {
+			t.Errorf("normal VerifySession did not extend: before=%v after=%v", before, extended)
+		}
+	})
+}
+
 // VerifySession with a never-issued token returns ErrSessionNotFound.
 // Not an AC; defensive sanity check.
 func TestSession_VerifyUnknownToken(t *testing.T) {

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -99,7 +99,7 @@ func (h *handlers) PostAuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Mint session + refresh + access tokens. All three share this users row.
-	sessionToken, _, err := identity.IssueSession(r.Context(), h.pool, u.ID, r.RemoteAddr, r.UserAgent())
+	sessionToken, sess, err := identity.IssueSession(r.Context(), h.pool, u.ID, r.RemoteAddr, r.UserAgent())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"session issue failed", true)
@@ -112,7 +112,9 @@ func (h *handlers) PostAuthLogin(w http.ResponseWriter, r *http.Request) {
 			"jwt issue failed", true)
 		return
 	}
-	refresh, err := identity.IssueRefreshToken(r.Context(), h.pool, u.ID)
+	// AUTH-1 (b): anchor the refresh lineage to the session's absolute deadline
+	// so refreshing cannot extend the session past its absolute timeout.
+	refresh, err := identity.IssueRefreshToken(r.Context(), h.pool, u.ID, sess.AbsoluteExpiresAt)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"refresh issue failed", true)
@@ -231,7 +233,8 @@ func (h *handlers) PostAuthRefresh(w http.ResponseWriter, r *http.Request) {
 				"refresh token reuse detected; all sessions revoked", false)
 		case errors.Is(err, identity.ErrRefreshTokenExpired),
 			errors.Is(err, identity.ErrRefreshTokenRevoked),
-			errors.Is(err, identity.ErrRefreshTokenNotFound):
+			errors.Is(err, identity.ErrRefreshTokenNotFound),
+			errors.Is(err, identity.ErrRefreshSessionExpired):
 			writeError(w, http.StatusUnauthorized, "auth.refresh_invalid", "client",
 				"refresh token invalid or expired", false)
 		default:
@@ -288,6 +291,13 @@ func (h *handlers) PostAuthRefreshCookie(w http.ResponseWriter, r *http.Request)
 			clearAuthCookies(w)
 			writeError(w, http.StatusUnauthorized, "auth.refresh_invalid", "client",
 				"refresh token invalid or expired", false)
+		case errors.Is(err, identity.ErrRefreshSessionExpired):
+			// AUTH-1 (b): the session's absolute timeout has passed. Refusing to
+			// refresh is the whole point — clear cookies and make the browser
+			// re-authenticate rather than silently extend past the ceiling.
+			clearAuthCookies(w)
+			writeError(w, http.StatusUnauthorized, "auth.session_expired", "client",
+				"session absolute timeout reached; please sign in again", false)
 		default:
 			writeError(w, http.StatusInternalServerError, "server.error", "server",
 				"refresh failed", true)
@@ -298,10 +308,16 @@ func (h *handlers) PostAuthRefreshCookie(w http.ResponseWriter, r *http.Request)
 	userID, _ := uuid.Parse(pair.Claims.Subject)
 	role, _ := h.users.PrimaryRoleFor(r.Context(), userID)
 
-	// Mint a fresh session so the user gets a new 15-min inactivity
-	// window. The old session (whose cookie may be expired) is left to
-	// the inactivity-sweep — issuing a new one is enough.
-	sessionToken, _, err := identity.IssueSession(r.Context(), h.pool, userID, r.RemoteAddr, r.UserAgent())
+	// Mint a new session, but carry the ORIGINAL absolute deadline so the
+	// refresh cannot reset the absolute ceiling (AUTH-1 b). Legacy refresh
+	// tokens (minted before migration 0047, no carried deadline) fall back to a
+	// fresh window until they age out within 7 days.
+	var sessionToken string
+	if pair.AbsoluteExpiresAt.IsZero() {
+		sessionToken, _, err = identity.IssueSession(r.Context(), h.pool, userID, r.RemoteAddr, r.UserAgent())
+	} else {
+		sessionToken, _, err = identity.IssueSessionWithAbsolute(r.Context(), h.pool, userID, r.RemoteAddr, r.UserAgent(), pair.AbsoluteExpiresAt)
+	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"session issue failed", true)

--- a/internal/server/sso_handlers.go
+++ b/internal/server/sso_handlers.go
@@ -246,12 +246,13 @@ func (h *handlers) GetAuthSSOCallback(w http.ResponseWriter, r *http.Request, id
 
 	// Mint the session + refresh cookies (the session cookie is the
 	// credential; no JSON body on a redirect). Mirrors PostAuthLogin.
-	sessionToken, _, err := identity.IssueSession(r.Context(), h.pool, result.UserID, r.RemoteAddr, r.UserAgent())
+	sessionToken, ssoSess, err := identity.IssueSession(r.Context(), h.pool, result.UserID, r.RemoteAddr, r.UserAgent())
 	if err != nil {
 		http.Redirect(w, r, "/login?sso_error=session", http.StatusFound)
 		return
 	}
-	refresh, err := identity.IssueRefreshToken(r.Context(), h.pool, result.UserID)
+	// AUTH-1 (b): anchor the refresh lineage to the session absolute deadline.
+	refresh, err := identity.IssueRefreshToken(r.Context(), h.pool, result.UserID, ssoSess.AbsoluteExpiresAt)
 	if err != nil {
 		http.Redirect(w, r, "/login?sso_error=session", http.StatusFound)
 		return

--- a/specs/system/auth-identity.spec.yaml
+++ b/specs/system/auth-identity.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-auth-identity
   title: Auth identity primitives (password, session, JWT, MFA)
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 1
 
@@ -115,6 +115,31 @@ spec:
         common compromised passwords (identity.DefaultBreachCorpus), so an
         air-gapped install rejects breached passwords with no external file;
         an operator may extend coverage with a full HIBP dump.
+      type: security
+      enforcement: error
+    - id: C-28
+      description: >-
+        v1.4.0 (AUTH-1 b) — the session ABSOLUTE timeout MUST be a hard ceiling
+        that the cookie-refresh path cannot reset. The original login's absolute
+        deadline (login time + absolute window) is stamped on the refresh token
+        at issue and carried UNCHANGED through every rotation. ConsumeRefreshToken
+        MUST refuse (ErrRefreshSessionExpired) once now is past that deadline,
+        even though the 7-day refresh window is still open; PostAuthRefreshCookie
+        maps it to 401 + clears both cookies. A session re-minted by refresh MUST
+        inherit the original deadline (IssueSessionWithAbsolute), never a fresh
+        one. Refresh tokens issued before the migration carry no deadline and are
+        exempt until they age out within 7 days.
+      type: security
+      enforcement: error
+    - id: C-29
+      description: >-
+        v1.4.0 (AUTH-1 c) — the server idle window MUST track real user activity,
+        not background HTTP traffic. VerifySession with WithoutSlide validates the
+        session and enforces both deadlines but MUST NOT advance expires_at /
+        last_seen. The identity binder passes WithoutSlide when the request
+        carries the X-Background-Refresh marker (set by the SPA on background
+        polls / SSE). Fail-safe: an UNMARKED request slides as before, so a client
+        that does not send the header is unaffected (no premature logout).
       type: security
       enforcement: error
 
@@ -240,3 +265,44 @@ spec:
       description: identity.DefaultBreachCorpus() loads a non-empty embedded baseline; ValidatePassword with it rejects common compromised passwords that pass the length floor (e.g. "password123", "qwerty123", "Password1") with ErrPasswordBreached, and accepts a strong unique password. Production users.NewService is wired with this corpus, not nil.
       priority: critical
       references_constraints: [C-15]
+    - id: AC-28
+      description: >-
+        AUTH-1 (b) — ConsumeRefreshToken on a token whose carried
+        absolute_expires_at is in the PAST returns ErrRefreshSessionExpired (the
+        7-day token window may still be open), and does NOT rotate/issue a new
+        pair. A token whose absolute deadline is in the future rotates normally.
+      priority: critical
+      references_constraints: [C-28]
+    - id: AC-29
+      description: >-
+        AUTH-1 (b) — a successful ConsumeRefreshToken carries the ORIGINAL
+        absolute deadline onto the rotated row unchanged (the new refresh row's
+        absolute_expires_at equals the consumed row's), and returns it on the
+        TokenPair so the cookie-refresh handler can stamp it onto the re-minted
+        session via IssueSessionWithAbsolute (the new session's
+        absolute_expires_at equals the original, not now + window).
+      priority: critical
+      references_constraints: [C-28]
+    - id: AC-30
+      description: >-
+        AUTH-1 (c) — VerifySession with WithoutSlide returns the validated
+        session but does NOT advance expires_at or last_seen (a row read after
+        the call shows the pre-call expires_at), while a normal VerifySession on
+        the same session still extends it. Expiry enforcement is unchanged under
+        WithoutSlide (an idle- or absolute-expired session still returns
+        ErrSessionExpired).
+      priority: critical
+      references_constraints: [C-29]
+    - id: AC-31
+      description: >-
+        AUTH-1 (c), both ends. Server: the identity Binder passes WithoutSlide
+        when the request carries X-Background-Refresh — a marked request does NOT
+        advance the session expires_at, an unmarked request does (binder
+        behavioral test). Client: the SPA API client sets the X-Background-Refresh
+        header on safe/background reads when there has been no new user activity
+        since the last reported request, gated on the idle-timer activity signal
+        (the 'ow.session.lastActivity' localStorage key) so it stays inert — and
+        the server keeps sliding as before — until that signal exists
+        (source-inspection of frontend/src/api/client.ts).
+      priority: high
+      references_constraints: [C-29]

--- a/specs/system/auth-identity.spec.yaml
+++ b/specs/system/auth-identity.spec.yaml
@@ -138,8 +138,12 @@ spec:
         session and enforces both deadlines but MUST NOT advance expires_at /
         last_seen. The identity binder passes WithoutSlide when the request
         carries the X-Background-Refresh marker (set by the SPA on background
-        polls / SSE). Fail-safe: an UNMARKED request slides as before, so a client
-        that does not send the header is unaffected (no premature logout).
+        polls) OR targets the SSE events stream (/api/v1/events) — a long-lived
+        subscription that reconnects through proxies and cannot send a custom
+        header (EventSource), so without this exemption an open SPA would keep an
+        unattended session alive forever. Fail-safe: an UNMARKED non-SSE request
+        slides as before, so a client that does not send the header is unaffected
+        (no premature logout).
       type: security
       enforcement: error
 


### PR DESCRIPTION
Completes **AUTH-1** (slice 1, the client idle timer, is #675).

## (b) Absolute timeout is now a real ceiling
The cookie-refresh path re-minted a session with a **fresh** absolute window on the 7-day refresh token, so the absolute timeout (default 12h) never bit — a browser could live the full 7 days.

Fix: carry the **original login's absolute deadline** through the refresh-token lineage.
- Migration **0047** adds `refresh_tokens.absolute_expires_at`; stamped at login (`IssueRefreshToken`), copied **unchanged** on every rotation.
- `ConsumeRefreshToken` refuses once past it (`ErrRefreshSessionExpired`); `PostAuthRefreshCookie` → 401 + clears cookies.
- A refreshed session **inherits** the original deadline (`IssueSessionWithAbsolute`), never a fresh one (idle expiry capped at the ceiling).
- Legacy tokens (pre-migration, NULL deadline) are exempt until they age out within 7 days — no forced logout on upgrade.

## (c) Server idle window tracks real user activity, not HTTP traffic
Background polling (15–60s) + SSE used to slide `expires_at` on every request, so the server-side idle window never elapsed.

Fix: `VerifySession` gains `WithoutSlide`; the binder passes it when a request carries **`X-Background-Refresh`**. The SPA API client marks background/poll GETs with that header, **gated on the idle-timer activity signal** (slice 1's `ow.session.lastActivity` key).
- **Fail-safe:** an unmarked request slides exactly as before, so the change is **inert until the activity signal exists** (i.e. until #675 ships) — no premature logout, no regression.

## Tests / SDD
- Spec `system-auth-identity` **v1.4.0**: **C-28/C-29** + **AC-28..AC-31**.
- New Go tests: refresh absolute ceiling + carry-forward (AC-28/29), `VerifySession` no-slide (AC-30), binder slides only on user activity (AC-31). Frontend client source-inspection (AC-31).
- Identity + server-auth suites green; full frontend suite **338 green**; tsc + eslint + gofmt clean; `specter` 113 specs, `system-auth-identity` **31/31 100%**.

## Sequencing note
Backend (b) is fully active on merge. (c)'s server side is safe immediately (defaults to slide); (c)'s client marking only takes effect once **#675** (which writes the activity key) lands — until then it's inert by design.