### PR TITLE
docs(guides): DOC-3 truthfulness pass — endpoints, RBAC matrix, corpus version

### DIFF
--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Database migration guide
 
-**Last Updated:** 2026-06-22 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
 
 This guide covers how OpenWatch's PostgreSQL schema is versioned, how migrations
 are applied in production, and how to add a new migration. OpenWatch is a single
@@ -51,8 +51,7 @@ development; OpenWatch does not expose a rollback subcommand (see
 ## Applying migrations in production
 
 Run the `migrate` subcommand. It connects with the configured database DSN,
-applies every pending `Up` migration, and prints the resulting version and the
-list of embedded migration files.
+applies every pending `Up` migration, and prints the resulting schema version.
 
 ```bash
 sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
@@ -61,18 +60,15 @@ sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
 
 The DSN comes from `OPENWATCH_DATABASE_DSN` in `/etc/openwatch/secrets.env` (or
 `[database].dsn` in `/etc/openwatch/openwatch.toml`). The command times out after
-60 seconds, applies migrations idempotently (goose skips versions already recorded
-in `goose_db_version`), and reports output like:
+10 minutes, applies migrations idempotently (goose skips versions already recorded
+in `goose_db_version`), and prints the version transition:
 
 ```
-applying migrations against postgres://openwatch:***@127.0.0.1:5432/openwatch ...
-  current version: 46
-  migration files: 46
-    - 0001_initial.sql
-    - 0002_audit_events_taxonomy.sql
-    ...
-migrations applied
+migrations applied — version 47 -> 48
 ```
+
+When the schema is already current it reports that no migrations were pending
+(the version is unchanged). A failure aborts before changing the version.
 
 Run `openwatch migrate` after every package upgrade and before starting (or
 restarting) the service, so the schema matches the binary. The systemd unit

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -1,6 +1,6 @@
 # Host Management and Remediation
 
-**Last Updated:** 2026-06-22 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
 
 This guide covers adding and managing hosts, organizing them into groups,
 understanding server intelligence data, and using automated remediation to fix
@@ -148,9 +148,11 @@ hosts that have not been identified yet.
 
 ### Connectivity Monitoring
 
-Host connectivity is checked every 30 seconds automatically. Each check
-verifies ICMP reachability, SSH port availability, and SSH authentication.
-Host status (online, offline, degraded) updates in the host list.
+Host connectivity is probed every 5 minutes by default (operator-tunable, with
+a 60-second floor). Each probe layers ICMP reachability, then SSH port + banner
+reachability, then a privilege check; a host is marked degraded when a higher
+layer fails after a lower one succeeds. Host status (online, degraded,
+unreachable) updates in the host list.
 
 ---
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,6 +1,6 @@
 # OpenWatch install guide (native packages)
 
-**Last Updated:** 2026-06-22 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
 
 This guide takes an administrator from a fresh Linux host to a running,
 logged-in OpenWatch: install the package, point it at PostgreSQL, create the
@@ -108,7 +108,7 @@ Install **both** files in one transaction. `openwatch` declares a hard
 dependency on `kensa-rules` — the rule corpus the scan engine loads from
 `/usr/share/kensa/rules`. Installing `openwatch` alone fails the dependency
 check (by design: a corpus-less node cannot scan). `kensa-rules` is `noarch`
-and versioned on the Kensa content line (e.g. `0.5.0`), independent of the
+and versioned on the Kensa content line (e.g. `0.6.0`), independent of the
 platform version, so the rules can update without re-releasing OpenWatch.
 
 Use the filenames you downloaded (`aarch64` for the arm64 openwatch RPM; the
@@ -180,7 +180,10 @@ sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
 ```
 
 `create-admin` reads the password from stdin when `--password` is omitted, which
-keeps it out of your shell history. For automation, pipe it instead:
+keeps it out of your shell history. Note that the interactive prompt does not
+mask input: the characters you type are echoed to the terminal. Run it where the
+screen is not observed or recorded, or pipe the password in. For automation,
+pipe it instead:
 
 ```bash
 printf '%s' "$ADMIN_PASSWORD" | sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -7,7 +7,9 @@
 > (1) running the OpenWatch server and (2) being added as a managed/scanned
 > host.
 
-**Last verified:** 2026-06-16 against Kensa rule corpus **v0.4.3** (539 rules).
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
+
+**Last verified:** 2026-06-25 against Kensa rule corpus **v0.6.0** (538 rules).
 
 ---
 
@@ -99,9 +101,9 @@ crash:
    cycle).
 3. **The compliance scan skips everything.** Kensa SSHes to the host, reads
    `/etc/os-release`, and filters its corpus to rules whose `platforms` match
-   the detected distro. **Every rule in v0.4.3 declares `platforms: family:
+   the detected distro. **Every rule in v0.6.0 declares `platforms: family:
    rhel`** (version-pinned to `rhel8`/`rhel9`/`rhel10`). A Fedora or Ubuntu
-   host matches none, so **all ~539 rules are skipped**.
+   host matches none, so **all 538 rules are skipped**.
 
 Skipping is the correct outcome: applying RHEL 9 STIG/CIS checks to Fedora 40 or
 Ubuntu 24.04 would evaluate the wrong files, services, and defaults and report
@@ -163,5 +165,5 @@ compliance score.
 - Collector (OS-agnostic, `rpm || dpkg`): `internal/intelligence/collector/collector.go`
 - Kensa invocation / rule load: `internal/kensa/scanfunc.go`, `internal/kensa/catalog.go`
 - Framework-lens OS filter (`osFamilyTokens`): `internal/server/host_compliance_lens_handler.go`
-- Rule corpus applicability (verified): Kensa v0.4.3 — **539/539 rules `platforms: family: rhel`**, pinned `rhel8`/`rhel9`/`rhel10`
+- Rule corpus applicability (verified): Kensa v0.6.0 — **538/538 rules `platforms: family: rhel`**, pinned `rhel8`/`rhel9`/`rhel10`
 - Framework mappings: `CLAUDE.md` (CIS RHEL 9 v2.0.0, STIG RHEL 9 V2R7)

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Scanning and Compliance
 
-**Last Updated:** 2026-06-22 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
 
 This guide covers how OpenWatch performs compliance scanning, how to read
 results and posture scores, and how to use drift detection, alerts, and
@@ -416,49 +416,48 @@ curl -k -X POST https://localhost:8443/api/v1/hosts/HOST_UUID/scans \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### Query Posture
+### Query compliance (current lens)
+
+Per-host compliance is read from the host's lens, not a `/compliance/posture`
+endpoint. Add `?framework=cis-rhel9-v2.0.0` to project a specific framework.
 
 ```bash
-curl -k "https://localhost:8443/api/v1/compliance/posture?host_id=HOST_UUID" \
+curl -k "https://localhost:8443/api/v1/hosts/HOST_UUID/compliance" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### Query Historical Posture
+### Query compliance trend
+
+Point-in-time posture history is served as a trend over the last N days (daily
+posture snapshots), not an `as_of` query.
 
 ```bash
-curl -k "https://localhost:8443/api/v1/compliance/posture?host_id=HOST_UUID&as_of=2026-02-15" \
+curl -k "https://localhost:8443/api/v1/hosts/HOST_UUID/compliance/trend?days=30" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### Query Drift
+### List alerts
 
 ```bash
-curl -k "https://localhost:8443/api/v1/compliance/posture/drift?host_id=HOST_UUID&start_date=2026-02-01&end_date=2026-02-28" \
+curl -k "https://localhost:8443/api/v1/alerts?state=active" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### List Alerts
+### Acknowledge an alert
 
 ```bash
-curl -k "https://localhost:8443/api/v1/compliance/alerts?status=active" \
+curl -k -X POST "https://localhost:8443/api/v1/alerts/ALERT_ID:acknowledge" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-### Acknowledge an Alert
+### Export audit events
+
+The audit export is a `GET` with query filters (defaults to CSV); add filters
+like `action`, `actor_type`, `resource_type`.
 
 ```bash
-curl -k -X POST "https://localhost:8443/api/v1/compliance/alerts/ALERT_ID/acknowledge" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" -d '{}'
-```
-
-### Create an Export
-
-```bash
-curl -k -X POST https://localhost:8443/api/v1/compliance/audit/exports \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"query_definition": {"severities": ["critical"], "statuses": ["fail"]}, "format": "csv"}'
+curl -k "https://localhost:8443/api/v1/audit/events/export?format=csv" \
+  -H "Authorization: Bearer $TOKEN" -o audit.csv
 ```
 
 See the [API Guide](API_GUIDE.md) for the complete endpoint reference.

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -1,6 +1,6 @@
 # OpenWatch security hardening guide
 
-**Applies to:** OpenWatch 0.2.0 pre-release (rc series; Go single-binary build)
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0 pre-release (rc series; Go single-binary build)
 **Audience:** System administrators, security engineers, compliance officers
 
 This guide covers the security controls you operate when you deploy OpenWatch

--- a/docs/guides/USER_ROLES.md
+++ b/docs/guides/USER_ROLES.md
@@ -1,6 +1,6 @@
 # User roles and permissions
 
-**Last Updated:** 2026-06-22 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
+**Last Updated:** 2026-06-25 · **Applies to:** OpenWatch 0.2.0-rc series (Go single-binary)
 
 This guide describes the role-based access control (RBAC) system in the Go-era
 OpenWatch. It covers the five built-in roles, the permissions they grant, and how
@@ -68,20 +68,24 @@ The day-to-day operator. Adds write and execute authority over the operational
 surface: `host:write`, `host:connectivity_check`, `host:intelligence_refresh`,
 `credential:read`, `scan:execute`, `scan:cancel`, `scan_template:write`,
 `baseline:write`, alert `acknowledge`/`resolve`, `notification:test`,
-`remediation:request`, and the exception request/comment verbs.
+`remediation:request`, the free-core `remediation:execute`/`remediation:rollback`
+host-mutating verbs, and the exception request/comment verbs.
 
 Cannot delete hosts, manage credentials beyond reading them, approve
-remediations, install licenses or policies, or manage users.
+remediations (separation of duties: a different `security_admin`/`admin`
+approves), install licenses or policies, or manage users.
 
 ### `security_admin`
 
 Full security operations. Grants category wildcards (`host:*`, `credential:*`,
 `scan:*`, `scan_template:*`, `baseline:*`, `exception:*`, `alert:*`,
-`notification:*`, `remediation:*`, `integration:*`, `audit:*`) plus
-`user:read`, `user:write`, `license:install`, and the policy
-`reload`/`install` verbs. This includes the dangerous and license-gated actions
-`remediation:execute` and `remediation:rollback` (both gated by the
-`remediation_execution` feature).
+`notification:*`, `remediation:*`, `integration:*`, `audit:*`, `token:*`) plus
+`user:read`, `user:write`, `license:install`, the
+`system:auth_policy_read`/`auth_policy_write` verbs, and the policy
+`reload`/`install` verbs. This includes the dangerous host-mutating actions
+`remediation:execute` and `remediation:rollback` (free-core, not license-gated)
+and the license-gated `audit:export` (via `audit:*`, requires the `audit_export`
+feature at runtime).
 
 Cannot perform the high-privilege `admin:*` bundle: managing other users' roles,
 SSO providers, retention policy, system settings, or `user:delete`.
