### PR TITLE
feat(notifications): Slice 4 — exception expiry lifecycle in the bell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   remediation that fails (or a rollback that does not restore) reaches the
   operators who can re-run it. Each item is severity-ranked and deep-links to
   where you act on it. (notifications Slice 3)
+- Approvers are now warned before a compliance exception lapses (within 72
+  hours) and notified when it does, so a waiver expiring and its rules snapping
+  back into scope never goes unnoticed. The "expiring soon" warning is shown
+  once per approver rather than re-pinging on every hourly sweep. (notifications
+  Slice 4)
 
 ---
 

--- a/internal/exception/notify_test.go
+++ b/internal/exception/notify_test.go
@@ -1,0 +1,87 @@
+// @spec system-notifications
+//
+// AC traceability (this file):
+//
+//	AC-19  TestExpiringSoonSweep_InWindowApprovedOnly — the sweep query selects
+//	       only approved exceptions expiring within the window and warns each.
+//
+// Skipped without OPENWATCH_TEST_DSN (shared per-package isolated DB).
+package exception
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+)
+
+// fakeNotifier records which exceptions each governance hook fired for.
+type fakeNotifier struct {
+	expiringSoon []uuid.UUID
+	expired      []uuid.UUID
+}
+
+func (f *fakeNotifier) ExceptionRequested(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (f *fakeNotifier) ExceptionDecided(context.Context, uuid.UUID, uuid.UUID, string, bool) error {
+	return nil
+}
+func (f *fakeNotifier) ExceptionExpiringSoon(_ context.Context, id, _ uuid.UUID, _ string) error {
+	f.expiringSoon = append(f.expiringSoon, id)
+	return nil
+}
+func (f *fakeNotifier) ExceptionExpired(_ context.Context, id, _ uuid.UUID, _ string) error {
+	f.expired = append(f.expired, id)
+	return nil
+}
+
+// @ac AC-19
+func TestExpiringSoonSweep_InWindowApprovedOnly(t *testing.T) {
+	t.Run("system-notifications/AC-19", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		fake := &fakeNotifier{}
+		svc := NewService(pool, fakeEmitter(&[]emitCall{})).WithNotifier(fake)
+
+		requester := seedUser(t, pool, "req")
+		reviewer := seedUser(t, pool, "rev")
+		host := seedHost(t, pool, requester)
+
+		soon := time.Now().UTC().Add(24 * time.Hour)                // inside the 72h window
+		far := time.Now().UTC().Add(ExpiringSoonWindow + time.Hour) // outside
+
+		// In-window, approved → must be warned.
+		inWin, err := svc.Request(ctx, host, "rule-soon", "reason", requester, &soon)
+		if err != nil {
+			t.Fatalf("request in-window: %v", err)
+		}
+		if _, err := svc.Approve(ctx, inWin.ID, reviewer, "ok"); err != nil {
+			t.Fatalf("approve in-window: %v", err)
+		}
+		// Out-of-window, approved → must NOT be warned.
+		farEx, _ := svc.Request(ctx, host, "rule-far", "reason", requester, &far)
+		if _, err := svc.Approve(ctx, farEx.ID, reviewer, "ok"); err != nil {
+			t.Fatalf("approve far: %v", err)
+		}
+		// In-window but only requested (not approved) → must NOT be warned.
+		if _, err := svc.Request(ctx, host, "rule-pending", "reason", requester, &soon); err != nil {
+			t.Fatalf("request pending: %v", err)
+		}
+
+		n, err := svc.ExpiringSoonSweep(ctx)
+		if err != nil {
+			t.Fatalf("ExpiringSoonSweep: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("want 1 warned, got %d", n)
+		}
+		if len(fake.expiringSoon) != 1 || fake.expiringSoon[0] != inWin.ID {
+			t.Errorf("only the in-window approved exception should be warned, got %v (want %v)",
+				fake.expiringSoon, inWin.ID)
+		}
+	})
+}

--- a/internal/exception/run.go
+++ b/internal/exception/run.go
@@ -17,22 +17,28 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) *cron.Schedul
 	if interval == 0 {
 		interval = ExpirySweepInterval
 	}
