### PR TITLE
feat(notifications): Slice 2 — transaction-log rule-regression projector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- In-app notifications now surface compliance regressions: when a scan flips a
+  passing rule to failing, the bell shows one grouped per-host notification
+  ("web-01: 3 rules regressed (1 critical)"), severity-ranked and deep-linked to
+  the host. A host's first scan (all-new baseline) does not flood the bell, and
+  repeat regressions collapse onto a single re-surfacing entry. (notifications
+  Slice 2)
+
 ---
 
 ## [0.2.0-rc.15] Eyrie — 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- In-app notifications now surface compliance regressions: when a scan flips a
-  passing rule to failing, the bell shows one grouped per-host notification
-  ("web-01: 3 rules regressed (1 critical)"), severity-ranked and deep-linked to
-  the host. A host's first scan (all-new baseline) does not flood the bell, and
-  repeat regressions collapse onto a single re-surfacing entry. (notifications
-  Slice 2)
+- In-app notifications now flag when a scan turns a passing rule into a failing
+  one: the bell shows one grouped per-host notification ("web-01: 3 rules
+  regressed (1 critical)"), severity-ranked and deep-linked to the host. A
+  host's first scan (all-new baseline) does not flood the bell, and repeat
+  failures collapse onto a single re-surfacing entry. (notifications Slice 2)
 
 ---
 

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -646,6 +646,7 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		Emit:        audit.Emit,
 		Bus:         bus,
 		Sched:       complianceSched,
+		Regressions: notifyfeed.NewProjector(notifFeedStore),
 	})
 
 	// Report signing key. Optional: an empty path yields an ephemeral

--- a/cmd/openwatch/worker.go
+++ b/cmd/openwatch/worker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/knownhosts"
 	"github.com/Hanalyx/openwatch/internal/license"
 	openlog "github.com/Hanalyx/openwatch/internal/log"
