### PR TITLE
license: relicense OpenWatch core from AGPLv3 to Apache 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Relicensed the OpenWatch core from the AGPLv3-based Community License to the
+  **Apache License 2.0** (see LICENSE and NOTICE). OpenWatch is now permissively
+  open source: free to use, modify, self-host, and redistribute, including
+  commercially, with attribution and no copyleft obligation. The compiled binary
+  still statically links the Kensa engine (BSL-1.1), so a binary distribution is
+  a combined Apache/BSL work (see NOTICE).
+
 ---
 
 ## [0.2.0] Eyrie — 2026-06-29

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,12 +352,12 @@ wired into a GitHub Actions workflow; configure `SONAR_TOKEN` only if you re-ena
 
 ## License
 
-By contributing to OpenWatch, you agree that your contributions will be licensed under the [OpenWatch Community License (AGPLv3 + Managed Service Exception)](LICENSE).
+By contributing to OpenWatch, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE), the same license as the rest of the codebase (inbound = outbound, per Apache 2.0 Section 5).
 
-Your contributions will be subject to the same AGPLv3 + MSE terms as the rest of the codebase, ensuring:
-- Your code remains open source
-- Modifications must be shared under the same terms
-- Commercial SaaS offerings require separate licensing from Hanalyx LLC
+Apache 2.0 is permissive:
+- Anyone can use, modify, self-host, and redistribute OpenWatch, including commercially, with attribution.
+- There is no copyleft or share-alike obligation on modifications.
+- The compiled binary links the Kensa engine (BSL-1.1); see [NOTICE](NOTICE) for the combined-work terms.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,52 +1,201 @@
-# OpenWatch Community License (AGPLv3 + Managed Service Exception)
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-**Version 1.0 – 2025 Hanalyx LLC**
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-## 1. Base License
+   1. Definitions.
 
