### PR TITLE
chore(release): cut v0.2.0-rc.15 (Eyrie)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0-rc.15] Eyrie — 2026-06-25
+
+A security + reliability candidate on top of rc.14: a production-breaking
+remediation fix, full session-timeout enforcement, the durable change-driven
+notification bell, and a dashboard/hosts compliance-parity fix.
+
 ### Added
 - In-app notification feed (the bell): a durable, per-user feed of meaningful
   changes fanned in from the alert engine (host unreachable/recovered,

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.14"
+VERSION="0.2.0-rc.15"
 CODENAME="Eyrie"


### PR DESCRIPTION
Release-prep for **v0.2.0-rc.15** (Eyrie). Bumps `version.env` and cuts the CHANGELOG `[Unreleased]` into a dated `[0.2.0-rc.15]` section.

### Covered since rc.14
| PR | Area |
|----|------|
| #673 | **PKG-3** — remediation 'not wired' on hardened installs (production-breaking) |
| #675 / #678 | **AUTH-1** — client idle timer; absolute-timeout hard ceiling; server slides only on user activity (incl. SSE exemption) |
| #679 | **Notifications Slice 1** — durable change-driven bell |
| #676 | **Avg-compliance parity** /hosts ↔ /dashboard |

### Validation (local)
- `go test ./packaging/tests/` — changelog, version-consistency, FIPS, package-build all green.

After this merges and main is green, the `v0.2.0-rc.15` tag triggers `release.yml` (signed RPM/DEB amd64+arm64, SBOMs, GitHub pre-release). **rc.15 is the release that carries the production-breaking PKG-3 fix.**