+	"github.com/Hanalyx/openwatch/internal/notifyfeed"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	"github.com/Hanalyx/openwatch/internal/scheduler"
@@ -266,6 +267,7 @@ func cmdWorker(cfg *config.Config, args []string, stdout, stderr *os.File) int {
 		Emit:                 audit.Emit,
 		Sched:                sched,
 		RemediationProcessor: remediationWorker,
+		Regressions:          notifyfeed.NewProjector(notifyfeed.NewStore(pool)),
 	})
 
 	ctx, stop := signal.NotifyContext(bootCtx, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/notifyfeed/projector.go
+++ b/internal/notifyfeed/projector.go
@@ -1,0 +1,211 @@
+package notifyfeed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// Projector turns the transaction-log changes a completed scan wrote into a
+// single, grouped, per-host in-app notification — the headline "a rule that was
+// passing is now failing" surface (notifications_design.md §3, Slice 2).
+//
+// It is the second producer of the bell, alongside the alertrouter Channel
+// (host_unreachable/recovered, drift_*). The Channel covers fleet/host-level
+// alerts; the Projector covers RULE-level regressions, which the alert engine
+// does not classify. Both write through the same notifyfeed.Store, so read
+// state, grouping, and fan-out are uniform.
+//
+// Runs in the scan worker (where transactionlog.Writer.Apply commits), called
+// best-effort after the outcomes persist. Spec: system-notifications.
+type Projector struct {
+	store *Store
+}
+
+// NewProjector returns a regression projector over the given feed store.
+func NewProjector(store *Store) *Projector { return &Projector{store: store} }
+
+// regressionRow is one candidate change for a scan: a rule that flipped to fail.
+type regressionRow struct {
+	ruleID     string
+	severity   string
+	changeKind string
+}
+
+// ProjectScan reads the changes the given scan wrote for the given host and, if
+// any qualify as a regression, records ONE grouped "rule_regression"
+// notification fanned to every active recipient.
+//
+// What qualifies (notifications_design.md §3 "Compliance"):
+//   - state_changed -> fail: a rule that was passing (or skipped/errored) now
+//     fails. The unambiguous regression; always counted.
+//   - first_seen -> fail, severity critical: a brand-new critical finding. Only
+//     counted when the host has prior scan history — on a host's FIRST scan
+//     every rule is first_seen, which is a baseline, not a regression, and must
+//     not flood the bell with "N rules regressed".
+//
+// Grouping (design §8): one notification per host (group_key
+// "rule_regression:<host>"), so a burst of N rules in one scan is one row, and a
+// later scan's regressions collapse onto (and re-surface) the same row rather
+// than piling up. The notification severity is the highest among the regressed
+// rules; the title summarizes the counts.
+//
+// Best-effort: a nil/empty result is a no-op returning nil. The caller treats
+// any error as non-fatal (the scan already persisted).
+func (p *Projector) ProjectScan(ctx context.Context, scanID, hostID uuid.UUID) error {
+	if scanID == uuid.Nil || hostID == uuid.Nil {
+		return fmt.Errorf("notifyfeed: ProjectScan requires scanID and hostID")
+	}
+
+	rows, err := p.store.pool.Query(ctx, `
+		SELECT rule_id, COALESCE(severity, ''), change_kind
+		  FROM transactions
+		 WHERE scan_id = $1 AND host_id = $2 AND status = 'fail'
+		   AND change_kind IN ('state_changed', 'first_seen')`,
+		scanID, hostID)
+	if err != nil {
+		return fmt.Errorf("notifyfeed: project read changes: %w", err)
+	}
+	var candidates []regressionRow
+	for rows.Next() {
+		var r regressionRow
+		if err := rows.Scan(&r.ruleID, &r.severity, &r.changeKind); err != nil {
+			rows.Close()
+			return fmt.Errorf("notifyfeed: project scan row: %w", err)
+		}
+		candidates = append(candidates, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("notifyfeed: project read changes: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// first_seen rows only count as "new critical finding" when this is not
+	// the host's first scan (otherwise the whole baseline is first_seen).
+	hasPriorHistory := false
+	if hasFirstSeen(candidates) {
+		if err := p.store.pool.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM transactions WHERE host_id = $1 AND scan_id <> $2)`,
+			hostID, scanID).Scan(&hasPriorHistory); err != nil {
+			return fmt.Errorf("notifyfeed: project prior-history check: %w", err)
+		}
+	}
+
+	regressed := make([]regressionRow, 0, len(candidates))
+	for _, r := range candidates {
+		switch r.changeKind {
+		case "state_changed":
+			regressed = append(regressed, r)
+		case "first_seen":
+			// New finding: only a critical one, and only on a host with
+			// prior scan history, is bell-worthy.
+			if hasPriorHistory && r.severity == "critical" {
+				regressed = append(regressed, r)
+			}
+		}
+	}
+	if len(regressed) == 0 {
+		return nil
+	}
+
+	total := len(regressed)
+	criticalCount := 0
+	topSeverity := ""
+	for _, r := range regressed {
+		if r.severity == "critical" {
+			criticalCount++
+		}
+		if severityRank(r.severity) > severityRank(topSeverity) {
+			topSeverity = r.severity
+		}
+	}
+	if topSeverity == "" {
+		topSeverity = "low" // a fail with no severity still warrants a low-rank ping
+	}
+
+	name := p.hostName(ctx, hostID)
+
+	n := Notification{
+		Kind:     "rule_regression",
+		Severity: topSeverity,
+		Title:    regressionTitle(name, total, criticalCount),
+		Body:     regressionBody(total, criticalCount),
+		HostID:   &hostID,
+		Link:     "/hosts/" + hostID.String(),
+		GroupKey: "rule_regression:" + hostID.String(),
+	}
+	if err := p.store.RecordFanout(ctx, n); err != nil {
+		return fmt.Errorf("notifyfeed: project record: %w", err)
+	}
+	return nil
+}
+
+// hostName returns the host's display name (falling back to hostname, then the
+// id) for the notification title. A lookup failure degrades to the id rather
+// than failing the projection.
+func (p *Projector) hostName(ctx context.Context, hostID uuid.UUID) string {
+	var name string
+	if err := p.store.pool.QueryRow(ctx,
+		`SELECT COALESCE(NULLIF(display_name, ''), hostname) FROM hosts WHERE id = $1`,
+		hostID).Scan(&name); err != nil || name == "" {
+		return hostID.String()
+	}
+	return name
+}
+
+// hasFirstSeen reports whether any candidate is a first_seen change (so we only
+// pay for the prior-history query when it can matter).
+func hasFirstSeen(rows []regressionRow) bool {
+	for _, r := range rows {
+		if r.changeKind == "first_seen" {
+			return true
+		}
+	}
+	return false
+}
+
+// severityRank orders the alertrouter severity strings for "highest wins".
+func severityRank(s string) int {
+	switch s {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// regressionTitle builds "web-01: 3 rules regressed (1 critical)".
+func regressionTitle(host string, total, critical int) string {
+	t := fmt.Sprintf("%s: %d %s regressed", host, total, plural(total, "rule", "rules"))
+	if critical > 0 {
+		t += fmt.Sprintf(" (%d critical)", critical)
+	}
+	return t
+}
+
+// regressionBody is the short detail line under the title.
+func regressionBody(total, critical int) string {
+	b := fmt.Sprintf("The latest scan flipped %d %s from passing to failing.",
+		total, plural(total, "rule", "rules"))
+	if critical > 0 {
+		b += fmt.Sprintf(" %d %s critical.", critical, plural(critical, "is", "are"))
+	}
+	return b
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}

--- a/internal/notifyfeed/projector_test.go
+++ b/internal/notifyfeed/projector_test.go
@@ -1,0 +1,232 @@
+// @spec system-notifications
+//
+// AC traceability (this file):
+//
+//	AC-12  TestProjector_GroupsRegressionsPerHost — one grouped row per recipient, severity-ranked
+//	AC-13  TestProjector_FirstScanSuppressed — baseline first_seen does not flood; first_seen critical counts only with prior history
+//	AC-14  TestProjector_NoRegressionNoOp — nothing to report writes nothing; re-scan collapses + re-surfaces
+//
+// Skipped without OPENWATCH_TEST_DSN (uses the shared per-package isolated DB).
+//
+// Isolation note: dbtest.Pool is shared across this package's tests and
+// notifyfeed.RecordFanout writes one row per user in the WHOLE users table, so
+// these tests use per-call-unique usernames and assert on rows scoped to each
+// test's own (unique) host id rather than on the recipient's total list length.
+package notifyfeed
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+)
+
+// uniq returns a per-call-unique token so seeded usernames/hostnames never
+// collide on the shared per-package test DB (not reset between test functions).
+// Uses the trailing random bytes of a v7 uuid — the LEADING bytes are the
+// millisecond timestamp and are identical across a fast test run.
+func uniq() string {
+	id, _ := uuid.NewV7()
+	return id.String()[24:]
+}
+
+func seedHost(t *testing.T, pool *pgxpool.Pool, creator uuid.UUID, hostname, displayName string) uuid.UUID {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, display_name, created_by)
+		 VALUES ($1, $2, '10.0.0.9', $3, $4)`,
+		id, hostname, nullIfEmpty(displayName), creator); err != nil {
+		t.Fatalf("seed host %s: %v", hostname, err)
+	}
+	return id
+}
+
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func seedTxn(t *testing.T, pool *pgxpool.Pool, hostID, scanID uuid.UUID, ruleID, status, severity, changeKind string, at time.Time) {
+	t.Helper()
+	id, _ := uuid.NewV7()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO transactions
+			(id, host_id, rule_id, scan_id, status, severity, change_kind, evidence, occurred_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, '{}'::jsonb, $8)`,
+		id, hostID, ruleID, scanID, status, nullIfEmpty(severity), changeKind, at); err != nil {
+		t.Fatalf("seed txn %s/%s: %v", ruleID, changeKind, err)
+	}
+}
+
+// notifsForHost returns the user's notifications scoped to one host id, so
+// fan-out rows from other tests on the shared DB don't perturb the assertion.
+func notifsForHost(t *testing.T, s *Store, user, host uuid.UUID) []Notification {
+	t.Helper()
+	all, err := s.List(context.Background(), user, false, 200)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var out []Notification
+	for _, n := range all {
+		if n.HostID != nil && *n.HostID == host {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// @ac AC-12
+func TestProjector_GroupsRegressionsPerHost(t *testing.T) {
+	t.Run("system-notifications/AC-12", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		p := NewProjector(s)
+
+		u1 := seedUser(t, pool, "alice-"+uniq())
+		u2 := seedUser(t, pool, "bob-"+uniq())
+		creator := seedUser(t, pool, "creator-"+uniq())
+		host := seedHost(t, pool, creator, "web-"+uniq(), "Web One")
+
+		now := time.Now().UTC()
+		scan, _ := uuid.NewV7()
+		// Three rules flipped to fail (1 critical, 2 high). Noise that must NOT
+		// count: a fail->pass recovery and a severity_changed row.
+		seedTxn(t, pool, host, scan, "rule.crit", "fail", "critical", "state_changed", now)
+		seedTxn(t, pool, host, scan, "rule.hi1", "fail", "high", "state_changed", now)
+		seedTxn(t, pool, host, scan, "rule.hi2", "fail", "high", "state_changed", now)
+		seedTxn(t, pool, host, scan, "rule.fixed", "pass", "high", "state_changed", now) // recovery
+		seedTxn(t, pool, host, scan, "rule.sev", "fail", "medium", "severity_changed", now)
+
+		if err := p.ProjectScan(ctx, scan, host); err != nil {
+			t.Fatalf("ProjectScan: %v", err)
+		}
+
+		for _, u := range []uuid.UUID{u1, u2} {
+			list := notifsForHost(t, s, u, host)
+			if len(list) != 1 {
+				t.Fatalf("user %s: want 1 host notification, got %d", u, len(list))
+			}
+			n := list[0]
+			if n.Kind != "rule_regression" {
+				t.Errorf("kind = %q, want rule_regression", n.Kind)
+			}
+			if n.Severity != "critical" {
+				t.Errorf("severity = %q, want critical (highest of the group)", n.Severity)
+			}
+			if want := "Web One: 3 rules regressed (1 critical)"; n.Title != want {
+				t.Errorf("title = %q, want %q", n.Title, want)
+			}
+			if n.Link != "/hosts/"+host.String() {
+				t.Errorf("link = %q, want /hosts/<host>", n.Link)
+			}
+		}
+	})
+}
+
+// @ac AC-13
+func TestProjector_FirstScanSuppressed(t *testing.T) {
+	t.Run("system-notifications/AC-13", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		p := NewProjector(s)
+
+		u := seedUser(t, pool, "alice-"+uniq())
+		creator := seedUser(t, pool, "creator-"+uniq())
+		hostname := "db-" + uniq()
+		host := seedHost(t, pool, creator, hostname, "") // no display name → title uses hostname
+
+		now := time.Now().UTC()
+		// First scan: every fail is first_seen (baseline), including a critical.
+		firstScan, _ := uuid.NewV7()
+		seedTxn(t, pool, host, firstScan, "rule.a", "fail", "critical", "first_seen", now)
+		seedTxn(t, pool, host, firstScan, "rule.b", "fail", "high", "first_seen", now)
+
+		if err := p.ProjectScan(ctx, firstScan, host); err != nil {
+			t.Fatalf("ProjectScan first: %v", err)
+		}
+		if list := notifsForHost(t, s, u, host); len(list) != 0 {
+			t.Fatalf("first scan must not notify (baseline), got %d", len(list))
+		}
+
+		// A later scan now has prior history, so a NEW critical first_seen
+		// finding is bell-worthy (a new high first_seen is not).
+		secondScan, _ := uuid.NewV7()
+		seedTxn(t, pool, host, secondScan, "rule.newcrit", "fail", "critical", "first_seen", now.Add(time.Hour))
+		seedTxn(t, pool, host, secondScan, "rule.newhi", "fail", "high", "first_seen", now.Add(time.Hour))
+
+		if err := p.ProjectScan(ctx, secondScan, host); err != nil {
+			t.Fatalf("ProjectScan second: %v", err)
+		}
+		list := notifsForHost(t, s, u, host)
+		if len(list) != 1 {
+			t.Fatalf("second scan: want 1 notification, got %d", len(list))
+		}
+		// Only the critical first_seen counts → "1 rule regressed (1 critical)".
+		if want := hostname + ": 1 rule regressed (1 critical)"; list[0].Title != want {
+			t.Errorf("title = %q, want %q (hostname fallback; new high suppressed)", list[0].Title, want)
+		}
+	})
+}
+
+// @ac AC-14
+func TestProjector_NoRegressionNoOp(t *testing.T) {
+	t.Run("system-notifications/AC-14", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		p := NewProjector(s)
+
+		u := seedUser(t, pool, "alice-"+uniq())
+		creator := seedUser(t, pool, "creator-"+uniq())
+		host := seedHost(t, pool, creator, "app-"+uniq(), "App One")
+
+		now := time.Now().UTC()
+		// A scan with only a recovery + severity churn → nothing to report.
+		quiet, _ := uuid.NewV7()
+		seedTxn(t, pool, host, quiet, "rule.ok", "pass", "high", "state_changed", now)
+		seedTxn(t, pool, host, quiet, "rule.sev", "fail", "low", "severity_changed", now)
+		if err := p.ProjectScan(ctx, quiet, host); err != nil {
+			t.Fatalf("ProjectScan quiet: %v", err)
+		}
+		if list := notifsForHost(t, s, u, host); len(list) != 0 {
+			t.Fatalf("quiet scan must not notify, got %d", len(list))
+		}
+
+		// Two scans that each regress collapse onto ONE per-host row (group_key
+		// is per host); the second re-surfaces it UNREAD.
+		scanA, _ := uuid.NewV7()
+		seedTxn(t, pool, host, scanA, "rule.x", "fail", "high", "state_changed", now)
+		if err := p.ProjectScan(ctx, scanA, host); err != nil {
+			t.Fatalf("ProjectScan A: %v", err)
+		}
+		if _, err := s.MarkAllRead(ctx, u); err != nil {
+			t.Fatalf("mark read: %v", err)
+		}
+
+		scanB, _ := uuid.NewV7()
+		seedTxn(t, pool, host, scanB, "rule.y", "fail", "critical", "state_changed", now.Add(time.Hour))
+		if err := p.ProjectScan(ctx, scanB, host); err != nil {
+			t.Fatalf("ProjectScan B: %v", err)
+		}
+
+		list := notifsForHost(t, s, u, host)
+		if len(list) != 1 {
+			t.Fatalf("two regressing scans must collapse to 1 row, got %d", len(list))
+		}
+		if list[0].ReadAt != nil {
+			t.Errorf("second regression must re-surface the row unread")
+		}
+		if list[0].Severity != "critical" {
+			t.Errorf("collapsed row should reflect latest scan severity critical, got %q", list[0].Severity)
+		}
+	})
+}

--- a/internal/worker/scan_worker.go
+++ b/internal/worker/scan_worker.go
@@ -78,9 +78,10 @@ type ScanWorker struct {
 	writer      *transactionlog.Writer
 	scanResults *scanresult.Writer // nil = durable per-scan results not recorded (legacy tests)
 	queueKey    []byte
-	bus         *eventbus.Bus      // nil = no scan.completed publication (dedicated worker process)
-	sched       *scheduler.Service // nil = no post-scan schedule update (legacy tests)
-	remProc     *RemediationWorker // nil = "remediation" jobs fail (legacy tests)
+	bus         *eventbus.Bus       // nil = no scan.completed publication (dedicated worker process)
+	sched       *scheduler.Service  // nil = no post-scan schedule update (legacy tests)
+	remProc     *RemediationWorker  // nil = "remediation" jobs fail (legacy tests)
+	regressions RegressionProjector // nil = no in-app rule-regression notifications
 
 	pollInterval time.Duration
 
@@ -136,9 +137,24 @@ type Config struct {
 	// dead-lettering them. Spec api-remediation.
 	RemediationProcessor *RemediationWorker
 
+	// Regressions, when non-nil, projects each completed scan's
+	// transaction-log regressions (a passing rule now fails) into a grouped
+	// in-app notification. Best-effort: a projection error never fails the
+	// scan. nil disables the in-app rule-regression bell (legacy tests, and
+	// any boot path without the notification feed). Spec system-notifications.
+	Regressions RegressionProjector
+
 	// clock allows tests to inject a controllable time source.
 	// Production passes time.Now.
 	Clock func() time.Time
+}
+
+// RegressionProjector turns a completed scan's transaction-log changes into a
+// grouped in-app notification. notifyfeed.Projector implements it; the worker
+// holds the interface to avoid importing the feed package's concrete type and
+// to let tests stub it. Spec system-notifications (Slice 2).
+type RegressionProjector interface {
+	ProjectScan(ctx context.Context, scanID, hostID uuid.UUID) error
 }
 
 // NewScanWorker wires a ScanWorker. The dependencies are constructed at
@@ -165,6 +181,7 @@ func NewScanWorker(cfg Config) *ScanWorker {
 		bus:          cfg.Bus,
 		sched:        cfg.Sched,
 		remProc:      cfg.RemediationProcessor,
+		regressions:  cfg.Regressions,
 		pollInterval: cfg.PollInterval,
 		clock:        cfg.Clock,
 		emit:         cfg.Emit,
@@ -386,6 +403,19 @@ func (w *ScanWorker) ProcessJob(ctx context.Context, j *queue.Job) {
 				slog.String("host_id", payload.HostID.String()),
 				slog.String("error", err.Error()))
 			// Non-fatal: the scan itself succeeded and persisted.
+		}
+	}
+
+	// Project rule-level regressions (a passing rule now fails) into a
+	// grouped in-app notification. Best-effort and non-fatal: the scan and
+	// its compliance state already persisted; a feed write must never fail or
+	// retry the scan. Spec system-notifications (Slice 2).
+	if w.regressions != nil {
+		if err := w.regressions.ProjectScan(ctx, j.ID, payload.HostID); err != nil {
+			slog.WarnContext(ctx, "worker regression projection failed",
+				slog.String("scan_id", j.ID.String()),
+				slog.String("host_id", payload.HostID.String()),
+				slog.String("error", err.Error()))
 		}
 	}
 

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-notifications
   title: Notification channels — encrypted store + SSRF-guarded delivery
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -102,6 +102,25 @@ spec:
         self-scoped to the caller (no cross-user access).
       type: security
       enforcement: error
+    - id: C-07
+      description: >-
+        v1.4.0 (Slice 2) — the bell's second producer is a transaction-log
+        regression projector (notifyfeed.Projector). After a scan's outcomes
+        persist, ProjectScan reads that scan's transactions for the host and
+        records ONE grouped "rule_regression" notification (fanned per active
+        recipient) when any rule regressed. A regression is a state_changed ->
+        fail row (a passing/skipped/errored rule now fails); a first_seen ->
+        fail row counts ONLY when its severity is critical AND the host has
+        prior scan history (on a host's first scan every rule is first_seen —
+        baseline, not regression — and MUST NOT flood the bell). The grouped
+        row's group_key is per host ("rule_regression:<host>") so a burst of N
+        rules in one scan is one row and a later scan's regressions collapse
+        onto (and re-surface) it; the notification severity is the highest among
+        the regressed rules and the title summarizes the counts. The projector
+        runs best-effort in the scan worker: a projection failure never fails or
+        retries the scan.
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -163,3 +182,30 @@ spec:
         the group_key; a fleet alert (no host) carries no host link.
       priority: high
       references_constraints: [C-06]
+    - id: AC-12
+      description: >-
+        v1.4.0 — Projector.ProjectScan turns a scan's state_changed -> fail
+        transactions into ONE grouped rule_regression notification per active
+        recipient: severity is the highest among the regressed rules, the title
+        reads "<host>: <N> rule(s) regressed (<C> critical)", host_id + a
+        /hosts/{id} deep-link are set, and fail->pass recoveries and
+        severity_changed rows are excluded from the count.
+      priority: high
+      references_constraints: [C-07]
+    - id: AC-13
+      description: >-
+        v1.4.0 — first-scan baseline suppression: a scan whose fail rows are all
+        first_seen with no prior host scan history produces NO notification; once
+        the host has prior history, a NEW first_seen critical fail is counted
+        (and a first_seen high fail is not), so a follow-up scan with one new
+        critical yields "1 rule regressed (1 critical)".
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-14
+      description: >-
+        v1.4.0 — no-op + collapse: a scan with only a recovery + severity churn
+        records nothing; two regressing scans on the same host collapse onto one
+        per-host row (group_key rule_regression:<host>) and the second
+        re-surfaces it unread with the latest scan's severity.
+      priority: high
+      references_constraints: [C-07]


### PR DESCRIPTION
## Summary

Notifications **Slice 2** (per the [change-driven design](docs/engineering/notifications_design.md) §3/§9): the bell's headline use case — **a rule that was passing is now failing**. Slice 1 wired the durable per-user feed + the alert-engine channel (host unreachable/recovered, drift). This adds the second producer: a **transaction-log regression projector**.

When a scan flips passing rules to failing, the operator gets **one grouped per-host notification** — `web-01: 3 rules regressed (1 critical)` — severity-ranked and deep-linked to the host, instead of nothing (the alert engine doesn't classify rule-level changes).

## What it does

- **`internal/notifyfeed/projector.go`** — `Projector.ProjectScan(scanID, hostID)` reads the scan's `transactions` for the host and records one grouped `rule_regression` notification per active recipient:
  - **Regression** = `state_changed → fail` (a passing/skipped/errored rule now fails).
  - **New critical finding** = `first_seen → fail` **only** when `severity=critical` **and** the host has prior scan history. On a host's first scan every rule is `first_seen` (baseline) — counting those would flood the bell with "N rules regressed", so they're suppressed.
  - **Grouping**: `group_key = rule_regression:<host>` — a burst of N rules in one scan is one row, and a later scan's regressions collapse onto (and re-surface unread) the same row rather than piling up. Severity = highest among regressed rules; title summarizes counts.
- **`internal/worker/scan_worker.go`** — `RegressionProjector` interface + nil-safe `Config`/field; called **best-effort** after `Writer.Apply` succeeds. A feed-write failure logs and is swallowed — it never fails or retries the scan (the compliance state already persisted).
- **Wiring** in both scan-worker boot paths: `cmd/openwatch/main.go` (serve, reusing the Slice-1 feed store) and `cmd/openwatch/worker.go` (dedicated worker).

## Spec & tests

- `system-notifications` **v1.4.0**: new **C-07** + **AC-12/13/14** (grouping/severity-rank, first-scan suppression, no-op + collapse). `specter check` green (114 specs); `specter coverage --strictness annotation` = system-notifications **14/14 ACs, 100%**.
- DB-backed tests in `internal/notifyfeed/projector_test.go` (grouping, severity ranking, first-scan suppression, recovery/severity-churn no-op, two-scan collapse + re-surface).

## Scope notes

- **No frontend change** — the new rows render in the existing Slice-1 bell drawer (generic title/body/severity/link).
- **Recipient scoping** stays Slice-1 (all active users): host:read is granted to every role today, so "users who can see the host" is everyone. Finer per-host scoping awaits a host-ACL model (design §7) and is deferred.
- **Band drops** (design §3) come from the scheduler/posture producer, not the transaction log — out of this projector's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)