### PR TITLE
docs(changelog): record post-rc.17 changes in [Unreleased] (GA pre-stage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Two-factor authentication enrollment now shows a scannable QR code, so most
+  authenticator apps (Authy, Google Authenticator, 1Password, and similar) can
+  be set up by scanning instead of pasting the setup URI by hand.
+
+### Fixed
+
+- A user who began two-factor enrollment but never confirmed it is no longer
+  asked for a one-time code at the next sign-in. Previously an unconfirmed
+  enrollment demanded a code the user could not produce, locking them out with
+  no recovery codes; now only a verified authenticator is required at login.
+
 ---
 
 ## [0.2.0-rc.17] Eyrie — 2026-06-27


### PR DESCRIPTION
Pre-stages the GA changelog so promoting `v0.2.0-rc.17` to a bare `v0.2.0` tag is a trivial rename.

- Records the two operator-facing changes since rc.17 in `[Unreleased]`: the MFA enrollment **QR code** (Added) and the unverified-enrollment **lockout fix** (Fixed). The other post-rc.17 merges were repo hygiene and dev tooling (not operator-facing).
- At GA tag time, `[Unreleased]` rolls into `## [0.2.0] Eyrie — <date>`.

The full pre-staged GA artifacts (ready `[0.2.0]` block, curated GitHub release-notes body, and the step-by-step promotion checklist) live in `docs/engineering/GA_RELEASE_v0.2.0.md` (local/gitignored).

Verified: `TestChangelog_*` format gate green.