### PR TITLE
feat(scans): live per-host Running/Queued indicator during a scan

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,69 +133,14 @@
         "filename": ".github/workflows/go-ci.yml",
         "hashed_secret": "0e4f7f719374de1c33da2c0e5c0db5bcdc2e15d4",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 38
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/go-ci.yml",
         "hashed_secret": "0e4f7f719374de1c33da2c0e5c0db5bcdc2e15d4",
         "is_verified": false,
-        "line_number": 52
-      }
-    ],
-    "docs/engineering/README.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/engineering/README.md",
-        "hashed_secret": "0c844daf0b10d7b50720c33c183234207817b028",
-        "is_verified": false,
-        "line_number": 168
-      }
-    ],
-    "docs/engineering/install_guide.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/engineering/install_guide.md",
-        "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
-        "is_verified": false,
-        "line_number": 80
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/engineering/install_guide.md",
-        "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
-        "is_verified": false,
-        "line_number": 146
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/engineering/install_guide.md",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 377
-      }
-    ],
-    "docs/engineering/prototypes/openwatch-v1/Host Management.html": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/engineering/prototypes/openwatch-v1/Host Management.html",
-        "hashed_secret": "15cec270f44d7f4f1751d3f3ba0c59de746d783e",
-        "is_verified": false,
-        "line_number": 1034
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/engineering/prototypes/openwatch-v1/Host Management.html",
-        "hashed_secret": "9d4f0dbeba51b67921005512a26e5e651bedb626",
-        "is_verified": false,
-        "line_number": 1035
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/engineering/prototypes/openwatch-v1/Host Management.html",
-        "hashed_secret": "eadc3f93238dda49ec69d9ffa9416a74f348d9ca",
-        "is_verified": false,
-        "line_number": 1036
+        "line_number": 53
       }
     ],
     "docs/guides/API_GUIDE.md": [
@@ -204,7 +149,7 @@
         "filename": "docs/guides/API_GUIDE.md",
         "hashed_secret": "b48cf0140bea12734db05ebcdb012f1d265bed84",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 63
       }
     ],
     "docs/guides/DATABASE_MIGRATIONS.md": [
@@ -222,7 +167,7 @@
         "filename": "docs/guides/ENVIRONMENT_REFERENCE.md",
         "hashed_secret": "7205a0abf00d1daec13c63ece029057c974795a9",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 111
       }
     ],
     "docs/guides/INSTALLATION.md": [
@@ -254,7 +199,7 @@
         "filename": "docs/guides/PRODUCTION_DEPLOYMENT.md",
         "hashed_secret": "1a1d18a6cd33ec395692c25b8e26d90b4de8b5b4",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 120
       }
     ],
     "docs/guides/SECRET_ROTATION.md": [
@@ -263,14 +208,14 @@
         "filename": "docs/guides/SECRET_ROTATION.md",
         "hashed_secret": "ac21558017ec548c0355b86ee37c03ebbb44d0f7",
         "is_verified": false,
-        "line_number": 64
+        "line_number": 63
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/SECRET_ROTATION.md",
         "hashed_secret": "ac21558017ec548c0355b86ee37c03ebbb44d0f7",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 71
       }
     ],
     "docs/guides/runbooks/SECURITY_INCIDENT.md": [
@@ -284,15 +229,6 @@
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/runbooks/SECURITY_INCIDENT.md",
-        "hashed_secret": "45065ce1e8e982145327f46a77a380fb89cb529d",
-        "is_verified": false,
-        "line_number": 298
-      }
-    ],
-    "docs/runbooks/SECURITY_INCIDENT.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docs/runbooks/SECURITY_INCIDENT.md",
         "hashed_secret": "45065ce1e8e982145327f46a77a380fb89cb529d",
         "is_verified": false,
         "line_number": 298
@@ -316,20 +252,57 @@
         "line_number": 111
       }
     ],
+    "internal/credential/credential.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/credential/credential.go",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "is_verified": false,
+        "line_number": 274
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/credential/credential.go",
+        "hashed_secret": "f120ed08cee9e86427c9273b6d4dd6bbf8b0b278",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/credential/credential.go",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 280
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/credential/credential.go",
+        "hashed_secret": "6eaad027cdc58c70fa0deb42541e4ef9f69335cc",
+        "is_verified": false,
+        "line_number": 282
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/credential/credential.go",
+        "hashed_secret": "e3780650309f71a6c834b9ae59053fd04f83b202",
+        "is_verified": false,
+        "line_number": 289
+      }
+    ],
     "internal/credential/credential_test.go": [
       {
         "type": "Private Key",
         "filename": "internal/credential/credential_test.go",
         "hashed_secret": "27c6929aef41ae2bcadac15ca6abcaff72cda9cd",
         "is_verified": false,
-        "line_number": 241
+        "line_number": 221
       },
       {
         "type": "Secret Keyword",
         "filename": "internal/credential/credential_test.go",
         "hashed_secret": "eb89d14c54488aaffa31e9d4a3a7c086189e68a2",
         "is_verified": false,
-        "line_number": 298
+        "line_number": 278
       }
     ],
     "internal/db/db_gaps_test.go": [
@@ -338,7 +311,16 @@
         "filename": "internal/db/db_gaps_test.go",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 28
+      }
+    ],
+    "internal/dbbackup/dbbackup_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/dbbackup/dbbackup_test.go",
+        "hashed_secret": "3a0d41545ba3595ee93dfe6605baffcef53fb985",
+        "is_verified": false,
+        "line_number": 20
       }
     ],
     "internal/identity/jwt.go": [
@@ -381,7 +363,7 @@
         "filename": "internal/intelligence/discovery/firewall_fallback_test.go",
         "hashed_secret": "b9042ff97324570798584f0d7fc157136e958932",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 94
       }
     ],
     "internal/license/testdata/license-privkey-test.pem": [
@@ -393,6 +375,24 @@
         "line_number": 1
       }
     ],
+    "internal/notification/store.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/notification/store.go",
+        "hashed_secret": "98292288b8e2ce2aec8675215186a0a33a0c8f7a",
+        "is_verified": false,
+        "line_number": 258
+      }
+    ],
+    "internal/notification/store_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/notification/store_test.go",
+        "hashed_secret": "6447a70b8898354925242ff84cd1790e22101288",
+        "is_verified": false,
+        "line_number": 93
+      }
+    ],
     "internal/policy/testdata/policy-privkey-test.pem": [
       {
         "type": "Private Key",
@@ -402,2388 +402,95 @@
         "line_number": 1
       }
     ],
