### PR TITLE
chore(dev): rebuild embedded SPA on launcher start when frontend changed

### DIFF
--- a/scripts/openwatch.sh
+++ b/scripts/openwatch.sh
@@ -175,6 +175,23 @@ backend_start() {
   # shellcheck disable=SC1090
   set -a; source "$ENV_FILE"; set +a
 
+  # Keep the embedded SPA fresh. The Go binary serves the React app at :8443 via
+  # go:embed (internal/server/spa), baked in at compile time. The launcher also
+  # runs Vite on :5173 for live HMR, but a dev hitting :8443 directly should
+  # still see frontend changes. Rebuild + restage the embed only when frontend
+  # source is newer than it (or it is missing / the lint placeholder), so a
+  # backend-only restart stays fast. Without this, :8443 silently serves a stale
+  # UI after a frontend change.
+  local spa_embed="$ROOT/internal/server/spa"
+  if [[ ! -f "$spa_embed/index.html" ]] \
+    || grep -q 'SPA placeholder' "$spa_embed/index.html" 2>/dev/null \
+    || [[ -n "$(find "$FE_DIR/src" "$FE_DIR/index.html" "$FE_DIR/package.json" "$FE_DIR/vite.config.ts" -newer "$spa_embed/index.html" -print -quit 2>/dev/null)" ]]; then
+    log "rebuilding embedded SPA (frontend changed) ..."
+    ( cd "$FE_DIR" && { [[ -d node_modules ]] || npm ci --no-audit --no-fund; } && npx vite build ) \
+      || die "frontend (vite) build failed"
+    rm -rf "$spa_embed" && mkdir -p "$spa_embed" && cp -r "$FE_DIR/dist/." "$spa_embed/"
+  fi
+
   log "building dist/openwatch ..."
   # Inject version metadata (same -X flags as the Makefile) so the dev app
   # reports the real version (e.g. on /settings/about and `--version`) instead


### PR DESCRIPTION
**Symptom:** after a frontend change, the app at `https://127.0.0.1:8443` kept showing the old UI (e.g. the new MFA QR code didn't appear) even after `scripts/openwatch.sh restart`.

**Cause:** the Go binary serves the React app via `go:embed` of `internal/server/spa`, staged at compile time. The launcher rebuilt the Go binary on every start but never restaged the embed, so `:8443` served a stale bundle until someone ran `make spa` by hand. (The Vite server on `:5173` has live HMR; `:8443` silently lagged.)

**Fix:** `backend_start` now restages the embed (`vite build` → `internal/server/spa`) before the Go build — but **only when frontend source is newer** than the staged embed (or it's missing / the lint placeholder), so a backend-only restart stays fast.

Verified locally: `bash -n` clean; a restart with an up-to-date embed **skips** the rebuild (fast path); touching a frontend source file triggers it on the next start.