### PR TITLE
docs(guides): GA truthfulness + Ubuntu support + fixes (Kensa v0.7.0)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "docs/guides/DATABASE_MIGRATIONS.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 205
+        "line_number": 217
       }
     ],
     "docs/guides/ENVIRONMENT_REFERENCE.md": [
@@ -225,13 +225,36 @@
         "line_number": 110
       }
     ],
+    "docs/guides/INSTALLATION.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/guides/INSTALLATION.md",
+        "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/guides/INSTALLATION.md",
+        "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/guides/INSTALLATION.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 381
+      }
+    ],
     "docs/guides/PRODUCTION_DEPLOYMENT.md": [
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/PRODUCTION_DEPLOYMENT.md",
         "hashed_secret": "1a1d18a6cd33ec395692c25b8e26d90b4de8b5b4",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 121
       }
     ],
     "docs/guides/SECRET_ROTATION.md": [
@@ -248,6 +271,22 @@
         "hashed_secret": "ac21558017ec548c0355b86ee37c03ebbb44d0f7",
         "is_verified": false,
         "line_number": 72
+      }
+    ],
+    "docs/guides/runbooks/SECURITY_INCIDENT.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/guides/runbooks/SECURITY_INCIDENT.md",
+        "hashed_secret": "45065ce1e8e982145327f46a77a380fb89cb529d",
+        "is_verified": false,
+        "line_number": 295
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/guides/runbooks/SECURITY_INCIDENT.md",
+        "hashed_secret": "45065ce1e8e982145327f46a77a380fb89cb529d",
+        "is_verified": false,
+        "line_number": 298
       }
     ],
     "docs/runbooks/SECURITY_INCIDENT.md": [
@@ -2858,5 +2897,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T15:23:32Z"
+  "generated_at": "2026-06-29T04:50:17Z"
 }

--- a/docs/guides/COMPLIANCE_CONTROLS.md
+++ b/docs/guides/COMPLIANCE_CONTROLS.md
@@ -36,14 +36,14 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | AU-2 | Event Logging | Structured audit events for auth/scan/admin actions | Audit events from `/api/v1/audit/events` |
 | AU-3 | Content of Audit Records | User, timestamp, action, resource, outcome | Fields in each record from `/api/v1/audit/events` |
 | AU-6 | Audit Record Review | Audit query API (`/api/v1/audit/events`) | Query results from `/api/v1/audit/events` |
-| AU-9 | Protection of Audit Information | Audit events stored append-only in PostgreSQL | Append-only `audit_events` table in the database |
+| AU-9 | Protection of Audit Information | Audit events stored append-only in PostgreSQL | Append-only audit records in the database |
 | AU-12 | Audit Record Generation | API routes generate audit events | Events emitted per action in the audit log |
 
 ### Configuration management (CM)
 
 | Control | Title | OpenWatch Implementation | Evidence |
 |---------|-------|-------------------------|----------|
-| CM-2 | Baseline Configuration | Kensa YAML rules define expected configurations | Kensa rules (538 native YAML rules); scan results |
+| CM-2 | Baseline Configuration | Kensa YAML rules define expected configurations | Kensa rules (630 native YAML rules); scan results |
 | CM-3 | Configuration Change Control | Database migration tracking, version control | Migration version reported by `openwatch migrate` |
 | CM-6 | Configuration Settings | Configuration validation at startup | Output of `openwatch check-config` |
 | CM-8 | System Component Inventory | Host management with discovery and metadata | Host list and collected system info from the API |
@@ -91,7 +91,7 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | 1.1 | Enterprise Asset Inventory | Host management with system info collection |
 | 2.1 | Software Inventory | Server intelligence (package collection) |
 | 3.3 | Data Encryption | AES-256-GCM at rest, TLS 1.2+ in transit |
-| 4.1 | Secure Configuration | Kensa compliance scanning (538-rule corpus) |
+| 4.1 | Secure Configuration | Kensa compliance scanning (630-rule corpus) |
 | 4.2 | Baseline Network Configuration | Network discovery and topology mapping |
 | 5.2 | Unique Passwords | Argon2id hashing, 8-char minimum (15 for admin), breached-password screening |
 | 5.4 | MFA | TOTP-based MFA with backup codes |

--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -83,8 +83,16 @@ sudo systemctl start openwatch
 
 ## Checking the current schema version
 