@@ -98,7 +102,7 @@ the `admin:*` bundle (`user_manage`, `role_manage`, `retention_policy`,
 
 Permissions are named `resource:action`, both lowercase
 (for example `host:read`, `scan:execute`, `remediation:rollback`). The registry
-defines 19 categories. Two attributes affect enforcement:
+defines 67 permissions across 20 categories. Two attributes affect enforcement:
 
 - `dangerous: true` marks destructive or high-impact actions (for example
   `host:delete`, `license:install`, `user:delete`). The UI uses this for
@@ -106,8 +110,9 @@ defines 19 categories. Two attributes affect enforcement:
 - `license_gated: <feature>` makes a permission inert unless the active license
   enables that feature. A role may grant the permission, but the combined
   RBAC-plus-license middleware denies the call with `402` until the license
-  enables it. Today this applies to `audit:export` (`audit_export`) and
-  `remediation:execute` / `remediation:rollback` (`remediation_execution`).
+  enables it. Today this applies to exactly one permission: `audit:export`
+  (`audit_export`). Remediation (`remediation:execute` / `remediation:rollback`)
+  is free-core and not license-gated; it is marked `dangerous` instead.
 
 Enforcement happens in middleware generated from the OpenAPI `x-required-permission`
 extension, so handlers never check RBAC inline. A request with a missing or
@@ -160,14 +165,17 @@ they are granted by the role but require the matching license feature at runtime
 | `license:read` | Y | Y | Y | Y | Y |
 | `license:install` | - | - | - | Y | Y |
 | `license:revoke` | - | - | - | - | Y |
+| `token:read` | - | - | - | Y | Y |
+| `token:write` | - | - | - | Y | Y |
+| `token:delete` | - | - | - | Y | Y |
 | `policy:read` | Y | Y | Y | Y | Y |
 | `policy:reload` | - | - | - | Y | Y |
 | `policy:install` | - | - | - | Y | Y |
 | `remediation:read` | Y | Y | Y | Y | Y |
 | `remediation:request` | - | - | Y | Y | Y |
 | `remediation:approve` | - | - | - | Y | Y |
-| `remediation:execute` (LG) | - | - | - | Y | Y |
-| `remediation:rollback` (LG) | - | - | - | Y | Y |
+| `remediation:execute` | - | - | Y | Y | Y |
+| `remediation:rollback` | - | - | Y | Y | Y |
 | `integration:read` | Y | Y | Y | Y | Y |
 | `integration:write` | - | - | - | Y | Y |
 | `integration:execute` | - | - | - | Y | Y |
@@ -175,6 +183,8 @@ they are granted by the role but require the matching license feature at runtime
 | `audit:export` (LG) | - | Y | - | Y | Y |
 | `system:read` | Y | Y | Y | Y | Y |
 | `system:config_write` | - | - | - | - | Y |
+| `system:auth_policy_read` | - | - | - | Y | Y |
+| `system:auth_policy_write` | - | - | - | Y | Y |
 | `role:read` | Y | - | - | - | Y |
 | `role:write` | - | - | - | - | Y |
 | `role:assign` | - | - | - | - | Y |


### PR DESCRIPTION
## Summary

Completes the **DOC-3** operator-guide truthfulness audit. Every change below was verified against the current Go source / generated artifacts (`internal/server/openapi_embed.yaml`, `internal/auth/{permissions,roles}.gen.go`, `cmd/openwatch/main.go`, `internal/liveness/types.go`, and the bundled Kensa v0.6.0 rule corpus), not assumed.

## Corrections

- **SCANNING_AND_COMPLIANCE** — replaced 5 dead `/api/v1/compliance/{posture,drift,alerts,audit/exports}` curl examples with the real endpoints: host compliance lens (`/hosts/{id}/compliance?framework=`), `/hosts/{id}/compliance/trend?days=`, `/alerts?state=`, `/alerts/{id}:acknowledge`, `/audit/events/export?format=`. All paths and query params confirmed present in the OpenAPI source.
- **USER_ROLES** — RBAC matrix was missing `token:read/write/delete` and `system:auth_policy_read/write` (now **67 rows = full registry**). `remediation:execute`/`rollback` are **free-core** (`dangerous: true`, not license-gated) and **held by `ops_lead`** — fixed the matrix cells, the security_admin/ops_lead prose, and the license-gating note (the **only** license-gated permission is `audit:export`). `19 → 20` categories.
- **DATABASE_MIGRATIONS** — real `migrations applied — version N -> N` output and the **10-minute** apply timeout (was a fabricated output block + "60 seconds").
- **HOSTS_AND_REMEDIATION** — connectivity is probed **every 5 minutes** (`DefaultProbeInterval`, 60s floor), layering ICMP → SSH banner → privilege; was "every 30 seconds" + "SSH authentication".
- **INSTALLATION** — `kensa-rules` example `0.5.0 → 0.6.0` (the version rc.15 ships); added a caveat that the `create-admin` prompt **echoes** the typed password (`fmt.Fscanln`, no masking). The `postgresql-server` package dependency claim was **verified correct** and kept.
- **LINUX_DISTRIBUTION_SUPPORT** — re-verified against **Kensa v0.6.0**: **538/538** rules declare `platforms.family: rhel` (was `v0.4.3` / 539).
- Added `Last Updated` headers to **SECURITY_HARDENING** and **LINUX_DISTRIBUTION_SUPPORT**; bumped edited guides to 2026-06-25.

## Notes
- Docs-only; no code or generated-artifact changes.
- The pervasive spaced em-dash style across all guides is pre-existing and out of scope for this pass (my new prose uses periods/semicolons); a blanket reformat can be a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)