### PR TITLE
feat(notifications): Slice 3 — governance action queue (RBAC-scoped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   regressed (1 critical)"), severity-ranked and deep-linked to the host. A
   host's first scan (all-new baseline) does not flood the bell, and repeat
   failures collapse onto a single re-surfacing entry. (notifications Slice 2)
+- The notification bell is now an action queue for governance: an exception
+  awaiting approval reaches the users who can approve it (auditors and
+  security/admin roles), an approve or reject reaches the requester, and a
+  remediation that fails (or a rollback that does not restore) reaches the
+  operators who can re-run it. Each item is severity-ranked and deep-links to
+  where you act on it. (notifications Slice 3)
 
 ---
 

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -588,9 +588,13 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	// a fresh boot has today's row. Spec system-posture-snapshots.
 	posture.Run(ctx, pool, 0)
 
+	// Governance action-queue notifications (Slice 3): exceptions pending /
+	// decided, remediation failures. Reuses the Slice-1 feed store.
+	govProjector := notifyfeed.NewGovernanceProjector(notifFeedStore)
+
 	// Compliance exception governance + its hourly expiry sweep.
 	// Spec api-compliance-exceptions.
-	exceptionSvc := exception.NewService(pool, audit.Emit)
+	exceptionSvc := exception.NewService(pool, audit.Emit).WithNotifier(govProjector)
 	exceptionSvc.Run(ctx, 0)
 
 	// Remediation governance: request/approve/reject + projected lift (free
@@ -628,13 +632,14 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		remExecutor = remExecutor.WithRemediateFunc(remFn, rbFn)
 	}
 	remediationWorker := worker.NewRemediationWorker(worker.RemediationConfig{
-		Pool:     pool,
-		Executor: remExecutor,
-		Service:  remediationSvc,
-		Writer:   remTxWriter,
-		QueueKey: scanQueueKey,
-		Bus:      bus,
-		Emit:     audit.Emit,
+		Pool:       pool,
+		Executor:   remExecutor,
+		Service:    remediationSvc,
+		Writer:     remTxWriter,
+		QueueKey:   scanQueueKey,
+		Bus:        bus,
+		Emit:       audit.Emit,
+		Governance: govProjector,
 	})
 
 	scanWorker := worker.NewScanWorker(worker.Config{

--- a/cmd/openwatch/worker.go
+++ b/cmd/openwatch/worker.go
@@ -230,13 +230,18 @@ func cmdWorker(cfg *config.Config, args []string, stdout, stderr *os.File) int {
 	} else {
 		remExecutor = remExecutor.WithRemediateFunc(remFn, rbFn)
 	}
+	// One in-app feed store, shared by the remediation-failure governance
+	// notifier and the scan worker's regression projector.
+	notifFeedStore := notifyfeed.NewStore(pool)
+
 	remediationWorker := worker.NewRemediationWorker(worker.RemediationConfig{
-		Pool:     pool,
-		Executor: remExecutor,
-		Service:  remediation.NewService(pool, audit.Emit),
-		Writer:   writer,
-		QueueKey: queueKey,
-		Emit:     audit.Emit,
+		Pool:       pool,
+		Executor:   remExecutor,
+		Service:    remediation.NewService(pool, audit.Emit),
+		Writer:     writer,
+		QueueKey:   queueKey,
+		Emit:       audit.Emit,
+		Governance: notifyfeed.NewGovernanceProjector(notifFeedStore),
 		// Bus nil: the dedicated worker has no SSE subscribers (cross-process
 		// delivery is a known non-goal, same as scan.completed).
 	})
@@ -267,7 +272,7 @@ func cmdWorker(cfg *config.Config, args []string, stdout, stderr *os.File) int {
 		Emit:                 audit.Emit,
 		Sched:                sched,
 		RemediationProcessor: remediationWorker,
-		Regressions:          notifyfeed.NewProjector(notifyfeed.NewStore(pool)),
+		Regressions:          notifyfeed.NewProjector(notifFeedStore),
 	})
 
 	ctx, stop := signal.NotifyContext(bootCtx, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/auth/grant.go
+++ b/internal/auth/grant.go
@@ -22,3 +22,22 @@ func RoleGrantsWithin(caller Identity, requested RoleID) bool {
 	}
 	return true
 }
+
+// RolesWithPermission returns the built-in role IDs whose definition grants p,
+// in declaration order. It is the recipient-resolution primitive for
+// permission-scoped fan-out (e.g. "every role that can approve an exception"):
+// callers translate a permission into the set of roles, then query user_roles
+// for the holders. An unknown/empty permission yields no roles.
+func RolesWithPermission(p Permission) []RoleID {
+	var out []RoleID
+	for _, id := range BuiltInRoleIDs() {
+		def := BuiltInRoles[id]
+		for _, granted := range def.Permissions {
+			if granted == p {
+				out = append(out, id)
+				break
+			}
+		}
+	}
+	return out
+}

--- a/internal/auth/grant_test.go
+++ b/internal/auth/grant_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"sort"
+	"testing"
+)
+
+func roleSet(ids []RoleID) map[RoleID]bool {
+	m := make(map[RoleID]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+func TestRolesWithPermission(t *testing.T) {
+	cases := []struct {
+		perm Permission
+		want []RoleID
+	}{
+		// exception:approve is held by the auditor (review role) and the two
+		// security roles — but NOT ops_lead (who can only request).
+		{ExceptionApprove, []RoleID{RoleAuditor, RoleSecurityAdmin, RoleAdmin}},
+		// remediation:execute is held by the operator tier and up.
+		{RemediationExecute, []RoleID{RoleOpsLead, RoleSecurityAdmin, RoleAdmin}},
+		// host:read is universal across the five built-in roles.
+		{HostRead, []RoleID{RoleViewer, RoleAuditor, RoleOpsLead, RoleSecurityAdmin, RoleAdmin}},
+		// admin-only verb.
+		{SystemConfigWrite, []RoleID{RoleAdmin}},
+	}
+	for _, c := range cases {
+		got := roleSet(RolesWithPermission(c.perm))
+		want := roleSet(c.want)
+		if len(got) != len(want) {
+			t.Errorf("RolesWithPermission(%s): got %v, want %v", c.perm, sortedRoles(got), c.want)
+			continue
+		}
+		for r := range want {
+			if !got[r] {
+				t.Errorf("RolesWithPermission(%s): missing %s (got %v)", c.perm, r, sortedRoles(got))
+			}
+		}
+	}
+
+	// An unknown permission yields no roles.
+	if got := RolesWithPermission(Permission("does:not_exist")); len(got) != 0 {
+		t.Errorf("unknown permission must yield no roles, got %v", got)
+	}
+}
+
+func sortedRoles(m map[RoleID]bool) []RoleID {
+	out := make([]RoleID, 0, len(m))
+	for r := range m {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/internal/exception/service.go
+++ b/internal/exception/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -19,15 +20,33 @@ import (
 // pass a fake.
 type EmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
 
+// Notifier receives exception lifecycle signals for the in-app notification
+// feed. notifyfeed.GovernanceProjector implements it; the service holds the
+// interface so it does not import the feed package. Methods are best-effort:
+// the service logs (never fails the transition on) a notifier error. nil
+// disables in-app exception notifications.
+type Notifier interface {
+	ExceptionRequested(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error
+	ExceptionDecided(ctx context.Context, exceptionID, requestedBy uuid.UUID, ruleID string, approved bool) error
+}
+
 // Service is the exception governance service.
 type Service struct {
-	pool *pgxpool.Pool
-	emit EmitFunc
+	pool     *pgxpool.Pool
+	emit     EmitFunc
+	notifier Notifier
 }
 
 // NewService wires the service. emit is audit.Emit in production.
 func NewService(pool *pgxpool.Pool, emit EmitFunc) *Service {
 	return &Service{pool: pool, emit: emit}
+}
+
+// WithNotifier attaches the in-app notification projector and returns the
+// service for chaining at boot. nil leaves in-app notifications disabled.
+func (s *Service) WithNotifier(n Notifier) *Service {
+	s.notifier = n
+	return s
 }
 
 const selectCols = `id, host_id, rule_id, reason, status, requested_by,
@@ -91,6 +110,7 @@ func (s *Service) Request(ctx context.Context, hostID uuid.UUID, ruleID, reason 
 	}
 
 	s.emitEvent(ctx, audit.ComplianceExceptionRequested, e, requestedBy, "requested")
+	s.notifyRequested(ctx, e)
 	return e, nil
 }
 
@@ -98,16 +118,24 @@ func (s *Service) Request(ctx context.Context, hostID uuid.UUID, ruleID, reason 
 // reviewer must differ from the requester (separation of duties).
 // Emits compliance.exception.approved.
 func (s *Service) Approve(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
-	return s.review(ctx, id, reviewedBy, note, StatusRequested, StatusApproved,
+	e, err := s.review(ctx, id, reviewedBy, note, StatusRequested, StatusApproved,
 		audit.ComplianceExceptionApproved, true)
+	if err == nil {
+		s.notifyDecided(ctx, e, true)
+	}
+	return e, err
 }
 
 // Reject transitions a 'requested' exception to 'rejected'. Like
 // Approve, the reviewer must differ from the requester. Emits
 // compliance.exception.rejected.
 func (s *Service) Reject(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
-	return s.review(ctx, id, reviewedBy, note, StatusRequested, StatusRejected,
+	e, err := s.review(ctx, id, reviewedBy, note, StatusRequested, StatusRejected,
 		audit.ComplianceExceptionRejected, true)
+	if err == nil {
+		s.notifyDecided(ctx, e, false)
+	}
+	return e, err
 }
 
 // Revoke transitions an 'approved' exception to 'revoked' before its
@@ -309,6 +337,31 @@ func (s *Service) emitEvent(ctx context.Context, code audit.Code, e Exception, a
 		ResourceID:   e.ID.String(),
 		Detail:       detail,
 	})
+}
+
+// notifyRequested fans an "exception pending approval" notification to
+// approvers. Best-effort: a notifier error is logged, never propagated (the
+// exception was already persisted). No-op when no notifier is wired.
+func (s *Service) notifyRequested(ctx context.Context, e Exception) {
+	if s.notifier == nil {
+		return
+	}
+	if err := s.notifier.ExceptionRequested(ctx, e.ID, e.HostID, e.RuleID); err != nil {
+		slog.WarnContext(ctx, "exception requested notification failed",
+			slog.String("exception_id", e.ID.String()), slog.String("error", err.Error()))
+	}
+}
+
+// notifyDecided notifies the requester that their exception was approved or
+// rejected. Best-effort, like notifyRequested.
+func (s *Service) notifyDecided(ctx context.Context, e Exception, approved bool) {
+	if s.notifier == nil {
+		return
+	}
+	if err := s.notifier.ExceptionDecided(ctx, e.ID, e.RequestedBy, e.RuleID, approved); err != nil {
+		slog.WarnContext(ctx, "exception decided notification failed",
+			slog.String("exception_id", e.ID.String()), slog.String("error", err.Error()))
+	}
 }
 
 // isUniqueViolation reports whether err is a Postgres unique-violation

--- a/internal/notifyfeed/governance.go
+++ b/internal/notifyfeed/governance.go
@@ -1,0 +1,120 @@
+package notifyfeed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+)
+
+// GovernanceProjector turns governance + remediation lifecycle events into
+// RBAC-scoped in-app notifications — the bell's "action queue" (Slice 3). Unlike
+// the alert Channel and the regression Projector (which fan to every active
+// user), governance items reach only the users who can act on them: an
+// exception pending approval reaches approvers, a decision reaches the
+// requester, a failed remediation reaches the operators who can re-run it.
+//
+// It implements the Notifier interface the exception service and the
+// GovernanceNotifier the remediation worker hold, so neither producer imports
+// this package. Spec: system-notifications (Slice 3).
+type GovernanceProjector struct {
+	store *Store
+}
+
+// NewGovernanceProjector returns a governance projector over the feed store.
+func NewGovernanceProjector(store *Store) *GovernanceProjector {
+	return &GovernanceProjector{store: store}
+}
+
+// exceptionQueueLink is where the exception queue lives in the UI
+// (frontend/src/components/settings/ExceptionQueue.tsx, mounted on the policies
+// settings page). Approvers act on the queue here.
+const exceptionQueueLink = "/settings/policies"
+
+// ExceptionRequested records an "exception pending approval" notification for
+// every user whose role can approve it (exception:approve → security_admin,
+// admin). Grouped per exception so a re-surfaced request collapses onto one
+// row. Best-effort: an error is returned for the caller to log, never to fail
+// the request.
+func (g *GovernanceProjector) ExceptionRequested(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error {
+	host := g.store.hostName(ctx, hostID)
+	h := hostID
+	n := Notification{
+		Kind:     "exception_pending",
+		Severity: "high",
+		Title:    fmt.Sprintf("Exception awaiting approval: %s on %s", ruleID, host),
+		Body:     "A compliance exception request needs review and approval or rejection.",
+		HostID:   &h,
+		Link:     exceptionQueueLink,
+		GroupKey: "exception_pending:" + exceptionID.String(),
+	}
+	if err := g.store.RecordForRoles(ctx, roleStrings(auth.RolesWithPermission(auth.ExceptionApprove)), n); err != nil {
+		return fmt.Errorf("notifyfeed: exception requested: %w", err)
+	}
+	return nil
+}
+
+// ExceptionDecided records the outcome notification for the requester (only),
+// closing the loop for the person who asked. Grouped per exception.
+func (g *GovernanceProjector) ExceptionDecided(ctx context.Context, exceptionID, requestedBy uuid.UUID, ruleID string, approved bool) error {
+	if requestedBy == uuid.Nil {
+		return nil
+	}
+	verb, kind := "rejected", "exception_rejected"
+	if approved {
+		verb, kind = "approved", "exception_approved"
+	}
+	// Requester-facing: the rule id identifies the request; no host lookup.
+	n := Notification{
+		UserID:   requestedBy,
+		Kind:     kind,
+		Severity: "medium",
+		Title:    fmt.Sprintf("Exception %s: %s", verb, ruleID),
+		Body:     fmt.Sprintf("Your compliance exception request for %s was %s.", ruleID, verb),
+		Link:     exceptionQueueLink,
+		GroupKey: "exception_decided:" + exceptionID.String(),
+	}
+	if err := g.store.Record(ctx, n); err != nil {
+		return fmt.Errorf("notifyfeed: exception decided: %w", err)
+	}
+	return nil
+}
+
+// RemediationFailed records a "remediation failed / rolled back" notification
+// for the operators who can act on it (remediation:execute → ops_lead,
+// security_admin, admin). Grouped per (host, rule). finalStatus is the
+// terminal remediation status ("failed" | "rolled_back"); action is
+// "execute" | "rollback".
+func (g *GovernanceProjector) RemediationFailed(ctx context.Context, hostID uuid.UUID, ruleID, action, finalStatus string) error {
+	host := g.store.hostName(ctx, hostID)
+	h := hostID
+	lead := "Remediation failed"
+	if finalStatus == "rolled_back" {
+		lead = "Remediation rolled back"
+	}
+	n := Notification{
+		Kind:     "remediation_failed",
+		Severity: "high",
+		Title:    fmt.Sprintf("%s: %s on %s", lead, ruleID, host),
+		Body:     "An automated fix did not complete successfully. Review the host and re-run or remediate manually.",
+		HostID:   &h,
+		Link:     "/hosts/" + hostID.String(),
+		GroupKey: "remediation_failed:" + hostID.String() + ":" + ruleID,
+	}
+	if err := g.store.RecordForRoles(ctx, roleStrings(auth.RolesWithPermission(auth.RemediationExecute)), n); err != nil {
+		return fmt.Errorf("notifyfeed: remediation failed: %w", err)
+	}
+	return nil
+}
+
+// roleStrings adapts auth.RoleID values to the plain strings RecordForRoles
+// queries user_roles.role_id with.
+func roleStrings(ids []auth.RoleID) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = string(id)
+	}
+	return out
+}

--- a/internal/notifyfeed/governance_test.go
+++ b/internal/notifyfeed/governance_test.go
@@ -1,0 +1,164 @@
+// @spec system-notifications
+//
+// AC traceability (this file):
+//
+//	AC-15  TestGovernance_ExceptionRequestedFansToApprovers — pending → approvers only (RBAC-scoped fan-out)
+//	AC-16  TestGovernance_ExceptionDecidedNotifiesRequester — decision → requester only
+//	AC-17  TestGovernance_RemediationFailedFansToOperators — failure → remediation operators only
+//
+// Skipped without OPENWATCH_TEST_DSN. Assertions filter by the per-test-unique
+// group_key so the role-scoped fan-out from other tests on the shared DB does
+// not perturb counts.
+package notifyfeed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+)
+
+func seedUserWithRole(t *testing.T, pool *pgxpool.Pool, name, roleID string) uuid.UUID {
+	t.Helper()
+	id := seedUser(t, pool, name)
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2)`, id, roleID); err != nil {
+		t.Fatalf("grant %s to %s: %v", roleID, name, err)
+	}
+	return id
+}
+
+// notifByGroupKey returns the user's single notification with the given
+// group_key, or nil if none — isolating the assertion from other tests' fan-out
+// on the shared DB (group_key embeds a per-test unique id).
+func notifByGroupKey(t *testing.T, s *Store, user uuid.UUID, groupKey string) *Notification {
+	t.Helper()
+	all, err := s.List(context.Background(), user, false, 200)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for i := range all {
+		if all[i].GroupKey == groupKey {
+			return &all[i]
+		}
+	}
+	return nil
+}
+
+// @ac AC-15
+func TestGovernance_ExceptionRequestedFansToApprovers(t *testing.T) {
+	t.Run("system-notifications/AC-15", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		g := NewGovernanceProjector(s)
+
+		approver := seedUserWithRole(t, pool, "secadmin-"+uniq(), "security_admin")
+		adminU := seedUserWithRole(t, pool, "admin-"+uniq(), "admin")
+		viewer := seedUserWithRole(t, pool, "viewer-"+uniq(), "viewer")
+		creator := seedUser(t, pool, "creator-"+uniq())
+		host := seedHost(t, pool, creator, "web-"+uniq(), "Web One")
+
+		excID, _ := uuid.NewV7()
+		if err := g.ExceptionRequested(ctx, excID, host, "rule.sshd_config"); err != nil {
+			t.Fatalf("ExceptionRequested: %v", err)
+		}
+		gk := "exception_pending:" + excID.String()
+
+		// Approvers (security_admin, admin) receive it.
+		for _, u := range []uuid.UUID{approver, adminU} {
+			n := notifByGroupKey(t, s, u, gk)
+			if n == nil {
+				t.Fatalf("approver %s did not receive the pending-exception notification", u)
+			}
+			if n.Kind != "exception_pending" || n.Severity != "high" {
+				t.Errorf("kind/severity = %q/%q, want exception_pending/high", n.Kind, n.Severity)
+			}
+			if n.Link != "/settings/policies" {
+				t.Errorf("link = %q, want /settings/policies", n.Link)
+			}
+		}
+		// A viewer (no exception:approve) does NOT.
+		if n := notifByGroupKey(t, s, viewer, gk); n != nil {
+			t.Errorf("viewer must not receive an approver-scoped notification")
+		}
+	})
+}
+
+// @ac AC-16
+func TestGovernance_ExceptionDecidedNotifiesRequester(t *testing.T) {
+	t.Run("system-notifications/AC-16", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		g := NewGovernanceProjector(s)
+
+		requester := seedUser(t, pool, "req-"+uniq())
+		other := seedUser(t, pool, "other-"+uniq())
+
+		excID, _ := uuid.NewV7()
+		if err := g.ExceptionDecided(ctx, excID, requester, "rule.audit_rules", true); err != nil {
+			t.Fatalf("ExceptionDecided: %v", err)
+		}
+		gk := "exception_decided:" + excID.String()
+
+		n := notifByGroupKey(t, s, requester, gk)
+		if n == nil {
+			t.Fatalf("requester did not receive the decision notification")
+		}
+		if n.Kind != "exception_approved" || n.Severity != "medium" {
+			t.Errorf("kind/severity = %q/%q, want exception_approved/medium", n.Kind, n.Severity)
+		}
+		// No one else gets a requester-facing decision.
+		if n := notifByGroupKey(t, s, other, gk); n != nil {
+			t.Errorf("a non-requester must not receive the decision notification")
+		}
+
+		// A rejection maps to exception_rejected.
+		excID2, _ := uuid.NewV7()
+		if err := g.ExceptionDecided(ctx, excID2, requester, "rule.x", false); err != nil {
+			t.Fatalf("ExceptionDecided reject: %v", err)
+		}
+		if n := notifByGroupKey(t, s, requester, "exception_decided:"+excID2.String()); n == nil || n.Kind != "exception_rejected" {
+			t.Errorf("rejection should record kind exception_rejected")
+		}
+	})
+}
+
+// @ac AC-17
+func TestGovernance_RemediationFailedFansToOperators(t *testing.T) {
+	t.Run("system-notifications/AC-17", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		g := NewGovernanceProjector(s)
+
+		opsLead := seedUserWithRole(t, pool, "ops-"+uniq(), "ops_lead")
+		viewer := seedUserWithRole(t, pool, "viewer-"+uniq(), "viewer")
+		creator := seedUser(t, pool, "creator-"+uniq())
+		host := seedHost(t, pool, creator, "db-"+uniq(), "DB One")
+
+		if err := g.RemediationFailed(ctx, host, "rule.firewalld", "execute", "failed"); err != nil {
+			t.Fatalf("RemediationFailed: %v", err)
+		}
+		gk := "remediation_failed:" + host.String() + ":rule.firewalld"
+
+		n := notifByGroupKey(t, s, opsLead, gk)
+		if n == nil {
+			t.Fatalf("ops_lead did not receive the remediation-failure notification")
+		}
+		if n.Kind != "remediation_failed" || n.Severity != "high" {
+			t.Errorf("kind/severity = %q/%q, want remediation_failed/high", n.Kind, n.Severity)
+		}
+		if n.Link != "/hosts/"+host.String() {
+			t.Errorf("link = %q, want /hosts/<host>", n.Link)
+		}
+		// A viewer (no remediation:execute) does NOT receive it.
+		if n := notifByGroupKey(t, s, viewer, gk); n != nil {
+			t.Errorf("viewer must not receive an operator-scoped notification")
+		}
+	})
+}

--- a/internal/notifyfeed/notifyfeed.go
+++ b/internal/notifyfeed/notifyfeed.go
@@ -47,6 +47,20 @@ type Store struct {
 // NewStore returns a feed store over the given pool.
 func NewStore(pool *pgxpool.Pool) *Store { return &Store{pool: pool} }
 
+// hostName returns the host's display name (falling back to hostname, then the
+// id) for a notification title. A lookup failure degrades to the id string
+// rather than failing the projection. Shared by the regression + governance
+// projectors.
+func (s *Store) hostName(ctx context.Context, hostID uuid.UUID) string {
+	var name string
+	if err := s.pool.QueryRow(ctx,
+		`SELECT COALESCE(NULLIF(display_name, ''), hostname) FROM hosts WHERE id = $1`,
+		hostID).Scan(&name); err != nil || name == "" {
+		return hostID.String()
+	}
+	return name
+}
+
 // Record upserts one notification for one user. A repeat of the same change
 // (same user_id + group_key) collapses onto the existing row, refreshing its
 // content + occurred_at and re-surfacing it as UNREAD — so a recurring problem
@@ -119,6 +133,51 @@ func (s *Store) RecordFanout(ctx context.Context, n Notification) error {
 		n.Kind, n.Severity, n.Title, n.Body, n.HostID, n.Link, n.GroupKey, n.OccurredAt,
 	); err != nil {
 		return fmt.Errorf("notifyfeed: record fanout: %w", err)
+	}
+	return nil
+}
+
+// RecordForRoles records one notification for every active (non-deleted) user
+// who holds at least one of the given built-in roles, in a single statement
+// (same upsert/collapse semantics as RecordFanout). This is the RBAC-scoped
+// fan-out behind governance notifications — e.g. an exception pending approval
+// reaches only users whose role grants exception:approve, not the whole fleet.
+// An empty roleIDs slice matches no one (a no-op). The UserID on the template
+// is ignored; recipients come from users joined to user_roles. EXISTS (not
+// JOIN) keeps a user holding two matching roles to one row, avoiding an ON
+// CONFLICT double-hit within the statement.
+func (s *Store) RecordForRoles(ctx context.Context, roleIDs []string, n Notification) error {
+	if n.GroupKey == "" {
+		return errors.New("notifyfeed: RecordForRoles requires GroupKey")
+	}
+	if len(roleIDs) == 0 {
+		return nil
+	}
+	if n.OccurredAt.IsZero() {
+		n.OccurredAt = time.Now().UTC()
+	}
+	const stmt = `
+		INSERT INTO notifications
+			(id, user_id, kind, severity, title, body, host_id, link, group_key, occurred_at)
+		SELECT gen_random_uuid(), u.id, $1, $2, $3, $4, $5, $6, $7, $8
+		  FROM users u
+		 WHERE u.deleted_at IS NULL
+		   AND EXISTS (
+			SELECT 1 FROM user_roles ur
+			 WHERE ur.user_id = u.id AND ur.role_id = ANY($9::text[]))
+		ON CONFLICT (user_id, group_key) DO UPDATE SET
+			kind        = EXCLUDED.kind,
+			severity    = EXCLUDED.severity,
+			title       = EXCLUDED.title,
+			body        = EXCLUDED.body,
+			host_id     = EXCLUDED.host_id,
+			link        = EXCLUDED.link,
+			occurred_at = EXCLUDED.occurred_at,
+			read_at     = NULL`
+	if _, err := s.pool.Exec(ctx, stmt,
+		n.Kind, n.Severity, n.Title, n.Body, n.HostID, n.Link, n.GroupKey, n.OccurredAt, roleIDs,
+	); err != nil {
+		return fmt.Errorf("notifyfeed: record for roles: %w", err)
 	}
 	return nil
 }

--- a/internal/notifyfeed/projector.go
+++ b/internal/notifyfeed/projector.go
@@ -127,7 +127,7 @@ func (p *Projector) ProjectScan(ctx context.Context, scanID, hostID uuid.UUID) e
 		topSeverity = "low" // a fail with no severity still warrants a low-rank ping
 	}
 