-The `migrate` subcommand prints the current version after applying. To inspect
-the version table directly with `psql`:
+The `migrate` subcommand prints the current version after applying. To check the
+schema state **without applying anything**, pass `--status`. It reports the
+current version and whether any migrations are pending, and makes no changes:
+
+```bash
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
+    openwatch migrate --status
+```
+
+To inspect the version table directly with `psql`:
 
 ```bash
 psql "$OPENWATCH_DATABASE_DSN" -c \
@@ -163,8 +171,18 @@ Plan accordingly:
 
 ## Backup before migrating
 
-Take a logical backup with `pg_dump` before applying migrations to any
-environment you cannot afford to lose:
+The `migrate` subcommand can take the pre-migration backup for you: pass
+`--backup-dir <dir>` and it writes a logical dump into that directory before
+applying any pending migration. This is the recommended path on production
+upgrades:
+
+```bash
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
+    openwatch migrate --backup-dir /var/backups/openwatch
+```
+
+To take the backup yourself instead, use `pg_dump` before applying migrations to
+any environment you cannot afford to lose:
 
 ```bash
 pg_dump "$OPENWATCH_DATABASE_DSN" \
@@ -250,6 +268,8 @@ journalctl -u openwatch -n 50 --no-pager
 |------|-----------|
 | Migration files | Embedded in the `openwatch` binary |
 | `migrate` subcommand | `openwatch migrate` |
+| Check status, apply nothing | `openwatch migrate --status` |
+| Auto-backup before applying | `openwatch migrate --backup-dir <dir>` |
 | Config layering and DSN | [Install guide](INSTALLATION.md) |
 | systemd unit | `openwatch.service` |
 | Install and upgrade flow | [Install guide](INSTALLATION.md) |

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -189,7 +189,7 @@ needing to SSH in manually.
 
 ## Remediation overview
 
-OpenWatch can automatically fix compliance findings through Kensa's 23
+OpenWatch can automatically fix compliance findings through Kensa's 27
 remediation mechanisms. All changes are made over SSH—nothing is installed
 on target hosts.
 
@@ -232,9 +232,8 @@ For organizations that require an approval step:
 3. Once approved, a user with `remediation:execute` clicks **Fix** to apply the
    change. Execution is operator-initiated, not automatic.
 
-See Remediation and Exception Governance
-for the full role matrix. Single-operator workspaces cannot self-approve today;
-see the governance ADR.
+See [User roles](USER_ROLES.md) for the full role matrix. Single-operator
+workspaces cannot self-approve a bulk/automated remediation request today.
 
 ---
 
@@ -282,10 +281,9 @@ returned to its previous state.
 ## Required permissions
 
 Built-in roles, least to most privilege: `viewer` → `auditor` → `ops_lead` →
-`security_admin` → `admin` (`admin` holds every permission). The permission
-source of truth is `auth/permissions.yaml`; see
-Remediation and Exception Governance
-for the complete matrix.
+`security_admin` → `admin` (`admin` holds every permission). The authoritative
+role-to-permission mapping is served by the roles API, `GET /api/v1/roles`; see
+[User roles](USER_ROLES.md) for the complete matrix.
 
 | Operation | Permission | Roles that hold it |
 |-----------|------------|--------------------|

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -108,7 +108,7 @@ Install **both** files in one transaction. `openwatch` declares a hard
 dependency on `kensa-rules`—the rule corpus the scan engine loads from
 `/usr/share/kensa/rules`. Installing `openwatch` alone fails the dependency
 check (by design: a corpus-less node cannot scan). `kensa-rules` is `noarch`