+    "internal/report/export_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "internal/report/export_test.go",
+        "hashed_secret": "e8b2cccf31904f5d9c62838922648cfeaa4c07e0",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "internal/report/signing_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "internal/report/signing_test.go",
+        "hashed_secret": "ce4303f6b22257d9c9cf314ef1dee4707c6e1c13",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
     "internal/server/api/server.gen.go": [
       {
         "type": "Secret Keyword",
         "filename": "internal/server/api/server.gen.go",
         "hashed_secret": "9fd0aaae1a3d0bc789d081307161ea9a821f9dee",
         "is_verified": false,
-        "line_number": 2455
+        "line_number": 3761
       },
       {
-        "type": "Base64 High Entropy String",
+        "type": "Secret Keyword",
         "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3159eab931ed1e79dab62d10730230debb191cc2",
+        "hashed_secret": "eca525ee60b3564d9633eb140726685271d52341",
         "is_verified": false,
-        "line_number": 6729
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a59e3ab18433cd88f0a1938ba8c0850b5eab57e",
-        "is_verified": false,
-        "line_number": 6730
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7fa95dadfd7f89de084964aec24aed6d7fb94fb0",
-        "is_verified": false,
-        "line_number": 6731
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4124ecd760b8fbab6fe25b47eb9a49b2df5d3abd",
-        "is_verified": false,
-        "line_number": 6732
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "173980de959310d782272d01059564448df5822d",
-        "is_verified": false,
-        "line_number": 6733
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5e6daa18fc4c42608b430cf0f28ad480cfec32c7",
-        "is_verified": false,
-        "line_number": 6734
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "63eb929094fbaafaa9790335d6e197448ca39384",
-        "is_verified": false,
-        "line_number": 6735
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "be8ff8b175be1107c49cdce099b4828590be5520",
-        "is_verified": false,
-        "line_number": 6736
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9dfc00518b4749a5a6af62b42f0a1eae301e9799",
-        "is_verified": false,
-        "line_number": 6737
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f4dc14ebfcbdef750ce865da91a47a0febb99265",
-        "is_verified": false,
-        "line_number": 6738
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b9d68b36f7f1afc814be7c01909a5d1399f5c6c1",
-        "is_verified": false,
-        "line_number": 6739
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "556279d68a1f5945f13c330817120a998fba198c",
-        "is_verified": false,
-        "line_number": 6740
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8766e9c5d43ec945606264406f4cb4395ff568c8",
-        "is_verified": false,
-        "line_number": 6741
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d12f03662aa2f2af4d50322a121e0998aa6f3e16",
-        "is_verified": false,
-        "line_number": 6742
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9853eef34e9f16baaf99fda1298c177fd6963922",
-        "is_verified": false,
-        "line_number": 6743
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e30abc12f19899698011589b6f7fdddcb4c85cfe",
-        "is_verified": false,
-        "line_number": 6744
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ac1d631c2a2616af9ad0ec36af02ad747f1c66a5",
-        "is_verified": false,
-        "line_number": 6745
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2f381199e16395fcfeed47f6336b31bb43390b66",
-        "is_verified": false,
-        "line_number": 6746
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "be0e459360abf3015b29388201df7ec7d28e7c63",
-        "is_verified": false,
-        "line_number": 6747
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a46ade403fa5fce6d5c66a48f00fc47cf09d0e4",
-        "is_verified": false,
-        "line_number": 6748
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f1ef354d6bcfb618911f16f749c50e4c0d89dbe1",
-        "is_verified": false,
-        "line_number": 6749
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bdfbdc0c6de5681875dcfccb6b5484d22ccc24b0",
-        "is_verified": false,
-        "line_number": 6750
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e1b82eba91762cd9fa78d9a0fc501e9748512d44",
-        "is_verified": false,
-        "line_number": 6751
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5897f6b515fe9170fa127e6121feaa7f8c1fe948",
-        "is_verified": false,
-        "line_number": 6752
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cae517fc96782919f904877de70d98bb2cc50d4f",
-        "is_verified": false,
-        "line_number": 6753
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2b51734b4e5a2161fa215577c6f1f822e8195dde",
-        "is_verified": false,
-        "line_number": 6754
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f2695ce8d9430cfd60b3fbc85b2c5b6c4bea0929",
-        "is_verified": false,
-        "line_number": 6755
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "29284c588ecd3ef1eb99bbb250b48d1ede0056e7",
-        "is_verified": false,
-        "line_number": 6756
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c25fac8e60dd816ddbfb1b6414dea8a813926223",
-        "is_verified": false,
-        "line_number": 6757
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "04996af1d9efb3b0aaf8cfcba6c338308ef693de",
-        "is_verified": false,
-        "line_number": 6758
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f5064da23b76f1dcb01f841b68998590bc8d0841",
-        "is_verified": false,
-        "line_number": 6759
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "edbad133e9e4437c916bf8060f23184c3e2dfc69",
-        "is_verified": false,
-        "line_number": 6760
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4ed72a053fe1fcd0b636e03deb0ade68525b112f",
-        "is_verified": false,
-        "line_number": 6761
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a959d0fa7230a98394c726b9c300a1be3ecc3c7",
-        "is_verified": false,
-        "line_number": 6762
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "23b02a1eba5af7f9e3ce2740e7b23bcfbb18b23f",
-        "is_verified": false,
-        "line_number": 6763
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "808a26483bb938e774b75944e7987d471e0142a7",
-        "is_verified": false,
-        "line_number": 6764
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "35556c052df51c9fcd53800cfbde5cb06c9b6948",
-        "is_verified": false,
-        "line_number": 6765
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "539ca06beac4d8a8fb9e8fbd823c76fdab5e4d38",
-        "is_verified": false,
-        "line_number": 6766
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4eceb73525ce91e1f7ee47581ebca47d40a3262b",
-        "is_verified": false,
-        "line_number": 6767
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7f3fee50afe09c23aa7cf9ebc4b469c33583e7db",
-        "is_verified": false,
-        "line_number": 6768
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e0b9c8e1d10dd30029e38487e76f2004ece49cf6",
-        "is_verified": false,
-        "line_number": 6769
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7ddf0b0348b10158680cffb961371af86f61ef35",
-        "is_verified": false,
-        "line_number": 6770
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "94a5def8e00b13bd4d8aab3f9d63fa135d0d91b5",
-        "is_verified": false,
-        "line_number": 6771
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2d5149d6b4939d65c67038f4332c2ebcde899542",
-        "is_verified": false,
-        "line_number": 6772
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1bed7b368bcffe709130e85c73ab8d5b27a83fe6",
-        "is_verified": false,
-        "line_number": 6773
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f2e1bf88be19923018b440ee6d66c344a989a9d7",
-        "is_verified": false,
-        "line_number": 6774
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8eed0708ffb3f820941a34120a76b1beecde047a",
-        "is_verified": false,
-        "line_number": 6775
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1b178e64f7f205274854a74bed163a4c64de806d",
-        "is_verified": false,
-        "line_number": 6776
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7fd662062ae626cb7d707861ad02f086ccbe439f",
-        "is_verified": false,
-        "line_number": 6777
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "57b3bb5e6e2517fea9afb2afd39fc8988189a356",
-        "is_verified": false,
-        "line_number": 6778
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "98fe368c8c3b75aac2bac2bc4a969ca40c2358d8",
-        "is_verified": false,
-        "line_number": 6779
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a98050c3e02fac8eddc273347fc16da0efa1ce0",
-        "is_verified": false,
-        "line_number": 6780
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "af878a086a1c7c5c000830a60fc5ea794385772e",
-        "is_verified": false,
-        "line_number": 6781
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9cc5480e2242591230fa7cd388cb339537751389",
-        "is_verified": false,
-        "line_number": 6782
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cc864a2f0daf2c55c554e3654b5b1ddec4137810",
-        "is_verified": false,
-        "line_number": 6783
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5c54a8e6b28f72613a8553b1bfa9e0f114c396a3",
-        "is_verified": false,
-        "line_number": 6784
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d54e3db656348bcae9b40bfaf8d76a4ee795860b",
-        "is_verified": false,
-        "line_number": 6785
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "64f1ecee152c84f5fc01af111412ecf5ea92ee84",
-        "is_verified": false,
-        "line_number": 6786
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c65b6bc4b84c21250bce686b697092fde40e7a70",
-        "is_verified": false,
-        "line_number": 6787
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c51811e265e25722230bfd2cc945e0c6e0427903",
-        "is_verified": false,
-        "line_number": 6788
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c41911618f2c6f8656d04ac57ab02f10add886f8",
-        "is_verified": false,
-        "line_number": 6789
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7256818dc68ec5df20382866e835ebedffb0b16c",
-        "is_verified": false,
-        "line_number": 6790
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fb0216b3932437aa9260df899257ac1604af3435",
-        "is_verified": false,
-        "line_number": 6791
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "32c9bbc1668f048b5dc31176835613fe0e1406d1",
-        "is_verified": false,
-        "line_number": 6792
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a17cdd467a9f201f59bdb7e0a37e07d99aceae55",
-        "is_verified": false,
-        "line_number": 6793
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c1a4ef876596aa2a24784738f641259ca1032b06",
-        "is_verified": false,
-        "line_number": 6794
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cff2509bb88c6ce950b0cae3e3157b7dbb032c50",
-        "is_verified": false,
-        "line_number": 6795
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "87677f1ddcecbd6233f8cb3d4eaa2a8a878eed6b",
-        "is_verified": false,
-        "line_number": 6796
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a1984db41ac65db2a831602e094689cd8b43fc51",
-        "is_verified": false,
-        "line_number": 6797
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a20da5406d5595dae75e94a42adbdd0f035f0d47",
-        "is_verified": false,
-        "line_number": 6798
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "921b51c6744233c860e23319b369faf87a27437e",
-        "is_verified": false,
-        "line_number": 6799
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "24a6837dcc66845499ed97b40df81d689e710853",
-        "is_verified": false,
-        "line_number": 6800
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "34ed76118550dd933f8efe3aa98d84dea57556f4",
-        "is_verified": false,
-        "line_number": 6801
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d4cd80d782a813b08896c6d999aaf876667984fa",
-        "is_verified": false,
-        "line_number": 6802
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "454d42c3566b6017797b98438f009919204bad83",
-        "is_verified": false,
-        "line_number": 6803
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "123889b633ca684a846d356eb1ef8947d0d0b382",
-        "is_verified": false,
-        "line_number": 6804
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "33b88f1a526f431e7b5e69e3480763da49275cb1",
-        "is_verified": false,
-        "line_number": 6805
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "55792a32513d8fe64a35a67d2d2810525bf1005d",
-        "is_verified": false,
-        "line_number": 6806
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "52f3cfe7f28ffb57cc97b2fd96076c11709bcc48",
-        "is_verified": false,
-        "line_number": 6807
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "aaf1b745eb58d13df95946ec677d057d9c51153a",
-        "is_verified": false,
-        "line_number": 6808
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3cfc7f20cdfd193f2a799450ecec5d7dceeb78b8",
-        "is_verified": false,
-        "line_number": 6809
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "960a4f76c38e614785d29b1124b4e6b25f8916cd",
-        "is_verified": false,
-        "line_number": 6810
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8f065644f229bce96cc1fc3fe08c06bae7d3c144",
-        "is_verified": false,
-        "line_number": 6811
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "15d17f798765c2de66867685e8a159d518f5764c",
-        "is_verified": false,
-        "line_number": 6812
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "74504d175f654dc34a85e335bccd6c1808274d7a",
-        "is_verified": false,
-        "line_number": 6813
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8d80215b0dc0b72122bce8dfade204856a034af8",
-        "is_verified": false,
-        "line_number": 6814
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "96b5661a7d7cb3af5d12708bcdbe50765d6277cd",
-        "is_verified": false,
-        "line_number": 6815
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ac43167f4e0ed3c3209aa2d788ffbd74d2972407",
-        "is_verified": false,
-        "line_number": 6816
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f8de4e149895d491b285323af21c84dccf512424",
-        "is_verified": false,
-        "line_number": 6817
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e03937e07374c9ee5711d1eb0e190f86951877fb",
-        "is_verified": false,
-        "line_number": 6818
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2fc5b0b05b157a2aac6975373808f6bb2db68f36",
-        "is_verified": false,
-        "line_number": 6819
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "18bcbbd4019c765b70879dfa50018eadabe45ec6",
-        "is_verified": false,
-        "line_number": 6820
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f023b278f164f2b1de8c97aeb883e71e1f796738",
-        "is_verified": false,
-        "line_number": 6821
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "772fcecdae94db60d23c517f90ec9d3737563377",
-        "is_verified": false,
-        "line_number": 6822
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c7cfd312105cda4ed0a35bdbe5910869e12e9cf6",
-        "is_verified": false,
-        "line_number": 6823
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2f4e8d760cf3d7ce0079e169abb4002c68cad02f",
-        "is_verified": false,
-        "line_number": 6824
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f2e9fba8a3b98df82687783baccc995765ed47ee",
-        "is_verified": false,
-        "line_number": 6825
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "de5886bf0d3c00ffd8e4868917a099987a992efe",
-        "is_verified": false,
-        "line_number": 6826
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "121c50f7f3361f26d921d2ee7794c5711b206461",
-        "is_verified": false,
-        "line_number": 6827
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "759a17b960321266cff6cbb8b2a8586cd9f059ab",
-        "is_verified": false,
-        "line_number": 6828
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2f97d0098d5333d8511cb728e1b47eab78923cbc",
-        "is_verified": false,
-        "line_number": 6829
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5b62c6f5ed1f3db38a00551fd06807fd456d5fd4",
-        "is_verified": false,
-        "line_number": 6830
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1b764154f997e82f2545efad1a5d895b67ff3800",
-        "is_verified": false,
-        "line_number": 6831
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2c1a0e3e6d6a09ed05a7d4704cc59ec3d689ea2b",
-        "is_verified": false,
-        "line_number": 6832
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2190615a8b4434c36198205e6f3f93fdca7eb67e",
-        "is_verified": false,
-        "line_number": 6833
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8edd713d732ce8680f642f9e861821360bc96f87",
-        "is_verified": false,
-        "line_number": 6834
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "36bfdadc60f47f905721cf6b8aeea37b3e1fed44",
-        "is_verified": false,
-        "line_number": 6835
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ba1acd8b2d5b7311eda6adf70fd76d0985cb50c4",
-        "is_verified": false,
-        "line_number": 6836
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f14f1247143daabddef2ff20fd7725a7b72606dc",
-        "is_verified": false,
-        "line_number": 6837
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7c2e60d8714c24d905165d290c465e36b9814f88",
-        "is_verified": false,
-        "line_number": 6838
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d7440559179f686348bb29887d2c6a5fdd4c9304",
-        "is_verified": false,
-        "line_number": 6839
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9199fefbf2b28217901e117802245295800ab12f",
-        "is_verified": false,
-        "line_number": 6840
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "47d6955dd30c92e74f1c81aba33ee7f7db4dacfb",
-        "is_verified": false,
-        "line_number": 6841
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "61c51c6b24f8487e088158623155cad3a46aecc0",
-        "is_verified": false,
-        "line_number": 6842
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "04cd8933a8fb69c22f67ceb68aa53584aaec22f4",
-        "is_verified": false,
-        "line_number": 6843
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "99b0b9719bcaad9f4645b0267d618dd46b473fb6",
-        "is_verified": false,
-        "line_number": 6844
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "238bcf26c7cda5c376138b471e48ab5cc957c97d",
-        "is_verified": false,
-        "line_number": 6845
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d38cbde98dca2fd0dfbfdfc85e284867a0b1c615",
-        "is_verified": false,
-        "line_number": 6846
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ea363186d2098d7c219d4b661f8660e06453c67d",
-        "is_verified": false,
-        "line_number": 6847
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4d790af5120fdd1060a2ea843e31d08ba11a4e0c",
-        "is_verified": false,
-        "line_number": 6848
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "10d3265898502a46c09fd6c10a4adcf007d5e153",
-        "is_verified": false,
-        "line_number": 6849
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a93617de13c0bf62f6abcd9e72b7674cac019ebc",
-        "is_verified": false,
-        "line_number": 6850
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ff70627d7a5f8dfb7442044b0f7cb37ea76a19e5",
-        "is_verified": false,
-        "line_number": 6851
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c2a62123d000e065dc53009732d06812f07ca0f5",
-        "is_verified": false,
-        "line_number": 6852
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ecc62527d0fa82014400cef943ced2577de34352",
-        "is_verified": false,
-        "line_number": 6853
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bb7cc71911e2b900fb25efa3ff6a334e14f8d1a5",
-        "is_verified": false,
-        "line_number": 6854
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c345b51334320aebe374b63f16bdf164cbd63530",
-        "is_verified": false,
-        "line_number": 6855
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "65ad722baa900148c1b91e4f11e4aac0773582cc",
-        "is_verified": false,
-        "line_number": 6856
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f86eb6ec5f3de9ef5a2ca580f66910888701b2d0",
-        "is_verified": false,
-        "line_number": 6857
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b31a2fe3d8a97682c07664a2790fb298976bfd0a",
-        "is_verified": false,
-        "line_number": 6858
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f537d8b0bc95ce2055ddccd260970325b3897182",
-        "is_verified": false,
-        "line_number": 6859
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ad7f65a2973341ee99637a30fe6d7f04f26b1b99",
-        "is_verified": false,
-        "line_number": 6860
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "47c4c85942c399116fbeac64667add6db31e7619",
-        "is_verified": false,
-        "line_number": 6861
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "86a0f6af775bdb4b94d6349a38e68a04e132fc02",
-        "is_verified": false,
-        "line_number": 6862
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1c408e6b03ac8c58443b1d197420f7a51c75ffd0",
-        "is_verified": false,
-        "line_number": 6863
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3aece0099f92b5bbbdffc576939731a27e2604d3",
-        "is_verified": false,
-        "line_number": 6864
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6b4da3f74dc1c8ea4daf41cd30092ec716223044",
-        "is_verified": false,
-        "line_number": 6865
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b578d1f4c0eb1cd12d6b62592dba47603694d821",
-        "is_verified": false,
-        "line_number": 6866
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0d6b854b0d4fb1971501faf1966754f600d23676",
-        "is_verified": false,
-        "line_number": 6867
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "63b43610a50e2a75945922613ee37bb24ada3322",
-        "is_verified": false,
-        "line_number": 6868
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6818f6797ec7bbac46df1fa623ddd2d1bc066741",
-        "is_verified": false,
-        "line_number": 6869
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "040953c3b09c4db7d3845e7823b2e054e66f30d3",
-        "is_verified": false,
-        "line_number": 6870
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8a10093c77c5188f2a4760c14756a4117dc1fc0e",
-        "is_verified": false,
-        "line_number": 6871
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e1a6323a65c59aaf3e9ff773afab51abede78200",
-        "is_verified": false,
-        "line_number": 6872
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d2703d2d470cc497aa838363b7fe2da2cc30ccda",
-        "is_verified": false,
-        "line_number": 6873
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b8f7298320373001da04221bff849e31a1a055ac",
-        "is_verified": false,
-        "line_number": 6874
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4a196d6675bbcf966d90a862ede21eeee1ff3665",
-        "is_verified": false,
-        "line_number": 6875
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fe6f798a29aaeff08b086ae369582b9ec2bbe863",
-        "is_verified": false,
-        "line_number": 6876
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7b897c91f1e4ca176d2b4e5b1ead9a0ab905eb4e",
-        "is_verified": false,
-        "line_number": 6877
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1e7b8a6edf76514bfa9fb6b61b7f64c0e0b8ff15",
-        "is_verified": false,
-        "line_number": 6878
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f18b8e60ec2d8ba3199f4f1abb31e75143c9603d",
-        "is_verified": false,
-        "line_number": 6879
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b40083646a6dd6787e7380b8756016e317583ee9",
-        "is_verified": false,
-        "line_number": 6880
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1fcdfec292f7ec1a7dcd73363c2d3f5a21582747",
-        "is_verified": false,
-        "line_number": 6881
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "845f5f79ef3a3d50674832aad5df2acf73cd6bb3",
-        "is_verified": false,
-        "line_number": 6882
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bde069071f12b4be2bff6d289a609142cb2a501e",
-        "is_verified": false,
-        "line_number": 6883
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "95b0022e51e73701bccf09aec825fd956d676fa1",
-        "is_verified": false,
-        "line_number": 6884
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "edcfb12d9a6c9a8a8dbb3e241eae3904ddd95ece",
-        "is_verified": false,
-        "line_number": 6885
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "447805bb80dcb9d464bce018db77dd24dfff1da1",
-        "is_verified": false,
-        "line_number": 6886
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bb6075a7ce638a2fd5ebd8e1fc48bb70a4f7e0e0",
-        "is_verified": false,
-        "line_number": 6887
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ba18c82328bf542b068a4fba862aa18fe364db04",
-        "is_verified": false,
-        "line_number": 6888
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0347ce35d0a9bde07bfa07c24c669e52ae58bc15",
-        "is_verified": false,
-        "line_number": 6889
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "14088ce8bd07cff46c997dc407b5d03bd6d5d52e",
-        "is_verified": false,
-        "line_number": 6890
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "34c5d37764bb49838c1f5b983b9a754e81db1448",
-        "is_verified": false,
-        "line_number": 6891
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b60ae9b5bc5a4601918fafafe983a0e6e22f6e74",
-        "is_verified": false,
-        "line_number": 6892
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "42439102c1b55a32bd54ec3b76e3b5d7f598565c",
-        "is_verified": false,
-        "line_number": 6893
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "91d8d670706874c473322f60ae711d23a6fd97b7",
-        "is_verified": false,
-        "line_number": 6894
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c2927629c2d0ebe6ed735907bf3d62911ec22fef",
-        "is_verified": false,
-        "line_number": 6895
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "81ed78a223fd9fdea1f0457d473a1c24f2e46446",
-        "is_verified": false,
-        "line_number": 6896
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b51c82e05266890a78d588b8bb3b3db3a6ca76d8",
-        "is_verified": false,
-        "line_number": 6897
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b9b1dff7da3e0fcb96e79c252d198d642b4450d0",
-        "is_verified": false,
-        "line_number": 6898
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "288cd0b081f757ca3411329c7a00572ddd6bfbf6",
-        "is_verified": false,
-        "line_number": 6899
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "10841d240ae097faf213003eb20b948881b81b17",
-        "is_verified": false,
-        "line_number": 6900
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fe7afbe87bf6ca81a9798154959174994bb84cd0",
-        "is_verified": false,
-        "line_number": 6901
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8042f8970914204e29e1e1413973da77e81a7d39",
-        "is_verified": false,
-        "line_number": 6902
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a6c2c55bba3a6faa0816b7f0106572d40ce92715",
-        "is_verified": false,
-        "line_number": 6903
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "68e81a9b3f6911ec67a6e16cd6b17d622e42d55f",
-        "is_verified": false,
-        "line_number": 6904
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "642a9d13d24190dc9079a045d61ac2bd0a0b593b",
-        "is_verified": false,
-        "line_number": 6905
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "214cd24d59f28b390f516e6ccfe00b6d59664f53",
-        "is_verified": false,
-        "line_number": 6906
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c1c19c1c8f758eae0989e5435b2527d5ab8ea8c2",
-        "is_verified": false,
-        "line_number": 6907
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "46a7fa5d812759ea619e3f5170c6f954335cb70f",
-        "is_verified": false,
-        "line_number": 6908
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2307ec191593afc0ddd6319d6de5103e210eea11",
-        "is_verified": false,
-        "line_number": 6909
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3b136ed728a56f8318bf7822030ffb0ebfe65c3f",
-        "is_verified": false,
-        "line_number": 6910
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8e73375a67d29627d24f452fe34d68f4044dbf83",
-        "is_verified": false,
-        "line_number": 6911
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f588d0195639b0cf83d71ce605bcfddf1cd7f2b2",
-        "is_verified": false,
-        "line_number": 6912
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e49ee88d31628dcf321929b23ab150d460aecdee",
-        "is_verified": false,
-        "line_number": 6913
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5ce2dec018287fbe3a39495f77670ad5b7626d4d",
-        "is_verified": false,
-        "line_number": 6914
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6a6214ab06cff79198eda51fd34b485b3fd8b10b",
-        "is_verified": false,
-        "line_number": 6915
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5103bf39d9bc36ddd175a535850244af77e565ad",
-        "is_verified": false,
-        "line_number": 6916
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1a1187a0aa8aaaebd857d6cb11fdc506b6490dfa",
-        "is_verified": false,
-        "line_number": 6917
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a04ab1f322cef610aa2e90ca3e81a3e2c909b7f3",
-        "is_verified": false,
-        "line_number": 6918
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "cf6160456db5ce0fea51c0c830b47db541763ea8",
-        "is_verified": false,
-        "line_number": 6919
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d37612d201b10edcc56c99468d884eac8b6a3ba2",
-        "is_verified": false,
-        "line_number": 6920
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e3ae1116efa5ac0ab89894744d665c58e0eb81ef",
-        "is_verified": false,
-        "line_number": 6921
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2996e7ad4aeb3bd4c1b60b22adb3ba22c88fa151",
-        "is_verified": false,
-        "line_number": 6922
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2c4665ff8d436948fa26cd92dce8fcfb22a200b3",
-        "is_verified": false,
-        "line_number": 6923
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "450a80451c6434ff5cb714586914fe7fa05d499d",
-        "is_verified": false,
-        "line_number": 6924
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b8ce617890bd199bfb0a9159c04f025ecc222c18",
-        "is_verified": false,
-        "line_number": 6925
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5da8ab62af40a1b54a84fca65e14ae18015b2b28",
-        "is_verified": false,
-        "line_number": 6926
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b66461b9e2010a5dcc89070f57fb32ea8a9739e1",
-        "is_verified": false,
-        "line_number": 6927
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4ceb29f1c24808cae7092aee6e1283d7290d307a",
-        "is_verified": false,
-        "line_number": 6928
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "49638b0138a476eab6314d084878df039dbf98f1",
-        "is_verified": false,
-        "line_number": 6929
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d77a90b918e32abcbd6b16d3ed9cfc06fbc552fb",
-        "is_verified": false,
-        "line_number": 6930
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "17a4d2288a228851c0514a5399727d0c2167a902",
-        "is_verified": false,
-        "line_number": 6931
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b709c8d6f9ce9674d5aeb1689f652a6317523239",
-        "is_verified": false,
-        "line_number": 6932
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "32f197170779f30742a6911ad9d45b4840551ea6",
-        "is_verified": false,
-        "line_number": 6933
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "15393a1264349580d565657de8f54e2d335b8631",
-        "is_verified": false,
-        "line_number": 6934
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "71b15ebad8ececc46298b41595d8cad9bbc433b6",
-        "is_verified": false,
-        "line_number": 6935
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "100c270329360d6940f59bbd98d0ea0d0d7a423a",
-        "is_verified": false,
-        "line_number": 6936
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "40ede73c5c73268fdf21fce27b5453dc2274deb8",
-        "is_verified": false,
-        "line_number": 6937
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8b11464c58651223eab21d06236c53ebb75651c9",
-        "is_verified": false,
-        "line_number": 6938
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "213ae6be71b127b064d6afadacb2eb0b73951a34",
-        "is_verified": false,
-        "line_number": 6939
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "867f9dc2ce7560df52dc3318282a706cf2348463",
-        "is_verified": false,
-        "line_number": 6940
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2cc80b1044677dcf09035d3eed9914e93b8129e4",
-        "is_verified": false,
-        "line_number": 6941
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "062d7b6fc39c11052eb49c93ad32d3fed3607192",
-        "is_verified": false,
-        "line_number": 6942
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "389cac13a067ae212533eefe7156c4ca6fdecad0",
-        "is_verified": false,
-        "line_number": 6943
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "18fadd39781dd35ce371d8c06e89e82dbda16c76",
-        "is_verified": false,
-        "line_number": 6944
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ca28bce2d3feb85a99f4af4bed77a16da6a41015",
-        "is_verified": false,
-        "line_number": 6945
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2a8baee18cfa15f2321b719c631c4a0c9da93dd0",
-        "is_verified": false,
-        "line_number": 6946
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "81eae591c8e8f93fbd2a0553ad478a630ef14d21",
-        "is_verified": false,
-        "line_number": 6947
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bcffeee4fd10c84b64601f5e3e5b461fa4f2edb2",
-        "is_verified": false,
-        "line_number": 6948
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "39bf9bd872e6f43cdec7050e3df0d0ea979366dd",
-        "is_verified": false,
-        "line_number": 6949
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "013a5edb834a720ec8954496dd04ffed54f09401",
-        "is_verified": false,
-        "line_number": 6950
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2518ca1e63924846c07b9ecd293b9648751fc232",
-        "is_verified": false,
-        "line_number": 6951
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d0f808e40425a6642c9a6d65f63ac1ac92be0f04",
-        "is_verified": false,
-        "line_number": 6952
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2e3ffee516e2da9697f9dd68ce0a2dda32dc1a29",
-        "is_verified": false,
-        "line_number": 6953
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2ffed486b79d5057007b6cf929118d5030c502da",
-        "is_verified": false,
-        "line_number": 6954
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0c2efa4b5ac6677534ea9deaf045892de9eae585",
-        "is_verified": false,
-        "line_number": 6955
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "481ebc8197214b63a065e368132988a84bc5ea62",
-        "is_verified": false,
-        "line_number": 6956
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "50f5628d93cf3b6f0db689d0c6d50ff95c4386cb",
-        "is_verified": false,
-        "line_number": 6957
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7995297c6cab1f5f0c5d459344a940806cb42853",
-        "is_verified": false,
-        "line_number": 6958
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3750f9ca8ad35ba189be1f10c54587955f47d403",
-        "is_verified": false,
-        "line_number": 6959
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4959227900cdebbcb99fb74285513bd2bf7340df",
-        "is_verified": false,
-        "line_number": 6960
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e326e4e9cb46a215980ec397b598b5d6d80fa19d",
-        "is_verified": false,
-        "line_number": 6961
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3c5d7436df5a8d403302838513e7f38b8261aede",
-        "is_verified": false,
-        "line_number": 6962
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a79928d9f43935ac2a0387c3b719aea3641057f7",
-        "is_verified": false,
-        "line_number": 6963
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "981c55047f6beab5c2b66b7b7c30bd3fa97d76cc",
-        "is_verified": false,
-        "line_number": 6964
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "130724d4197f2bd91f6420b629d341be9d47ba92",
-        "is_verified": false,
-        "line_number": 6965
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d5f842264318463927824f70d4337eaa8d7a9e55",
-        "is_verified": false,
-        "line_number": 6966
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5629df8f251573df63dbe115dd3d979a61df4a3d",
-        "is_verified": false,
-        "line_number": 6967
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2d6610a211328f269c775acf5029137be125e00d",
-        "is_verified": false,
-        "line_number": 6968
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "493436b55004efb25efd964448802d9ec587f9c1",
-        "is_verified": false,
-        "line_number": 6969
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f0473306d3d08b6874fe3feae83bb4061efbf457",
-        "is_verified": false,
-        "line_number": 6970
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "eced69bd8b0cf0907249aca909c977b4acbf6325",
-        "is_verified": false,
-        "line_number": 6971
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5f1df3ede43eb47fd0565142e61c23a1c483bbc7",
-        "is_verified": false,
-        "line_number": 6972
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a1577bcd710705efbde6782df303443f28d2b777",
-        "is_verified": false,
-        "line_number": 6973
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8a6d4c8bfe272414463245ae14cfb7eb7efbcdcc",
-        "is_verified": false,
-        "line_number": 6974
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c436519470b13b0bfc8f504b330296646eec0bb2",
-        "is_verified": false,
-        "line_number": 6975
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2facd42d6dbdb1b2196bcd62d3a9295c412c7f99",
-        "is_verified": false,
-        "line_number": 6976
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ec47250388bd9b84ede11b5ec7d46532bdeeaf32",
-        "is_verified": false,
-        "line_number": 6977
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "811fe2a0424b8e4a9a37c6ba32eb2f655c815e3d",
-        "is_verified": false,
-        "line_number": 6978
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9a1d3870442bb0225a4d2b3398586aef54395f91",
-        "is_verified": false,
-        "line_number": 6979
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9cae4afd46c9e27586e13ac923e80338887de459",
-        "is_verified": false,
-        "line_number": 6980
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "06d8c4bc82d508b228872e571c96487aca5d265a",
-        "is_verified": false,
-        "line_number": 6981
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ef954451d461788aed5ba5e09758aea2fcbe286b",
-        "is_verified": false,
-        "line_number": 6982
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a2cbe3bae984a69382e26ca559f77b0c06b5bce7",
-        "is_verified": false,
-        "line_number": 6983
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "446ca671fc770db9bd07a3012d9bc9aa8d6702bb",
-        "is_verified": false,
-        "line_number": 6984
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "70f054069ca0d36277e16418cca80069938ab272",
-        "is_verified": false,
-        "line_number": 6985
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "527a8eda722e3e99cae7a24ca5af13afbbaa3c98",
-        "is_verified": false,
-        "line_number": 6986
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "696ac301602576a3df61da4c14a417bcf7827988",
-        "is_verified": false,
-        "line_number": 6987
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "112d280b6a766f4d2a463c6405c65b8fe52dbe74",
-        "is_verified": false,
-        "line_number": 6988
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9ac14af68c1bad54ea26c5c72fc31d2f9d063502",
-        "is_verified": false,
-        "line_number": 6989
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8cb2ee38b2ed00cb2a1d846ef0623f94e2497266",
-        "is_verified": false,
-        "line_number": 6990
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "800a31113f9ed6c54c646b8d2703fc1f7e5f6d0b",
-        "is_verified": false,
-        "line_number": 6991
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "384e88a143360ca9bdbee55b422b8c9c12e2c4ec",
-        "is_verified": false,
-        "line_number": 6992
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "08627c9d75ded2c1fdd8ec12d53ac27d9642a902",
-        "is_verified": false,
-        "line_number": 6993
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b8b61f2ac9ccb5309cf85b7a362d1109ef9f1c0b",
-        "is_verified": false,
-        "line_number": 6994
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2377a1599bd01c3fc94dd0f3a3bfb5f91639c969",
-        "is_verified": false,
-        "line_number": 6995
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e6c6d184b4c07ac102c5662fc6755449e11b4a3f",
-        "is_verified": false,
-        "line_number": 6996
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e9635a4eb02cc5998bee20b08b777e0f05e395e3",
-        "is_verified": false,
-        "line_number": 6997
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c2c8999f4c4c1df1bd14b96c19655dbb43ee6ebd",
-        "is_verified": false,
-        "line_number": 6998
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7dd4f76e109da6ccd0a01aad0db45d0b9afe0569",
-        "is_verified": false,
-        "line_number": 6999
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "83fac8829ae3ae04fe21f49593970307ac2c83b7",
-        "is_verified": false,
-        "line_number": 7000
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b3acd0172bf354baf08e8bef0042521f03af99df",
-        "is_verified": false,
-        "line_number": 7001
-      },
+        "line_number": 3890
+      }
+    ],
+    "internal/server/api_scans_test.go": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "87e1485609df6d0447a2f096b173273697a43c7b",
-        "is_verified": false,
-        "line_number": 7002
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "afabdeef2d8a69fd3616240431e4fb24a3c4edd7",
-        "is_verified": false,
-        "line_number": 7003
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a1dc5722f41d889aa93661d13bd928bd2cf301f0",
-        "is_verified": false,
-        "line_number": 7004
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "46a46c99f08dd6302ed3e6e8cf33709f25032eac",
-        "is_verified": false,
-        "line_number": 7005
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6a58e6e6437fe95afa15bf95bb7f80b4f0750508",
-        "is_verified": false,
-        "line_number": 7006
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0bfb7071eaffa4e133a54a4bb6a4f13902e4aec6",
-        "is_verified": false,
-        "line_number": 7007
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "ff0d29e3ecc129c194b7df8c9402af9c26c6e0e6",
-        "is_verified": false,
-        "line_number": 7008
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c2e8410383f7cd7c81881b5e6518c606271614e4",
-        "is_verified": false,
-        "line_number": 7009
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "dc37df9635d034a79fd52232552d6ea30d30ce7b",
-        "is_verified": false,
-        "line_number": 7010
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5b22f35d6cd1120ab7e80ae5badc20aa68da96c0",
-        "is_verified": false,
-        "line_number": 7011
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fdba67ea1ca125569b76d074f13bed966a30e424",
-        "is_verified": false,
-        "line_number": 7012
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6e6506b174b034e1d2a6288301512b24ac821e7d",
-        "is_verified": false,
-        "line_number": 7013
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bcf2914064a169e4aeadbeeb803b8aadec2abd0b",
-        "is_verified": false,
-        "line_number": 7014
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "08f81ab1b06bf334fa3aa59332cad31a6a6b3861",
-        "is_verified": false,
-        "line_number": 7015
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2fea1ce8d23d39bd577304b55395ac0de2846082",
-        "is_verified": false,
-        "line_number": 7016
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "8ec9aee98e59a6d0748167f5d035a68304672d01",
-        "is_verified": false,
-        "line_number": 7017
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a8b21b70f8399af3c7432ccc006268633b576697",
-        "is_verified": false,
-        "line_number": 7018
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "623f1af634c2f689ba46659b2ca28eff2b325e05",
-        "is_verified": false,
-        "line_number": 7019
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0de3276030bedd1bb45c535f25b944b4eb8b52ad",
-        "is_verified": false,
-        "line_number": 7020
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d2bd62a11f2c02b05c1f32f3a639c0bcbbe01229",
-        "is_verified": false,
-        "line_number": 7021
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6c53280df024d152c32994b28008c37fcdf1bace",
-        "is_verified": false,
-        "line_number": 7022
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "80776e6393c39c585b4a2e2c9b6080779f049c34",
-        "is_verified": false,
-        "line_number": 7023
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "fbf8e7ff1a937206811fd9d66db2f7dea36b942b",
-        "is_verified": false,
-        "line_number": 7024
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b19414cfb02d84fb1a21917e65d52c4f50ca96ca",
-        "is_verified": false,
-        "line_number": 7025
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bc20e83fcc706745ba6e75b3803ed3346fc268de",
-        "is_verified": false,
-        "line_number": 7026
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d3b4ec81150242e0996c7490d4c73561e9efe392",
-        "is_verified": false,
-        "line_number": 7027
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "aa490d3e15781c7b0b23cdef9a5190b8fbe2de99",
-        "is_verified": false,
-        "line_number": 7028
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "67fa40526a4565609d24ae8050295745cd04812a",
-        "is_verified": false,
-        "line_number": 7029
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "83830a473f5d0c2de8f3b7650773bd167976ec6b",
-        "is_verified": false,
-        "line_number": 7030
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "34e6fea8bf266ffe7d5e7cec2fded5f79817df16",
-        "is_verified": false,
-        "line_number": 7031
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "0eb8e5192bcb043da065af4da57d2b43e68ef55a",
-        "is_verified": false,
-        "line_number": 7032
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "62d8b8d1360885fc7fdd8557407d26162fab7903",
-        "is_verified": false,
-        "line_number": 7033
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "a5d43dd79bd00c0e254a3e0642cd5ad813b78010",
-        "is_verified": false,
-        "line_number": 7034
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "11eb31253198b61e606ce01ea326726bed28f5b8",
-        "is_verified": false,
-        "line_number": 7035
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3a441e9da9362b07734865ffed915db471ce2cc1",
-        "is_verified": false,
-        "line_number": 7036
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "3c392827d9a15dd787ce94bf072c0e3462c4da9f",
-        "is_verified": false,
-        "line_number": 7037
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c9b06bed6910b62a53ed3e88c6473710e4fd35d7",
-        "is_verified": false,
-        "line_number": 7038
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "65b4f8212c0a2095ce4c56d6b6a21405460f55cb",
-        "is_verified": false,
-        "line_number": 7039
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "97e259a552bbf5c6776f08942f8fce29f8cb08f4",
-        "is_verified": false,
-        "line_number": 7040
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "c635c4857ab3ffcb9464ff16e5373d199bf25f54",
-        "is_verified": false,
-        "line_number": 7041
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6e419575e432d23a7cf979adf870ffed602e6ecb",
-        "is_verified": false,
-        "line_number": 7042
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "05ac1658df9576d7592f33b3ea50ac19d556d297",
-        "is_verified": false,
-        "line_number": 7043
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e46703da7dcae4a9ccfab288b7bef6b99b8dac90",
-        "is_verified": false,
-        "line_number": 7044
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1a3d54b2e282600f11118e08fa2fdb5f18b60abb",
-        "is_verified": false,
-        "line_number": 7045
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "4dcda0781f114b459c27f3fa5e3aa4ca69360f1f",
-        "is_verified": false,
-        "line_number": 7046
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1a5bb954c273e434b65d53ca9f55e41d2c6ee1ec",
-        "is_verified": false,
-        "line_number": 7047
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "96b6ebc97563ed473e11a6851ff04e8cdcad3def",
-        "is_verified": false,
-        "line_number": 7048
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bbed265ea2ecf59eb1cd9147284d8550b40abed2",
-        "is_verified": false,
-        "line_number": 7049
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "7fbe4ecd31e25b22d4249d2a63c759c4fe5eb5e3",
-        "is_verified": false,
-        "line_number": 7050
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "9ce1a25feb466002998f9981ea6d965dedcda87e",
-        "is_verified": false,
-        "line_number": 7051
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "18890757e8e8721bdbb65a83bc9bf73510d2265d",
-        "is_verified": false,
-        "line_number": 7052
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "1f20abf8d6b8d69a2626969e95da1aaaa23b1555",
-        "is_verified": false,
-        "line_number": 7053
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2499dd81bd7218a6983ec2c3b73658b04e2fa5eb",
-        "is_verified": false,
-        "line_number": 7054
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "800cd6049e43e0ac24fc84cc763ce6685c5715ab",
-        "is_verified": false,
-        "line_number": 7055
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5104d8822243835dd87fc9a279fc1e72f99619b1",
-        "is_verified": false,
-        "line_number": 7056
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "d0044626e4544a3f70eeb8d67909360e0ada3552",
-        "is_verified": false,
-        "line_number": 7057
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "5ad034932012c66ba57ed18cf748f0fff2d968e8",
-        "is_verified": false,
-        "line_number": 7058
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "6286e436a3d5c4961f9d515ef297f934742e44d0",
-        "is_verified": false,
-        "line_number": 7059
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "bf7961c9cb81e88be1f53230f3a898a4eefd73ac",
-        "is_verified": false,
-        "line_number": 7060
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "b0a3f651ad1f0d47ad257d9bb8f3690332a124b8",
-        "is_verified": false,
-        "line_number": 7061
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f405721b3854362698ce2f54aebd6e6ff7eed825",
-        "is_verified": false,
-        "line_number": 7062
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "88217524f6672538b7fb5b113c5be3ba286b823c",
-        "is_verified": false,
-        "line_number": 7063
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "e9b34783cbe8190ee7fc19b004ed411159f530cb",
-        "is_verified": false,
-        "line_number": 7064
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "f74211ce0bf71def709a31d5003d5013fc5b607b",
-        "is_verified": false,
-        "line_number": 7065
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "internal/server/api/server.gen.go",
-        "hashed_secret": "2ae4acc212f2889dff9baf132b3bd96a0bbb5671",
+        "type": "Secret Keyword",
+        "filename": "internal/server/api_scans_test.go",
+        "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
         "is_verified": false,
