### PR TITLE
chore(dev): auto-migrate the dev DB on launcher start

### DIFF
--- a/scripts/openwatch.sh
+++ b/scripts/openwatch.sh
@@ -192,6 +192,15 @@ backend_start() {
     -X github.com/Hanalyx/openwatch/internal/version.BuildTime=${ow_built}" \
     -o "$BIN" ./cmd/openwatch
 
+  # Keep the dev DB in lockstep with the freshly-built binary. goose is
+  # idempotent (a no-op when already current), so this is cheap on every start
+  # and prevents the drift class where a rebuilt binary expects a newer schema
+  # than the dev DB has — which surfaces as a 500 only on code paths that touch
+  # the new columns/tables (e.g. login's refresh-token insert). OPENWATCH_*
+  # config (incl. the DSN) is already sourced from $ENV_FILE above.
+  log "applying database migrations ..."
+  "$BIN" migrate || die "migrate failed — refusing to start against an unmigrated DB (see above)"
+
   log "starting backend (listen ${OPENWATCH_SERVER_LISTEN}) ..."
   OPENWATCH_SERVER_TLS_CERT="$TLS_DIR/cert.pem" \
   OPENWATCH_SERVER_TLS_KEY="$TLS_DIR/key.pem" \


### PR DESCRIPTION
`scripts/openwatch.sh` now runs `openwatch migrate` after building the dev binary and before starting the server.

**Why:** the dev DB is migrated manually, so a rebuilt dev binary could get ahead of the schema. That's what caused the login 500 earlier this session — the binary was at rc.17 (with migration 0047's `refresh_tokens.absolute_expires_at`) while the dev DB was at goose v46, so a *successful* login failed at the refresh-token insert. Wrong-password logins returned 401 before that line, which is why it only showed up on real logins.

**Behavior:** goose is idempotent — a no-op when the DB is already current (`goose: no migrations to run`), so it's cheap on every `start`/`restart`. If migrate fails (e.g. DB unreachable), the launcher refuses to start rather than run against a broken schema.

Dev-only: packaged installs migrate via the package's own `openwatch migrate` step (covered by `package-smoke`), and CI provisions its own schema.

Verified locally: `bash -n` clean; `restart` shows the migrate step run as a no-op and the backend come up healthy.