-	name := p.hostName(ctx, hostID)
+	name := p.store.hostName(ctx, hostID)
 
 	n := Notification{
 		Kind:     "rule_regression",
@@ -142,19 +142,6 @@ func (p *Projector) ProjectScan(ctx context.Context, scanID, hostID uuid.UUID) e
 		return fmt.Errorf("notifyfeed: project record: %w", err)
 	}
 	return nil
-}
-
-// hostName returns the host's display name (falling back to hostname, then the
-// id) for the notification title. A lookup failure degrades to the id rather
-// than failing the projection.
-func (p *Projector) hostName(ctx context.Context, hostID uuid.UUID) string {
-	var name string
-	if err := p.store.pool.QueryRow(ctx,
-		`SELECT COALESCE(NULLIF(display_name, ''), hostname) FROM hosts WHERE id = $1`,
-		hostID).Scan(&name); err != nil || name == "" {
-		return hostID.String()
-	}
-	return name
 }
 
 // hasFirstSeen reports whether any candidate is a first_seen change (so we only

--- a/internal/worker/remediation_worker.go
+++ b/internal/worker/remediation_worker.go
@@ -53,9 +53,18 @@ type RemediationWorker struct {
 	svc      *remediation.Service
 	writer   *transactionlog.Writer
 	queueKey []byte
-	bus      *eventbus.Bus // nil = no remediation.completed publication (dedicated worker)
+	bus      *eventbus.Bus      // nil = no remediation.completed publication (dedicated worker)
+	gov      GovernanceNotifier // nil = no in-app remediation-failure notification
 	emit     EmitFunc
 	clock    func() time.Time
+}
+
+// GovernanceNotifier receives terminal remediation-failure signals for the
+// in-app feed. notifyfeed.GovernanceProjector implements it; the worker holds
+// the interface to avoid importing the feed package. Best-effort at the call
+// site — a notify error never fails the job. Spec system-notifications (Slice 3).
+type GovernanceNotifier interface {
+	RemediationFailed(ctx context.Context, hostID uuid.UUID, ruleID, action, finalStatus string) error
 }
 
 // RemediationConfig is the constructor bundle. All fields except Bus/Clock/Emit