-OpenWatch Core (the "Software") is licensed under the terms of the GNU Affero General Public License, Version 3 ("AGPLv3") as published by the Free Software Foundation.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-The full text of the AGPLv3 is available at:
-[https://www.gnu.org/licenses/agpl-3.0.html](https://www.gnu.org/licenses/agpl-3.0.html)
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-This License Addendum ("Managed Service Exception" or "MSE") modifies certain terms of the AGPLv3 as applied to the Software.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-## 2. Managed Service Restriction
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-You may not provide the Software, or any modified version of it, as part of a managed service, hosted service, or software-as-a-service (SaaS) offering to third parties without prior written permission or a commercial license from Hanalyx LLC.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-For the purpose of this restriction:
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-* "Offering as a managed service" means making the Software's functionality available to third parties over a network, where those third parties can access or use the Software without running their own instance.
-* Running the Software for your own internal business purposes—whether on-premises or in your own cloud account—is permitted.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-## 3. Rights Retained Under AGPLv3
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-Except for the restriction in Section 2, you retain all rights granted under the AGPLv3, including the rights to:
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-* Use, study, and modify the Software for any purpose.
-* Distribute original or modified versions of the Software.
-* Provide source code to users who interact with the Software over a network, as required by AGPLv3 Section 13.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-All AGPLv3 obligations and copyleft conditions remain in full effect.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-## 4. Commercial Licensing
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-A commercial license is available from Hanalyx LLC for organizations that wish to:
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-* Offer OpenWatch Core as a managed or hosted service to third parties, or
-* Integrate it into proprietary commercial products under different terms.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-For commercial licensing inquiries, contact:
-[legal@hanalyx.com](mailto:legal@hanalyx.com)
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-## 5. Precedence
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-If any term of this Addendum conflicts with the AGPLv3, the Managed Service Exception shall take precedence solely with respect to the Managed Service Restriction described in Section 2.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-## 6. Disclaimer
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-This License is provided "as is," without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. See the AGPLv3 for full terms and conditions.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-© 2025 Hanalyx LLC. All rights reserved.
-This Software is licensed under the GNU AGPLv3 with the OpenWatch Managed Service Exception (MSE).
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Hanalyx LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+OpenWatch
+Copyright 2025 Hanalyx LLC
+
+This product is licensed under the Apache License, Version 2.0 (see LICENSE),
+with the following attributions.
+
+================================================================================
+Bundled third-party components
+================================================================================
+
+The compiled openwatch binary statically links the Kensa compliance engine
+(github.com/Hanalyx/kensa), which is licensed under the Business Source License
+1.1 (BSL-1.1), not Apache 2.0. A binary distribution of OpenWatch is therefore a
+combined work that includes a BSL-1.1 component, and redistribution of the
+binary is subject to the BSL-1.1 terms with respect to the Kensa portion.
+
+A full inventory of bundled open-source dependencies and their licenses is
+maintained in THIRD-PARTY-NOTICES.md.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **The Compliance Operating System — See Everything, Continuously.**
 
-[![License: AGPLv3 + MSE](https://img.shields.io/badge/License-AGPLv3%20%2B%20MSE-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go CI](https://github.com/Hanalyx/OpenWatch/actions/workflows/go-ci.yml/badge.svg)](https://github.com/Hanalyx/OpenWatch/actions/workflows/go-ci.yml)
 [![Documentation](https://img.shields.io/badge/docs-latest-brightgreen)](https://hanalyx.github.io/OpenWatch/)
 [![GitHub Discussions](https://img.shields.io/github/discussions/Hanalyx/OpenWatch)](https://github.com/Hanalyx/OpenWatch/discussions)
@@ -277,9 +277,13 @@ built or tested here. See [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a
 
 ## License
 
-**OpenWatch Community License (AGPLv3 + Managed Service Exception)**
+OpenWatch is licensed under the **Apache License 2.0** (see [LICENSE](LICENSE)
+and [NOTICE](NOTICE)).
 
-- Free to use, modify, and self-host
-- Cannot offer as a managed/hosted service without a commercial license
+- Free to use, modify, self-host, and redistribute under Apache 2.0.
+- The compiled binary statically links the Kensa compliance engine, which is
+  BSL-1.1, so a binary distribution is a combined Apache/BSL work (see
+  [NOTICE](NOTICE)).
 
-See [LICENSE](LICENSE) for details. Commercial licensing: [legal@hanalyx.com](mailto:legal@hanalyx.com)
+Third-party dependency licenses: [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).
+Commercial inquiries: [legal@hanalyx.com](mailto:legal@hanalyx.com)

--- a/internal/db/migrations/0037_remediation.sql
+++ b/internal/db/migrations/0037_remediation.sql
@@ -1,7 +1,7 @@
 -- 0037_remediation.sql
 --
 -- Remediation governance (scan plan Phase 7, remediation half). The free
--- (AGPLv3 core) see-and-govern loop: an operator's intent to fix a failing
+-- (Apache 2.0 core) see-and-govern loop: an operator's intent to fix a failing
 -- rule on a host, with a request -> approve | reject lifecycle, mirroring the
 -- exception governance overlay (0026_compliance_exceptions).
 --

--- a/internal/remediation/types.go
+++ b/internal/remediation/types.go
@@ -1,4 +1,4 @@
-// Package remediation implements the free (AGPLv3 core) half of Phase 7
+// Package remediation implements the free (Apache 2.0 core) half of Phase 7
 // remediation governance: an operator's intent to fix a failing rule on a
 // host, with a request -> approve | reject lifecycle and a read-only
 // projected-lift estimate.

--- a/packaging/rpm/openwatch.spec
+++ b/packaging/rpm/openwatch.spec
@@ -30,7 +30,7 @@ Version:        %{ow_version}
 Release:        %{ow_release}%{?dist}
 Summary:        OpenWatch Compliance Platform (Go binary)
 
-License:        Proprietary
+License:        Apache-2.0
 URL:            https://github.com/Hanalyx/openwatch
 Source0:        %{name}-%{version}.tar.gz
 

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -8,7 +8,7 @@ spec:
   context:
     system: openwatch
     feature: >
-      The free (AGPLv3 core) Phase 7 remediation surface: a see-govern-and-act
+      The free (Apache 2.0 core) Phase 7 remediation surface: a see-govern-and-act
       loop over failing rules. Operators view what is remediable and the
       projected compliance-score lift, request a fix, route it through
       approval, then EXECUTE the approved single-rule fix (Tier A free core):


### PR DESCRIPTION
Relicenses the OpenWatch core from the AGPLv3-based **Community License (AGPLv3 + MSE)** to the **Apache License 2.0**, per the open-core licensing strategy.

## Changes
- **LICENSE** → full Apache License 2.0 text (was AGPLv3 + Managed Service Exception).
- **NOTICE** → new: Apache 2.0 attribution + the **Kensa BSL-1.1 combined-work disclosure** (the compiled binary statically links Kensa, which is BSL-1.1, so a binary distribution is a combined Apache/BSL work).
- **README.md** → Apache 2.0 badge + rewritten license section.
- **CONTRIBUTING.md** → Apache 2.0 (inbound = outbound); removed the copyleft / "SaaS requires separate license" language that no longer applies under a permissive license.
- **packaging/rpm/openwatch.spec** → `License: Proprietary` → `License: Apache-2.0` (the GA RPM had declared "Proprietary").
- Source/spec comments `(AGPLv3 core)` → `(Apache 2.0 core)`.

`THIRD-PARTY-NOTICES.md`'s "no GPL/AGPL **dependencies**" line is intentionally unchanged — it describes bundled deps, not OpenWatch's own license.

## Please review before merging — this is a one-way legal change
- **Counsel:** relicensing AGPL→Apache is irreversible and is your/Hanalyx's legal decision; merge when counsel is comfortable. (Copyright is held by Hanalyx — the only human contributor — so there's no external CLA blocker.)
- **No `ee/` references:** the EE-tier carve isn't on main yet, so this keeps the license text to what actually exists (Apache core + BSL Kensa). When the `ee/` tier lands, add its `ee/LICENSE` + references then.
- **v0.2.0 already shipped** under the old license; this applies to `main` and the next release. If you want a clean GA under Apache, that's a `v0.2.1` (re-tagging the published `v0.2.0` is discouraged).

Verified: only the THIRD-PARTY deps statement still mentions AGPL (correct); LICENSE is Apache; RPM declares Apache-2.0; changelog gate + specter + build green.

**I left this unmerged on purpose** — it's yours to merge.