-        "line_number": 7066
+        "line_number": 310
       }
     ],
     "internal/server/credentials_handlers.go": [
       {
         "type": "Secret Keyword",
         "filename": "internal/server/credentials_handlers.go",
+        "hashed_secret": "16628a2888971f89350f9e723aa98af39486b54f",
+        "is_verified": false,
+        "line_number": 161
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/server/credentials_handlers.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-        "line_number": 296
+        "line_number": 163
+      }
+    ],
+    "internal/server/notifications_handlers.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/server/notifications_handlers.go",
+        "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
+        "is_verified": false,
+        "line_number": 242
+      }
+    ],
+    "internal/ssh/sudo.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/ssh/sudo.go",
+        "hashed_secret": "c6fcd99559b7b8626f622074178541e4cd4f6cd0",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/ssh/sudo.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/ssh/sudo.go",
+        "hashed_secret": "9284627354f1dd875414ac7c4f54f3fa43358903",
+        "is_verified": false,
+        "line_number": 94
       }
     ],
     "internal/ssh/sudo_test.go": [
@@ -2802,13 +509,22 @@
         "line_number": 133
       }
     ],
-    "scripts/README.md": [
+    "internal/sso/store.go": [
       {
-        "type": "Basic Auth Credentials",
-        "filename": "scripts/README.md",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "type": "Secret Keyword",
+        "filename": "internal/sso/store.go",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 423
+        "line_number": 171
+      }
+    ],
+    "internal/systemconfig/security_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/systemconfig/security_test.go",
+        "hashed_secret": "e6cdb18498748c77bd335e15c2f9ee1793d37932",
+        "is_verified": false,
+        "line_number": 18
       }
     ],
     "specs/api/auth.spec.yaml": [
@@ -2825,6 +541,15 @@
         "hashed_secret": "8fd5892aa7195547cde5035ef6dd7052c5bc8e9a",
         "is_verified": false,
         "line_number": 112
+      }
+    ],
+    "specs/api/notifications.spec.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "specs/api/notifications.spec.yaml",
+        "hashed_secret": "2fc25288324e4835b6a503e949318b5c354a7b5b",
+        "is_verified": false,
+        "line_number": 49
       }
     ],
     "specs/frontend/settings.spec.yaml": [
@@ -2854,7 +579,7 @@
         "filename": "specs/frontend/settings.spec.yaml",
         "hashed_secret": "119c2d04c23cb8e69e813d2185e42c4e105b0d30",
         "is_verified": false,
-        "line_number": 242
+        "line_number": 263
       }
     ],
     "specs/system/config.spec.yaml": [
@@ -2872,30 +597,30 @@
         "filename": "specs/system/ssh-connectivity.spec.yaml",
         "hashed_secret": "ecbd8a3af1465605f00d8fc2d52174e3551fdd5b",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": "specs/system/ssh-connectivity.spec.yaml",
         "hashed_secret": "e038248aaba7d6df9d363f2c4e2807530f4a3923",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": "specs/system/ssh-connectivity.spec.yaml",
         "hashed_secret": "4d40f45984f4afb490af725698bd96294f664ab6",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 161
       },
       {
         "type": "Secret Keyword",
         "filename": "specs/system/ssh-connectivity.spec.yaml",
         "hashed_secret": "37badbea15195cb7e3902b93be544d3bbea47efd",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 165
       }
     ]
   },
-  "generated_at": "2026-06-29T04:50:17Z"
+  "generated_at": "2026-07-06T20:45:43Z"
 }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4731,6 +4731,16 @@ components:
           type: integer
           nullable: true
           description: Wall-clock duration of the latest completed run (finished_at - started_at); null when never scanned or timestamps absent.