-and versioned on the Kensa content line (for example `0.6.0`), independent of the
+and versioned on the Kensa content line (for example `0.7.0`), independent of the
 platform version, so the rules can update without re-releasing OpenWatch.
 
 Use the filenames you downloaded (`aarch64` for the arm64 openwatch RPM; the
@@ -290,8 +290,8 @@ Once you are signed in:
    exceptions over time.
 4. **Add more administrators or scoped roles** from Settings as needed.
 
-For the day-to-day workflows, see [the operator guides](../guides/) (hosts and
-remediation, scanning and compliance, user roles).
+For the day-to-day workflows, see [Hosts and remediation](HOSTS_AND_REMEDIATION.md),
+[Scanning and compliance](SCANNING_AND_COMPLIANCE.md), and [User roles](USER_ROLES.md).
 
 ---
 
@@ -507,11 +507,10 @@ SQL
 
 ## Where to go next
 
-- **Operator guides:** [the operator guides](../guides/)—hosts and remediation,
-  scanning and compliance, user roles.
-- **API contract:** every endpoint with its required permission, license gate,
-  and audit events.
-- **Release process:** `docs/runbooks/RELEASING.md`.
+- **Operator guides:** [Hosts and remediation](HOSTS_AND_REMEDIATION.md),
+  [Scanning and compliance](SCANNING_AND_COMPLIANCE.md), [User roles](USER_ROLES.md).
+- **API contract:** [API guide](API_GUIDE.md)—every endpoint with its required
+  permission, license gate, and audit events.
 
 ---
 

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -1,31 +1,35 @@
 # Linux distribution support matrix
 
 > **Scope.** OpenWatch targets Linux, but **not every Linux distribution is
-> supported to the same degree**, and compliance *scanning* in particular is
-> currently **RHEL-family only**, because that is what the bundled Kensa rule
-> corpus covers. This page states, with evidence, which distributions work for
-> (1) running the OpenWatch server and (2) being added as a managed/scanned
-> host.
+> supported to the same degree**. As of Kensa v0.7.0, compliance *scanning* is
+> supported on the **RHEL family and on Ubuntu**, because those are the
+> platforms the bundled Kensa rule corpus covers. This page states, with
+> evidence, which distributions work for (1) running the OpenWatch server and
+> (2) being added as a managed/scanned host.
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0-rc series (Go single-binary)
+**Last updated:** 2026-06-29 · **Applies to:** OpenWatch v0.2.0-rc series (Go single-binary)
 
-**Last verified:** 2026-06-25 against Kensa rule corpus **v0.6.0** (538 rules).
+**Last verified:** 2026-06-29 against Kensa rule corpus **v0.7.0** (630 rules).
+Per-OS counts below are read from each rule's `platforms:` declarations in the
+corpus, not from a live scan.
 
 ---
 
 ## TL;DR
 
-- **Compliance scanning works on RHEL 8 / 9 / 10 and its binary-compatible
-  rebuilds** (Rocky, AlmaLinux, CentOS Stream, Oracle Linux). **Every bundled
-  rule declares `platforms: family: rhel`**—there are *no* Ubuntu, Debian,
-  Fedora, or SUSE rules in the corpus.
-- **Adding a non-RHEL host (for example Fedora, Ubuntu) is not blocked**, but the scan
-  will **skip 100% of rules** because none apply to that platform. This is
-  intentional: running RHEL hardening checks against a different distro would
-  report *wrong* compliance, so Kensa skips rather than misreport.
+- **Compliance scanning works on RHEL 8 / 9 / 10** and its binary-compatible
+  rebuilds (Rocky, AlmaLinux, CentOS Stream, Oracle Linux), **and on Ubuntu
+  22.04 / 24.04 LTS.** Kensa v0.7.0 ships 630 rules across these platforms.
+- **Each rule declares the platforms it applies to**, so a host is only
+  evaluated against rules that match its detected OS. Ubuntu hosts are scanned
+  against the Ubuntu rule set; RHEL hosts against the RHEL rule set.
+- **Fedora, Debian, and SUSE remain inventory only**—the corpus carries no rules
+  for them, so a scan reports 0 applicable rules. This is intentional: running
+  rules written for another distro would report *wrong* compliance, so Kensa
+  skips rather than misreport.
 - **Host discovery and Server Intelligence are OS-agnostic** (plain SSH +
-  portable probes), so they nominally work on any SSH-reachable Linux,
-  but they produce no compliance posture without applicable scan rules.
+  portable probes), so they work on any SSH-reachable Linux, including the
+  inventory-only distros.
 
 ---
 
@@ -38,8 +42,8 @@ OpenWatch ships as native packages built for:
 | **RHEL 9 / CentOS Stream 9** | native **RPM** | Built/tested on CentOS Stream 9. RHEL 9, Rocky 9, AlmaLinux 9 are binary-compatible. |
 | **Ubuntu 24.04 LTS** | native **DEB** | Built/tested on Ubuntu 24.04. |
 
-Other distributions may run the server from source (Go 1.26 + PostgreSQL 16),
-but only the above are packaged, tested, and released.
+Other distributions may run the server from source (Go 1.26 + PostgreSQL 14 or
+newer), but only the above are packaged, tested, and released.
 
 > The server OS is **independent** of the managed-host OS. You can run the
 > OpenWatch server on Ubuntu and scan RHEL hosts, or vice-versa.