-	if n, err := s.ExpireSweep(ctx); err != nil {
-		slog.WarnContext(ctx, "exception boot expiry sweep failed", "err", err)
-	} else if n > 0 {
-		slog.InfoContext(ctx, "exception expiry sweep", "expired", n)
-	}
+	s.sweepOnce(ctx, "boot ")
 	tick := cron.New(interval, func(ctx context.Context) error {
-		n, err := s.ExpireSweep(ctx)
-		if err != nil {
-			slog.ErrorContext(ctx, "exception expiry sweep failed", "err", err)
-			return err
-		}
-		if n > 0 {
-			slog.InfoContext(ctx, "exception expiry sweep", "expired", n)
-		}
+		s.sweepOnce(ctx, "")
 		return nil
 	})
 	tick.Start(ctx)
 	return tick
+}
+
+// sweepOnce runs both expiry passes: flip lapsed exceptions to expired (and
+// notify), then warn approvers about those expiring soon. Both are best-effort
+// for notifications; a hard ExpireSweep error is logged but does not stop the
+// tick (the next pass retries).
+func (s *Service) sweepOnce(ctx context.Context, phase string) {
+	if n, err := s.ExpireSweep(ctx); err != nil {
+		slog.WarnContext(ctx, "exception "+phase+"expiry sweep failed", "err", err)
+	} else if n > 0 {
+		slog.InfoContext(ctx, "exception expiry sweep", "expired", n)
+	}
+	if n, err := s.ExpiringSoonSweep(ctx); err != nil {
+		slog.WarnContext(ctx, "exception "+phase+"expiring-soon sweep failed", "err", err)
+	} else if n > 0 {
+		slog.InfoContext(ctx, "exception expiring-soon sweep", "warned", n)
+	}
 }

--- a/internal/exception/service.go
+++ b/internal/exception/service.go
@@ -28,6 +28,8 @@ type EmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
 type Notifier interface {
 	ExceptionRequested(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error
 	ExceptionDecided(ctx context.Context, exceptionID, requestedBy uuid.UUID, ruleID string, approved bool) error
+	ExceptionExpiringSoon(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error
+	ExceptionExpired(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error
 }
 
 // Service is the exception governance service.
@@ -308,6 +310,7 @@ func (s *Service) ExpireSweep(ctx context.Context) (int, error) {
 	for _, e := range expired {
 		// System-actor expiry: no reviewer.
 		s.emitEvent(ctx, audit.ComplianceExceptionExpired, e, uuid.Nil, "expired")
+		s.notifyExpired(ctx, e)
 	}
 	return len(expired), nil
 }
@@ -362,6 +365,70 @@ func (s *Service) notifyDecided(ctx context.Context, e Exception, approved bool)
 		slog.WarnContext(ctx, "exception decided notification failed",
 			slog.String("exception_id", e.ID.String()), slog.String("error", err.Error()))
 	}
+}
+
+// notifyExpiringSoon warns approvers an approved exception is about to lapse.
+// Best-effort; quiet fan-out at the projector keeps the hourly sweep from
+// re-nagging.
+func (s *Service) notifyExpiringSoon(ctx context.Context, e Exception) {
+	if s.notifier == nil {
+		return
+	}
+	if err := s.notifier.ExceptionExpiringSoon(ctx, e.ID, e.HostID, e.RuleID); err != nil {
+		slog.WarnContext(ctx, "exception expiring-soon notification failed",
+			slog.String("exception_id", e.ID.String()), slog.String("error", err.Error()))
+	}
+}
+
+// notifyExpired tells approvers an exception lapsed (rules back in scope).
+func (s *Service) notifyExpired(ctx context.Context, e Exception) {
+	if s.notifier == nil {
+		return
+	}
+	if err := s.notifier.ExceptionExpired(ctx, e.ID, e.HostID, e.RuleID); err != nil {
+		slog.WarnContext(ctx, "exception expired notification failed",
+			slog.String("exception_id", e.ID.String()), slog.String("error", err.Error()))
+	}
+}
+
+// ExpiringSoonWindow is how far ahead the expiring-soon sweep looks: approvers
+// are warned this long before an approved exception lapses.
+const ExpiringSoonWindow = 72 * time.Hour
+
+// ExpiringSoonSweep warns approvers about approved exceptions whose expires_at
+// falls within ExpiringSoonWindow. Read-only (no state change); the projector's
+// quiet fan-out makes repeated hourly sweeps notify each recipient at most once.
+// A no-op without a notifier wired. Returns the count warned.
+func (s *Service) ExpiringSoonSweep(ctx context.Context) (int, error) {
+	if s.notifier == nil {
+		return 0, nil
+	}
+	cutoff := time.Now().UTC().Add(ExpiringSoonWindow)
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+selectCols+`
+		  FROM compliance_exceptions
+		 WHERE status = 'approved' AND expires_at IS NOT NULL
+		   AND expires_at > now() AND expires_at <= $1
+		 ORDER BY expires_at`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("exception: expiring-soon sweep: %w", err)
+	}
+	defer rows.Close()
+	var soon []Exception
+	for rows.Next() {
+		e, err := scanException(rows)
+		if err != nil {
+			return 0, fmt.Errorf("exception: expiring-soon scan: %w", err)
+		}
+		soon = append(soon, e)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("exception: expiring-soon iterate: %w", err)
+	}
+	for _, e := range soon {
+		s.notifyExpiringSoon(ctx, e)
+	}
+	return len(soon), nil
 }
 
 // isUniqueViolation reports whether err is a Postgres unique-violation

