### PR TITLE
fix(auth): unverified MFA enrollment must not gate login; show QR on enroll

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@tanstack/react-router": "^1.170.16",
         "lucide-react": "^1.21.0",
         "openapi-fetch": "^0.17.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-dropzone": "^15.0.0",
@@ -5733,6 +5734,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-router": "^1.170.16",
     "lucide-react": "^1.21.0",
     "openapi-fetch": "^0.17.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-dropzone": "^15.0.0",

--- a/frontend/src/pages/settings/ProfilePage.tsx
+++ b/frontend/src/pages/settings/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useQueryClient } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
 import api from '@/api/client';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
@@ -376,11 +377,19 @@ function FormInput({
   );
 }
 
+// secretFromUri extracts the base32 TOTP secret from an otpauth:// provisioning
+// URI, for the manual-entry fallback. The enroll response returns only the full
+// URI (which the QR encodes); the secret is the `secret` query parameter.
+function secretFromUri(uri: string): string {
+  const s = uri.match(/[?&]secret=([^&]+)/i)?.[1];
+  return s ? decodeURIComponent(s) : '';
+}
+
 function MFASection() {
   const identity = useAuthStore((s) => s.identity);
   const setIdentity = useAuthStore((s) => s.setIdentity);
   const queryClient = useQueryClient();
-  const [enrollment, setEnrollment] = useState<{ secret: string; uri: string } | null>(null);
+  const [enrollment, setEnrollment] = useState<{ uri: string } | null>(null);
   const [otp, setOtp] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -393,8 +402,8 @@ function MFASection() {
     try {
       const { data, error: apiErr } = await api.POST('/api/v1/auth/mfa:enroll', {});
       if (apiErr) throw apiErr;
-      const d = data as { provisioning_uri: string; secret: string };
-      setEnrollment({ uri: d.provisioning_uri, secret: d.secret });
+      const d = data as { provisioning_uri: string };
+      setEnrollment({ uri: d.provisioning_uri });
     } catch {
       setError('Failed to start enrollment.');
     } finally {
@@ -458,32 +467,42 @@ function MFASection() {
             }}
           >
             <p style={{ margin: 0, color: 'var(--ow-fg-1)', fontSize: 13 }}>
-              Scan this URI in your authenticator app, or enter the secret manually, then enter the
-              6-digit code to confirm enrollment.
+              Scan this QR code with your authenticator app (Authy, Google Authenticator, 1Password,
+              etc.), or enter the secret manually, then enter the 6-digit code to confirm
+              enrollment.
             </p>
-            <code
+            <div
               style={{
-                fontFamily: 'var(--ow-font-mono)',
-                fontSize: 12,
-                background: 'var(--ow-bg-2)',
-                padding: '10px 12px',
+                padding: 12,
+                borderRadius: 8,
+                width: 'fit-content',
                 border: '1px solid var(--ow-line)',
-                borderRadius: 6,
-                wordBreak: 'break-all',
               }}
             >
-              {enrollment.uri}
-            </code>
+              {/* qrcode.react renders a white background + black modules by
+                  default (scannable on the dark UI); marginSize adds the quiet
+                  zone. No hardcoded colors needed. */}
+              <QRCodeSVG
+                value={enrollment.uri}
+                size={176}
+                level="M"
+                marginSize={2}
+                aria-label="MFA enrollment QR code"
+              />
+            </div>
             <div>
-              <span style={{ color: 'var(--ow-fg-2)', fontSize: 12, marginRight: 8 }}>Secret:</span>
+              <span style={{ color: 'var(--ow-fg-2)', fontSize: 12, marginRight: 8 }}>
+                Secret (manual entry):
+              </span>
               <code
                 style={{
                   fontFamily: 'var(--ow-font-mono)',
                   fontSize: 13,
                   color: 'var(--ow-fg-0)',
+                  wordBreak: 'break-all',
                 }}
               >
-                {enrollment.secret}
+                {secretFromUri(enrollment.uri)}
               </code>
             </div>
             <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -164,6 +164,12 @@ func TestAuthLogin_MFARequired(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EnrollMFA: %v", err)
 		}
+		// Mark the enrollment verified — only a verified secret gates login.
+		// EnrollMFA alone leaves last_verified_at NULL (see AC-13).
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE auth_mfa_secrets SET last_verified_at = now() WHERE user_id = $1`, u.ID); err != nil {
+			t.Fatalf("mark verified: %v", err)
+		}
 		resp := login(t, url, map[string]string{
 			"username": u.Username, "password": u.Password,
 		})
@@ -174,6 +180,32 @@ func TestAuthLogin_MFARequired(t *testing.T) {
 		b, _ := io.ReadAll(resp.Body)
 		if !strings.Contains(string(b), "auth.mfa_required") {
 			t.Errorf("body lacks auth.mfa_required: %s", b)
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: an unverified MFA enrollment (secret written by EnrollMFA but never
+// confirmed via VerifyMFA, so last_verified_at IS NULL) must NOT require an OTP
+// at sign-in — the user logs in normally (200) and can re-attempt enrollment.
+// Regression guard for the lockout where a begun-but-abandoned enrollment
+// stranded the user behind an OTP they could not produce.
+func TestAuthLogin_UnverifiedMFA_DoesNotGate(t *testing.T) {
+	t.Run("api-auth/AC-13", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		usrSvc := users.NewService(pool, nil)
+		u := seedAuthUser(t, usrSvc, "ac12", false)
+		// Begin enrollment only — no VerifyMFA, so last_verified_at stays NULL.
+		if _, err := identity.EnrollMFA(context.Background(), pool, u.ID, u.Username); err != nil {
+			t.Fatalf("EnrollMFA: %v", err)
+		}
+		resp := login(t, url, map[string]string{
+			"username": u.Username, "password": u.Password,
+		})
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d (want 200; unverified enrollment must not gate login): %s", resp.StatusCode, b)
 		}
 	})
 }
@@ -190,6 +222,11 @@ func TestAuthLogin_MFASucceeds(t *testing.T) {
 		uri, err := identity.EnrollMFA(context.Background(), pool, u.ID, u.Username)
 		if err != nil {
 			t.Fatalf("EnrollMFA: %v", err)
+		}
+		// Mark verified so the secret gates login (only verified MFA does; AC-13).
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE auth_mfa_secrets SET last_verified_at = now() WHERE user_id = $1`, u.ID); err != nil {
+			t.Fatalf("mark verified: %v", err)
 		}
 		secret := otpSecretFromURI(t, uri)
 		otp, _ := totp.GenerateCode(secret, time.Now().UTC())
@@ -212,6 +249,11 @@ func TestAuthLogin_MFAInvalid(t *testing.T) {
 		usrSvc := users.NewService(pool, nil)
 		u := seedAuthUser(t, usrSvc, "ac06", false)
 		_, _ = identity.EnrollMFA(context.Background(), pool, u.ID, u.Username)
+		// Mark verified so the secret gates login (only verified MFA does; AC-13).
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE auth_mfa_secrets SET last_verified_at = now() WHERE user_id = $1`, u.ID); err != nil {
+			t.Fatalf("mark verified: %v", err)
+		}
 		resp := login(t, url, map[string]any{
 			"username": u.Username, "password": u.Password, "otp": "000000",
 		})

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -505,11 +505,18 @@ func userToMe(u users.User, role string) api.AuthMeResponse {
 	}
 }
 
-// mfaEnrolled returns whether the user has an MFA secret row.
+// mfaEnrolled returns whether the user has a VERIFIED MFA secret. A secret
+// row alone is not enough: EnrollMFA writes the secret with last_verified_at
+// NULL when a user *begins* enrollment, and VerifyMFA stamps last_verified_at
+// once they prove they hold the authenticator. Gating login on mere row
+// presence would lock out a user who started enrollment but never verified
+// (e.g. closed the QR before scanning) — they would be asked for an OTP they
+// cannot produce, with no recovery codes to fall back on. Only a verified
+// secret requires an OTP at sign-in.
 func mfaEnrolled(ctx context.Context, h *handlers, userID uuid.UUID) (bool, error) {
 	var count int64
 	err := h.pool.QueryRow(ctx,
-		`SELECT count(*) FROM auth_mfa_secrets WHERE user_id = $1`, userID,
+		`SELECT count(*) FROM auth_mfa_secrets WHERE user_id = $1 AND last_verified_at IS NOT NULL`, userID,
 	).Scan(&count)
 	if err != nil {
 		return false, err

--- a/specs/api/auth.spec.yaml
+++ b/specs/api/auth.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-auth
   title: Auth HTTP surface (login, MFA, refresh, me, password change)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -112,3 +112,6 @@ spec:
       description: POST /auth/password:change with current_password + new_password validates the current password, applies the NIST policy to the new password, updates the hash, and emits auth.password.changed audit; wrong current_password returns 401 auth.invalid_credentials.
       priority: critical
       references_constraints: [C-05]
+    - id: AC-13
+      description: POST /auth/login for a user with an UNVERIFIED MFA enrollment (a secret row exists but last_verified_at IS NULL — enrollment was begun via mfa:enroll but never confirmed via mfa:verify) does NOT require an OTP; it returns 200 and signs the user in. Only a verified secret gates login, so an abandoned enrollment cannot lock a user out.
+      priority: high


### PR DESCRIPTION
Two MFA fixes from a reported issue: *"if a user tries to enable MFA and never verifies, why is the authenticator still required on next login?"*

## 1. Lockout bug
`auth_mfa_secrets` already has a `last_verified_at` column that is the intended "is MFA active" flag: `EnrollMFA` writes the secret with it **NULL** when a user *begins* enrollment, and `VerifyMFA` stamps it on confirmation. But the login gate, `mfaEnrolled`, checked only that a **secret row exists**:

```sql
SELECT count(*) FROM auth_mfa_secrets WHERE user_id = $1   -- before
```

So a user who started enrollment (QR shown, secret written) but never scanned/verified was demanded an OTP at next sign-in — one they cannot produce, and with **no recovery codes** (open `SEC-M4`) it's a hard lockout needing admin DB surgery.

**Fix:** gate on the verified flag the schema already maintains:

```sql
SELECT count(*) FROM auth_mfa_secrets WHERE user_id = $1 AND last_verified_at IS NOT NULL
```

Only a **verified** secret requires an OTP. An abandoned enrollment no longer locks the user out (they sign in and can re-enroll). This also corrects `/auth/me`'s `mfaEnabled` (same helper), so the settings page stops showing "Enabled" for an unconfirmed enrollment.

- Spec: `api-auth` **AC-13** (v1.1.0) + regression test (`TestAuthLogin_UnverifiedMFA_DoesNotGate`).
- The AC-04/05/06 tests previously created "enrolled" users via `EnrollMFA` only (unverified) — they **encoded the bug**; they now mark the secret verified.

## 2. QR code on enrollment
The enroll panel showed the `otpauth://` URI as a text blob and a blank "Secret" (the response never returned a `secret` field). It now renders a **scannable QR** (`qrcode.react`, a react-only dependency) and derives the manual-entry secret from the provisioning URI. Most authenticator apps scan the QR directly. The QR uses the library's default white-on-black rendering (no hardcoded colors — passes the settings no-hex rule).

## Verification
- `go test ./internal/server` auth suite green (AC-04/05/06 verified-path, AC-13 new)
- `specter check` 114 / `coverage` 100% (api-auth 13/13) / `check --test` 0 errors
- frontend `tsc`/`eslint`/`prettier`/`build` clean; vitest **345/345**