### PR TITLE
feat(ui): live version on landing/login badge; drop "pre-release"

### DIFF
--- a/frontend/src/hooks/useVersion.ts
+++ b/frontend/src/hooks/useVersion.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import api from '@/api/client';
+
+// useVersion returns the running binary's version (e.g. "0.2.0") from
+// GET /api/v1/version, the anonymous build-metadata endpoint. The version is
+// always read live from the server — never hardcoded in the UI — so the landing
+// and login pages reflect whatever release is actually deployed. Returns null
+// until the fetch resolves (callers render the codename alone in the meantime).
+export function useVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data } = await api.GET('/api/v1/version');
+        // The product version is the `openwatch` field (e.g. "0.2.0"); `kensa`,
+        // `go`, `commit`, `build_time` are the other build-metadata fields.
+        if (!cancelled && data?.openwatch) setVersion(data.openwatch);
+      } catch {
+        // Leave null on failure; the UI degrades to the codename only.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return version;
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { RadarField } from '@/components/RadarField';
+import { useVersion } from '@/hooks/useVersion';
 import owIcon from '@/assets/openwatch-icon.png';
 
 // HomePage — the public, non-login landing surface at "/". Renders the
@@ -14,6 +15,7 @@ import owIcon from '@/assets/openwatch-icon.png';
 const SCAN = 'rgb(96,212,228)';
 
 export function HomePage() {
+  const version = useVersion();
   return (
     <div
       style={{
@@ -120,7 +122,7 @@ export function HomePage() {
               }}
             />
             <span style={{ color: 'var(--ow-fg-1)', fontWeight: 600 }}>Eyrie</span>
-            <span>· pre-release</span>
+            {version && <span>· v{version}</span>}
           </span>
         </header>
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import api from '@/api/client';
 import { useAuthStore, type Identity } from '@/store/useAuthStore';
 import { RadarField } from '@/components/RadarField';
+import { useVersion } from '@/hooks/useVersion';
 import owIcon from '@/assets/openwatch-icon.png';
 
 // Login page — frontend-auth-login spec.
@@ -76,6 +77,7 @@ export function LoginPage() {
   const setIdentity = useAuthStore((s) => s.setIdentity);
   const identity = useAuthStore((s) => s.identity);
   const authLoading = useAuthStore((s) => s.loading);
+  const version = useVersion();
 
   const [mfaRequired, setMfaRequired] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(
@@ -347,7 +349,7 @@ export function LoginPage() {
             }}
           />
           <span style={{ color: 'var(--ow-fg-1)', fontWeight: 600 }}>Eyrie</span>
-          <span>· pre-release</span>
+          {version && <span>· v{version}</span>}
         </span>
       </div>
 


### PR DESCRIPTION
The landing (`/`) and login (`/login`) codename badge read **"Eyrie · pre-release"** with no version. It now reads **"Eyrie · v0.2.0"** where the version is fetched **live** from `GET /api/v1/version` (the anonymous build-metadata endpoint) — never hardcoded — so the badge always reflects the deployed release. The "pre-release" label is removed (we are GA).

- New `useVersion()` hook (reads the `openwatch` field from `/api/v1/version`; degrades to the codename alone if the fetch fails or is loading).
- Wired into `LoginPage` and `HomePage`.

Verified: `tsc`/`eslint`/`prettier` clean, `npm run build` OK, vitest 345/345.

Note: I couldn't find a literal "OPENWATCH // v0.2.0 // EYRIE" string in the current code — the badge was "OpenWatch … Eyrie · pre-release" (no version). This change adds the dynamic version there and drops "pre-release". If you meant a different element (e.g. one of the decorative footers `EYRIE // ENCRYPTED SESSION // TLS 1.3`), point me at it and I'll adjust.