--- a/internal/notifyfeed/governance.go
+++ b/internal/notifyfeed/governance.go
@@ -82,6 +82,49 @@ func (g *GovernanceProjector) ExceptionDecided(ctx context.Context, exceptionID,
 	return nil
 }
 
+// ExceptionExpiringSoon warns approvers that an approved exception is about to
+// lapse (after which its rules re-enter scope). Uses the QUIET fan-out: the
+// expiry sweep re-evaluates hourly, so a non-quiet record would re-surface the
+// same warning unread every hour. Grouped per exception.
+func (g *GovernanceProjector) ExceptionExpiringSoon(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error {
+	host := g.store.hostName(ctx, hostID)
+	h := hostID
+	n := Notification{
+		Kind:     "exception_expiring",
+		Severity: "medium",
+		Title:    fmt.Sprintf("Exception expiring soon: %s on %s", ruleID, host),
+		Body:     "An approved compliance exception is about to expire. Its rules will re-enter scope unless renewed.",
+		HostID:   &h,
+		Link:     exceptionQueueLink,
+		GroupKey: "exception_expiring:" + exceptionID.String(),
+	}
+	if err := g.store.RecordForRolesQuiet(ctx, roleStrings(auth.RolesWithPermission(auth.ExceptionApprove)), n); err != nil {
+		return fmt.Errorf("notifyfeed: exception expiring soon: %w", err)
+	}
+	return nil
+}
+
+// ExceptionExpired notifies approvers that an exception has lapsed and its rules
+// are back in scope. Fires once per exception (the sweep flips each to expired
+// exactly once), so the standard fan-out is used. Grouped per exception.
+func (g *GovernanceProjector) ExceptionExpired(ctx context.Context, exceptionID, hostID uuid.UUID, ruleID string) error {
+	host := g.store.hostName(ctx, hostID)
+	h := hostID
+	n := Notification{
+		Kind:     "exception_expired",
+		Severity: "medium",
+		Title:    fmt.Sprintf("Exception expired: %s on %s", ruleID, host),
+		Body:     "A compliance exception has expired. Its rules are back in scope and will be evaluated on the next scan.",
+		HostID:   &h,
+		Link:     exceptionQueueLink,
+		GroupKey: "exception_expired:" + exceptionID.String(),
+	}
+	if err := g.store.RecordForRoles(ctx, roleStrings(auth.RolesWithPermission(auth.ExceptionApprove)), n); err != nil {
+		return fmt.Errorf("notifyfeed: exception expired: %w", err)
+	}
+	return nil
+}
+
 // RemediationFailed records a "remediation failed / rolled back" notification
 // for the operators who can act on it (remediation:execute → ops_lead,
 // security_admin, admin). Grouped per (host, rule). finalStatus is the

--- a/internal/notifyfeed/governance_test.go
+++ b/internal/notifyfeed/governance_test.go
@@ -5,6 +5,7 @@
 //	AC-15  TestGovernance_ExceptionRequestedFansToApprovers — pending → approvers only (RBAC-scoped fan-out)
 //	AC-16  TestGovernance_ExceptionDecidedNotifiesRequester — decision → requester only
 //	AC-17  TestGovernance_RemediationFailedFansToOperators — failure → remediation operators only
+//	AC-18  TestGovernance_ExceptionExpiry — expiring-soon (quiet/sticky) + expired → approvers
 //
 // Skipped without OPENWATCH_TEST_DSN. Assertions filter by the per-test-unique
 // group_key so the role-scoped fan-out from other tests on the shared DB does
@@ -159,6 +160,58 @@ func TestGovernance_RemediationFailedFansToOperators(t *testing.T) {
 		// A viewer (no remediation:execute) does NOT receive it.
 		if n := notifByGroupKey(t, s, viewer, gk); n != nil {
 			t.Errorf("viewer must not receive an operator-scoped notification")
+		}
+	})
+}
+
+// @ac AC-18
+func TestGovernance_ExceptionExpiry(t *testing.T) {
+	t.Run("system-notifications/AC-18", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewStore(pool)
+		g := NewGovernanceProjector(s)
+
+		approver := seedUserWithRole(t, pool, "secadmin-"+uniq(), "security_admin")
+		viewer := seedUserWithRole(t, pool, "viewer-"+uniq(), "viewer")
+		creator := seedUser(t, pool, "creator-"+uniq())
+		host := seedHost(t, pool, creator, "web-"+uniq(), "Web One")
+
+		// Expiring-soon → approvers (medium), and NOT viewers.
+		soonID, _ := uuid.NewV7()
+		if err := g.ExceptionExpiringSoon(ctx, soonID, host, "rule.ssh"); err != nil {
+			t.Fatalf("ExceptionExpiringSoon: %v", err)
+		}
+		soonGK := "exception_expiring:" + soonID.String()
+		n := notifByGroupKey(t, s, approver, soonGK)
+		if n == nil || n.Kind != "exception_expiring" || n.Severity != "medium" {
+			t.Fatalf("approver should get a medium exception_expiring notification, got %+v", n)
+		}
+		if notifByGroupKey(t, s, viewer, soonGK) != nil {
+			t.Errorf("viewer must not receive an approver-scoped warning")
+		}
+
+		// Quiet/sticky: the approver reads it, then a repeat sweep records the
+		// same warning — it must STAY read (ON CONFLICT DO NOTHING), not
+		// re-surface unread.
+		if err := s.MarkRead(ctx, approver, n.ID); err != nil {
+			t.Fatalf("mark read: %v", err)
+		}
+		if err := g.ExceptionExpiringSoon(ctx, soonID, host, "rule.ssh"); err != nil {
+			t.Fatalf("ExceptionExpiringSoon repeat: %v", err)
+		}
+		if again := notifByGroupKey(t, s, approver, soonGK); again == nil || again.ReadAt == nil {
+			t.Errorf("repeated expiring-soon warning must stay read (quiet), got %+v", again)
+		}
+
+		// Expired → approvers (medium), distinct kind/group.
+		expID, _ := uuid.NewV7()
+		if err := g.ExceptionExpired(ctx, expID, host, "rule.ssh"); err != nil {
+			t.Fatalf("ExceptionExpired: %v", err)
+		}
+		e := notifByGroupKey(t, s, approver, "exception_expired:"+expID.String())
+		if e == nil || e.Kind != "exception_expired" || e.Severity != "medium" {
+			t.Errorf("approver should get a medium exception_expired notification, got %+v", e)
 		}
 	})
 }

