### PR TITLE
release: cut v0.2.0-rc.17 (Eyrie) — docs freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [0.2.0-rc.17] Eyrie — 2026-06-27
+
 ### Security
 
+- Replaced the embedded license and admin-policy signing keys with production
+  keys generated offline; the private keys never enter the repository, and a
+  build guard now fails the build if a shipped key matches the test key. This
+  closes a flaw where anyone with repository access could forge a license or
+  an admin policy.
+- Hardened the SSO/OIDC client against server-side request forgery: the
+  discovery, token, and JWKS fetches now refuse to connect to loopback,
+  private, carrier-grade NAT, and link-local addresses, including the cloud
+  metadata endpoint. The same guard now backs outbound notification webhooks.
 - Bumped `js-yaml` to `>= 4.2.0` (CVE-2026-53550, a quadratic-complexity
   denial-of-service in YAML merge-key handling). Dev-only transitive
   dependency; not in the shipped UI bundle.

--- a/docs/guides/runbooks/DISK_FULL.md
+++ b/docs/guides/runbooks/DISK_FULL.md
@@ -276,7 +276,7 @@ retention planning.
 
 ## Not yet implemented
 
-OpenWatch is currently `v0.2.0-rc.16`, a pre-release. The following do not exist in
+OpenWatch is currently `v0.2.0-rc.17`, a pre-release. The following do not exist in
 the current code and must not be relied on:
 
 - **Automated retention / pruning jobs** for `audit_events` or other tables.

--- a/docs/guides/runbooks/SERVICE_DOWN.md
+++ b/docs/guides/runbooks/SERVICE_DOWN.md
@@ -361,7 +361,7 @@ Include when escalating:
 
 ## Not yet implemented
 
-OpenWatch is currently `v0.2.0-rc.16`, a pre-release. The following do not exist in
+OpenWatch is currently `v0.2.0-rc.17`, a pre-release. The following do not exist in
 the current code and must not be relied on in this runbook:
 
 - **A packaged systemd unit for the scan worker.** Only `openwatch.service`

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.2.0-rc.16"
+VERSION="0.2.0-rc.17"
 CODENAME="Eyrie"


### PR DESCRIPTION
Stage 1 docs freeze for **v0.2.0-rc.17**. Merge this, then the `v0.2.0-rc.17` tag triggers `release.yml` (signed RPM/DEB amd64+arm64, SBOMs, pre-release) + `package-smoke.yml`.

## Changes
- `packaging/version.env` → `0.2.0-rc.17`
- `CHANGELOG.md`: roll `[Unreleased]` into a dated `[0.2.0-rc.17]` section, plus two operator-facing security entries for this cycle.
- Refresh the rc version string in the `SERVICE_DOWN` / `DISK_FULL` runbooks.

## What rc.17 bundles since rc.16
- **#701** — SEC-H1: real offline license + policy signing keys + build-fail regression guards.
- **#702** — `owlicgen` (license minter) removed from the product; issuance is Hanalyx infra.
- **#703** — SEC-H2: OIDC/notification SSRF guard (shared, CGNAT-aware); non-gating transactionlog perf test.

## Verified
- changelog format gate (`TestChangelog_*`) green
- binary reports `0.2.0-rc.17` via ldflags
- `specter check` 114 specs, coverage 100%