@@ -55,19 +59,35 @@ sensitivity:
 |-------|--------------|----------------|
 | **Discovery** | SSH in, read `/etc/os-release`, fingerprint OS/CPU/mem/disk | **OS-agnostic**—works on any SSH-reachable Linux |
 | **Server Intelligence** | Collect packages/services/users/network/firewall | **OS-agnostic**—portable probes; `rpm -qa` *or* `dpkg -l`, `firewall-cmd`/`ufw`/`nft`/`iptables` |
-| **Compliance scan (Kensa)** | Evaluate hardening rules, produce posture | **RHEL-family only**—the bundled corpus is 100% `family: rhel` |
+| **Compliance scan (Kensa)** | Evaluate hardening rules, produce posture | **RHEL family and Ubuntu**—each rule is filtered to the platforms it declares |
+
+### Per-OS rule applicability
+
+Rule applicability is read from the v0.7.0 corpus (each rule's `platforms:`
+block). These are the approximate counts of rules that apply per OS:
+
+| OS | Rules applicable (approx.) |
+|----|----------------------------|
+| RHEL 8 | ~460 |
+| RHEL 9 | ~466 |
+| RHEL 10 | ~310 |
+| Ubuntu 22.04 | ~115 |
+| Ubuntu 24.04 | ~117 |
+
+A rule can apply to several platforms, so these counts overlap; the corpus total
+is 630 distinct rules.
 
 ### Support matrix
 
 | Distribution | Discovery | Intelligence | Compliance scan | Overall |
 |--------------|-----------|--------------|-----------------|---------|
 | **RHEL 8 / 9 / 10** | Supported | Supported | Supported, full | **Supported** |
-| **Rocky Linux 8 / 9** | Supported | Supported | Supported (matches `family: rhel` via `ID_LIKE`) | **Supported** |
-| **AlmaLinux 8 / 9** | Supported | Supported | Supported (matches `family: rhel` via `ID_LIKE`) | **Supported** |
-| **CentOS Stream 9** | Supported | Supported | Supported (matches `family: rhel` via `ID_LIKE`) | **Supported** |
-| **Oracle Linux 8 / 9** | Supported | Supported | Supported (matches `family: rhel` via `ID_LIKE`) | **Supported** |
-| **Fedora** | Supported | Supported | Not supported, **all rules skip** | **Not supported for scanning** |
-| **Ubuntu 22.04 / 24.04** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
+| **Rocky Linux 8 / 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
+| **AlmaLinux 8 / 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
+| **CentOS Stream 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
+| **Oracle Linux 8 / 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
+| **Ubuntu 22.04 / 24.04 LTS** | Supported | Supported | Supported (~115–117 applicable rules) | **Supported** |
+| **Fedora** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
 | **Debian 12** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
 | **SUSE / openSUSE / SLES** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
 | **Alpine / Arch / Gentoo / other** | Supported (best-effort) | Partial | Not supported, **all rules skip** | **Unsupported** |
@@ -82,7 +102,7 @@ unverified support; **Not supported** means no coverage for that phase.
 
 ---
 
-## 3. Why a Fedora (or Ubuntu) host scans nothing
+## 3. Why a Fedora or Debian host scans nothing
 
 This is the behaviour you will see and it is **working as designed**, not a
 crash:
@@ -90,7 +110,7 @@ crash:
 1. **Discovery succeeds.** OpenWatch reads `/etc/os-release` and stores the
    `os_family`. The family is the lower-cased `ID` field:
    - Fedora → `os_family = "fedora"`
-   - Ubuntu → `os_family = "ubuntu"`
+   - Debian → `os_family = "debian"`
    - The `ID_LIKE`-to-`rhel` rollup only runs when `ID` is **empty**, so a host
      that advertises its own `ID` keeps it. (RHEL clones still match because
      Kensa reads their `ID_LIKE`, which contains `rhel`.)
@@ -100,12 +120,12 @@ crash:
    cycle).
 3. **The compliance scan skips everything.** Kensa SSHes to the host, reads
    `/etc/os-release`, and filters its corpus to rules whose `platforms` match
-   the detected distro. **Every rule in v0.6.0 declares `platforms: family:
-   rhel`** (version-pinned to `rhel8`/`rhel9`/`rhel10`). A Fedora or Ubuntu
-   host matches none, so **all 538 rules are skipped**.
+   the detected distro. The v0.7.0 corpus carries rules for the RHEL family and
+   Ubuntu only, so a Fedora, Debian, or SUSE host matches none and **all rules
+   are skipped**.
 