--- a/internal/notifyfeed/notifyfeed.go
+++ b/internal/notifyfeed/notifyfeed.go
@@ -182,6 +182,41 @@ func (s *Store) RecordForRoles(ctx context.Context, roleIDs []string, n Notifica
 	return nil
 }
 
+// RecordForRolesQuiet is RecordForRoles with at-most-once-per-recipient
+// semantics: ON CONFLICT it does NOTHING (the existing row is left untouched —
+// content, occurred_at, AND read state preserved). This is for repeatedly-swept
+// warnings (e.g. "exception expiring soon", re-evaluated every hour): a
+// recipient is notified once and the row does not re-surface unread on every
+// sweep, which would be noise. A recipient who joins later still gets it on the
+// next sweep (their INSERT). Empty roleIDs is a no-op.
+func (s *Store) RecordForRolesQuiet(ctx context.Context, roleIDs []string, n Notification) error {
+	if n.GroupKey == "" {
+		return errors.New("notifyfeed: RecordForRolesQuiet requires GroupKey")
+	}
+	if len(roleIDs) == 0 {
+		return nil
+	}
+	if n.OccurredAt.IsZero() {
+		n.OccurredAt = time.Now().UTC()
+	}
+	const stmt = `
+		INSERT INTO notifications
+			(id, user_id, kind, severity, title, body, host_id, link, group_key, occurred_at)
+		SELECT gen_random_uuid(), u.id, $1, $2, $3, $4, $5, $6, $7, $8
+		  FROM users u
+		 WHERE u.deleted_at IS NULL
+		   AND EXISTS (
+			SELECT 1 FROM user_roles ur
+			 WHERE ur.user_id = u.id AND ur.role_id = ANY($9::text[]))
+		ON CONFLICT (user_id, group_key) DO NOTHING`
+	if _, err := s.pool.Exec(ctx, stmt,
+		n.Kind, n.Severity, n.Title, n.Body, n.HostID, n.Link, n.GroupKey, n.OccurredAt, roleIDs,
+	); err != nil {
+		return fmt.Errorf("notifyfeed: record for roles quiet: %w", err)
+	}
+	return nil
+}
+
 // List returns a user's notifications newest-first (by occurred_at). When
 // unreadOnly is true, only unread rows are returned. limit caps the result
 // (defaulted/clamped to a sane page size).

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-notifications
   title: Notification channels — encrypted store + SSRF-guarded delivery