@@ -69,6 +78,12 @@ type RemediationConfig struct {
 	Bus      *eventbus.Bus
 	Emit     EmitFunc
 	Clock    func() time.Time
+
+	// Governance, when non-nil, receives a notification when a remediation
+	// reaches a terminal FAILURE (an execute that failed, or a rollback that
+	// did not restore). A successful user-initiated rollback is the intended
+	// outcome and is NOT notified. Spec system-notifications (Slice 3).
+	Governance GovernanceNotifier
 }
 
 // NewRemediationWorker wires a RemediationWorker.
@@ -86,8 +101,24 @@ func NewRemediationWorker(cfg RemediationConfig) *RemediationWorker {
 		writer:   cfg.Writer,
 		queueKey: cfg.QueueKey,
 		bus:      cfg.Bus,
+		gov:      cfg.Governance,
 		emit:     cfg.Emit,
 		clock:    cfg.Clock,
+	}
+}
+
+// notifyRemediationFailed fans a terminal-failure notification to the operators
+// who can act (remediation:execute holders). Best-effort + nil-safe: a notify
+// error is logged, never propagated.
+func (w *RemediationWorker) notifyRemediationFailed(ctx context.Context, hostID uuid.UUID, ruleID, action string) {
+	if w.gov == nil {
+		return
+	}
+	if err := w.gov.RemediationFailed(ctx, hostID, ruleID, action, "failed"); err != nil {
+		slog.WarnContext(ctx, "remediation failure notification failed",
+			slog.String("host_id", hostID.String()),
+			slog.String("rule_id", ruleID),
+			slog.String("error", err.Error()))
 	}
 }
 
