### PR TITLE
fix(settings): label free tier 'Open-core' and drop the Features row on /settings/about

### DIFF
--- a/frontend/src/pages/settings/StubbedPages.tsx
+++ b/frontend/src/pages/settings/StubbedPages.tsx
@@ -107,7 +107,7 @@ export function IntegrationsPage() {
 
 // ── About ───────────────────────────────────────────────────────────────
 const LICENSE_TIER_LABEL: Record<string, string> = {
-  free: 'Free',
+  free: 'Open-core',
   openwatch_plus: 'OpenWatch+',
   enterprise: 'Enterprise',
 };
@@ -234,33 +234,6 @@ export function AboutPage() {
                   </span>
                 </>
               ) : null}
-
-              <span style={{ color: 'var(--ow-fg-2)', alignSelf: 'start' }}>Features</span>
-              <span>
-                {lic && lic.features.length > 0 ? (
-                  <span style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-                    {lic.features.map((f) => (
-                      <span
-                        key={f}
-                        style={{
-                          padding: '2px 8px',
-                          borderRadius: 'var(--ow-radius-sm)',
-                          background: 'var(--ow-bg-3)',
-                          color: 'var(--ow-fg-1)',
-                          fontSize: 12,
-                          fontFamily: 'var(--ow-font-mono)',
-                        }}
-                      >
-                        {f}
-                      </span>
-                    ))}
-                  </span>
-                ) : (
-                  <span style={{ color: 'var(--ow-fg-3)' }}>
-                    {lic ? 'No paid features entitled' : '…'}
-                  </span>
-                )}
-              </span>
             </div>
           )}
         </SettingCard>


### PR DESCRIPTION
Small `/settings/about` cleanup, consistent with the open-core model.

## Changes
- **Free tier label → "Open-core"** — `LICENSE_TIER_LABEL.free` was `'Free'`, now `'Open-core'`. The free tier *is* the open-core edition.
- **Removed the per-license Features row** — no need to surface entitled feature IDs (the open-core tier has none anyway). Tier + Status (and Customer/Expires for licensed deployments) still render live from `GET /api/v1/license`.

## Not changed (by design)
- **Version display.** The page reads the version live from the running binary (`GET /api/v1/version`, ldflags-injected from `version.env` at build time). It correctly reflects whatever binary is running; a stale local display means a stale local build (rebuild), not a code issue. Left as-is so it never misreports the running version.

## Verification
- `npx tsc --noEmit` clean
- `npx eslint` clean
- `frontend/tests/pages/settings.test.ts` 32/32 (incl. `frontend-settings/AC-20` — About renders license/version from the API via the lookup maps, which are untouched)

Note: "Open-core" is a tier label (product positioning), not a license string — it does not name AGPL/Apache and does not pre-announce any license change.