-  version: "1.5.0"
+  version: "1.6.0"
   status: approved
   tier: 2
 
@@ -143,6 +143,25 @@ spec:
         a notify failure never fails the governance transition or the job.
       type: security
       enforcement: error
+    - id: C-09
+      description: >-
+        v1.6.0 (Slice 4) — the governance action queue completes the exception
+        lifecycle: GovernanceProjector.ExceptionExpiringSoon warns approvers
+        (roles granting exception:approve) that an approved exception is within
+        ExpiringSoonWindow (72h) of lapsing — kind "exception_expiring", medium,
+        deep-linked to the queue, grouped per exception; and
+        GovernanceProjector.ExceptionExpired notifies approvers when one lapses
+        (rules back in scope) — kind "exception_expired", medium. The
+        expiring-soon warning MUST use notifyfeed.Store.RecordForRolesQuiet (ON
+        CONFLICT DO NOTHING) so the hourly sweep notifies each recipient AT MOST
+        ONCE and does not re-surface a read warning every hour; expired fires
+        once per exception so it uses the standard fan-out. exception.Service
+        drives both from its existing sweep loop: ExpireSweep notifies per newly
+        expired exception, and ExpiringSoonSweep selects only approved
+        exceptions with expires_at in (now, now+window] and warns each. All
+        notifications are best-effort (a failure never fails the sweep).
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -257,3 +276,22 @@ spec:
         and to no one else (a viewer does not receive it).
       priority: high
       references_constraints: [C-08]
