### PR TITLE
fix(frontend): bump js-yaml to >=4.2.0 (CVE-2026-53550, Dependabot #140)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4601,10 +4601,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,5 +61,8 @@
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.9"
+  },
+  "overrides": {
+    "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
Resolves Dependabot alert #140.

## The vulnerability
- **js-yaml@4.1.1** — GHSA-h67p-54hq-rp68 / CVE-2026-53550, quadratic-complexity DoS parsing crafted YAML merge keys. Medium, CVSS availability-only (`C:N/I:N/A:L`).
- **Transitive dev dependency** (`frontend/package-lock.json`, dev scope): pulled in by `eslint` -> `@eslint/eslintrc` and `openapi-typescript` -> `@redocly/openapi-core`. **Not in the shipped SPA bundle.**
- Fixed in **4.2.0**.

## Fix
Pin via `overrides` in `frontend/package.json` to `^4.2.0` (forces the resolution regardless of the parents' ranges). npm dedups both consumers to a single js-yaml@4.2.0.

## Verification
- `npm ls js-yaml` -> 4.2.0 (both consumers)
- `npm audit` -> **0 vulnerabilities**
- `eslint --max-warnings=0 .` clean (it's the primary js-yaml consumer)
- `tsc --noEmit` clean

Diff is scoped to `package.json` + `package-lock.json`.