### PR TITLE
chore(deps): bump Kensa to v0.7.6 (+ Go 1.26.5)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -94,7 +94,7 @@ jobs:
         if: steps.paths.outputs.go == 'true'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
           cache-dependency-path: go.sum
 
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/go/bin/golangci-lint
-          key: golangci-bin-v1.64.8-go1.26.4-${{ runner.os }}
+          key: golangci-bin-v1.64.8-go1.26.5-${{ runner.os }}
 
       - name: Set up golangci-lint
         if: steps.paths.outputs.go == 'true' && steps.cache-golangci-bin.outputs.cache-hit != 'true'

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **Kensa bumped to v0.7.6, patching a root command injection in the
+  remediation handlers.** The `file_content`, `file_absent`, and
+  `config_append` handlers interpolated `owner`/`group`/`mode` values into
+  `chown`/`chmod` unquoted, so a rule or scan-variable value such as
+  `owner: "root; touch /tmp/x"` could execute as root on the target host.
+  OpenWatch runs single-rule remediation (apply + rollback) in-process
+  through these handlers, so this reaches the host-mutating path shipped in
+  0.3.0. All sites now shell-quote the value. The public Kensa surface
+  OpenWatch links (`api/`, `pkg/kensa/`) is unchanged.
+
+### Changed
+
+- **Go toolchain 1.26.4 to 1.26.5** (required by Kensa v0.7.6).
+- **Kensa rule corpus 647 to 748 rules** (RHEL 10 STIG V1R1 coverage
+  campaign; additive, no rules removed). Ships via the `kensa-rules`
+  package, now 0.7.6.
+- **Three built-in scan-variable defaults now use the STIG baseline:**
+  `shadow_crypt_min_rounds` 5000 to 100000, `ssh_client_alive_interval`
+  900 to 600, and a new `account_inactive_days` (35). Operators who rely
+  on the shipped defaults (no override set under Settings, Scan Variables)
+  will see the affected rules evaluated against the stricter thresholds on
+  the next scan. A host that passed under the old defaults may flip to fail
+  (recorded as a pass-to-fail transition). Set a scan-variable override to
+  retain the previous values.
+- **`kernel_module_state` check widened (leniency only):** a module
+  disabled via an `install /bin/false` override, or absent from the kernel
+  tree entirely, now counts as disabled. This only turns former false
+  failures into passes.
+
 ---
 
 ## [0.3.0] Eyrie — 2026-07-06

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/Hanalyx/kensa v0.7.4
+	github.com/Hanalyx/kensa v0.7.6
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-pdf/fpdf v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Hanalyx/openwatch
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Hanalyx/kensa v0.7.4 h1:/IKNdt+fXocb0qs0xCW/6kiMyqHrRbQI9H/pr66LPRQ=
-github.com/Hanalyx/kensa v0.7.4/go.mod h1:26P7d00ZSqAPg6XRA49WXaufECqdpZPASWzphGVaFuA=
+github.com/Hanalyx/kensa v0.7.6 h1:SDSvP2Blg92tCEY2l6iLoHsOjSnTwVx4DR6qYue8OWM=
+github.com/Hanalyx/kensa v0.7.6/go.mod h1:DPuksmA1bOQXyQT+3OwLrZs0yJw9nlOIhG1CEsvX2oI=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=

--- a/internal/kensa/types.go
+++ b/internal/kensa/types.go
@@ -10,7 +10,7 @@ import (
 // KensaModuleVersion is the version pin recorded in the spec's context
 // block. AC-10 source-inspects to verify this matches the corresponding
 // entry in app/go.mod.
-const KensaModuleVersion = "v0.7.4"
+const KensaModuleVersion = "v0.7.6"
 
 // Sentinel errors returned by Executor.Run. Tests use errors.Is for
 // classification; the audit emission path maps each to a typed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -32,7 +32,7 @@ var (
 const kensaModulePath = "github.com/Hanalyx/kensa"
 
 // Go returns the Go toolchain version the binary was built with, e.g.
-// "go1.26.4". Sourced from the runtime, never hardcoded.
+// "go1.26.5". Sourced from the runtime, never hardcoded.
 func Go() string {
 	return runtime.Version()
 }

--- a/specs/api/version.spec.yaml
+++ b/specs/api/version.spec.yaml
@@ -64,7 +64,7 @@ spec:
     - id: AC-02
       description: >
         Response body includes non-empty openwatch, kensa, and go version
-        strings. The go value is the live runtime toolchain (e.g. "go1.26.4"),
+        strings. The go value is the live runtime toolchain (e.g. "go1.26.5"),
         evidencing the values are build/runtime-sourced rather than literals.
       priority: critical
       references_constraints: [C-04]

--- a/specs/system/kensa-executor.spec.yaml
+++ b/specs/system/kensa-executor.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-kensa-executor
   title: Kensa executor wrapper
-  version: "2.6.0"
+  version: "2.7.0"
   status: approved
   tier: 1
 
@@ -10,7 +10,7 @@ spec:
     feature: Kensa scan execution bridge
     description: >
       The executor invokes Kensa (Go module github.com/Hanalyx/kensa
-      pinned to v0.7.4) to run a scan against a single host using the
+      pinned to v0.7.6) to run a scan against a single host using the
       FULL rule corpus applicable to the host's detected OS
       capabilities. The Kensa API (`Kensa.Scan(ctx, host, rules,
       opts...)` per kensa-go/api/kensa.go:228) takes a `[]*api.Rule`