+    - id: AC-18
+      description: >-
+        v1.6.0 — ExceptionExpiringSoon records a medium "exception_expiring"
+        (link /settings/policies, grouped per exception) for approvers and not
+        viewers, via the QUIET fan-out: after a recipient reads it, a repeated
+        record for the same exception leaves it READ (does not re-surface
+        unread). ExceptionExpired records a medium "exception_expired" for
+        approvers.
+      priority: high
+      references_constraints: [C-09]
+    - id: AC-19
+      description: >-
+        v1.6.0 — Service.ExpiringSoonSweep warns only approved exceptions whose
+        expires_at is within (now, now+ExpiringSoonWindow]: an in-window
+        approved exception is warned, an out-of-window approved one and an
+        in-window still-requested one are not; the count returned matches the
+        warned set.
+      priority: high
+      references_constraints: [C-09]


### PR DESCRIPTION
## Summary

Notifications **Slice 4** (per the [design](docs/engineering/notifications_design.md) §3/§9): complete the governance **action queue** by closing the exception lifecycle in the bell. Slice 3 covered pending → decided; this adds **expiring-soon** (warn before a waiver lapses) and **expired** (its rules snap back into scope).

## What it does

| Event | Recipients | kind / severity | Fan-out |
|---|---|---|---|
| Exception **expiring soon** (≤72h) | approvers (`exception:approve`) | `exception_expiring` / medium | **quiet** (at-most-once) |
| Exception **expired** | approvers | `exception_expired` / medium | standard (fires once per exception) |

Both deep-link to `/settings/policies` and group per exception.

## Why the "quiet" variant

The expiry sweep runs **hourly**. A normal scoped fan-out re-surfaces a read notification unread on every sweep — exactly the noise the design forbids (§7 "noise is a bug"). New **`notifyfeed.Store.RecordForRolesQuiet`** uses `ON CONFLICT DO NOTHING`: a recipient is warned **once**, their read state sticks, and a late-joining approver still gets it on the next sweep. Expired fires once per exception (the sweep flips each to `expired` exactly once), so it uses the standard fan-out.

## Wiring

`exception.Service` drives both from its **existing** hourly sweep loop — no new cron:
- `Run → sweepOnce`: `ExpireSweep` (now notifies per newly-expired exception) then `ExpiringSoonSweep` (selects approved exceptions with `expires_at ∈ (now, now+72h]`, warns each), at boot + per tick.
- `Notifier` interface extended with the two methods; all calls best-effort (never fail the sweep).
- **No `cmd` change** — the existing `WithNotifier(govProjector)` now satisfies the extended interface (the projector implements all four methods).

## Spec & tests

- `system-notifications` **v1.6.0**: **C-09** + **AC-18/19**. `specter check` green (114 specs); annotation coverage = system-notifications **19/19 ACs, 100%**.
- Tests: quiet/sticky fan-out + expiring/expired projector (`notifyfeed`); the `ExpiringSoonSweep` window query with a fake notifier proving only in-window **approved** exceptions are warned (`exception`).

## Deferred (design Slice 4 tail, with rationale)
- **License grace/expiry** — the license is verified at **boot only**, never re-verified at runtime, so a grace transition isn't detected without a restart; a reliable notifier needs periodic re-verification first (separate work).
- **Repeated-failed-login / lockout** — there's no lockout primitive (only auth rate-limiting); a reliable signal needs a windowed failed-login threshold projector over the audit log.
- **Info-level good-news digests** (batched recoveries) — lowest-value tier; batching complexity not yet justified.

## Scope notes
- **No frontend change** — rows render in the existing Slice-1 bell drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)