+        scan_state:
+          type: string
+          enum: [queued, running]
+          nullable: true
+          description: >
+            In-flight scan state for this host, independent of the latest
+            COMPLETED run above. 'queued' = enqueued, awaiting a worker;
+            'running' = actively executing; null = no scan in flight. Drives
+            the host-detail hero "Running"/"Queued" badge. Spec
+            api-host-compliance AC-17.
 
     HostComplianceLensSummary:
       type: object
@@ -4865,6 +4875,18 @@ components:
           nullable: true
           description: Null when no liveness probe has ever run against this host.
         compliance_summary: {$ref: '#/components/schemas/HostComplianceSummary'}
+        # v1.7.0 — MAX(host_rule_state.last_checked_at); null when the host
+        # has never been checked. Drives the detail hero "LAST SCAN" tile.
+        # Spec api-hosts C-14.
+        last_scan_at: {type: string, format: date-time, nullable: true}
+        # v1.7.0 — in-flight scan state (queued|running); null when idle.
+        # Independent of last_scan_at. Drives the detail hero "Running"/
+        # "Queued" badge, updated live via scan.started/scan.completed SSE.
+        # Spec api-hosts C-14.
+        scan_state:
+          type: string
+          enum: [queued, running]
+          nullable: true
 
     # List-view item: HostResponse plus optional liveness sub-object.
     # Liveness comes from a single LEFT JOIN — bounded overhead even on
@@ -4901,6 +4923,17 @@ components:
         # when the host has no completed scan yet (icon hidden). Spec
         # api-hosts C-13.
         latest_scan_id: {type: string, format: uuid, nullable: true}
+        # v1.7.0 — in-flight scan state for this host, independent of
+        # last_scan_at/latest_scan_id (which track the latest COMPLETED
+        # run). 'queued' = enqueued awaiting a worker; 'running' = actively
+        # executing; null = idle. Loaded with one grouped query over the
+        # scan_runs_active partial index for the whole page (no N+1). Drives
+        # the hosts-list card/row + scans-coverage "Running"/"Queued"
+        # indicator. Spec api-hosts C-14.
+        scan_state:
+          type: string
+          enum: [queued, running]
+          nullable: true
         liveness:
           allOf: [{$ref: '#/components/schemas/HostLiveness'}]
           nullable: true