@@ -107,7 +107,7 @@ spec:
       type: security
       enforcement: error
     - id: C-07
-      description: Kensa Go module version MUST be pinned in app/go.mod; bumps require this spec's version bump
+      description: Kensa Go module version MUST be pinned in go.mod; bumps require this spec's version bump
       type: technical
       enforcement: warning
     - id: C-08
@@ -131,7 +131,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-13
-      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.7.4 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
+      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.7.6 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
       type: technical
       enforcement: error
     - id: C-14


### PR DESCRIPTION
## Summary

Bumps **Kensa v0.7.4 → v0.7.6** and, as its prerequisite, the **Go toolchain 1.26.4 → 1.26.5**. Kensa v0.7.6 is a security + coverage patch whose public surface (`api/`, `pkg/kensa/`) is byte-identical to v0.7.4 (a drop-in bump), but its transitively-linked handlers carry a root-command-injection fix that lands on OpenWatch's in-process remediation path.

## Why this matters (security)

The `file_content` / `file_absent` / `config_append` remediation handlers interpolated `owner`/`group`/`mode` values into `chown`/`chmod` **unquoted**, so a rule or scan-variable value like `owner: "root; touch /tmp/x"` could execute **as root** on the target host. OpenWatch runs single-rule remediation (apply + rollback, shipped in 0.3.0) in-process through these handlers via `internal/kensa/remediatefunc.go`, so the fix reaches a host-mutating path we ship today. v0.7.6 shell-quotes all nine sites.

## What reaches OpenWatch

- **Security fix** on the remediation apply/rollback path (above).
- **Rule corpus 647 → 748** (+101, zero removals): RHEL 10 STIG V1R1 coverage campaign. Ships via the `kensa-rules` package (now 0.7.6). Verified: `stage-kensa-rules.sh` stages 748.
- **Three built-in scan-variable defaults shifted to the STIG baseline** — `shadow_crypt_min_rounds` 5000→100000, `ssh_client_alive_interval` 900→600, new `account_inactive_days` (35). **Operators on the shipped defaults (no Settings override) will see the affected rules evaluated against stricter thresholds on the next scan; a passing host may flip to fail (pass→fail transition).** Documented in the CHANGELOG with the mitigation (set a scan-variable override to retain old values).
- **`kernel_module_state` widened (leniency-only):** `install /bin/false` overrides and modules absent from the kernel tree now count as disabled — only turns former false-FAILs into passes.

## Toolchain

Kensa v0.7.6 requires `go >= 1.26.5`. Bumped the `go.mod` directive, all four `actions/setup-go` pins (go-ci, release, package-smoke ×2), and the golangci cache key. All CI jobs fetch Go via `actions/setup-go`, so 1.26.5 is pulled cleanly on every runner/container.

## SDD

- `system-kensa-executor` AC-10 three-way agreement kept consistent: `KensaModuleVersion` const, `go.mod` pin, and spec `context` all say `v0.7.6`; spec bumped 2.6.0 → 2.7.0 per C-07 ("bumps require this spec's version bump"). Also corrects a stale `app/go.mod` reference.
- `specter check` (115 specs pass), `specter check --test` (0 errors), `specter coverage --strictness annotation` (115/115, 100%).
- `variables_test.go` asserts no specific default values, so the shifted defaults break no test.

## Verification

- `go build ./...`, `go vet ./...`, `go mod verify` — clean
- `internal/kensa`, `internal/version`, `internal/systemconfig` tests pass (incl. AC-10 version-agreement tests)
- changelog gate (`packaging/tests`) passes
- `stage-kensa-rules.sh` → 748 rules from `kensa@v0.7.6`

## Release framing

No version stamp in this PR — documented under CHANGELOG `[Unreleased]`. Given 0.3.0 shipped the remediation feature four days ago, this warrants a **v0.3.1 patch** framed as a security fix once merged.