-Skipping is the correct outcome: applying RHEL 9 STIG/CIS checks to Fedora 40 or
-Ubuntu 24.04 would evaluate the wrong files, services, and defaults and report
+Skipping is the correct outcome: applying rules written for one distro to
+another would evaluate the wrong files, services, and defaults and report
 **false** compliance.
 
 > **Did Server Intelligence actually fail on your host?** The collector is
@@ -113,7 +133,7 @@ Ubuntu 24.04 would evaluate the wrong files, services, and defaults and report
 > failure usually points at the **SSH/sudo/connectivity** for that specific host
 > (for example the credential can't `sudo`, or the host is unreachable) rather than the
 > distribution. Check the host's connectivity tile and the audit log for the
-> actual error before assuming it is a Fedora limitation.
+> actual error before assuming it is a distribution limitation.
 
 ---
 
@@ -128,30 +148,31 @@ OpenWatch derives the OS family from `/etc/os-release` as follows:
 | 3 | neither recognized | `"other"` |
 
 The stored `os_family` drives the frontend OS label and the framework-lens
-filter. Note `fedora` is **not** a recognized framework-lens token, so a Fedora
-host is also offered no version-pinned framework lenses.
+filter. RHEL and Ubuntu hosts are offered the framework lenses for their
+detected OS; an inventory-only distro (such as Fedora) is offered no
+version-pinned framework lenses.
 
 ---
 
 ## 5. Adding support for another distribution
 
 Compliance coverage is defined by the **Kensa rule corpus**, not by OpenWatch
-application code. To make (say) Ubuntu or Fedora scannable, the
+application code. To make (say) Debian or Fedora scannable, the
 [Kensa project](https://github.com/Hanalyx/kensa) must ship rules that declare
-those platforms in their `platforms:` block (for example `family: debian` /
-`family: fedora`) with the appropriate framework mappings (CIS Ubuntu, and so on).
+those platforms in their `platforms:` block with the appropriate framework
+mappings.
 
 > **Status:** the **Kensa team is actively expanding distribution coverage.**
-> Because applicability lives entirely in the rule corpus, broader distro
-> support arrives by **bundling a newer `kensa-rules` package, with no
-> OpenWatch code change.** Discovery and Server Intelligence already work on
-> those hosts today; only the rules are missing. This matrix should be
-> re-verified (the "Last verified" corpus version at the top) whenever the
-> bundled Kensa version is bumped.
+> Ubuntu 22.04 / 24.04 support arrived in Kensa v0.7.0. Because applicability
+> lives entirely in the rule corpus, broader distro support arrives by
+> **bundling a newer `kensa-rules` package, with no OpenWatch code change.**
+> Discovery and Server Intelligence already work on those hosts today; only the
+> rules are missing. This matrix should be re-verified (the "Last verified"
+> corpus version at the top) whenever the bundled Kensa version is bumped.
 
-Until that corpus lands, treat non-RHEL hosts as **inventory-only**: useful for
-visibility (packages, services, drift on the intelligence side) but without a
-compliance score.
+Until that corpus lands, treat unsupported distros as **inventory-only**: useful
+for visibility (packages, services, drift on the intelligence side) but without
+a compliance score.
 
 ---
 
@@ -161,6 +182,8 @@ compliance score.
 - Server Intelligence is OS-agnostic: it runs `rpm -qa` or `dpkg -l` with
   partial-success semantics.
 - Kensa filters its corpus by the host's detected platform at scan time.
-- Rule corpus applicability (verified): Kensa v0.6.0—**538/538 rules
-  `platforms: family: rhel`**, pinned `rhel8`/`rhel9`/`rhel10`.
-- Framework mappings: CIS RHEL 9 v2.0.0, STIG RHEL 9 V2R7.
+- Rule corpus applicability (read from the corpus platform declarations):
+  Kensa v0.7.0, **630 rules** spanning RHEL 8/9/10 and Ubuntu 22.04/24.04.
+  Approximate per-OS applicability: rhel8 ~460, rhel9 ~466, rhel10 ~310,
+  ubuntu22 ~115, ubuntu24 ~117.
+- Framework mappings: CIS RHEL 9 v2.0.0, STIG RHEL 9 V2R7, plus CIS/STIG Ubuntu.

--- a/docs/guides/MONITORING_SETUP.md
+++ b/docs/guides/MONITORING_SETUP.md
@@ -112,9 +112,8 @@ Log level precedence follows the standard config layering documented in the
 
 ## 4. Audit events
 
-Every server action that mutates state, authenticates, or authorizes emits a
-row to the `audit_events` PostgreSQL table (migrations `0001_initial.sql` and
-`0002_audit_events_taxonomy.sql`). This is the durable record for security
+Every server action that mutates state, authenticates, or authorizes emits an
+audit record to PostgreSQL. This is the durable record for security
 review; the journal is the operational record.
 
 Query audit events through the API (requires a bearer token with the
@@ -362,7 +361,7 @@ operators do not look for them:
   `monitoring/` Compose stack and no container runtime in this architecture.
 - **Distributed tracing**—not implemented. Correlation IDs in the JSON logs
   are the current mechanism for following a request across log lines.
-- **Detailed authenticated health endpoints** (per-service, content, history) —
+- **Detailed authenticated health endpoints** (per-service, content, history)—
   not implemented. The current health contract is a single binary
   `healthy`/`degraded` status.
 

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -268,9 +268,8 @@ you have never restored is a hypothesis, not a backup.
 ## Operational runbooks
 
 Concise, single-binary runbooks follow. Diagnose with `systemctl`, `journalctl`,
-`psql`, `df`, and `top`—not `docker`. The standalone files under
-[`docs/runbooks/`](../runbooks/) still describe the archived Python/Docker stack
-and are pending a Go-era rewrite; prefer the steps below until they are updated.
+`psql`, `df`, and `top`—not `docker`. For the full incident runbooks, see
+[the runbooks directory](runbooks/).
 
 ### SERVICE_DOWN—service unavailable
 
@@ -414,7 +413,6 @@ psql -h 127.0.0.1 -U openwatch -d openwatch -c "\
 ## See also
 
 - [Install guide](INSTALLATION.md)—canonical install and provisioning.
-- Kensa ↔ OpenWatch boundary—compliance engine integration.
-- RBAC registry—roles and permissions.
-- API contract—every endpoint, its permission, and audit events.
-- Releasing runbook—building and signing releases.
+- [User roles](USER_ROLES.md)—roles and permissions.
+- [API guide](API_GUIDE.md)—every endpoint, its permission, and audit events.
+- [Operational runbooks](runbooks/)—incident response procedures.

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -27,13 +27,13 @@ Kensa retrieves SSH credentials from OpenWatch's encrypted store
 SSH connection to target host
         |
         v
-538 YAML rules evaluated (check commands, config values, file permissions)
+630 YAML rules evaluated (check commands, config values, file permissions)
         |
         v
 Each rule returns: pass/fail, severity, detail, evidence
         |
         v
-Write-on-change: changed verdicts -> transactions; current state -> host_rule_state
+Only changed verdicts are recorded; current per-rule state is kept up to date
         |
         v
 Daily posture snapshot rolls up; drift alerts generated if thresholds met
@@ -56,14 +56,20 @@ Key points:
 |-----------|------------|-------|
 | CIS RHEL 9 v2.0.0 | cis-rhel9-v2.0.0 | 271 |
 | STIG RHEL 9 V2R7 | stig-rhel9-v2r7 | 338 |
+| CIS Ubuntu 24.04 LTS | cis-ubuntu24 | (Ubuntu rules: ~117 on 24.04, ~115 on 22.04) |
+| STIG Ubuntu 22.04 | stig-ubuntu22 | (see Ubuntu rule applicability above) |
 | NIST 800-53 Rev 5 | nist-800-53-r5 | 87 |
 | PCI-DSS v4.0 | pci-dss-v4.0 | 45 |
 | FedRAMP Moderate | fedramp-moderate | 87 |
 
+RHEL and Ubuntu are both supported scan targets. See
+[Linux distribution support](LINUX_DISTRIBUTION_SUPPORT.md) for the full
+per-OS rule applicability matrix.
+
 Framework mappings are carried per-rule as Kensa's normalized `framework_refs`
 (a multi-valued framework_id -> control-ids map, since one rule can satisfy
-several controls within a framework). They are stored on each `host_rule_state`
-row as `framework_refs` JSONB and projected into the lens views at query time—
+several controls within a framework). They are stored per host-rule as
+`framework_refs` JSONB and projected into the lens views at query time—
 there is no separate sync service in the Go rebuild.
 
 ---
@@ -215,7 +221,7 @@ compliance state. You do not need to trigger manual scans for routine monitoring
 A host is classified into one of five score bands (plus Unknown for
 never-scanned hosts) after every scan, and the next scan is scheduled from the
 band's interval. The intervals below are the **defaults**—they are
-operator-editable per band under **Settings -> Scanning & monitoring ->
+operator-editable per band under **Settings -> Scanning and monitoring ->
 Compliance scanner**, clamped to a 5-minute floor and a 48-hour ceiling.
 
 | Compliance State | Score Range | Default Interval |

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -448,7 +448,7 @@ sudo journalctl -u openwatch --since '10 min ago' | jq -r 'select(.level=="ERROR
    sudo -u postgres pg_dump -Fc openwatch > /tmp/openwatch-evidence.dump
    ```
 
-3. **Review authentication and authorization events** in the audit trail —
+3. **Review authentication and authorization events** in the audit trail—
    `auth.login.success`, `auth.login.failure`, role and user changes—for the
    incident window. Query the audit tables directly with `psql` or via the audit
    API.
@@ -514,7 +514,7 @@ Source for every checklist item is cited in the section above that introduces it
   [User roles](USER_ROLES.md)
 - Audit event taxonomy:
   the audit-event reference
-- Kensa ↔ OpenWatch boundary:
+- Kensa and OpenWatch boundary:
   the Kensa scanning engine
 - API contract (per-operation required permission, license gate, audit events):
   served at `/api/v1`; `GET /api/v1/version` reports the running build

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -26,7 +26,7 @@ migration mechanics, see the [database migrations guide](DATABASE_MIGRATIONS.md)
 ## Quick upgrade (automatic, recommended)
 
 On a single-instance install an upgrade is **one command**. The package
-post-install scriptlet applies any pending database migrations automatically —
+post-install scriptlet applies any pending database migrations automatically—
 taking a backup restore point first—and restarts the service.
 
 ```bash
@@ -197,7 +197,7 @@ sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
 ```
 
 The command prints the current version, the count of migration files, and each
-filename, then `migrations applied`. If it fails, the service is still stopped —
+filename, then `migrations applied`. If it fails, the service is still stopped—
 fix the cause or restore the backup (see [Rollback](#rollback)) before starting.
 
 ### Step 6—Start the service

--- a/docs/guides/USER_ROLES.md
+++ b/docs/guides/USER_ROLES.md
@@ -24,8 +24,8 @@ The live model is observable from the running service:
 - Each protected operation declares the permission it requires; a request
   missing that permission is denied.
 
-For the rationale, the custom-role design, and how wildcards expand, see
-[User roles](USER_ROLES.md).
+For the live, authoritative role-to-permission mapping, query the roles API,
+`GET /api/v1/roles`.
 
 ## Built-in roles
 
@@ -264,12 +264,11 @@ registry permission and category wildcards such as `host:*`, but not the bare
 custom role lists is validated against the registry; unknown permissions are
 rejected with `400`.
 
-For the custom-role design, validation rules, and the relationship between
-wildcards and newly added permissions, see [User roles](USER_ROLES.md).
+For the live permission registry, including category wildcards and newly added
+permissions, query the permissions-registry API endpoint.
 
 ## Related documentation
 
-- [User roles](USER_ROLES.md)—RBAC design and custom roles
-- `docs/guides/INSTALLATION.md`—install, `migrate`, `create-admin`, service start
+- [Installation guide](INSTALLATION.md)—install, `migrate`, `create-admin`, service start
 - The running binary serves its API contract under `/api/v1`; the permission and
   role registry is available from the permissions-registry API endpoint

--- a/docs/guides/runbooks/DATABASE_ISSUES.md
+++ b/docs/guides/runbooks/DATABASE_ISSUES.md
@@ -286,7 +286,7 @@ SHOW effective_cache_size;
 "
 ```
 
-Consider reducing `work_mem` if it is set high, or adding a memory limit to the container to prevent it from being targeted by the host OOM killer.
+Consider reducing `work_mem` if it is set high, or constraining the PostgreSQL service's memory (for example a systemd `MemoryMax=` on the postgresql unit) to keep it from being targeted by the host OOM killer.
 
 ---
 
@@ -303,7 +303,7 @@ Expected: `accepting connections`.
 ### 2. Health endpoint reports database healthy
 
 ```bash
-curl -sk https://localhost:8443/api/v1/health | python3 -m json.tool
+curl -sk https://localhost:8443/api/v1/health | jq
 ```
 
 Confirm `"status": "healthy"` and `"db_connected": true`.
@@ -349,7 +349,7 @@ Escalate if any of the following conditions are met:
 - WAL corruption or replication errors are present in logs.
 
 **Information to include when escalating**:
-- PostgreSQL container logs (last 200 lines).
+- PostgreSQL logs (last 200 lines), for example `journalctl -u postgresql -n 200`.
 - Output of `pg_isready`.
 - Connection count and max_connections values.
 - Database size and disk usage.

--- a/docs/guides/runbooks/SECURITY_INCIDENT.md
+++ b/docs/guides/runbooks/SECURITY_INCIDENT.md
@@ -264,15 +264,15 @@ WHERE username = 'USERNAME' AND deleted_at IS NULL;
 
 ### Revoke every session (full re-authentication)
 
-To force all users to re-authenticate, rotate the JWT signing key. The signing key is a file referenced by `[identity].jwt_private_key` (or `OPENWATCH_IDENTITY_JWT_PRIVATE_KEY`). Replacing it invalidates every issued access token because existing tokens no longer verify:
+To force all users to re-authenticate, rotate the JWT signing key. The signing key is the file at `/etc/openwatch/keys/jwt_private.pem`. Replacing it invalidates every issued access token because existing tokens no longer verify:
 
 ```bash
 # Back up the current key, generate a replacement (RSA, matching the existing key type)
-sudo cp /etc/openwatch/identity/jwt_private_key.pem /etc/openwatch/identity/jwt_private_key.pem.bak
+sudo cp /etc/openwatch/keys/jwt_private.pem /etc/openwatch/keys/jwt_private.pem.bak
 sudo openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
-  -out /etc/openwatch/identity/jwt_private_key.pem
-sudo chown root:openwatch /etc/openwatch/identity/jwt_private_key.pem
-sudo chmod 0640 /etc/openwatch/identity/jwt_private_key.pem
+  -out /etc/openwatch/keys/jwt_private.pem
+sudo chown root:openwatch /etc/openwatch/keys/jwt_private.pem
+sudo chmod 0640 /etc/openwatch/keys/jwt_private.pem
 
 # The key is loaded at startup; restart to pick up the new key
 sudo systemctl restart openwatch
@@ -346,7 +346,7 @@ Expect `active (running)`.
 ### 2. Health endpoint reports healthy
 
 ```bash
-curl -sk https://localhost:8443/api/v1/health | python3 -m json.tool
+curl -sk https://localhost:8443/api/v1/health | jq
 ```
 
 Expect `"status": "healthy"`.


### PR DESCRIPTION
Brings the public operator guides (hanalyx.com/docs source) current with Kensa v0.7.0 and fixes the issues the GA docs audit surfaced. Audit findings were verified against the code/binary before fixing.

## Truthfulness (was GA-blocking)
- Rule corpus **538 → 630** across the guides.
- **`LINUX_DISTRIBUTION_SUPPORT.md` rewritten**: scanning now covers **RHEL 8/9/10 and Ubuntu 22.04/24.04** (was RHEL-only). Per-OS counts from the corpus `platforms:` declarations (rhel8~460, rhel9~466, rhel10~310, ubuntu22~115, ubuntu24~117); Fedora/Debian/SUSE remain inventory-only.
- `SCANNING_AND_COMPLIANCE` framework table gains Ubuntu; Kensa example `0.6.0 → 0.7.0` (INSTALLATION); **27** remediation mechanisms (was 23); documented `migrate --status` / `--backup-dir`.

## Correctness bug
- `runbooks/SECURITY_INCIDENT.md`: JWT key path corrected to `/etc/openwatch/keys/jwt_private.pem` (was a nonexistent `identity/...` path — the containment step would silently fail).

## Internal-reference removal (must not publish)
- Dropped a source-path leak (`auth/permissions.yaml` → roles API), schema/migration-filename leaks, a broken `../runbooks/` link, a "Python/Docker stack" aside, and self/repo-relative links.

## Style
- Fixed spaced em-dashes, `&` → "and", `↔` glyph; `python3 -m json.tool` → `jq`; removed container framing from a runbook.

## Notes
- `.secrets.baseline` updated with **two docs-only** detect-secrets false positives (documentation password placeholders in INSTALLATION/SECURITY_INCIDENT) — no real secrets, no repo-wide rescan (verified: only those two doc files added).
- Planning docs (CLAUDE/STATUS/BACKLOG) updated separately (local). CHANGELOG `[Unreleased]` already carries the Kensa v0.7.0 + MFA entries.

Verified on branch: no `538`/`~539`, no `internal/`/`frontend/src`/`docs/engineering`/`specs/` refs, no emoji.