### PR TITLE
chore(release): cut v0.2.0-rc.16 (Eyrie)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0-rc.16] Eyrie — 2026-06-25
+
+Extends the change-driven notification bell from a durable feed into a full,
+severity-ranked, RBAC-scoped action queue: compliance regressions, governance
+decisions, remediation failures, and exception-expiry warnings now reach the
+specific users who must act on them.
+
 ### Added
 - In-app notifications now flag when a scan turns a passing rule into a failing
   one: the bell shows one grouped per-host notification ("web-01: 3 rules

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.15"
+VERSION="0.2.0-rc.16"
 CODENAME="Eyrie"


### PR DESCRIPTION
## Summary

Cuts **v0.2.0-rc.16** (Eyrie). Bumps `packaging/version.env` and rolls the CHANGELOG `[Unreleased]` accumulator into a dated section.

## What's in rc.16 (since rc.15)

The change-driven notification bell grows from a durable feed into a full **action queue**:
- **Slice 2** (#685) — rule-regression projector: a scan that flips a passing rule to failing shows one grouped per-host notification, severity-ranked, with first-scan-baseline suppression.
- **Slice 3** (#686) — RBAC-scoped governance queue: exception pending → approvers, decided → requester, remediation failed → operators.
- **Slice 4** (#687) — exception expiry lifecycle: warn approvers ≤72h before a waiver lapses (quiet/at-most-once) + notify when it does.

Plus the DOC-3 operator-guide truthfulness pass (#682) merged earlier in the window.

## After merge

Tagging `v0.2.0-rc.16` on green triggers `release.yml` (signed RPM/DEB amd64+arm64, SBOMs, pre-release) + package-smoke.

## Not in this release
The three notification deferrals (license expiry, failed-login/lockout, good-news digests) remain tracked follow-ups, each behind a prerequisite. rc, not GA — Stage 3 fleet-verification not run this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)