@@ -257,6 +288,9 @@ func (w *RemediationWorker) finishExecute(ctx context.Context, j *queue.Job,
 		RuleFlipped: committed,
 		CompletedAt: w.clock().UTC(),
 	})
+	if final.Status == remediation.StatusFailed {
+		w.notifyRemediationFailed(ctx, final.HostID, final.RuleID, RemediationActionExecute)
+	}
 
 	if err := queue.Complete(ctx, w.pool, j.ID); err != nil {
 		slog.WarnContext(ctx, "remediation queue.Complete failed",
@@ -347,6 +381,7 @@ func (w *RemediationWorker) processRollback(ctx context.Context, j *queue.Job, p
 		detail = rbErr.Error()
 	}
 	_ = queue.Fail(ctx, w.pool, j.ID, "rollback did not restore: "+detail)
+	w.notifyRemediationFailed(ctx, p.HostID, p.RuleID, RemediationActionRollback)
 }
 
 // flipRuleToPass writes a single-rule transaction-log batch marking p.RuleID

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-notifications
   title: Notification channels — encrypted store + SSRF-guarded delivery
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -121,6 +121,28 @@ spec:
         retries the scan.
       type: technical
       enforcement: error
+    - id: C-08
+      description: >-
+        v1.5.0 (Slice 3) — the bell's third producer is the governance
+        action-queue: a notifyfeed.GovernanceProjector with RBAC-scoped fan-out.
+        notifyfeed.Store.RecordForRoles MUST fan one row per active user holding
+        any of the given built-in roles (DISTINCT, same upsert/collapse as
+        RecordFanout), and auth.RolesWithPermission(p) MUST resolve a permission
+        to the role IDs that grant it. The projector MUST: (a) on an exception
+        request, notify only users who can approve it
+        (roles granting exception:approve), kind "exception_pending", severity
+        high, deep-linked to the exception queue (/settings/policies), grouped
+        per exception; (b) on an approve/reject, notify only the requester, kind
+        "exception_approved"/"exception_rejected", severity medium; (c) on a
+        TERMINAL remediation FAILURE (an execute that failed, or a rollback that
+        did not restore — NOT a successful user-initiated rollback), notify only
+        users who can act (roles granting remediation:execute), kind
+        "remediation_failed", severity high, deep-linked to /hosts/{id}, grouped
+        per (host, rule). The exception service and remediation worker hold the
+        producer interfaces (so neither imports notifyfeed) and call best-effort:
+        a notify failure never fails the governance transition or the job.
+      type: security
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -209,3 +231,29 @@ spec:
         re-surfaces it unread with the latest scan's severity.
       priority: high
       references_constraints: [C-07]
+    - id: AC-15
+      description: >-
+        v1.5.0 — GovernanceProjector.ExceptionRequested fans an
+        "exception_pending" (severity high, link /settings/policies, grouped per
+        exception) to every user whose role grants exception:approve (auditor,
+        security_admin, admin) and to no one else (a viewer does not receive
+        it). auth.RolesWithPermission(exception:approve) resolves that role set;
+        RecordForRoles fans one row per holder.
+      priority: high
+      references_constraints: [C-08]
+    - id: AC-16
+      description: >-
+        v1.5.0 — GovernanceProjector.ExceptionDecided notifies ONLY the
+        requester: an approve records kind "exception_approved" (severity
+        medium) for the requesting user and no one else; a reject records
+        "exception_rejected".
+      priority: high
+      references_constraints: [C-08]
+    - id: AC-17
+      description: >-
+        v1.5.0 — GovernanceProjector.RemediationFailed fans a "remediation_failed"
+        (severity high, link /hosts/{id}, grouped per host+rule) to every user
+        whose role grants remediation:execute (ops_lead, security_admin, admin)
+        and to no one else (a viewer does not receive it).
+      priority: high
+      references_constraints: [C-08]


### PR DESCRIPTION
## Summary

Notifications **Slice 3** (per the [change-driven design](docs/engineering/notifications_design.md) §3/§7/§9): turn the bell into an **action queue**. Where Slice 1 (alerts) and Slice 2 (rule regressions) fan to every active user, governance items route only to the users who can act on them.

## New primitives (the RBAC-scoped fan-out Slice 3 needed)

- **`auth.RolesWithPermission(p)`** — resolves a permission to the built-in roles that grant it (pure function over `BuiltInRoles`).
- **`notifyfeed.Store.RecordForRoles`** — fans one row per active user holding any of the given roles (`EXISTS`, so a user with two matching roles still gets one row; avoids an `ON CONFLICT` double-hit), with the same upsert/collapse/re-surface semantics as `RecordFanout`.

## Producer: `notifyfeed.GovernanceProjector`

| Event | Recipients | kind / severity | Link |
|---|---|---|---|
| Exception **requested** | roles granting `exception:approve` (**auditor, security_admin, admin**) | `exception_pending` / high | `/settings/policies` |
| Exception **approved/rejected** | the **requester** only | `exception_approved` / `_rejected`, medium | `/settings/policies` |
| Remediation **failed** / rollback didn't restore | roles granting `remediation:execute` (**ops_lead, security_admin, admin**) | `remediation_failed` / high | `/hosts/{id}` |

Grouping: exceptions per exception id, remediation per `(host, rule)`. A **successful user-initiated rollback is not notified** — it's the intended outcome, and alarming on it would violate the design's "noise is a bug" principle (§7).

## Producer hooks (best-effort, nil-safe, never fail the transition/job)

- `exception.Service.WithNotifier(...)` + calls in `Request`/`Approve`/`Reject`.
- `worker.RemediationWorker` `GovernanceNotifier` + calls on the two terminal-failure sites (execute→failed, rollback-not-clean).
- Wired in both boot paths: `cmd/openwatch/main.go` (serve) and `worker.go` (dedicated worker).

Both producers hold the interface in **their own** package, so neither imports `notifyfeed` (the projector satisfies them structurally).

## Spec & tests

- `system-notifications` **v1.5.0**: **C-08** + **AC-15/16/17**. `specter check` green (114 specs); annotation coverage = system-notifications **17/17 ACs, 100%**.
- `auth.RolesWithPermission` unit test (which caught my own wrong assumption — `exception:approve` includes **auditor**, confirming the projector notifies auditors); DB-backed governance fan-out tests proving approver-scoped / requester-only / operator-scoped routing and that out-of-scope roles receive nothing.

## Scope notes
- **No frontend change** — new rows render in the existing Slice-1 bell drawer.
- **Exception expiring-soon** (design §3) and **info-level digests / batched good-news** are **Slice 4**, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)