--- a/frontend/src/api/host-view-model.ts
+++ b/frontend/src/api/host-view-model.ts
@@ -48,6 +48,13 @@ export interface DevHost {
    * frontend-hosts-list AC-24, links to /scans/{latestScanId}.
    */
   latestScanId: string | null;
+  /**
+   * in-flight scan state from the list endpoint's scan_state
+   * (queued|running), null when no scan is in flight. Drives the card/row
+   * "Running"/"Queued" indicator in place of "Last scan …". Spec
+   * frontend-hosts-list AC-27.
+   */
+  scanState: 'queued' | 'running' | null;
 }
 
 export type DeltaTier = 'crit' | 'warn' | 'ok' | 'neutral';

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3079,6 +3079,11 @@ export interface components {
             policy_version: string;
             /** @description Wall-clock duration of the latest completed run (finished_at - started_at); null when never scanned or timestamps absent. */
             duration_seconds?: number | null;
+            /**
+             * @description In-flight scan state for this host, independent of the latest COMPLETED run above. 'queued' = enqueued, awaiting a worker; 'running' = actively executing; null = no scan in flight. Drives the host-detail hero "Running"/"Queued" badge. Spec api-host-compliance AC-17.
+             * @enum {string|null}
+             */
+            scan_state?: "queued" | "running" | null;
         };
         HostComplianceLensSummary: {
             /** Format: int64 */
@@ -3180,6 +3185,10 @@ export interface components {
             /** @description Null when no liveness probe has ever run against this host. */
             liveness?: components["schemas"]["HostLiveness"] | null;
             compliance_summary: components["schemas"]["HostComplianceSummary"];
+            /** Format: date-time */
+            last_scan_at?: string | null;
+            /** @enum {string|null} */
+            scan_state?: "queued" | "running" | null;
         };
         HostListItem: {
             /** Format: uuid */
@@ -3206,6 +3215,8 @@ export interface components {
             last_scan_at?: string | null;
             /** Format: uuid */
             latest_scan_id?: string | null;
+            /** @enum {string|null} */
+            scan_state?: "queued" | "running" | null;
             /** @description Null when no liveness probe has ever run against this host. */
             liveness?: components["schemas"]["HostLiveness"] | null;
             /** @description Null when the host has no host_rule_state rows (never scanned). */

--- a/frontend/src/hooks/useLiveEvents.ts
+++ b/frontend/src/hooks/useLiveEvents.ts
@@ -23,14 +23,15 @@ import { useAuthStore } from '@/store/useAuthStore';
 // to a manual fetch + ReadableStream loop.
 
 // Closed set of topics this hook subscribes to (v1.1.0: + scan.completed;
-// v1.2.0: + remediation.completed; v1.3.0: + report.ready). Each MUST
-// exist in backend eventbus.AllEventKinds (Go-side closed enum). Spec
-// frontend-live-events C-01 + AC-01 enforce.
+// v1.2.0: + remediation.completed; v1.3.0: + report.ready; v1.4.0:
+// + scan.started). Each MUST exist in backend eventbus.AllEventKinds
+// (Go-side closed enum). Spec frontend-live-events C-01 + AC-01 enforce.
 export const ALL_TOPICS = [
   'host.changed',
   'monitoring.band.changed',
   'host.discovered',
   'intelligence.event',
+  'scan.started',
   'scan.completed',
   'remediation.completed',
   'report.ready',
@@ -128,6 +129,20 @@ export function useLiveEvents(options: UseLiveEventsOptions = {}) {
           queryClient.invalidateQueries({
             queryKey: ['intelligence_state', hostId],
           });
+        }
+      },
+      // Spec frontend-live-events v1.4.0 C-08 + AC-11 — a scan entering
+      // execution flips the per-host indicator to "Running" on BOTH the
+      // list and the detail hero without polling. The worker publishes
+      // this the moment it marks the run running (before the scan runs);
+      // the paired scan.completed below clears it back to freshness.
+      'scan.started': (e) => {
+        const env = parseEnvelope(e);
+        if (!env) return;
+        const hostId = (env.payload?.HostID ?? env.payload?.host_id) as string | undefined;
+        queryClient.invalidateQueries({ queryKey: ['hosts'] });
+        if (hostId) {
+          queryClient.invalidateQueries({ queryKey: ['host', hostId] });
         }
       },
       // Spec frontend-live-events v1.1.0 C-07 + AC-08 — a completed

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -130,6 +130,10 @@ interface HostDetail {
   host: HostResponse;
   liveness: HostLiveness | null;
   compliance_summary: ComplianceSummary;
+  // v1.7.0 — MAX(host_rule_state.last_checked_at) and the in-flight scan
+  // state (queued/running); both nullable/absent when never scanned / idle.
+  last_scan_at?: string | null;
+  scan_state?: 'queued' | 'running' | null;
 }
 
 // ActivityItem mirrors the api.Activity envelope returned by
@@ -239,6 +243,8 @@ export function HostDetailPage() {
           host: raw.host,
           liveness: raw.liveness ?? null,
           compliance_summary: raw.compliance_summary ?? DEFAULT_SUMMARY,
+          last_scan_at: raw.last_scan_at ?? null,
+          scan_state: raw.scan_state ?? null,
         } satisfies HostDetail;
       }
       if (raw && typeof raw === 'object' && 'hostname' in raw && raw.hostname) {
@@ -376,6 +382,7 @@ export function HostDetailPage() {
             host={detailQuery.data.host}
             liveness={detailQuery.data.liveness}
             intelligenceSnapshot={intelligenceStateQuery.data ?? null}
+            scanState={detailQuery.data.scan_state ?? null}
           />
 
           {/* OFFLINE_BANNER */}
@@ -401,7 +408,15 @@ export function HostDetailPage() {
                 }}
                 aria-label="Host hero stats"
               >
-                <HeroCompliance summary={detailQuery.data.compliance_summary} lastScan={null} />
+                <HeroCompliance
+                  summary={detailQuery.data.compliance_summary}
+                  lastScan={
+                    detailQuery.data.last_scan_at
+                      ? relativeTime(detailQuery.data.last_scan_at)
+                      : null
+                  }
+                  scanState={detailQuery.data.scan_state ?? null}
+                />
                 <HeroAutoScan hostId={hostId} />
                 <HeroConnectivity
                   host={detailQuery.data.host}
@@ -505,11 +520,14 @@ function PageHead({
   host,
   liveness,
   intelligenceSnapshot,
+  scanState,
 }: {
   host: HostResponse;
   liveness: HostLiveness | null;
   /** Same intelligence_state.snapshot the System card reads. */
   intelligenceSnapshot: Record<string, unknown> | null;
+  /** In-flight scan state (queued/running) for the Run scan button. */
+  scanState: 'queued' | 'running' | null;
 }) {
   const [editOpen, setEditOpen] = useState(false);
   const [credOpen, setCredOpen] = useState(false);
@@ -658,7 +676,7 @@ function PageHead({
           <button type="button" style={ghostBtn} title="Open terminal (deferred)" disabled>
             <TerminalIcon size={14} /> Terminal
           </button>
-          <RunScanButton host={host} />
+          <RunScanButton host={host} scanState={scanState} />
           {canWrite && (
             <button
               type="button"
@@ -707,13 +725,25 @@ function PageHead({
 // polling here. 409 means a scan is already queued/running for this
 // host — surfaced as a transient inline note, not an error.
 //
+// v1.7.0: while a scan is actually in flight (scanState queued/running from
+// the detail query, kept live by the scan.started/scan.completed SSE topics)
+// the button stays disabled showing "Running…"/"Queued…" for the whole scan,
+// not just the request round-trip. Spec frontend-host-detail AC-45.
+//
 // Spec: frontend-host-detail (Run scan action) + api-host-scan.
-function RunScanButton({ host }: { host: HostResponse }) {
+function RunScanButton({
+  host,
+  scanState,
+}: {
+  host: HostResponse;
+  scanState: 'queued' | 'running' | null;
+}) {
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
+  const active = scanState === 'running' || scanState === 'queued';
 
   const runScan = async () => {
-    if (busy) return;
+    if (busy || active) return;
     setBusy(true);
     setNote(null);
     try {
@@ -753,11 +783,18 @@ function RunScanButton({ host }: { host: HostResponse }) {
         type="button"
         style={primaryBtn}
         onClick={runScan}
-        disabled={busy}
+        disabled={busy || active}
         aria-label={`Run compliance scan on ${host.hostname}`}
         title="Run an on-demand compliance scan"
       >
-        <Play size={14} /> {busy ? 'Queueing…' : 'Run scan'}
+        <Play size={14} />{' '}
+        {scanState === 'running'
+          ? 'Running…'
+          : scanState === 'queued'
+            ? 'Queued…'
+            : busy
+              ? 'Queueing…'
+              : 'Run scan'}
       </button>
     </span>
   );
@@ -1703,29 +1740,59 @@ const remTd: CSSProperties = {
 function HeroCompliance({
   summary,
   lastScan,
+  scanState,
 }: {
   summary: ComplianceSummary;
   lastScan: string | null;
+  scanState: 'queued' | 'running' | null;
 }) {
   // AC-04 / AC-05: keep the canonical math expression + label strings.
   // AC-35: subhead is "LAST SCAN <date>", NOT a Framework selector
   // (the Framework filter belongs on the Compliance tab when it ships).
+  // v1.7.0: an in-flight scan replaces the LAST SCAN subhead with a live
+  // "Running"/"Queued" badge until scan.completed clears it. Spec
+  // frontend-host-detail AC-45.
   const isEmpty = summary.total === 0;
   const pct = isEmpty ? 0 : Math.round((summary.passing / summary.total) * 100);
   return (
     <article style={heroCard} aria-labelledby="hero-compliance-title">
       <header style={heroHead}>
         <span id="hero-compliance-title">Compliance</span>
-        <span
-          style={{
-            fontSize: 11,
-            color: 'var(--ow-fg-3)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.04em',
-          }}
-        >
-          LAST SCAN {lastScan ?? '—'}
-        </span>
+        {scanState ? (
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 11,
+              fontWeight: 600,
+              color: 'var(--ow-link)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            <span
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: 'var(--ow-link)',
+              }}
+            />
+            {scanState === 'running' ? 'Running' : 'Queued'}
+          </span>
+        ) : (
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--ow-fg-3)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            LAST SCAN {lastScan ?? '—'}
+          </span>
+        )}
       </header>
       {isEmpty ? (
         <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12 }}>

--- a/frontend/src/pages/HostsListPage.tsx
+++ b/frontend/src/pages/HostsListPage.tsx
@@ -96,6 +96,8 @@ export interface ApiHost {
   last_scan_at?: string | null;
   /** v1.6.0 — id of the newest completed scan_run; null when none. Spec api-hosts C-13. */
   latest_scan_id?: string | null;
+  /** v1.7.0 — in-flight scan state (queued|running); null when idle. Spec api-hosts C-14. */
+  scan_state?: 'queued' | 'running' | null;
   liveness?: ApiHostLiveness | null;
   /**
    * v1.4.0 (api-hosts) — denormalized OS columns populated by
@@ -1110,6 +1112,15 @@ function HostsCards({ hosts }: { hosts: DevHost[] }) {
 // transient note, not an error. No polling — the scan.completed SSE
 // topic invalidates ['hosts'] when results land. Hidden for callers
 // without host:write.
+// scanStateLabel returns the in-flight indicator text for a host, or null
+// when no scan is in flight (callers fall back to the last-scan text). Drives
+// the card/row "Running…"/"Queued…" label. Spec frontend-hosts-list AC-27.
+function scanStateLabel(state: 'queued' | 'running' | null): string | null {
+  if (state === 'running') return 'Running…';
+  if (state === 'queued') return 'Queued…';
+  return null;
+}
+
 function ScanHostButton({ hostId, variant }: { hostId: string; variant: 'card' | 'row' }) {
   const canWrite = useAuthStore((s) => s.hasPermission('host:write'));
   const [busy, setBusy] = useState(false);
@@ -1435,11 +1446,12 @@ function HostCard({ host }: { host: DevHost }) {
             alignItems: 'center',
             gap: 6,
             fontSize: 12,
-            color: 'var(--ow-fg-2)',
+            color: host.scanState ? 'var(--ow-link)' : 'var(--ow-fg-2)',
+            fontWeight: host.scanState ? 600 : undefined,
           }}
         >
           <RefreshCw size={12} />
-          Last scan {host.lastScan}
+          {scanStateLabel(host.scanState) ?? `Last scan ${host.lastScan}`}
         </div>
         <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
           <ViewReportButton latestScanId={host.latestScanId} />
@@ -1631,8 +1643,15 @@ function HostRow({ host }: { host: DevHost }) {
         )}
       </td>
       <td style={td}>
-        <div style={{ fontFamily: 'var(--ow-font-mono)', fontSize: 12, color: 'var(--ow-fg-1)' }}>
-          {host.lastScan}
+        <div
+          style={{
+            fontFamily: host.scanState ? undefined : 'var(--ow-font-mono)',
+            fontSize: 12,
+            color: host.scanState ? 'var(--ow-link)' : 'var(--ow-fg-1)',
+            fontWeight: host.scanState ? 600 : undefined,
+          }}
+        >
+          {scanStateLabel(host.scanState) ?? host.lastScan}
         </div>
       </td>
       <td style={{ ...td, textAlign: 'right' }}>
@@ -1879,6 +1898,9 @@ export function apiHostToDev(h: ApiHost): DevHost {
     // v1.6.0: newest completed scan id for the "view report" link; null
     // (icon hidden) when the host has no completed scan. Spec api-hosts C-13.
     latestScanId: h.latest_scan_id ?? null,
+    // v1.7.0: in-flight scan state (queued/running) for the live
+    // "Running"/"Queued" indicator; null when idle. Spec api-hosts C-14.
+    scanState: h.scan_state ?? null,
   };
 }
 

--- a/frontend/src/pages/host-detail/ComplianceTab.tsx
+++ b/frontend/src/pages/host-detail/ComplianceTab.tsx
@@ -239,6 +239,7 @@ export function ComplianceTab({
         isPending={lensQuery.isPending}
         lastScanAt={lensQuery.data?.scan_context.last_scan_at ?? null}
         policyVersion={lensQuery.data?.scan_context.policy_version ?? ''}
+        scanState={lensQuery.data?.scan_context.scan_state ?? null}
       />
       <LensBar
         framework={framework}
@@ -282,11 +283,13 @@ function ScanContextStrip({
   isPending,
   lastScanAt,
   policyVersion,
+  scanState,
 }: {
   hostId: string;
   isPending: boolean;
   lastScanAt: string | null;
   policyVersion: string;
+  scanState: 'queued' | 'running' | null;
 }) {
   let sub: ReactNode;
   if (isPending) {
@@ -333,7 +336,7 @@ function ScanContextStrip({
           {sub}
         </div>
       </div>
-      <RescanButton hostId={hostId} />
+      <RescanButton hostId={hostId} scanState={scanState} />
     </div>
   );
 }
@@ -341,12 +344,22 @@ function ScanContextStrip({
 // RescanButton — same enqueue endpoint and semantics as the page-head
 // Run scan button (POST /hosts/{id}/scans, idempotency-keyed, 409 as a
 // transient note). The result refresh arrives via scan.completed SSE.
-function RescanButton({ hostId }: { hostId: string }) {
+function RescanButton({
+  hostId,
+  scanState,
+}: {
+  hostId: string;
+  scanState: 'queued' | 'running' | null;
+}) {
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
+  // While a scan is in flight (scan_context.scan_state, kept live by the
+  // scan.started/scan.completed SSE topics) the button stays disabled
+  // showing the live state. Spec frontend-host-compliance-tab AC-10.
+  const active = scanState === 'running' || scanState === 'queued';
 
   const rescan = async () => {
-    if (busy) return;
+    if (busy || active) return;
     setBusy(true);
     setNote(null);
     try {
@@ -381,7 +394,7 @@ function RescanButton({ hostId }: { hostId: string }) {
       <button
         type="button"
         onClick={rescan}
-        disabled={busy}
+        disabled={busy || active}
         aria-label="Re-scan this host"
         style={{
           height: 30,
@@ -392,11 +405,17 @@ function RescanButton({ hostId }: { hostId: string }) {
           borderRadius: 7,
           fontSize: 12,
           fontWeight: 600,
-          cursor: busy ? 'default' : 'pointer',
-          opacity: busy ? 0.6 : 1,
+          cursor: busy || active ? 'default' : 'pointer',
+          opacity: busy || active ? 0.6 : 1,
         }}
       >
-        {busy ? 'Queueing' : 'Re-scan'}
+        {scanState === 'running'
+          ? 'Running…'
+          : scanState === 'queued'
+            ? 'Queued…'
+            : busy
+              ? 'Queueing'
+              : 'Re-scan'}
       </button>
     </span>
   );

--- a/frontend/src/pages/scans/ScansPage.tsx
+++ b/frontend/src/pages/scans/ScansPage.tsx
@@ -32,7 +32,24 @@ const TONE = {
   ok: 'var(--ow-ok)',
   warn: 'var(--ow-warn)',
   crit: 'var(--ow-crit)',
+  run: 'var(--ow-link)', // in-flight scan (queued/running): accent, not a freshness tone
 };
+
+// freshnessPill resolves the FRESHNESS cell. An in-flight scan (scan_state
+// queued/running) takes precedence over the age-derived freshness so the
+// operator sees which host is actively being scanned; otherwise the pill
+// reflects last_scan_at age. Spec frontend-scans AC-04.
+function freshnessPill(
+  scanState: 'queued' | 'running' | null | undefined,
+  age: { text: string; tone: 'ok' | 'warn' | 'crit' },
+): { label: string; tone: keyof typeof TONE } {
+  if (scanState === 'running') return { label: 'Running', tone: 'run' };
+  if (scanState === 'queued') return { label: 'Queued', tone: 'run' };
+  return {
+    label: age.tone === 'ok' ? 'current' : age.tone === 'warn' ? 'stale' : 'never',
+    tone: age.tone,
+  };
+}
 
 export function ScansPage() {
   const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
@@ -159,6 +176,7 @@ function CoverageTab({
     id: string;
     hostname: string;
     last_scan_at?: string | null;
+    scan_state?: 'queued' | 'running' | null;
     compliance_summary?: { passing: number; total: number } | null;
   }[];
   isPending: boolean;
@@ -198,6 +216,7 @@ function CoverageTab({
       </Row>
       {hosts.map((h, i) => {
         const age = ageLabel(h.last_scan_at);
+        const pill = freshnessPill(h.scan_state, age);
         const cs = h.compliance_summary;
         const pct = cs && cs.total > 0 ? Math.round((cs.passing / cs.total) * 100) : null;
         const open = openHost === h.id;
@@ -236,7 +255,7 @@ function CoverageTab({
                   gap: 7,
                   fontSize: 12,
                   fontWeight: 500,
-                  color: TONE[age.tone],
+                  color: TONE[pill.tone],
                 }}
               >
                 <span
@@ -244,13 +263,15 @@ function CoverageTab({
                     width: 8,
                     height: 8,
                     borderRadius: '50%',
-                    background: TONE[age.tone],
+                    background: TONE[pill.tone],
                     flexShrink: 0,
                   }}
                 />
-                {age.tone === 'ok' ? 'current' : age.tone === 'warn' ? 'stale' : 'never'}
+                {pill.label}
               </span>
-              <span style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>{age.text}</span>
+              <span style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>
+                {h.scan_state ? 'in progress' : age.text}
+              </span>
             </Row>
             {open ? <HostScanHistory hostId={h.id} /> : null}
           </div>

--- a/frontend/tests/api/event-display.test.ts
+++ b/frontend/tests/api/event-display.test.ts
@@ -7,12 +7,7 @@ import { resolve } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
-import {
-  relativeTime,
-  severityLabel,
-  severityTone,
-  sourceLabel,
-} from '@/api/eventDisplay';
+import { relativeTime, severityLabel, severityTone, sourceLabel } from '@/api/eventDisplay';
 
 const read = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
 
@@ -71,6 +66,6 @@ describe('frontend-activity — shared event-display helpers', () => {
     expect(drawer).toContain("from '@/api/eventDisplay'");
     const host = read('src/pages/HostDetailPage.tsx');
     expect(host).not.toMatch(/function activityRelativeTime/);
-    expect(host).toContain("relativeTime(item.occurred_at)");
+    expect(host).toContain('relativeTime(item.occurred_at)');
   });
 });

--- a/frontend/tests/api/host-filtering.test.ts
+++ b/frontend/tests/api/host-filtering.test.ts
@@ -31,6 +31,7 @@ function host(overrides: Partial<DevHost> = {}): DevHost {
     lastCheckMinutes: 0,
     lastScan: 'just now',
     latestScanId: null,
+    scanState: null,
     ...overrides,
   };
 }

--- a/frontend/tests/hooks/useIdleLogout.test.tsx
+++ b/frontend/tests/hooks/useIdleLogout.test.tsx
@@ -163,7 +163,10 @@ describe('frontend-session-idle — client idle logout', () => {
 
   // @ac AC-05
   test('frontend-session-idle/AC-05 — AppFrame mounts the hook; listeners are user-input only', () => {
-    const appFrame = readFileSync(resolve(__dirname, '../../src/components/shell/AppFrame.tsx'), 'utf8');
+    const appFrame = readFileSync(
+      resolve(__dirname, '../../src/components/shell/AppFrame.tsx'),
+      'utf8',
+    );
     expect(appFrame).toContain('useIdleLogout');
 
     const hook = readFileSync(resolve(__dirname, '../../src/hooks/useIdleLogout.ts'), 'utf8');

--- a/frontend/tests/hooks/useLiveEvents.test.tsx
+++ b/frontend/tests/hooks/useLiveEvents.test.tsx
@@ -2,7 +2,7 @@
 //
 // AC traceability (this file):
 //
-//   AC-01  test('frontend-live-events/AC-01 — ALL_TOPICS is the closed v1.0 set')
+//   AC-01  test('frontend-live-events/AC-01 — ALL_TOPICS is the closed set')
 //   AC-02  test('frontend-live-events/AC-02 — host.changed invalidates [hosts] + [host, id]')
 //   AC-03  test('frontend-live-events/AC-03 — monitoring.band.changed invalidates [hosts] + [host, id]')
 //   AC-04  test('frontend-live-events/AC-04 — host.discovered invalidates [hosts] + [host, id]')
@@ -11,6 +11,7 @@
 //   AC-07  test('frontend-live-events/AC-07 — source-inspect: exactly one new EventSource(...) call')
 //   AC-08  test('frontend-live-events/AC-08 — scan.completed invalidates [hosts] + [host, id]')
 //   AC-10  test('frontend-live-events/AC-10 — report.ready invalidates [reports] + notification feed')
+//   AC-11  test('frontend-live-events/AC-11 — scan.started invalidates [hosts] + [host, id]')
 
 import { expect, test, beforeEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
@@ -85,19 +86,21 @@ beforeEach(() => {
 
 // @ac AC-01
 // AC-01: ALL_TOPICS exported as the closed set (v1.1.0 adds scan.completed;
-// v1.2.0 adds remediation.completed; v1.3.0 adds report.ready).
-test('frontend-live-events/AC-01 — ALL_TOPICS is the closed v1.0 set', () => {
+// v1.2.0 adds remediation.completed; v1.3.0 adds report.ready; v1.5.0 adds
+// scan.started).
+test('frontend-live-events/AC-01 — ALL_TOPICS is the closed set', () => {
   const want = [
     'host.changed',
     'monitoring.band.changed',
     'host.discovered',
     'intelligence.event',
+    'scan.started',
     'scan.completed',
     'remediation.completed',
     'report.ready',
   ];
   expect([...ALL_TOPICS]).toEqual(want);
-  expect(ALL_TOPICS.length).toBe(7);
+  expect(ALL_TOPICS.length).toBe(8);
 });
 
 // Helper to mount the hook and return the stub + spies.
@@ -165,6 +168,19 @@ test('frontend-live-events/AC-08 — scan.completed invalidates [hosts] + [host,
   const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
   expect(calls).toContainEqual(['hosts']);
   expect(calls).toContainEqual(['host', 'h-scan']);
+});
+
+// @ac AC-11
+// AC-11: scan.started flips the per-host indicator to "Running" live — it
+// invalidates [hosts] and [host, id] just like scan.completed, so the pill /
+// card / hero re-fetch and show the in-flight state the moment the worker
+// begins the scan.
+test('frontend-live-events/AC-11 — scan.started invalidates [hosts] + [host, id]', () => {
+  const { es, spy } = mountHook();
+  es.fire('scan.started', { HostID: 'h-start' });
+  const calls = spy.mock.calls.map((c) => c[0]?.queryKey);
+  expect(calls).toContainEqual(['hosts']);
+  expect(calls).toContainEqual(['host', 'h-start']);
 });
 
 // @ac AC-05

--- a/frontend/tests/pages/host-detail-compliance-tab.test.tsx
+++ b/frontend/tests/pages/host-detail-compliance-tab.test.tsx
@@ -444,4 +444,15 @@ describe('frontend-host-compliance-tab v1.2.0 — exception overlay', () => {
     // status chip is untouched (no remap of r.status by the overlay).
     expect(TAB_SRC).toContain("rule.status === 'fail' && canRequest");
   });
+
+  // @ac AC-10
+  test('frontend-host-compliance-tab/AC-10 — Re-scan reflects in-flight scan_state', () => {
+    // ScanContextStrip forwards scan_context.scan_state to RescanButton.
+    expect(TAB_SRC).toMatch(/scanState=\{lensQuery\.data\?\.scan_context\.scan_state/);
+    expect(TAB_SRC).toMatch(/<RescanButton hostId=\{hostId\} scanState=\{scanState\}/);
+    // RescanButton stays disabled + labelled while a scan is in flight.
+    expect(TAB_SRC).toMatch(/const active = scanState === 'running' \|\| scanState === 'queued'/);
+    expect(TAB_SRC).toMatch(/disabled=\{busy \|\| active\}/);
+    expect(TAB_SRC).toMatch(/scanState === 'running'\s*\?\s*'Running…'/);
+  });
 });

--- a/frontend/tests/pages/host-detail.test.ts
+++ b/frontend/tests/pages/host-detail.test.ts
@@ -161,4 +161,20 @@ describe('frontend-host-detail — structural', () => {
     // Navigates to /hosts on the detail variant after delete.
     expect(MENU_SRC).toMatch(/navigate\(\{\s*to:\s*'\/hosts'\s*\}\)/);
   });
+
+  // @ac AC-45
+  test('frontend-host-detail/AC-45 — hero + Run scan reflect in-flight scan_state', () => {
+    // The detail query threads last_scan_at + scan_state through, and the
+    // hero is no longer hardcoded lastScan={null}.
+    expect(PAGE_SRC).toMatch(/last_scan_at:\s*raw\.last_scan_at/);
+    expect(PAGE_SRC).toMatch(/scan_state:\s*raw\.scan_state/);
+    expect(PAGE_SRC).not.toMatch(/<HeroCompliance[\s\S]*?lastScan=\{null\}/);
+    expect(PAGE_SRC).toMatch(/scanState=\{detailQuery\.data\.scan_state/);
+    // Hero shows a Running/Queued badge instead of LAST SCAN when active.
+    expect(PAGE_SRC).toMatch(/scanState === 'running' \? 'Running' : 'Queued'/);
+    // Run scan button stays disabled + labelled while active.
+    expect(PAGE_SRC).toMatch(/const active = scanState === 'running' \|\| scanState === 'queued'/);
+    expect(PAGE_SRC).toMatch(/disabled=\{busy \|\| active\}/);
+    expect(PAGE_SRC).toMatch(/scanState === 'running'\s*\?\s*'Running…'/);
+  });
 });

--- a/frontend/tests/pages/hosts-list-extended.test.ts
+++ b/frontend/tests/pages/hosts-list-extended.test.ts
@@ -101,4 +101,17 @@ describe('frontend-hosts-list — v1.1.0 ACs', () => {
     const ariaLabels = [...PAGE_SRC.matchAll(/aria-label=/g)];
     expect(ariaLabels.length).toBeGreaterThanOrEqual(1);
   });
+
+  // @ac AC-27
+  test('frontend-hosts-list/AC-27 — card + row show Running/Queued from scan_state', () => {
+    // apiHostToDev maps the list item's scan_state onto DevHost.scanState.
+    expect(PAGE_SRC).toMatch(/scanState:\s*h\.scan_state\s*\?\?\s*null/);
+    // a scanStateLabel helper renders the in-flight label.
+    expect(PAGE_SRC).toContain('function scanStateLabel');
+    expect(PAGE_SRC).toMatch(/'running'.*'Running…'|return 'Running…'/s);
+    expect(PAGE_SRC).toMatch(/'queued'.*'Queued…'|return 'Queued…'/s);
+    // both the card footer and the row cell fall back to the last-scan text.
+    const uses = [...PAGE_SRC.matchAll(/scanStateLabel\(host\.scanState\)\s*\?\?/g)];
+    expect(uses.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/frontend/tests/pages/hosts-list.test.ts
+++ b/frontend/tests/pages/hosts-list.test.ts
@@ -66,6 +66,7 @@ function makeDevHost(overrides: Partial<DevHost> = {}): DevHost {
     lastCheckMinutes: null,
     lastScan: '—',
     latestScanId: null,
+    scanState: null,
     ...overrides,
   };
 }
@@ -138,7 +139,9 @@ test('frontend-hosts-list/AC-26 — avg compliance KPI sourced from /fleet/score
   expect(PAGE_SRC).toContain("api.GET('/api/v1/fleet/score'");
   // The KPI value is overridden with the canonical fleet score, same rounding
   // as the dashboard widget (Math.round(passing_fraction * 100)).
-  expect(PAGE_SRC).toMatch(/kpis\.avgCompliance\.value\s*=\s*Math\.round\(\s*fleetScoreQuery\.data\.passing_fraction\s*\*\s*100\s*\)/);
+  expect(PAGE_SRC).toMatch(
+    /kpis\.avgCompliance\.value\s*=\s*Math\.round\(\s*fleetScoreQuery\.data\.passing_fraction\s*\*\s*100\s*\)/,
+  );
   // Guarded so an empty fleet (no pass/fail evaluations) keeps the fallback.
   expect(PAGE_SRC).toMatch(/fleetScoreQuery\.data\.total_evaluations\s*>\s*0/);
 });
@@ -364,7 +367,7 @@ describe('frontend-hosts-list v1.7.0 — grouping + filters wiring', () => {
   // @ac AC-25
   test('frontend-hosts-list/AC-25 — view falls back to persisted hostsViewDefault; toggle persists it', () => {
     // No hardcoded 'cards' default — the fallback is the persisted store value.
-    expect(PAGE_SRC).toContain("usePreferencesStore((s) => s.hostsViewDefault)");
+    expect(PAGE_SRC).toContain('usePreferencesStore((s) => s.hostsViewDefault)');
     expect(PAGE_SRC).toMatch(
       /search\.view === 'table' \|\| search\.view === 'cards' \? search\.view : hostsViewDefault/,
     );

--- a/frontend/tests/pages/remediation-tab.test.ts
+++ b/frontend/tests/pages/remediation-tab.test.ts
@@ -99,7 +99,9 @@ describe('frontend-remediation-tab — source inspection', () => {
   test('frontend-remediation-tab/AC-04 — approved row Fix button posts :execute, gated, 409 inline', () => {
     // isAdmin computed from the admin permission, mirrored across the act gates.
     expect(PAGE).toContain("useAuthStore((s) => s.hasPermission('admin'))");
-    expect(PAGE).toContain("useAuthStore((s) => s.hasPermission('remediation:execute')) || isAdmin");
+    expect(PAGE).toContain(
+      "useAuthStore((s) => s.hasPermission('remediation:execute')) || isAdmin",
+    );
     // The Fix button posts :execute.
     expect(PAGE).toContain('/api/v1/remediation/requests/{rid}:execute');
     expect(TAB_REGION).toContain('Fix');
@@ -113,7 +115,9 @@ describe('frontend-remediation-tab — source inspection', () => {
 
   // @ac AC-05
   test('frontend-remediation-tab/AC-05 — executed row Fixed status + Roll back posts :rollback', () => {
-    expect(PAGE).toContain("useAuthStore((s) => s.hasPermission('remediation:rollback')) || isAdmin");
+    expect(PAGE).toContain(
+      "useAuthStore((s) => s.hasPermission('remediation:rollback')) || isAdmin",
+    );
     expect(PAGE).toContain("request.status === 'executed'");
     expect(TAB_REGION).toContain('Fixed');
     expect(TAB_REGION).toContain('Roll back');

--- a/frontend/tests/pages/rules-tab.test.tsx
+++ b/frontend/tests/pages/rules-tab.test.tsx
@@ -36,7 +36,12 @@ const RULES = {
       tags: ['ssh'],
       framework_refs: { cis_rhel9: ['5.2.8'], nist_800_53: ['AC-6'] },
       transactional: true,
-      remediation: { available: true, mechanisms: ['config_set_dropin'], restarts_services: [], reboot_behavior: 'boot-param' },
+      remediation: {
+        available: true,
+        mechanisms: ['config_set_dropin'],
+        restarts_services: [],
+        reboot_behavior: 'boot-param',
+      },
     },
     {
       id: 'auditd-enabled',
@@ -47,7 +52,12 @@ const RULES = {
       tags: [],
       framework_refs: { cis_rhel9: ['6.3.1.4'], stig_rhel9: ['V-258151'] },
       transactional: true,
-      remediation: { available: true, mechanisms: ['service_enabled'], restarts_services: ['auditd'], reboot_behavior: 'none' },
+      remediation: {
+        available: true,
+        mechanisms: ['service_enabled'],
+        restarts_services: ['auditd'],
+        reboot_behavior: 'none',
+      },
     },
     {
       id: 'manual-rule',
@@ -58,7 +68,12 @@ const RULES = {
       tags: [],
       framework_refs: { nist_800_53: ['CM-6'] },
       transactional: false,
-      remediation: { available: false, mechanisms: [], restarts_services: [], reboot_behavior: 'none' },
+      remediation: {
+        available: false,
+        mechanisms: [],
+        restarts_services: [],
+        reboot_behavior: 'none',
+      },
     },
   ],
 };
@@ -104,7 +119,9 @@ describe('frontend-rules-library', () => {
     await waitFor(() => expect(screen.getByText('Disable SSH root login')).toBeTruthy());
     expect(getMock).toHaveBeenCalledTimes(1);
 
-    fireEvent.change(screen.getByLabelText('Search rules, IDs, frameworks'), { target: { value: 'auditd' } });
+    fireEvent.change(screen.getByLabelText('Search rules, IDs, frameworks'), {
+      target: { value: 'auditd' },
+    });
     await waitFor(() => expect(screen.getByText('showing 1 of 3')).toBeTruthy());
     expect(screen.getByText('Install and enable auditd')).toBeTruthy();
     expect(screen.queryByText('Disable SSH root login')).toBeNull();

--- a/frontend/tests/pages/scan-detail.test.tsx
+++ b/frontend/tests/pages/scan-detail.test.tsx
@@ -19,7 +19,10 @@ vi.mock('@/api/client', () => ({ default: { GET: getMock } }));
 
 import { RuleDetailPanel } from '@/pages/scans/RuleDetailPanel';
 
-const PANEL_SRC = readFileSync(resolve(process.cwd(), 'src/pages/scans/RuleDetailPanel.tsx'), 'utf8');
+const PANEL_SRC = readFileSync(
+  resolve(process.cwd(), 'src/pages/scans/RuleDetailPanel.tsx'),
+  'utf8',
+);
 const PAGE_SRC = readFileSync(resolve(process.cwd(), 'src/pages/scans/ScanDetailPage.tsx'), 'utf8');
 const SCANS_SRC = readFileSync(resolve(process.cwd(), 'src/pages/scans/ScansPage.tsx'), 'utf8');
 const ROUTER_SRC = readFileSync(resolve(process.cwd(), 'src/routes/router.tsx'), 'utf8');
@@ -42,12 +45,20 @@ const EVIDENCE = {
   status: 'pass',
   severity: 'medium',
   detail: 'host is compliant',
-  checks: [{ method: 'config_value', command: 'grep MaxAuthTries /etc/ssh/sshd_config', stdout: 'MaxAuthTries 4', exit_code: 0 }],
+  checks: [
+    {
+      method: 'config_value',
+      command: 'grep MaxAuthTries /etc/ssh/sshd_config',
+      stdout: 'MaxAuthTries 4',
+      exit_code: 0,
+    },
+  ],
   framework_refs: {},
 };
 const OSCAL_DOC = { 'assessment-results': { uuid: 'oscal-1', results: [] } };
 
-const evidenceCalls = () => getMock.mock.calls.filter((c) => String(c[0]).endsWith('/evidence')).length;
+const evidenceCalls = () =>
+  getMock.mock.calls.filter((c) => String(c[0]).endsWith('/evidence')).length;
 const oscalCalls = () => getMock.mock.calls.filter((c) => String(c[0]).endsWith('/oscal')).length;
 const inPre = (needle: string) => (content: string, el: Element | null) =>
   el?.tagName === 'PRE' && content.includes(needle);
@@ -56,7 +67,10 @@ describe('frontend-scan-detail', () => {
   beforeEach(() => {
     getMock.mockReset();
     getMock.mockImplementation((path: string) =>
-      Promise.resolve({ data: String(path).endsWith('/oscal') ? OSCAL_DOC : EVIDENCE, error: undefined }),
+      Promise.resolve({
+        data: String(path).endsWith('/oscal') ? OSCAL_DOC : EVIDENCE,
+        error: undefined,
+      }),
     );
   });
 
@@ -92,7 +106,9 @@ describe('frontend-scan-detail', () => {
     await waitFor(() => expect(screen.getByText('host is compliant')).toBeTruthy());
     // Evidence renders the full result as raw JSON (in a <pre>), not a formatted layout.
     fireEvent.click(screen.getByRole('tab', { name: 'Evidence' }));
-    await waitFor(() => expect(screen.getByText(inPre('grep MaxAuthTries /etc/ssh/sshd_config'))).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByText(inPre('grep MaxAuthTries /etc/ssh/sshd_config'))).toBeTruthy(),
+    );
     expect(screen.getByText(inPre('"checks"'))).toBeTruthy();
     // OSCAL renders the OSCAL document as raw JSON.
     fireEvent.click(screen.getByRole('tab', { name: 'OSCAL' }));

--- a/frontend/tests/pages/scans.test.ts
+++ b/frontend/tests/pages/scans.test.ts
@@ -48,4 +48,18 @@ describe('frontend-scans — scan overview', () => {
     expect(PAGE_SRC).not.toMatch(/api\.(POST|PUT|DELETE)/);
     expect(stripComments(PAGE_SRC)).not.toContain('—');
   });
+
+  // @ac AC-04
+  test('frontend-scans/AC-04 — FRESHNESS pill reflects in-flight scan_state', () => {
+    // a freshnessPill helper maps scan_state to Running/Queued, taking
+    // precedence over the age-derived freshness, in an accent tone.
+    expect(PAGE_SRC).toContain('function freshnessPill');
+    expect(PAGE_SRC).toMatch(/scan_state/);
+    expect(PAGE_SRC).toMatch(/scanState === 'running'.*'Running'|label: 'Running'/s);
+    expect(PAGE_SRC).toMatch(/scanState === 'queued'.*'Queued'|label: 'Queued'/s);
+    // accent tone distinct from the freshness tones (ok/warn/crit)
+    expect(PAGE_SRC).toMatch(/run:\s*'var\(--ow-link\)'/);
+    // the pill is computed from scan_state before render
+    expect(PAGE_SRC).toContain('freshnessPill(h.scan_state');
+  });
 });

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -471,8 +471,7 @@ describe('frontend-settings — structural', () => {
     expect('Enable account').not.toContain('—');
     expect('Reset password').not.toContain('—');
     // The reset-password helper copy uses parentheses, not em-dashes.
-    const resetCopy =
-      USERMUT_SRC.match(/Set a new password on admin authority[^<]*/)?.[0] ?? '';
+    const resetCopy = USERMUT_SRC.match(/Set a new password on admin authority[^<]*/)?.[0] ?? '';
     expect(resetCopy.length).toBeGreaterThan(0);
     expect(resetCopy).not.toContain('—');
   });

--- a/frontend/tests/pages/shell-account-menu-ac02.test.tsx
+++ b/frontend/tests/pages/shell-account-menu-ac02.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@/api/client', () => ({
   default: { POST: vi.fn(async () => ({ response: { ok: true, status: 204 } })) },
 }));
 
-
 beforeEach(() => {
   clearAuth();
   navigateMock.mockReset();

--- a/frontend/tests/pages/shell-account-menu-ac03.test.tsx
+++ b/frontend/tests/pages/shell-account-menu-ac03.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@/api/client', () => ({
   default: { POST: vi.fn(async () => ({ response: { ok: true, status: 204 } })) },
 }));
 
-
 beforeEach(() => {
   clearAuth();
   navigateMock.mockReset();

--- a/frontend/tests/pages/shell-account-menu-ac04.test.tsx
+++ b/frontend/tests/pages/shell-account-menu-ac04.test.tsx
@@ -27,7 +27,6 @@ vi.mock('@/api/client', () => ({
   default: { POST: (...args: unknown[]) => logoutPostSpy(...args) },
 }));
 
-
 beforeEach(() => {
   clearAuth();
   navigateMock.mockReset();

--- a/frontend/tests/pages/shell-account-menu-ac05.test.tsx
+++ b/frontend/tests/pages/shell-account-menu-ac05.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@/api/client', () => ({
   default: { POST: vi.fn(async () => ({ response: { ok: true, status: 204 } })) },
 }));
 
-
 beforeEach(() => {
   clearAuth();
   navigateMock.mockReset();

--- a/frontend/tests/pages/shell-account-menu-ac06.test.tsx
+++ b/frontend/tests/pages/shell-account-menu-ac06.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@/api/client', () => ({
   default: { POST: vi.fn(async () => ({ response: { ok: true, status: 204 } })) },
 }));
 
-
 beforeEach(() => {
   clearAuth();
   navigateMock.mockReset();

--- a/frontend/tests/pages/shell-account-menu-ac07.test.tsx
+++ b/frontend/tests/pages/shell-account-menu-ac07.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@/api/client', () => ({
   default: { POST: vi.fn(async () => ({ response: { ok: true, status: 204 } })) },
 }));
 
-
 beforeEach(() => {
   clearAuth();
   navigateMock.mockReset();

--- a/internal/eventbus/bus_test.go
+++ b/internal/eventbus/bus_test.go
@@ -253,6 +253,7 @@ func TestEventKindEnum_HasExactlyTwoValues(t *testing.T) {
 		// HostChanged + MonitoringBandChanged (v1.1 SSE layer),
 		// HostDiscovered (system-host-discovery PR 1.1),
 		// IntelligenceEvent (system-os-intelligence PR 1.2),
+		// ScanStarted (per-host live "Running" indicator),
 		// ScanCompleted (api-host-scan / scan foundation),
 		// RemediationCompleted (api-remediation execute/rollback),
 		// ReportReady (api-reports async render, B3a).
@@ -263,6 +264,7 @@ func TestEventKindEnum_HasExactlyTwoValues(t *testing.T) {
 			EventKindMonitoringBandChanged: false,
 			EventKindHostDiscovered:        false,
 			EventKindIntelligenceEvent:     false,
+			EventKindScanStarted:           false,
 			EventKindScanCompleted:         false,
 			EventKindRemediationCompleted:  false,
 			EventKindReportReady:           false,

--- a/internal/eventbus/types.go
+++ b/internal/eventbus/types.go
@@ -43,6 +43,13 @@ const (
 	// system-os-intelligence AC-11.
 	EventKindIntelligenceEvent EventKind = "intelligence.event"
 
+	// EventKindScanStarted is emitted by the scan worker the moment a
+	// queued run enters execution (scan_runs marked running), BEFORE the
+	// scan itself runs. SSE subscribers flip the host's per-host
+	// indicator to "Running" without polling; the paired
+	// scan.completed clears it. Spec system-scan-runs / frontend-live-events.
+	EventKindScanStarted EventKind = "scan.started"
+
 	// EventKindScanCompleted is emitted by the scan worker after a
 	// compliance scan's outcomes are persisted (transactionlog applied
 	// + scan_runs marked completed). SSE subscribers refresh host
@@ -76,6 +83,7 @@ var AllEventKinds = []EventKind{
 	EventKindMonitoringBandChanged,
 	EventKindHostDiscovered,
 	EventKindIntelligenceEvent,
+	EventKindScanStarted,
 	EventKindScanCompleted,
 	EventKindRemediationCompleted,
 	EventKindReportReady,
@@ -224,6 +232,23 @@ func (i IntelligenceEvent) Kind() EventKind { return EventKindIntelligenceEvent 
 
 // Timestamp satisfies Event.
 func (i IntelligenceEvent) Timestamp() time.Time { return i.OccurredAt }
+
+// ScanStarted is fired by the scan worker the moment a queued run enters
+// execution (scan_runs flipped to running), before the scan runs. It
+// carries no counts — the outcome isn't known yet; it exists so SSE
+// consumers can flip the per-host indicator to "Running" live. The paired
+// ScanCompleted clears it.
+type ScanStarted struct {
+	ScanID    uuid.UUID
+	HostID    uuid.UUID
+	StartedAt time.Time
+}
+
+// Kind satisfies Event.
+func (s ScanStarted) Kind() EventKind { return EventKindScanStarted }
+
+// Timestamp satisfies Event.
+func (s ScanStarted) Timestamp() time.Time { return s.StartedAt }
 
 // ScanCompleted is fired by the scan worker once a compliance scan's
 // outcomes are persisted. Counts mirror the scan_runs row so SSE

--- a/internal/scanruns/scanruns.go
+++ b/internal/scanruns/scanruns.go
@@ -205,6 +205,39 @@ func ActiveForHost(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID) (*
 	return scanRun(row)
 }
 
+// ActiveByHostIDs returns the active (queued-or-running) scan status per
+// host, keyed by host id, for the given host ids — ONE grouped query for
+// the whole page (no per-host N+1), served by the scan_runs_active
+// partial index. Hosts with no active run don't appear in the map (the
+// list/lens handlers render that as scan_state: null). When a host has
+// both a queued and a running row, 'running' wins (the more informative
+// state to surface). Backs the per-host "Running"/"Queued" indicator on
+// the hosts list + scans coverage surfaces. Spec system-scan-runs AC-08.
+func ActiveByHostIDs(ctx context.Context, pool *pgxpool.Pool, ids []uuid.UUID) (map[uuid.UUID]Status, error) {
+	out := map[uuid.UUID]Status{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := pool.Query(ctx, `
+		SELECT DISTINCT ON (host_id) host_id, status
+		  FROM scan_runs
+		 WHERE host_id = ANY($1) AND status IN ('queued', 'running')
+		 ORDER BY host_id, (status = 'running') DESC, queued_at DESC`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("scanruns: active by host ids: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var hid uuid.UUID
+		var status string
+		if err := rows.Scan(&hid, &status); err != nil {
+			return nil, fmt.Errorf("scanruns: active by host ids scan: %w", err)
+		}
+		out[hid] = Status(status)
+	}
+	return out, rows.Err()
+}
+
 // ActiveCount returns the number of queued + running runs (the "scan
 // queue" depth on the fleet page and settings readout).
 func ActiveCount(ctx context.Context, pool *pgxpool.Pool) (int, error) {

--- a/internal/scanruns/scanruns_test.go
+++ b/internal/scanruns/scanruns_test.go
@@ -9,6 +9,7 @@
 //	AC-05  TestTerminalStates_NeverOverwritten
 //	AC-06  TestLatestForHost_And_ActiveCount
 //	AC-07  TestHostDelete_RestrictedByRuns
+//	AC-08  TestActiveByHostIDs
 package scanruns
 
 import (
@@ -279,6 +280,73 @@ func TestLatestForHost_And_ActiveCount(t *testing.T) {
 		}
 		if n != 2 {
 			t.Errorf("ActiveCount = %d, want 2", n)
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: ActiveByHostIDs returns the queued-or-running status per host in
+// one grouped query; completed/never-scanned hosts are absent from the map;
+// when a host has both a queued and a running row, 'running' wins.
+func TestActiveByHostIDs(t *testing.T) {
+	t.Run("system-scan-runs/AC-08", func(t *testing.T) {
+		pool := freshPool(t)
+		user := seedUser(t, pool)
+		queuedHost := seedHost(t, pool, user)
+		runningHost := seedHost(t, pool, user)
+		completedHost := seedHost(t, pool, user)
+		bothHost := seedHost(t, pool, user)
+		neverHost := seedHost(t, pool, user)
+		ctx := context.Background()
+
+		// queuedHost: a single queued run.
+		qID, _ := uuid.NewV7()
+		_ = Insert(ctx, pool, Run{ID: qID, HostID: queuedHost, TriggerSource: TriggerScheduled})
+
+		// runningHost: a single running run.
+		rID, _ := uuid.NewV7()
+		_ = MarkRunning(ctx, pool, rID, runningHost, "")
+
+		// completedHost: only a completed run — must be absent.
+		cID, _ := uuid.NewV7()
+		_ = Insert(ctx, pool, Run{ID: cID, HostID: completedHost, TriggerSource: TriggerScheduled})
+		_ = MarkCompleted(ctx, pool, cID, Counts{})
+
+		// bothHost: a queued AND a running run — running must win.
+		bQ, _ := uuid.NewV7()
+		_ = Insert(ctx, pool, Run{ID: bQ, HostID: bothHost, TriggerSource: TriggerScheduled})
+		bR, _ := uuid.NewV7()
+		_ = MarkRunning(ctx, pool, bR, bothHost, "")
+
+		ids := []uuid.UUID{queuedHost, runningHost, completedHost, bothHost, neverHost}
+		got, err := ActiveByHostIDs(ctx, pool, ids)
+		if err != nil {
+			t.Fatalf("ActiveByHostIDs: %v", err)
+		}
+
+		if got[queuedHost] != StatusQueued {
+			t.Errorf("queuedHost = %q, want %q", got[queuedHost], StatusQueued)
+		}
+		if got[runningHost] != StatusRunning {
+			t.Errorf("runningHost = %q, want %q", got[runningHost], StatusRunning)
+		}
+		if _, ok := got[completedHost]; ok {
+			t.Errorf("completedHost present (%q), want absent", got[completedHost])
+		}
+		if _, ok := got[neverHost]; ok {
+			t.Errorf("neverHost present (%q), want absent", got[neverHost])
+		}
+		if got[bothHost] != StatusRunning {
+			t.Errorf("bothHost = %q, want %q (running wins over queued)", got[bothHost], StatusRunning)
+		}
+
+		// Empty ids → empty map, no query.
+		empty, err := ActiveByHostIDs(ctx, pool, nil)
+		if err != nil {
+			t.Fatalf("ActiveByHostIDs(nil): %v", err)
+		}
+		if len(empty) != 0 {
+			t.Errorf("ActiveByHostIDs(nil) = %v, want empty", empty)
 		}
 	})
 }

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -611,6 +611,42 @@ func (e HostComplianceScheduleComplianceState) Valid() bool {
 	}
 }
 
+// Defines values for HostDetailResponseScanState.
+const (
+	HostDetailResponseScanStateQueued  HostDetailResponseScanState = "queued"
+	HostDetailResponseScanStateRunning HostDetailResponseScanState = "running"
+)
+
+// Valid indicates whether the value is a known member of the HostDetailResponseScanState enum.
+func (e HostDetailResponseScanState) Valid() bool {
+	switch e {
+	case HostDetailResponseScanStateQueued:
+		return true
+	case HostDetailResponseScanStateRunning:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for HostListItemScanState.
+const (
+	HostListItemScanStateQueued  HostListItemScanState = "queued"
+	HostListItemScanStateRunning HostListItemScanState = "running"
+)
+
+// Valid indicates whether the value is a known member of the HostListItemScanState enum.
+func (e HostListItemScanState) Valid() bool {
+	switch e {
+	case HostListItemScanStateQueued:
+		return true
+	case HostListItemScanStateRunning:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for HostLivenessMonitoringState.
 const (
 	HostLivenessMonitoringStateCritical    HostLivenessMonitoringState = "critical"
@@ -737,6 +773,24 @@ func (e HostMonitoringHistoryEntryPreviousState) Valid() bool {
 	case HostMonitoringHistoryEntryPreviousStateOnline:
 		return true
 	case HostMonitoringHistoryEntryPreviousStateUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for HostScanContextScanState.
+const (
+	HostScanContextScanStateQueued  HostScanContextScanState = "queued"
+	HostScanContextScanStateRunning HostScanContextScanState = "running"
+)
+
+// Valid indicates whether the value is a known member of the HostScanContextScanState enum.
+func (e HostScanContextScanState) Valid() bool {
+	switch e {
+	case HostScanContextScanStateQueued:
+		return true
+	case HostScanContextScanStateRunning:
 		return true
 	default:
 		return false
@@ -1030,13 +1084,13 @@ func (e ReportSigningKeyAlgorithm) Valid() bool {
 
 // Defines values for ScanRunQueuedStatus.
 const (
-	Queued ScanRunQueuedStatus = "queued"
+	ScanRunQueuedStatusQueued ScanRunQueuedStatus = "queued"
 )
 
 // Valid indicates whether the value is a known member of the ScanRunQueuedStatus enum.
 func (e ScanRunQueuedStatus) Valid() bool {
 	switch e {
-	case Queued:
+	case ScanRunQueuedStatusQueued:
 		return true
 	default:
 		return false
@@ -2311,10 +2365,15 @@ type HostCreateRequest struct {
 type HostDetailResponse struct {
 	ComplianceSummary HostComplianceSummary `json:"compliance_summary"`
 	Host              HostResponse          `json:"host"`
+	LastScanAt        *time.Time            `json:"last_scan_at,omitempty"`
 
 	// Liveness Null when no liveness probe has ever run against this host.
-	Liveness *HostLiveness `json:"liveness,omitempty"`
+	Liveness  *HostLiveness                `json:"liveness,omitempty"`
+	ScanState *HostDetailResponseScanState `json:"scan_state,omitempty"`
 }
+
+// HostDetailResponseScanState defines model for HostDetailResponse.ScanState.
+type HostDetailResponseScanState string
 
 // HostFailedRule defines model for HostFailedRule.
 type HostFailedRule struct {
@@ -2373,17 +2432,21 @@ type HostListItem struct {
 	LatestScanId      *openapi_types.UUID        `json:"latest_scan_id,omitempty"`
 
 	// Liveness Null when no liveness probe has ever run against this host.
-	Liveness           *HostLiveness `json:"liveness,omitempty"`
-	MaintenanceMode    *bool         `json:"maintenance_mode,omitempty"`
-	OsDiscoveredAt     *time.Time    `json:"os_discovered_at,omitempty"`
-	OsFamily           *string       `json:"os_family,omitempty"`
-	OsVersion          *string       `json:"os_version,omitempty"`
-	PlatformIdentifier *string       `json:"platform_identifier,omitempty"`
-	Port               int           `json:"port"`
-	Tags               *[]string     `json:"tags,omitempty"`
-	UpdatedAt          *time.Time    `json:"updated_at,omitempty"`
-	Username           *string       `json:"username,omitempty"`
+	Liveness           *HostLiveness          `json:"liveness,omitempty"`
+	MaintenanceMode    *bool                  `json:"maintenance_mode,omitempty"`
+	OsDiscoveredAt     *time.Time             `json:"os_discovered_at,omitempty"`
+	OsFamily           *string                `json:"os_family,omitempty"`
+	OsVersion          *string                `json:"os_version,omitempty"`
+	PlatformIdentifier *string                `json:"platform_identifier,omitempty"`
+	Port               int                    `json:"port"`
+	ScanState          *HostListItemScanState `json:"scan_state,omitempty"`
+	Tags               *[]string              `json:"tags,omitempty"`
+	UpdatedAt          *time.Time             `json:"updated_at,omitempty"`
+	Username           *string                `json:"username,omitempty"`
 }
+
+// HostListItemScanState defines model for HostListItem.ScanState.
+type HostListItemScanState string
 
 // HostListResponse defines model for HostListResponse.
 type HostListResponse struct {
@@ -2492,7 +2555,13 @@ type HostScanContext struct {
 
 	// ScanId id of the latest completed scan run; null when never scanned.
 	ScanId *openapi_types.UUID `json:"scan_id"`
+
+	// ScanState In-flight scan state for this host, independent of the latest COMPLETED run above. 'queued' = enqueued, awaiting a worker; 'running' = actively executing; null = no scan in flight. Drives the host-detail hero "Running"/"Queued" badge. Spec api-host-compliance AC-17.
+	ScanState *HostScanContextScanState `json:"scan_state,omitempty"`
 }
+
+// HostScanContextScanState In-flight scan state for this host, independent of the latest COMPLETED run above. 'queued' = enqueued, awaiting a worker; 'running' = actively executing; null = no scan in flight. Drives the host-detail hero "Running"/"Queued" badge. Spec api-host-compliance AC-17.
+type HostScanContextScanState string
 
 // HostSystemInfo Result of a Discovery run. Mirrors the host_system_info table
 // column-for-column. Spec system-host-discovery.

--- a/internal/server/api_host_compliance_test.go
+++ b/internal/server/api_host_compliance_test.go
@@ -22,6 +22,7 @@
 //	AC-16  TestHostComplianceFrameworks_OSAwareFiltering
 //	       TestFrameworkCompatibleWithOS_Table (non-DSN)
 //	       TestFirstSentence_TrimsCatalogProse (non-DSN)
+//	AC-17  TestHostComplianceLens_ScanStateReflectsInFlightRun
 package server
 
 import (
@@ -363,6 +364,7 @@ type lensResp struct {
 		ScanID          *string    `json:"scan_id"`
 		PolicyVersion   string     `json:"policy_version"`
 		DurationSeconds *int       `json:"duration_seconds"`
+		ScanState       *string    `json:"scan_state"`
 	} `json:"scan_context"`
 	Summary struct {
 		Passing  int64   `json:"passing"`
@@ -637,6 +639,59 @@ func TestHostComplianceLens_ScanContextLatestCompletedRun(t *testing.T) {
 		}
 		if body.ScanContext.PolicyVersion != "v2" {
 			t.Errorf("policy_version = %q, want v2", body.ScanContext.PolicyVersion)
+		}
+	})
+}
+
+// @ac AC-17
+// AC-17: scan_context.scan_state reflects the in-flight run (queued|running)
+// independent of the latest COMPLETED run; null when no scan is in flight and
+// the completed-run fields are undisturbed by a running scan.
+func TestHostComplianceLens_ScanStateReflectsInFlightRun(t *testing.T) {
+	t.Run("api-host-compliance/AC-17", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		base := time.Now().UTC().Truncate(time.Second)
+		seedRun := func(runStatus, policy string, finishedAt any) uuid.UUID {
+			t.Helper()
+			id := uuid.Must(uuid.NewV7())
+			_, err := pool.Exec(context.Background(), `
+				INSERT INTO scan_runs (id, host_id, trigger_source, status, finished_at, policy_version)
+				VALUES ($1, $2, 'scheduled', $3, $4, NULLIF($5, ''))`,
+				id, hostID, runStatus, finishedAt, policy)
+			if err != nil {
+				t.Fatalf("seed scan_run %s: %v", runStatus, err)
+			}
+			return id
+		}
+
+		// Never scanned, none active → scan_state null.
+		_, body := getLens(t, url, auth.RoleViewer, hostID.String(), "")
+		if body.ScanContext.ScanState != nil {
+			t.Errorf("no-run scan_state = %v, want null", body.ScanContext.ScanState)
+		}
+
+		// A completed run is present (fills last_scan_at) plus a queued run
+		// in flight → scan_state 'queued', completed fields undisturbed.
+		completed := seedRun("completed", "v1", base.Add(-time.Hour))
+		seedRun("queued", "v2", nil)
+		_, body = getLens(t, url, auth.RoleViewer, hostID.String(), "")
+		if body.ScanContext.ScanState == nil || *body.ScanContext.ScanState != "queued" {
+			t.Errorf("scan_state = %v, want queued", body.ScanContext.ScanState)
+		}
+		if body.ScanContext.ScanID == nil || *body.ScanContext.ScanID != completed.String() {
+			t.Errorf("scan_id = %v, want %s (running scan must not disturb completed fields)",
+				body.ScanContext.ScanID, completed)
+		}
+
+		// Flip the queued run to running → scan_state 'running'.
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE scan_runs SET status='running' WHERE host_id=$1 AND status='queued'`, hostID); err != nil {
+			t.Fatalf("flip to running: %v", err)
+		}
+		_, body = getLens(t, url, auth.RoleViewer, hostID.String(), "")
+		if body.ScanContext.ScanState == nil || *body.ScanContext.ScanState != "running" {
+			t.Errorf("scan_state = %v, want running", body.ScanContext.ScanState)
 		}
 	})
 }

--- a/internal/server/api_hosts_enrichment_test.go
+++ b/internal/server/api_hosts_enrichment_test.go
@@ -10,6 +10,7 @@
 //   AC-19  TestHosts_GetHosts_ListLivenessJoined
 //   AC-23  TestHosts_GetHosts_ListComplianceSummaryJoined
 //   AC-24  TestHosts_GetHosts_ListLatestScanIDJoined
+//   AC-25  TestHosts_GetHosts_ListScanStateJoined
 
 package server
 
@@ -495,6 +496,97 @@ func TestHosts_GetHosts_ListLatestScanIDJoined(t *testing.T) {
 			t.Error("no-scan host absent from /hosts response")
 		} else if got != nil {
 			t.Errorf("no-scan host latest_scan_id = %v, want null", *got)
+		}
+	})
+}
+
+// @ac AC-25
+// AC-25 (v1.7.0): GET /hosts items carry a nullable scan_state enum
+// (queued|running) for the in-flight run, independent of the completed-run
+// fields. A queued host resolves to "queued", a running host to "running",
+// and a host with only a completed run resolves to null with its
+// latest_scan_id still pointing at the completed run.
+func TestHosts_GetHosts_ListScanStateJoined(t *testing.T) {
+	t.Run("api-hosts/AC-25", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		queuedHost := createHostAPI(t, url, "queued-host", "production")
+		queuedID := queuedHost["id"].(string)
+		queuedUUID, _ := uuid.Parse(queuedID)
+		runningHost := createHostAPI(t, url, "running-host", "production")
+		runningID := runningHost["id"].(string)
+		runningUUID, _ := uuid.Parse(runningID)
+		completedHost := createHostAPI(t, url, "completed-host", "production")
+		completedID := completedHost["id"].(string)
+		completedUUID, _ := uuid.Parse(completedID)
+
+		base := time.Now().UTC().Truncate(time.Second)
+		seedScanRun(t, pool, queuedUUID, "queued", base)
+		seedScanRun(t, pool, runningUUID, "running", base)
+		completedRunID := seedScanRun(t, pool, completedUUID, "completed", base.Add(-time.Hour))
+
+		req := asRole(t, "GET", url+"/api/v1/hosts", auth.RoleAdmin, nil)
+		resp := doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		var body struct {
+			Hosts []struct {
+				ID           string  `json:"id"`
+				ScanState    *string `json:"scan_state"`
+				LatestScanID *string `json:"latest_scan_id"`
+			} `json:"hosts"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		seen := map[string]struct {
+			state  *string
+			latest *string
+		}{}
+		for _, h := range body.Hosts {
+			seen[h.ID] = struct {
+				state  *string
+				latest *string
+			}{h.ScanState, h.LatestScanID}
+		}
+
+		if got := seen[queuedID].state; got == nil || *got != "queued" {
+			t.Errorf("queued host scan_state = %v, want queued", got)
+		}
+		if got := seen[runningID].state; got == nil || *got != "running" {
+			t.Errorf("running host scan_state = %v, want running", got)
+		}
+		if got := seen[completedID].state; got != nil {
+			t.Errorf("completed-only host scan_state = %v, want null", *got)
+		}
+		// The completed run's latest_scan_id is undisturbed by scan_state.
+		if got := seen[completedID].latest; got == nil || *got != completedRunID.String() {
+			t.Errorf("completed host latest_scan_id = %v, want %s", got, completedRunID)
+		}
+
+		// GET /hosts/{id} (detail) carries scan_state + last_scan_at too.
+		detail := func(id string) (scanState *string, lastScanAt *string) {
+			dreq := asRole(t, "GET", url+"/api/v1/hosts/"+id, auth.RoleAdmin, nil)
+			dresp := doReq(t, dreq)
+			defer dresp.Body.Close()
+			if dresp.StatusCode != http.StatusOK {
+				t.Fatalf("GET /hosts/%s = %d, want 200", id, dresp.StatusCode)
+			}
+			var db struct {
+				ScanState  *string `json:"scan_state"`
+				LastScanAt *string `json:"last_scan_at"`
+			}
+			if err := json.NewDecoder(dresp.Body).Decode(&db); err != nil {
+				t.Fatalf("decode detail: %v", err)
+			}
+			return db.ScanState, db.LastScanAt
+		}
+		if st, _ := detail(queuedID); st == nil || *st != "queued" {
+			t.Errorf("detail queued host scan_state = %v, want queued", st)
+		}
+		if st, _ := detail(completedID); st != nil {
+			t.Errorf("detail completed-only host scan_state = %v, want null", *st)
 		}
 	})
 }

--- a/internal/server/host_compliance_lens_handler.go
+++ b/internal/server/host_compliance_lens_handler.go
@@ -88,6 +88,19 @@ func (h *handlers) GetHostCompliance(
 		return
 	}
 
+	// scan_state: the in-flight (queued/running) run, independent of the
+	// latest COMPLETED run above — null when no scan is in flight. Drives
+	// the host-detail hero "Running"/"Queued" badge. Spec
+	// api-host-compliance AC-17.
+	if active, err := scanruns.ActiveForHost(ctx, h.pool, hostID); err == nil {
+		s := api.HostScanContextScanState(active.Status)
+		scanCtx.ScanState = &s
+	} else if !errors.Is(err, scanruns.ErrNotFound) {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"scan state lookup failed", true)
+		return
+	}
+
 	// nil framework disables both the filter and the control-id
 	// projection ($2::text IS NULL short-circuits — same idiom as the
 	// failed-rules handler). One query, no pagination: the per-host

--- a/internal/server/host_scan_handler.go
+++ b/internal/server/host_scan_handler.go
@@ -129,7 +129,7 @@ func (h *handlers) PostHostScan(
 
 	writeJSON(w, http.StatusAccepted, api.ScanRunQueued{
 		ScanId:   jobID,
-		Status:   api.Queued,
+		Status:   api.ScanRunQueuedStatusQueued,
 		QueuedAt: now,
 	})
 }

--- a/internal/server/hosts_handlers.go
+++ b/internal/server/hosts_handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/host"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
 	"github.com/Hanalyx/openwatch/internal/queue"
+	"github.com/Hanalyx/openwatch/internal/scanruns"
 	"github.com/Hanalyx/openwatch/internal/server/api"
 	"github.com/google/uuid"
 	openapitypes "github.com/oapi-codegen/runtime/types"
@@ -73,11 +74,19 @@ func (h *handlers) GetHosts(w http.ResponseWriter, r *http.Request, params api.G
 			"latest_scan_id join failed", true)
 		return
 	}
+	// v1.7.0 — in-flight scan state per host (queued/running), one grouped
+	// query over the scan_runs_active partial index. Spec api-hosts C-14.
+	activeScanByID, err := scanruns.ActiveByHostIDs(r.Context(), h.pool, ids)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"scan_state join failed", true)
+		return
+	}
 
 	out := make([]api.HostListItem, len(list))
 	for i, item := range list {
 		out[i] = hostListItem(item, liveByID[item.ID], lastScanByID[item.ID],
-			complianceByID[item.ID], latestScanByID[item.ID])
+			complianceByID[item.ID], latestScanByID[item.ID], activeScanByID[item.ID])
 	}
 	writeJSON(w, http.StatusOK, api.HostListResponse{Hosts: out})
 }
@@ -222,6 +231,24 @@ func (h *handlers) GetHostByID(w http.ResponseWriter, r *http.Request, id openap
 		Liveness:          liveness,
 		ComplianceSummary: summary,
 	}
+	// v1.7.0 — last_scan_at (MAX host_rule_state.last_checked_at) + in-flight
+	// scan_state (queued/running) so the detail hero shows a real "LAST SCAN"
+	// timestamp and a live "Running"/"Queued" badge. Spec api-hosts C-14.
+	if lastScanByID, err := loadHostLastScanByIDs(ctx, h.pool, []uuid.UUID{hostID}); err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"last_scan_at lookup failed", true)
+		return
+	} else if ls, ok := lastScanByID[hostID]; ok {
+		resp.LastScanAt = &ls
+	}
+	if active, err := scanruns.ActiveForHost(ctx, h.pool, hostID); err == nil {
+		s := api.HostDetailResponseScanState(active.Status)
+		resp.ScanState = &s
+	} else if !errors.Is(err, scanruns.ErrNotFound) {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"scan state lookup failed", true)
+		return
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -342,7 +369,8 @@ func hostResponse(h host.Host) api.HostResponse {
 // and an optional compliance roll-up (api-hosts v1.5.0 C-12). All
 // three may be nil — never probed and never scanned, respectively.
 func hostListItem(h host.Host, liveness *api.HostLiveness, lastScan time.Time,
-	compliance *api.HostListComplianceSummary, latestScanID uuid.UUID) api.HostListItem {
+	compliance *api.HostListComplianceSummary, latestScanID uuid.UUID,
+	scanState scanruns.Status) api.HostListItem {
 	desc := h.Description
 	displayName := h.DisplayName
 	env := h.Environment
@@ -391,6 +419,12 @@ func hostListItem(h host.Host, liveness *api.HostLiveness, lastScan time.Time,
 	if latestScanID != uuid.Nil {
 		u := openapitypes.UUID(latestScanID)
 		item.LatestScanId = &u
+	}
+	// v1.7.0 — nil (null on the wire) when the host has no queued/running
+	// run. Spec api-hosts C-14.
+	if scanState != "" {
+		s := api.HostListItemScanState(scanState)
+		item.ScanState = &s
 	}
 	return item
 }

--- a/internal/worker/scan_worker.go
+++ b/internal/worker/scan_worker.go
@@ -308,6 +308,18 @@ func (w *ScanWorker) ProcessJob(ctx context.Context, j *queue.Job) {
 		// Non-fatal: the logbook is observability, not the scan itself.
 	}
 
+	// Announce scan start so SSE clients flip the host's per-host
+	// indicator to "Running" without polling (the paired scan.completed
+	// below clears it). Best-effort: the scan proceeds regardless.
+	// Spec system-scan-runs / frontend-live-events.
+	if w.bus != nil {
+		w.bus.Publish(ctx, eventbus.ScanStarted{
+			ScanID:    j.ID,
+			HostID:    payload.HostID,
+			StartedAt: w.clock().UTC(),
+		})
+	}
+
 	// Per-host concurrency guard via pg_advisory_xact_lock (C-09).
 	tx, err := acquireHostLock(ctx, w.pool, payload.HostID)
 	if err != nil {

--- a/specs/api/host-compliance.spec.yaml
+++ b/specs/api/host-compliance.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-host-compliance
   title: Per-host compliance lens + failed-rules API + fleet scan-queue KPI
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -187,3 +187,7 @@ spec:
       description: 'v1.3.0 - on a host with os_family=rhel, os_version=8.10 whose rows carry refs for cis_rhel8, cis_rhel9, stig_rhel10, nist_800_53, pci_dss_4 and srg, GET /compliance/frameworks lists exactly cis_rhel8 + the three OS-neutral ids; the same rows on a host with no os_family list all six; GET /compliance?framework=cis_rhel9 still projects normally on the RHEL 8 host (deep links unfiltered). The unit table for frameworkCompatibleWithOS covers neutral ids, family mismatch, major match, major+minor concatenation (ubuntu2404 vs 24.04), and the unknown-OS passthrough'
       priority: critical
       references_constraints: [C-06]
+    - id: AC-17
+      description: 'v1.4.0 - scan_context.scan_state reflects the host''s in-flight run independent of the latest COMPLETED run: a host with a queued run returns scan_state="queued"; a running run returns "running"; a host with only completed/failed runs (or never scanned) returns scan_state null while last_scan_at/scan_id keep tracking the latest COMPLETED run. It is sourced from scanruns.ActiveForHost so a running scan does not disturb last_scan_at.'
+      priority: high
+      references_constraints: [C-02]

--- a/specs/api/hosts.spec.yaml
+++ b/specs/api/hosts.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-hosts
   title: Host inventory CRUD HTTP surface + Slice B enrichments
-  version: "1.6.0"
+  version: "1.7.0"
   status: approved
   tier: 2
 
@@ -92,6 +92,10 @@ spec:
       enforcement: error
     - id: C-13
       description: 'v1.6.0 — GET /hosts response items MUST include a nullable latest_scan_id (uuid) holding the id of the newest COMPLETED scan_runs row for that host (status=completed, newest by queued_at). A host with no completed scan_run MUST receive null (never an error). It MUST be loaded with ONE query keyed by host_id for the whole page (DISTINCT ON / grouped — no per-host N+1). This id is the target of the host card "view report" link to GET /scans/{id}; a queued/running-only host yields null so the UI hides the affordance. Existing list semantics (filters, soft-delete exclusion) are untouched'
+      type: technical
+      enforcement: error
+    - id: C-14
+      description: 'v1.7.0 — GET /hosts response items MUST include a nullable scan_state enum (queued|running) holding the host''s in-flight scan state, independent of last_scan_at/latest_scan_id (which track the latest COMPLETED run). A host with a queued run yields "queued", a running run "running", a host with only completed/failed runs or none yields null (never an error; the completed-run fields are unaffected — a running scan does not disturb last_scan_at). It MUST be loaded with ONE grouped query keyed by host_id for the whole page over the scan_runs_active partial index (scanruns.ActiveByHostIDs — no per-host N+1); a host with both a queued and a running row resolves to "running". Drives the per-host live "Running"/"Queued" indicator on the hosts-list and scans-coverage surfaces'
       type: technical
       enforcement: error
 
@@ -188,3 +192,7 @@ spec:
       description: 'v1.6.0 — GET /hosts over a fleet where one host has a completed scan_run (plus an older completed one and a newer queued one), another host has only a queued/running scan_run, and a third has no scan_runs returns: the first item latest_scan_id = the newest COMPLETED run id (not the queued one, not the older completed one); the second item latest_scan_id null (queued/running is not a viewable report); the third item latest_scan_id null. The ids come from a single per-page query (no N+1).'
       priority: critical
       references_constraints: [C-13]
+    - id: AC-25
+      description: 'v1.7.0 — GET /hosts over a fleet where one host has a queued scan_run, another has a running scan_run, and a third has only a completed run (or none) returns: the first item scan_state="queued"; the second scan_state="running"; the third scan_state null with its last_scan_at/latest_scan_id still reflecting the completed run (a running scan does not disturb the completed-run fields). The states come from a single per-page grouped query over the scan_runs_active index (no N+1). The single-host GET /hosts/{id} response likewise carries scan_state (queued/running/null) plus last_scan_at (MAX host_rule_state.last_checked_at) for the detail hero: a host with a queued run returns scan_state="queued", and a host with only a completed run returns scan_state null.'
+      priority: high
+      references_constraints: [C-14]

--- a/specs/frontend/host-compliance-tab.spec.yaml
+++ b/specs/frontend/host-compliance-tab.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-compliance-tab
   title: Host detail Compliance tab — lens UI over the per-host compliance endpoints
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -165,3 +165,7 @@ spec:
       description: 'v1.2.0 - exception overlay (api-compliance-exceptions): the tab reads the host exceptions via useHostExceptions and annotates the rules table with an Exception column - a Waived pill for rules with an active (approved) exception, a Pending pill for rules with a requested one, and for a FAILING rule with no exception and a caller holding exception:request a Request button that opens a modal (reason required, optional expiry) posting POST /hosts/{id}/exceptions and invalidating ["host", hostId, "exceptions"] on success. The overlay NEVER changes a rule status chip - the failing rule still shows Non-compliant (overlay model, never mutates the lens).'
       priority: high
       references_constraints: [C-03]
+    - id: AC-10
+      description: 'v1.4.0 source-inspection - the scan-context strip Re-scan button reflects an in-flight scan: ScanContextStrip is passed scan_context.scan_state (queued|running) and forwards it to RescanButton, which stays disabled and shows "Running…"/"Queued…" for the whole scan (not just the request round-trip) and reverts to "Re-scan" when scanState is null. The state is kept live by the scan.started/scan.completed SSE invalidation of the ["host", hostId] lens query.'
+      priority: high
+      references_constraints: [C-01]

--- a/specs/frontend/host-detail.spec.yaml
+++ b/specs/frontend/host-detail.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-detail
   title: Host Detail page layout, behavior, and empty-state contracts
-  version: "1.8.0"
+  version: "1.9.0"
   status: approved
   tier: 2
 
@@ -260,5 +260,9 @@ spec:
       references_constraints: [C-04]
     - id: AC-44
       description: 'v1.8.0 source-inspection - the Audit log tab mounts HostAuditLogTab (not TabStub): audit_log is removed from the TAB_BACKEND_SUBSYSTEM stub registry, and the render switch routes activeTab === "audit_log" to <HostAuditLogTab>. HostAuditLogTab pages GET /api/v1/audit/events with resource_type="host" + resource_id=hostId via useInfiniteQuery, renders each row with the server-rendered readable message (it.message, never the raw it.action alone), is gated on useAuthStore hasPermission("audit:read") (rendering an "Audit log not available" empty state otherwise), and shows loading / error+Retry / "No audit events yet" / Load more states.'
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-45
+      description: 'v1.9.0 source-inspection — the overview Compliance hero reflects an in-flight scan: it is passed the detail response scan_state (queued|running) and last_scan_at (no longer hardcoded lastScan={null}); when scanState is set the LAST SCAN subhead is replaced by an accent "Running"/"Queued" badge, otherwise it shows the real formatted last-scan time. The page-head Run scan button stays disabled and shows "Running…"/"Queued…" while scanState is active (not just during the request round-trip), reverting to "Run scan" when idle. The detail query threads last_scan_at + scan_state through to the hero and button, kept live by the scan.started/scan.completed SSE invalidation of ["host", id].'
       priority: high
       references_constraints: [C-04]

--- a/specs/frontend/hosts-list.spec.yaml
+++ b/specs/frontend/hosts-list.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-hosts-list
   title: Hosts list — fleet dashboard with search, filter, card/table views
-  version: "1.8.0"
+  version: "1.9.0"
   status: approved
   tier: 2
 
@@ -225,3 +225,14 @@ spec:
         widget uses.
       priority: high
       references_constraints: [C-13]
+    - id: AC-27
+      description: >-
+        v1.9.0 source-inspection — an in-flight scan surfaces on the host
+        card and table row: apiHostToDev maps the list item's scan_state
+        (queued|running) onto DevHost.scanState (null when idle), and a
+        scanStateLabel helper renders "Running…" for running and "Queued…"
+        for queued in place of the "Last scan …" text (in an accent color),
+        on BOTH the card footer and the table-row Last scan cell. The label
+        falls back to the last-scan text when scanState is null.
+      priority: high
+      references_constraints: [C-02]

--- a/specs/frontend/live-events.spec.yaml
+++ b/specs/frontend/live-events.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-live-events
   title: useLiveEvents SSE hook — topic ↔ query-key invalidation contract
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -66,7 +66,7 @@ spec:
 
   constraints:
     - id: C-01
-      description: 'ALL_TOPICS MUST be a closed const-tuple containing exactly the seven kinds: host.changed, monitoring.band.changed, host.discovered, intelligence.event, scan.completed, remediation.completed (v1.2.0), report.ready (v1.3.0). Adding another requires bumping this spec''s version and updating the test'
+      description: 'ALL_TOPICS MUST be a closed const-tuple containing exactly the eight kinds: host.changed, monitoring.band.changed, host.discovered, intelligence.event, scan.started (v1.5.0), scan.completed, remediation.completed (v1.2.0), report.ready (v1.3.0). Adding another requires bumping this spec''s version and updating the test'
       type: technical
       enforcement: error
     - id: C-02
@@ -100,7 +100,7 @@ spec:
 
   acceptance_criteria:
     - id: AC-01
-      description: 'ALL_TOPICS as exported from useLiveEvents.ts equals exactly the closed set ["host.changed", "monitoring.band.changed", "host.discovered", "intelligence.event", "scan.completed", "remediation.completed", "report.ready"]. Verified by importing the const and asserting the array contents + length'
+      description: 'ALL_TOPICS as exported from useLiveEvents.ts equals exactly the closed set ["host.changed", "monitoring.band.changed", "host.discovered", "intelligence.event", "scan.started", "scan.completed", "remediation.completed", "report.ready"]. Verified by importing the const and asserting the array contents + length'
       priority: critical
       references_constraints: [C-01]
     - id: AC-02
@@ -139,3 +139,7 @@ spec:
       description: 'v1.4.0 — Firing report.ready invalidates ["reports"] AND ["notifications","feed"] (the durable bell refreshes). Spies observe ZERO ["host", ...] invalidation (a report is fleet-scoped, not per-host)'
       priority: high
       references_constraints: [C-08]
+    - id: AC-11
+      description: 'v1.5.0 — scan.started is in ALL_TOPICS and its handler invalidates ["hosts"] AND (when the payload carries HostID=H) ["host", H], mirroring scan.completed. This is the live push that flips the per-host indicator to "Running" the moment the worker begins the scan; the paired scan.completed clears it back to freshness.'
+      priority: high
+      references_constraints: [C-01, C-07]

--- a/specs/frontend/scans.spec.yaml
+++ b/specs/frontend/scans.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-scans
   title: Scans overview (coverage + change history)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -78,3 +78,7 @@ spec:
       description: 'Source-inspection — the Scans page issues no api.POST/PUT/DELETE (read-only), and its UI copy contains no em-dash.'
       priority: high
       references_constraints: [C-02]
+    - id: AC-04
+      description: 'v1.1.0 source-inspection — the Coverage tab FRESHNESS pill reflects an in-flight scan: a freshnessPill helper maps scan_state "running" to a "Running" label and "queued" to a "Queued" label (an accent tone distinct from the current/stale/never freshness tones), taking precedence over the last_scan_at age, so an operator sees which host is actively being scanned. The pill falls back to the age-derived current/stale/never label when scan_state is null.'
+      priority: high
+      references_constraints: [C-01]

--- a/specs/system/scan-runs.spec.yaml
+++ b/specs/system/scan-runs.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-scan-runs
   title: Scan-run logbook — operational record of compliance-scan attempts
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -102,3 +102,7 @@ spec:
       description: Deleting a host with extant scan_runs rows fails with an FK violation (ON DELETE RESTRICT).
       priority: high
       references_constraints: [C-04]
+    - id: AC-08
+      description: ActiveByHostIDs returns the active (queued|running) status per host for the given host ids in ONE grouped query — a queued-only host maps to 'queued', a running host to 'running', a host with only completed/failed runs or no runs is absent from the map, and a host with BOTH a queued and a running row maps to 'running' ('running' wins over 'queued'). An empty id slice returns an empty map with no query. Backs the per-host live "Running"/"Queued" indicator on the hosts-list and scans-coverage surfaces.
+      priority: high
+      references_constraints: [C-01, C-02]


### PR DESCRIPTION
## Problem
When a scan is executing, no UI surface shows **which** host is being scanned. The Scans page has only a fleet-wide "RUNNING: N" counter with no per-host attribution; the Coverage FRESHNESS pill, the Hosts card footer, and the host-detail hero are all derived from `last_scan_at` (the latest *completed* run), so an in-flight scan is invisible.

## Solution
The backend already tracked in-flight state (`scan_runs` + the `scan_runs_active` partial index) — it was just never exposed in a GET response nor announced when a scan started. This surfaces a per-host **Running/Queued** indicator on all three surfaces, updating **live** (no refresh).

| Surface | Now |
|---------|-----|
| Scans → Coverage FRESHNESS pill | **Running** / **Queued** accent pill while in-flight |
| Hosts card footer + table row | **Running…** / **Queued…** in place of "Last scan …" |
| Host-detail hero + Run scan button | live **Running/Queued** badge; button disabled "Running…" for the whole scan |

**Naming:** Running/Queued (matches the `scanruns` status enum and the existing Scans KPI labels), not "Scanning".

### Backend
- `scanruns.ActiveByHostIDs` — one grouped query returning queued/running per host over the `scan_runs_active` index (running wins over queued).
- `scan_state` on `HostListItem` + `HostScanContext` + `HostDetailResponse` (which also gets `last_scan_at`); wired via the existing enrichment pattern (no N+1) and `scanruns.ActiveForHost` on the single-host paths.
- New `scan.started` eventbus event, published by the worker at `MarkRunning` (before the scan runs); the paired `scan.completed` clears it. SSE topic auto-allowed via `AllEventKinds`.

### Frontend
- `useLiveEvents` subscribes to `scan.started`, invalidating `[hosts]`/`[host,id]` so the indicator lights up live at scan start.
- Coverage pill, Hosts card/row, host-detail hero, and both re-scan buttons render `scan_state`; the buttons stay disabled for the whole scan, not just the request round-trip.
- **Bug fix:** the host-detail hero was hardcoded `lastScan={null}` (always showed "—"); it now shows the real `last_scan_at`.

## SDD
9 new ACs, each with an annotated test: `system-scan-runs` AC-08, `api-host-compliance` AC-17, `api-hosts` C-14/AC-25, `frontend-{live-events AC-11, scans AC-04, hosts-list AC-27, host-detail AC-45, host-compliance-tab AC-10}`. `specter coverage` 100% (114 specs).

## Verification
- Backend: gofmt, `go vet`, `go build`, `internal/{scanruns,eventbus,worker,server}` tests (AC-25/AC-17 drive the real HTTP handlers against real Postgres).
- `make check-generated` — OpenAPI + generated Go/TS in sync.
- Frontend: `tsc` clean, 350 vitest tests pass.
- `specter check` + coverage 100%.

## Notes
- First commit (`chore(repo)`) is pre-existing local-hook cleanup that was blocking any frontend commit: prettier 3.8.4 fallout from #711 (13 test files) + a stale `.secrets.baseline` refresh. Neither runs in CI; kept separate from the feature.
- `HostDetailResponse` gaining `scan_state`/`last_scan_at` is a small scope addition beyond the plan's two schemas — required because the Overview hero reads `GET /hosts/{id}`, and it's what makes the `lastScan={null}` fix possible. Covered by the extended AC-25 test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)