### PR TITLE
chore(specs): register 27 unregistered specs in specter.yaml

### DIFF
--- a/specter.yaml
+++ b/specter.yaml
@@ -97,6 +97,33 @@ domains:
             - api-remediation
             - frontend-remediation-tab
             - frontend-session-idle
+            - system-event-bus
+            - system-alert-router
+            - system-drift-detector
+            - system-fleet-rollup
+            - system-liveness-loop
+            - system-scheduler
+            - system-discovery-scheduler
+            - system-daemon-orchestration
+            - system-kensa-executor
+            - system-transaction-log-writer
+            - system-supply-chain
+            - services-connectivity-config
+            - api-version
+            - api-fleet-observability
+            - api-system-discovery-config
+            - frontend-foundation
+            - frontend-homepage
+            - frontend-auth-login
+            - frontend-dashboard
+            - frontend-activity
+            - frontend-add-host
+            - frontend-hosts-list
+            - frontend-scans
+            - frontend-settings
+            - frontend-settings-scan-config
+            - frontend-settings-exception-queue
+            - frontend-settings-discovery-config
 settings:
     specs_dir: specs
     # Honored by `specter coverage` (not by `specter sync` — CI passes


### PR DESCRIPTION
`scripts/repo-facts.sh` (added in #721) surfaced that **114 spec files exist on disk but only 87 were registered** in `specter.yaml` — so **27 specs were ungated**: their acceptance criteria weren't enforced by the coverage gate even though the specs and their tests exist.

## What this does
Registers all 27 in the `default` domain's spec list. No dangling entries existed (every registered id already had a file), so this is purely additive.

## Why it's safe
Verified locally before pushing:
- `specter check` — all 114 specs pass schema validation.
- `specter check --test` — **0 errors** (dangling/unknown-ref hygiene).
- `specter coverage --strictness annotation` — **114/114 passing, 0 failing**: every AC of the 27 already has a test annotation (100% structural).

The 27 specs' tests already run in the existing suite (main is green), so the outcome gate (`specter sync`) should also pass — CI confirms it here.

## Registered
`system-{event-bus, alert-router, drift-detector, fleet-rollup, liveness-loop, scheduler, discovery-scheduler, daemon-orchestration, kensa-executor, transaction-log-writer, supply-chain}`, `services-connectivity-config`, `api-{version, fleet-observability, system-discovery-config}`, and 12 `frontend-*` specs (foundation, homepage, auth-login, dashboard, activity, add-host, hosts-list, scans, settings + scan-config/exception-queue/discovery-config).