### PR TITLE
fix(maintenance): enforce per-host and per-group maintenance everywhere

### DIFF
--- a/frontend/src/components/settings/OSDiscoverySection.tsx
+++ b/frontend/src/components/settings/OSDiscoverySection.tsx
@@ -191,7 +191,11 @@ export function OSDiscoverySectionView(props: {
   } = props;
 
   return (
-    <Section title="OS discovery" badge="Wired" badgeTier="ok">
+    <Section
+      title="OS discovery"
+      badge={draft ? (draft.maintenance_global ? 'Paused' : 'Running') : undefined}
+      badgeTier={draft?.maintenance_global ? 'warn' : 'ok'}
+    >
       {isLoading ? (
         <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12, padding: '8px 0' }}>
           Loading…

--- a/frontend/src/components/settings/OSIntelligenceSection.tsx
+++ b/frontend/src/components/settings/OSIntelligenceSection.tsx
@@ -171,7 +171,11 @@ export function OSIntelligenceSectionView(props: {
   } = props;
 
   return (
-    <Section title="OS Intelligence scheduler" badge="Wired" badgeTier="ok">
+    <Section
+      title="OS Intelligence scheduler"
+      badge={draft ? (draft.maintenance_global ? 'Paused' : 'Running') : undefined}
+      badgeTier={draft?.maintenance_global ? 'warn' : 'ok'}
+    >
       {isLoading ? (
         <div role="status" style={{ color: 'var(--ow-fg-2)', fontSize: 12, padding: '8px 0' }}>
           Loading…

--- a/frontend/tests/pages/settings-discovery-config.test.tsx
+++ b/frontend/tests/pages/settings-discovery-config.test.tsx
@@ -10,6 +10,7 @@
 //   AC-06  test('frontend-settings-discovery-config/AC-06 — ScanningPage mounts OSDiscoverySection BEFORE OSIntelligenceSection')
 //   AC-07  test('frontend-settings-discovery-config/AC-07 — visual states: loading, error, success-clean')
 //   AC-08  test('frontend-settings-discovery-config/AC-08 — Run now button: label flips, callback invoked, queued count rendered')
+//   AC-09  test('frontend-settings-discovery-config/AC-09 — section badge reflects maintenance state (Running vs Paused), not the static "Wired"')
 
 import { describe, expect, test, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -158,5 +159,24 @@ describe('frontend-settings-discovery-config — behavioral (pure view)', () => 
     // Sweep result shown.
     rerender(<OSDiscoverySectionView {...viewProps({ sweepResult: { enqueued: 7 } })} />);
     expect(screen.getByText(/queued\s+7\s+discoveries/i)).toBeInTheDocument();
+  });
+
+  // @ac AC-09
+  test('frontend-settings-discovery-config/AC-09 — section badge reflects maintenance state (Running vs Paused), not the static "Wired"', () => {
+    const { unmount } = render(
+      <OSDiscoverySectionView
+        {...viewProps({ draft: { ...liveConfig, maintenance_global: false } })}
+      />,
+    );
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.queryByText('Wired')).toBeNull();
+    unmount();
+
+    render(
+      <OSDiscoverySectionView
+        {...viewProps({ draft: { ...liveConfig, maintenance_global: true } })}
+      />,
+    );
+    expect(screen.getByText('Paused')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/settings-intelligence-config.test.tsx
+++ b/frontend/tests/pages/settings-intelligence-config.test.tsx
@@ -12,6 +12,7 @@
 //   AC-08  test('frontend-settings-intelligence-config/AC-08 — error alert surfaces the HTTP status (no "Failed to load — Failed to load")')
 //   AC-09  test('frontend-settings-intelligence-config/AC-09 — error state renders a Retry button that invokes onRetry')
 //   AC-10  test('frontend-settings-intelligence-config/AC-10 — post-save useEffect re-syncs draft from configQuery.data.config')
+//   AC-11  test('frontend-settings-intelligence-config/AC-11 — section badge reflects maintenance state (Running vs Paused), not the static "Wired"')
 
 import { describe, expect, test, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -202,5 +203,24 @@ describe('frontend-settings-intelligence-config — behavioral (pure view)', () 
     const retry = screen.getByRole('button', { name: /retry/i });
     fireEvent.click(retry);
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  // @ac AC-11
+  test('frontend-settings-intelligence-config/AC-11 — section badge reflects maintenance state (Running vs Paused), not the static "Wired"', () => {
+    const { unmount } = render(
+      <OSIntelligenceSectionView
+        {...viewProps({ draft: { ...liveConfig, maintenance_global: false } })}
+      />,
+    );
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.queryByText('Wired')).toBeNull();
+    unmount();
+
+    render(
+      <OSIntelligenceSectionView
+        {...viewProps({ draft: { ...liveConfig, maintenance_global: true } })}
+      />,
+    );
+    expect(screen.getByText('Paused')).toBeInTheDocument();
   });
 });

--- a/internal/db/migrations/0049_host_effective_maintenance.sql
+++ b/internal/db/migrations/0049_host_effective_maintenance.sql
@@ -1,0 +1,53 @@
+-- 0049_host_effective_maintenance.sql
+--
+-- A single source of truth for "is this host effectively in maintenance?".
+--
+-- Maintenance can be asserted at two scopes, and until now they were enforced
+-- inconsistently:
+--
+--   * Per-host  — hosts.maintenance_mode, toggled from the host-detail page.
+--     Honored by the liveness/connectivity, intelligence, and discovery loops,
+--     but NOT by the compliance-scan scheduler (which filtered a separate,
+--     never-written host_compliance_schedule.maintenance_mode column — so a host
+--     put in maintenance kept getting compliance-scanned).
+--   * Per-group — groups.maintenance, toggled from the Groups page. Written and
+--     counted, but read by NO runtime loop, so it paused nothing at all.
+--
+-- This view resolves both scopes (and the two group-membership kinds: manual
+-- members in group_members, and auto groups matched live by os_family) into one
+-- boolean per host. Every scheduler/probe loop JOINs it and skips a host when
+-- in_maintenance is true, so per-host and per-group maintenance now behave
+-- identically everywhere. The membership logic mirrors group.Service.Summary's
+-- "hosts in maintenance" query, keeping the count and the enforcement in sync.
+--
+-- Deleted hosts are intentionally NOT filtered here — each consuming query keeps
+-- its own deleted_at predicate, so the view stays a pure maintenance resolver.
+--
+-- Spec: system-scheduler, system-liveness-loop, system-intelligence-scheduler,
+--       system-discovery-scheduler, api-groups.
+
+-- +goose Up
+CREATE VIEW host_effective_maintenance AS
+SELECT
+    h.id AS host_id,
+    (
+        h.maintenance_mode
+        OR EXISTS (
+            SELECT 1
+              FROM group_members gm
+              JOIN groups g ON g.id = gm.group_id
+             WHERE gm.host_id = h.id
+               AND g.maintenance
+        )
+        OR EXISTS (
+            SELECT 1
+              FROM groups g
+             WHERE g.membership = 'auto'
+               AND g.maintenance
+               AND g.match_family = h.os_family
+        )
+    ) AS in_maintenance
+FROM hosts h;
+
+-- +goose Down
+DROP VIEW IF EXISTS host_effective_maintenance;

--- a/internal/intelligence/discovery/scheduler/service.go
+++ b/internal/intelligence/discovery/scheduler/service.go
@@ -201,14 +201,19 @@ func (s *Service) tickOnce(ctx context.Context) {
 // SQL query (AC-06). Excludes deleted, maintenance, and hosts whose
 // os_discovered_at is more recent than now() - intervalSec.
 //
+// Maintenance (per-host OR per-group) resolves via the
+// host_effective_maintenance view (migration 0049), matching the scan
+// scheduler and the other loops.
+//
 // NULL os_discovered_at is treated as due (never-discovered hosts go
 // first via NULLS FIRST ordering). Spec C-02 / AC-05.
 func (s *Service) listDiscoveryTargets(ctx context.Context, intervalSec int) ([]uuid.UUID, error) {
 	const q = `
 		SELECT h.id
 		  FROM hosts h
+		  JOIN host_effective_maintenance hem ON hem.host_id = h.id
 		 WHERE h.deleted_at IS NULL
-		   AND h.maintenance_mode = false
+		   AND NOT hem.in_maintenance
 		   AND (h.os_discovered_at IS NULL
 		        OR h.os_discovered_at + make_interval(secs => $1) <= now())
 		 ORDER BY h.os_discovered_at ASC NULLS FIRST`

--- a/internal/intelligence/scheduler/service.go
+++ b/internal/intelligence/scheduler/service.go
@@ -187,15 +187,19 @@ func (s *Service) tickOnce(ctx context.Context) {
 // Excludes: deleted hosts, maintenance hosts, hosts with future
 // intel-backoff suppress_until, hosts with future next_intelligence_at.
 func (s *Service) listIntelTargets(ctx context.Context) ([]uuid.UUID, error) {
+	// Maintenance (per-host OR per-group) resolves via the
+	// host_effective_maintenance view (migration 0049), matching the scan
+	// scheduler and the other loops.
 	const q = `
 		SELECT h.id
 		  FROM hosts h
+		  JOIN host_effective_maintenance hem ON hem.host_id = h.id
 		  LEFT JOIN host_intelligence_state hi
 		    ON hi.host_id = h.id
 		  LEFT JOIN host_backoff_state b
 		    ON b.host_id = h.id AND b.probe_type = 'intel'
 		 WHERE h.deleted_at IS NULL
-		   AND h.maintenance_mode = false
+		   AND NOT hem.in_maintenance
 		   AND (b.suppress_until IS NULL OR b.suppress_until <= $1)
 		   AND (hi.next_intelligence_at IS NULL OR hi.next_intelligence_at <= $1)
 		 ORDER BY hi.next_intelligence_at ASC NULLS FIRST`

--- a/internal/intelligence/scheduler/service_db_test.go
+++ b/internal/intelligence/scheduler/service_db_test.go
@@ -60,8 +60,9 @@ func insertSchedHost(t *testing.T, pool *pgxpool.Pool, name string) uuid.UUID {
 
 // @ac AC-06
 // AC-06: listIntelTargets returns only H1 (next NULL) and H2 (next in
-// past); skips H3 (next in future), H4 (maintenance), H5 (intel
-// backoff active).
+// past); skips H3 (next in future), H4 (per-host maintenance), H5 (intel
+// backoff active), H6 (per-group maintenance). H4 and H6 together prove
+// both maintenance scopes resolve through host_effective_maintenance.
 func TestListIntelTargets_FilterSemantics(t *testing.T) {
 	t.Run("system-intelligence-scheduler/AC-06", func(t *testing.T) {
 		pool := freshDBScheduler(t)
@@ -72,6 +73,7 @@ func TestListIntelTargets_FilterSemantics(t *testing.T) {
 		h3 := insertSchedHost(t, pool, "h3-future-next")
 		h4 := insertSchedHost(t, pool, "h4-maintenance")
 		h5 := insertSchedHost(t, pool, "h5-backoff")
+		h6 := insertSchedHost(t, pool, "h6-group-maintenance")
 
 		// h1: row absent → NULL next → due.
 		// h2: row present with past next.
@@ -87,13 +89,24 @@ func TestListIntelTargets_FilterSemantics(t *testing.T) {
 			`INSERT INTO host_intelligence_state (host_id, snapshot, collected_at, next_intelligence_at)
 			 VALUES ($1, '{}'::jsonb, now() - interval '1 hour', now() + interval '30 minutes')`,
 			h3)
-		// h4: NULL next but maintenance_mode=true.
+		// h4: NULL next but per-host maintenance_mode=true.
 		_, _ = pool.Exec(ctx, `UPDATE hosts SET maintenance_mode = true WHERE id = $1`, h4)
 		// h5: backoff suppress_until in future.
 		_, _ = pool.Exec(ctx, `
 			INSERT INTO host_backoff_state (host_id, probe_type, consecutive_failures, suppress_until)
 			VALUES ($1, 'intel', 3, now() + interval '1 hour')`,
 			h5)
+		// h6: NULL next but a member of a maintenance group (per-group scope).
+		gid, _ := uuid.NewV7()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO groups (id, name, kind, membership, maintenance)
+			 VALUES ($1, $2, 'site', 'manual', true)`, gid, "maint-"+gid.String()); err != nil {
+			t.Fatalf("seed maintenance group: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO group_members (group_id, host_id) VALUES ($1, $2)`, gid, h6); err != nil {
+			t.Fatalf("seed group member: %v", err)
+		}
 
 		svc := NewService(pool, nil)
 		got, err := svc.listIntelTargets(ctx)
@@ -115,10 +128,13 @@ func TestListIntelTargets_FilterSemantics(t *testing.T) {
 			t.Errorf("h3 (future next) wrongly included")
 		}
 		if seen[h4] {
-			t.Errorf("h4 (maintenance) wrongly included")
+			t.Errorf("h4 (per-host maintenance) wrongly included")
 		}
 		if seen[h5] {
 			t.Errorf("h5 (intel backoff) wrongly included")
+		}
+		if seen[h6] {
+			t.Errorf("h6 (per-group maintenance) wrongly included")
 		}
 	})
 }

--- a/internal/liveness/service.go
+++ b/internal/liveness/service.go
@@ -340,18 +340,24 @@ func (s *Service) listProbeTargets(ctx context.Context) ([]probeTarget, error) {
 	// which net.Dial rejects, marking every host unreachable. v1.2.1 C-17.
 	//
 	// v1.3.0 additions (C-20):
-	//   - WHERE hosts.maintenance_mode = false (per-host pause)
+	//   - exclude hosts in maintenance (per-host pause)
 	//   - ORDER BY hosts.check_priority DESC, hl.next_probe_at ASC NULLS FIRST
 	//     so critical hosts get drained before stable ones.
+	//
+	// v1.4.0: maintenance is resolved via the host_effective_maintenance
+	// view (migration 0049), so a host is skipped whether it is paused
+	// per-host (hosts.maintenance_mode) OR per-group (a maintenance group
+	// it belongs to) — matching the scan scheduler and the other loops.
 	const q = `
 		SELECT h.id, host(h.ip_address), COALESCE(h.port, 22), h.check_priority
 		  FROM hosts h
+		  JOIN host_effective_maintenance hem ON hem.host_id = h.id
 		  LEFT JOIN host_backoff_state b
 		    ON b.host_id = h.id AND b.probe_type = 'scan'
 		  LEFT JOIN host_liveness hl
 		    ON hl.host_id = h.id
 		 WHERE h.deleted_at IS NULL
-		   AND h.maintenance_mode = false
+		   AND NOT hem.in_maintenance
 		   AND (b.suppress_until IS NULL OR b.suppress_until <= $1)
 		   AND (hl.next_probe_at IS NULL OR hl.next_probe_at <= $1)
 		 ORDER BY h.check_priority DESC, hl.next_probe_at ASC NULLS FIRST`

--- a/internal/liveness/v130_source_test.go
+++ b/internal/liveness/v130_source_test.go
@@ -76,13 +76,15 @@ func TestTickRoutesMultiLayerWhenEnabled(t *testing.T) {
 }
 
 // @ac AC-33
-// AC-33: listProbeTargets MUST WHERE-out hosts.maintenance_mode = true.
-// A host flipped to maintenance gets no probe, no history row, no audit.
+// AC-33: listProbeTargets MUST exclude hosts in effective maintenance
+// (per-host OR per-group) via the host_effective_maintenance view. A host
+// in maintenance gets no probe, no history row, no audit.
 func TestListProbeTargetsExcludesMaintenance(t *testing.T) {
 	t.Run("system-liveness-loop/AC-33", func(t *testing.T) {
 		src := readSourceFile(t, "service.go")
-		if !strings.Contains(src, "h.maintenance_mode = false") {
-			t.Errorf("listProbeTargets must filter `h.maintenance_mode = false`")
+		if !strings.Contains(src, "host_effective_maintenance") ||
+			!strings.Contains(src, "NOT hem.in_maintenance") {
+			t.Errorf("listProbeTargets must exclude hosts via the host_effective_maintenance view (JOIN + NOT hem.in_maintenance)")
 		}
 	})
 }

--- a/internal/scheduler/readviews.go
+++ b/internal/scheduler/readviews.go
@@ -83,7 +83,8 @@ func PreviewSchedule(ctx context.Context, pool *pgxpool.Pool, now time.Time) (Sc
 		       COUNT(*) FILTER (WHERE s.next_scheduled_scan <= $1)
 		  FROM host_compliance_schedule s
 		  JOIN hosts h ON h.id = s.host_id AND h.deleted_at IS NULL
-		 WHERE s.maintenance_mode = false`, now,
+		  JOIN host_effective_maintenance hem ON hem.host_id = s.host_id
+		 WHERE NOT hem.in_maintenance`, now,
 	).Scan(&p.NextScanAt, &p.DueNow); err != nil {
 		return p, fmt.Errorf("scheduler: preview aggregates: %w", err)
 	}
@@ -93,7 +94,8 @@ func PreviewSchedule(ctx context.Context, pool *pgxpool.Pool, now time.Time) (Sc
 		       COUNT(*)::bigint
 		  FROM host_compliance_schedule s
 		  JOIN hosts h ON h.id = s.host_id AND h.deleted_at IS NULL
-		 WHERE s.maintenance_mode = false
+		  JOIN host_effective_maintenance hem ON hem.host_id = s.host_id
+		 WHERE NOT hem.in_maintenance
 		   AND s.next_scheduled_scan > $1
 		   AND s.next_scheduled_scan <= $1 + interval '24 hours'
 		 GROUP BY 1`, now)

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -79,9 +79,10 @@ const dispatchBatchSize = 100
 //
 // Steps:
 //  1. BEGIN transaction
-//  2. SELECT host_compliance_schedule ... FOR UPDATE SKIP LOCKED LIMIT N
-//     (filtered to rows where next_scheduled_scan <= now() and
-//     maintenance_mode = false)
+//  2. SELECT host_compliance_schedule ... FOR UPDATE OF s SKIP LOCKED LIMIT N
+//     (filtered to rows where next_scheduled_scan <= now() and the host is
+//     not in effective maintenance — per-host or per-group, via the
+//     host_effective_maintenance view)
 //  3. For each claimed row: build JobPayload, HMAC-sign, queue.Enqueue
 //     under job_type "scan", UPDATE next_scheduled_scan forward, emit
 //     scheduler.schedule.updated.
@@ -94,8 +95,9 @@ const dispatchBatchSize = 100
 //
 //   - AC-04 (C-03): FOR UPDATE SKIP LOCKED. Two concurrent Dispatch
 //     calls (from two workers or two ticks) claim disjoint rows.
-//   - AC-05 (C-05): maintenance_mode = true rows are excluded from the
-//     SELECT and so never dispatched.
+//   - AC-05 (C-05): hosts in effective maintenance (per-host or per-group,
+//     via host_effective_maintenance) are excluded from the SELECT and so
+//     never dispatched.
 //   - AC-06 (C-06, C-12): each job payload carries host_id,
 //     policy_version, enqueued_at; all HMAC-signed.
 //   - AC-13 (C-09): every UPDATE to host_compliance_schedule emits
@@ -118,13 +120,20 @@ func (s *Service) Dispatch(ctx context.Context) (int, error) {
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Maintenance is resolved via the host_effective_maintenance view
+	// (migration 0049), which unifies per-host (hosts.maintenance_mode)
+	// and per-group (groups.maintenance) scopes. Historically this filtered
+	// host_compliance_schedule.maintenance_mode — a column the API never
+	// wrote, so a host toggled into maintenance kept getting scanned. Lock
+	// only the schedule rows (FOR UPDATE OF s); the view is read-only.
 	const selectStmt = `
-		SELECT host_id, compliance_state, next_scheduled_scan
-		  FROM host_compliance_schedule
-		 WHERE next_scheduled_scan <= $1
-		   AND maintenance_mode = false
-		 ORDER BY next_scheduled_scan
-		 FOR UPDATE SKIP LOCKED
+		SELECT s.host_id, s.compliance_state, s.next_scheduled_scan
+		  FROM host_compliance_schedule s
+		  JOIN host_effective_maintenance hem ON hem.host_id = s.host_id
+		 WHERE s.next_scheduled_scan <= $1
+		   AND NOT hem.in_maintenance
+		 ORDER BY s.next_scheduled_scan
+		 FOR UPDATE OF s SKIP LOCKED
 		 LIMIT $2`
 
 	rows, err := tx.Query(ctx, selectStmt, now, limit)

--- a/internal/scheduler/service_test.go
+++ b/internal/scheduler/service_test.go
@@ -36,6 +36,7 @@ func freshPool(t *testing.T) *pgxpool.Pool {
 		"TRUNCATE TABLE host_backoff_state CASCADE",
 		"TRUNCATE TABLE host_compliance_schedule CASCADE",
 		"TRUNCATE TABLE job_queue CASCADE",
+		"TRUNCATE TABLE groups CASCADE",
 		"TRUNCATE TABLE hosts CASCADE",
 		"TRUNCATE TABLE users CASCADE",
 		"TRUNCATE TABLE audit_events CASCADE",
@@ -111,6 +112,35 @@ type scheduleSeed struct {
 
 func withNext(t time.Time) func(*scheduleSeed)   { return func(c *scheduleSeed) { c.next = t } }
 func withMaintenance(b bool) func(*scheduleSeed) { return func(c *scheduleSeed) { c.maintenance = b } }
+
+// setHostMaintenance flips hosts.maintenance_mode — the per-host flag the
+// host-detail toggle writes and the dispatcher (via host_effective_maintenance)
+// now honors.
+func setHostMaintenance(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, on bool) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`UPDATE hosts SET maintenance_mode = $2 WHERE id = $1`, hostID, on)
+	if err != nil {
+		t.Fatalf("set host maintenance: %v", err)
+	}
+}
+
+// seedManualMaintenanceGroup creates a manual group with maintenance=true and
+// adds hostID as a member — the per-group maintenance path.
+func seedManualMaintenanceGroup(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID) {
+	t.Helper()
+	gid, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO groups (id, name, kind, membership, maintenance)
+		 VALUES ($1, $2, 'site', 'manual', true)`, gid, "maint-"+gid.String())
+	if err != nil {
+		t.Fatalf("seed maintenance group: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO group_members (group_id, host_id) VALUES ($1, $2)`, gid, hostID); err != nil {
+		t.Fatalf("seed group member: %v", err)
+	}
+}
 
 // newTestService builds a Service ready for Dispatch with a deterministic
 // clock pinned to a passed-in time. Uses an in-memory audit recorder so
@@ -256,19 +286,26 @@ func TestDispatch_FuturesNotClaimed(t *testing.T) {
 }
 
 // @ac AC-05
-// AC-05: rows with maintenance_mode = true are skipped by Dispatch even
-// when their next_scheduled_scan is in the past.
+// AC-05: a host in effective maintenance is skipped by Dispatch even when
+// due — whether the maintenance is per-host (hosts.maintenance_mode, set by
+// the host-detail toggle) or per-group (a maintenance group it belongs to).
+// Enforcement resolves through the host_effective_maintenance view; the
+// skipped host's schedule row is left unadvanced so it resumes on the next
+// tick after maintenance clears.
 func TestDispatch_MaintenanceMode_RowSkipped(t *testing.T) {
 	t.Run("system-scheduler/AC-05", func(t *testing.T) {
 		pool := freshPool(t)
 		user := seedUser(t, pool)
-		hMaint := seedHost(t, pool, user)
-		hNormal := seedHost(t, pool, user)
+		hPerHost := seedHost(t, pool, user)  // per-host maintenance
+		hPerGroup := seedHost(t, pool, user) // per-group maintenance
+		hNormal := seedHost(t, pool, user)   // not in maintenance
 
-		// hMaint is due-now AND in maintenance — should be skipped.
-		seedSchedule(t, pool, hMaint, withMaintenance(true))
-		// hNormal is due-now and not in maintenance — should be dispatched.
+		// All three due-now; two are placed in maintenance by different scopes.
+		seedSchedule(t, pool, hPerHost)
+		seedSchedule(t, pool, hPerGroup)
 		seedSchedule(t, pool, hNormal)
+		setHostMaintenance(t, pool, hPerHost, true)
+		seedManualMaintenanceGroup(t, pool, hPerGroup)
 
 		var calls []emitCall
 		svc := newTestService(t, pool, time.Now(), &calls)
@@ -282,23 +319,22 @@ func TestDispatch_MaintenanceMode_RowSkipped(t *testing.T) {
 			t.Errorf("dispatched = %d, want 1 (only hNormal should be claimed)", dispatched)
 		}
 
-		// Verify hMaint's row was not mutated.
+		// Neither maintenance host's schedule was advanced (still in the past).
 		ctx2, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		var maintNext time.Time
-		var maintMaint bool
-		err = pool.QueryRow(ctx2,
-			`SELECT next_scheduled_scan, maintenance_mode
-			   FROM host_compliance_schedule WHERE host_id = $1`,
-			hMaint).Scan(&maintNext, &maintMaint)
-		if err != nil {
-			t.Fatalf("read hMaint: %v", err)
-		}
-		if !maintMaint {
-			t.Error("hMaint.maintenance_mode = false; the dispatcher mutated a maintenance row")
-		}
-		if !maintNext.Before(time.Now()) {
-			t.Errorf("hMaint.next_scheduled_scan = %v; should be unchanged (in the past from seed)", maintNext)
+		for _, tc := range []struct {
+			name   string
+			hostID uuid.UUID
+		}{{"per-host", hPerHost}, {"per-group", hPerGroup}} {
+			var next time.Time
+			if err := pool.QueryRow(ctx2,
+				`SELECT next_scheduled_scan FROM host_compliance_schedule WHERE host_id = $1`,
+				tc.hostID).Scan(&next); err != nil {
+				t.Fatalf("read %s schedule: %v", tc.name, err)
+			}
+			if !next.Before(time.Now()) {
+				t.Errorf("%s host next_scheduled_scan = %v; should be unchanged (dispatcher must skip it)", tc.name, next)
+			}
 		}
 	})
 }

--- a/internal/scheduler/service_test.go
+++ b/internal/scheduler/service_test.go
@@ -110,8 +110,7 @@ type scheduleSeed struct {
 	maintenance bool
 }
 
-func withNext(t time.Time) func(*scheduleSeed)   { return func(c *scheduleSeed) { c.next = t } }
-func withMaintenance(b bool) func(*scheduleSeed) { return func(c *scheduleSeed) { c.maintenance = b } }
+func withNext(t time.Time) func(*scheduleSeed) { return func(c *scheduleSeed) { c.next = t } }
 
 // setHostMaintenance flips hosts.maintenance_mode — the per-host flag the
 // host-detail toggle writes and the dispatcher (via host_effective_maintenance)

--- a/internal/server/api_system_scan_config_test.go
+++ b/internal/server/api_system_scan_config_test.go
@@ -366,7 +366,15 @@ func TestAPI_ScanSchedulePreview_ProjectionFigures(t *testing.T) {
 		later := seedHostForIntel(t, pool)
 		seedScheduleRow(t, pool, later, "compliant", now.Add(5*time.Hour+30*time.Minute), false)
 		maint := seedHostForIntel(t, pool)
-		seedScheduleRow(t, pool, maint, "critical", now.Add(10*time.Minute), true) // excluded
+		seedScheduleRow(t, pool, maint, "critical", now.Add(10*time.Minute), false)
+		// Put the HOST in maintenance — the real per-host flag the preview
+		// honors via the host_effective_maintenance view — not the dead
+		// host_compliance_schedule.maintenance_mode column. Due at +10m, so if
+		// it were NOT excluded it would win next_scan_at and fill bucket[0].
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE hosts SET maintenance_mode = true WHERE id = $1`, maint); err != nil {
+			t.Fatalf("set host maintenance: %v", err)
+		}
 
 		// Queue depth: one queued scan_runs row.
 		jobID := uuid.Must(uuid.NewV7())

--- a/internal/server/discovery_config_handlers.go
+++ b/internal/server/discovery_config_handlers.go
@@ -127,13 +127,15 @@ func (h *handlers) PostSystemDiscoverySweep(w http.ResponseWriter, r *http.Reque
 }
 
 // listUndiscoveredHosts returns the host ids the sweep should enqueue:
-// non-deleted, non-maintenance, hosts.os_discovered_at IS NULL.
+// non-deleted, non-maintenance (per-host OR per-group, via the
+// host_effective_maintenance view), hosts.os_discovered_at IS NULL.
 func (h *handlers) listUndiscoveredHosts(ctx context.Context) ([]uuid.UUID, error) {
 	const q = `
-		SELECT id FROM hosts
-		 WHERE deleted_at IS NULL
-		   AND maintenance_mode = false
-		   AND os_discovered_at IS NULL`
+		SELECT hst.id FROM hosts hst
+		  JOIN host_effective_maintenance hem ON hem.host_id = hst.id
+		 WHERE hst.deleted_at IS NULL
+		   AND NOT hem.in_maintenance
+		   AND hst.os_discovered_at IS NULL`
 	rows, err := h.pool.Query(ctx, q)
 	if err != nil {
 		return nil, err

--- a/specs/api/groups.spec.yaml
+++ b/specs/api/groups.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-groups
   title: Host groups - operator SITES (manual) and OS CATEGORIES (auto/manual) with per-group rollups
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -42,10 +42,12 @@ spec:
       group, ungrouped active hosts (no manual group and no auto match),
       and fleet avg_compliance_pct.
 
-      The maintenance flag pauses scanning and alerting for a group's
-      hosts (surfaced in the UI; enforcement is a follow-up). Kind and
-      membership are immutable after create; only name, subtype, and
-      color are editable.
+      The maintenance flag pauses compliance scans, connectivity probes,
+      intelligence, and discovery for a group's hosts: every scheduler/probe
+      loop resolves it through the host_effective_maintenance view
+      (migration 0049), which unions this flag with per-host
+      hosts.maintenance_mode. Kind and membership are immutable after
+      create; only name, subtype, and color are editable.
 
       Endpoints (the fleet KPI row ships inside the list response, so a
       single GET serves both the summary and the groups):
@@ -209,7 +211,9 @@ spec:
         SetMaintenance(on) and SetMaintenance(off) flip the maintenance
         flag, bump updated_at, and return the updated group; SetMaintenance
         on an unknown id returns ErrNotFound. The flag does not alter
-        membership or rollup member resolution.
+        membership or rollup member resolution. Enforcement (pausing the
+        member hosts' scans/probes) is carried by the scheduler/probe loops
+        via the host_effective_maintenance view, not by this endpoint.
       priority: high
       references_constraints: [C-03]
     - id: AC-07

--- a/specs/api/system-scan-config.spec.yaml
+++ b/specs/api/system-scan-config.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-system-scan-config
   title: Adaptive compliance scan scheduler config + fleet-state + schedule-preview HTTP surface
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -120,7 +120,7 @@ spec:
       priority: critical
       references_constraints: [C-05]
     - id: AC-07
-      description: 'GET /api/v1/system/scan/schedule-preview returns next_scan_at = the soonest FUTURE next_scheduled_scan (null when none), due_now = count of rows already past due, queued_jobs/running_jobs from scan_runs, and exactly 24 hourly buckets where a row due in N hours lands in bucket hour_offset=N; maintenance-mode rows are excluded from all figures; the call performs no writes'
+      description: 'GET /api/v1/system/scan/schedule-preview returns next_scan_at = the soonest FUTURE next_scheduled_scan (null when none), due_now = count of rows already past due, queued_jobs/running_jobs from scan_runs, and exactly 24 hourly buckets where a row due in N hours lands in bucket hour_offset=N; hosts in effective maintenance (per-host hosts.maintenance_mode OR per-group, via the host_effective_maintenance view) are excluded from all figures, matching the dispatcher; the call performs no writes'
       priority: critical
       references_constraints: [C-06]
     - id: AC-08

--- a/specs/frontend/settings-discovery-config.spec.yaml
+++ b/specs/frontend/settings-discovery-config.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings-discovery-config
   title: Settings Scanning page — OS discovery scheduler config section
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -79,6 +79,10 @@ spec:
       description: 'Error alert surfaces apiErrorMessage(error) (the canonical ErrorEnvelope.error.human_message). Falls back to "HTTP <status>" via formatApiError if the envelope is malformed. Mirrors frontend-settings-intelligence-config C-07'
       type: technical
       enforcement: error
+    - id: C-08
+      description: 'v1.1.0 — The section header badge MUST reflect the scheduler''s live state derived from maintenance_global (Running when active, Paused when in maintenance), never a static build-status label such as "Wired". Mirrors frontend-settings-intelligence-config C-10.'
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -113,3 +117,7 @@ spec:
       description: 'Rendering: clicking the Run now button invokes onRunNow exactly once. While isSweeping is true the button label reads "Sweeping…". When sweepResult is non-null and sweepError is null the inline "Queued N discoveries" text is visible'
       priority: critical
       references_constraints: [C-05]
+    - id: AC-09
+      description: 'v1.1.0 — The section header badge reflects the scheduler''s live state, not a static build-status label: "Running" (ok tier) when maintenance_global is false, "Paused" (warn tier) when true. The badge MUST NOT read the static "Wired". Rendering: the View with draft.maintenance_global=false shows "Running" and no "Wired"; with true shows "Paused"'
+      priority: medium
+      references_constraints: [C-08]

--- a/specs/frontend/settings-intelligence-config.spec.yaml
+++ b/specs/frontend/settings-intelligence-config.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings-intelligence-config
   title: Settings Scanning page — OS Intelligence scheduler config section
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -94,6 +94,10 @@ spec:
       description: 'v1.1.0 — On the post-save edge (mutation.isSuccess && configQuery.data), the draft MUST be re-synced from configQuery.data.config so a server-side clamp (or any future drift between client and server validation) cannot leave the operator with a stale draft that looks "saved" but does not match server truth. The re-sync MUST be gated on mutation.isSuccess specifically — never clobber an in-flight edit during an unrelated refetch'
       type: technical
       enforcement: error
+    - id: C-10
+      description: 'v1.2.0 — The section header badge MUST reflect the scheduler''s live state derived from maintenance_global (Running when active, Paused when in maintenance), never a static build-status label such as "Wired". A badge that does not track state is noise to an operator.'
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -136,3 +140,7 @@ spec:
       description: 'v1.1.0 — Source inspection: OSIntelligenceSection.tsx contains a useEffect that depends on mutation.isSuccess AND calls setDraft from configQuery.data.config inside the effect body. This is the post-save re-sync (C-09) — without it, server-side clamps would leave the operator with a stale "saved" draft'
       priority: critical
       references_constraints: [C-09]
+    - id: AC-11
+      description: 'v1.2.0 — The section header badge reflects the scheduler''s live state, not a static build-status label: "Running" (ok tier) when maintenance_global is false, "Paused" (warn tier) when true. The badge MUST NOT read the static "Wired". Rendering: the View with draft.maintenance_global=false shows "Running" and no "Wired"; with true shows "Paused"'
+      priority: medium
+      references_constraints: [C-10]

--- a/specs/system/discovery-scheduler.spec.yaml
+++ b/specs/system/discovery-scheduler.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-discovery-scheduler
   title: OS discovery recurring sweep scheduler
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -34,8 +34,10 @@ spec:
       Re-run discovery on the host detail page). See
       system-host-discovery v1.1.0 AC-15.
 
-      Maintenance: respects hosts.maintenance_mode = true the same way the
-      liveness + intelligence loops do — maintenance hosts are excluded
+      Maintenance: respects effective maintenance the same way the
+      liveness + intelligence loops do — a host paused per-host
+      (hosts.maintenance_mode) OR per-group (a maintenance group it belongs
+      to), resolved via the host_effective_maintenance view, is excluded
       from listDiscoveryTargets. MaintenanceGlobal pauses the whole loop.
 
       No per-host backoff state. Discovery failures (SSH dial timeout,
@@ -77,7 +79,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-02
-      description: 'listDiscoveryTargets MUST WHERE-out (a) deleted_at IS NOT NULL hosts, (b) hosts.maintenance_mode = true, AND (c) hosts whose hosts.os_discovered_at is within DiscoveryConfig.IntervalSec of now(). NULL os_discovered_at MUST be treated as due (never-discovered hosts)'
+      description: 'listDiscoveryTargets MUST WHERE-out (a) deleted_at IS NOT NULL hosts, (b) hosts in effective maintenance (per-host OR per-group, via the host_effective_maintenance view — migration 0049), AND (c) hosts whose hosts.os_discovered_at is within DiscoveryConfig.IntervalSec of now(). NULL os_discovered_at MUST be treated as due (never-discovered hosts)'
       type: technical
       enforcement: error
     - id: C-03

--- a/specs/system/intelligence-scheduler.spec.yaml
+++ b/specs/system/intelligence-scheduler.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-intelligence-scheduler
   title: OS Intelligence recurring scheduler loop
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -39,9 +39,10 @@ spec:
       successful cycle. NULL means "due immediately" (first contact),
       matching the host_liveness.next_probe_at convention.
 
-      Maintenance: respects the existing hosts.maintenance_mode flag
-      from system-liveness-loop v1.3.0 the same way the liveness loop
-      does — maintenance hosts are excluded from listProbeTargets.
+      Maintenance: respects effective maintenance the same way the
+      liveness loop does — a host paused per-host (hosts.maintenance_mode)
+      OR per-group (a maintenance group it belongs to), resolved via the
+      host_effective_maintenance view, is excluded from listIntelTargets.
 
     related_specs:
       - system-os-intelligence
@@ -80,7 +81,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-02
-      description: 'listIntelTargets MUST WHERE-out (a) deleted_at IS NOT NULL hosts, (b) hosts.maintenance_mode = true, (c) host_backoff_state.suppress_until > now() rows (for probe_type=''intel''), AND (d) hosts whose host_intelligence_state.next_intelligence_at is in the future. NULL next_intelligence_at MUST be treated as due (first-cycle hosts)'
+      description: 'listIntelTargets MUST WHERE-out (a) deleted_at IS NOT NULL hosts, (b) hosts in effective maintenance (per-host OR per-group, via the host_effective_maintenance view — migration 0049), (c) host_backoff_state.suppress_until > now() rows (for probe_type=''intel''), AND (d) hosts whose host_intelligence_state.next_intelligence_at is in the future. NULL next_intelligence_at MUST be treated as due (first-cycle hosts)'
       type: technical
       enforcement: error
     - id: C-03

--- a/specs/system/liveness-loop.spec.yaml
+++ b/specs/system/liveness-loop.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-liveness-loop
   title: Host liveness probe loop
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 1
 
@@ -128,7 +128,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-20
-      description: Tick ordering (v1.3.0) — listProbeTargets MUST ORDER BY hosts.check_priority DESC, hl.next_probe_at ASC NULLS FIRST. Critical hosts get drained before stable ones when a tick can't probe every due host. Per-host maintenance_mode=true MUST exclude the host from the tick entirely (no probe, no audit, no history row)
+      description: Tick ordering (v1.3.0) — listProbeTargets MUST ORDER BY hosts.check_priority DESC, hl.next_probe_at ASC NULLS FIRST. Critical hosts get drained before stable ones when a tick can't probe every due host. A host in effective maintenance (per-host or per-group, via host_effective_maintenance) MUST be excluded from the tick entirely (no probe, no audit, no history row)
       type: technical
       enforcement: error
     - id: C-21
@@ -269,7 +269,7 @@ spec:
       priority: critical
       references_constraints: [C-18]
     - id: AC-33
-      description: hosts.maintenance_mode=true causes the row to be excluded from listProbeTargets. No probe runs, no history row appends, no audit fires. Setting maintenance_mode=false on the next tick puts the host back in rotation at its prior monitoring_state.
+      description: 'v1.4.0 - a host in effective maintenance is excluded from listProbeTargets, resolved via the host_effective_maintenance view (migration 0049): per-host (hosts.maintenance_mode) OR per-group (a group with maintenance=true it belongs to). No probe runs, no history row appends, no audit fires. Clearing maintenance puts the host back in rotation at its prior monitoring_state on the next tick.'
       priority: critical
       references_constraints: [C-20]
     - id: AC-34

--- a/specs/system/scheduler.spec.yaml
+++ b/specs/system/scheduler.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-scheduler
   title: Adaptive compliance scheduler
-  version: "3.0.0"
+  version: "3.1.0"
   status: approved
   tier: 1
 
@@ -91,7 +91,7 @@ spec:
       type: business
       enforcement: error
     - id: C-05
-      description: Maintenance mode MUST block dispatch; row's next_scheduled_scan still advances on the next tick after maintenance_until
+      description: 'v3.1.0 - A host in EFFECTIVE maintenance MUST be excluded from dispatch, resolved via the host_effective_maintenance view (migration 0049): per-host (hosts.maintenance_mode, the host-detail toggle) OR per-group (a group with maintenance=true the host belongs to, manual member or auto os_family match). Maintenance is an explicit operator toggle with no auto-expiry; the host resumes on the next tick once maintenance clears. The dispatcher MUST NOT read host_compliance_schedule.maintenance_mode (a legacy column the API never wrote, so it enforced nothing).'
       type: technical
       enforcement: error
     - id: C-06
@@ -137,11 +137,11 @@ spec:
       priority: critical
       references_constraints: [C-02]
     - id: AC-04
-      description: Dispatcher's SELECT uses FOR UPDATE SKIP LOCKED; two concurrent tick processes dispatch disjoint hosts.
+      description: Dispatcher's SELECT uses FOR UPDATE ... SKIP LOCKED (locking only the schedule rows, FOR UPDATE OF s); two concurrent tick processes dispatch disjoint hosts.
       priority: critical
       references_constraints: [C-03]
     - id: AC-05
-      description: A row with maintenance_mode=true is skipped by the dispatcher; next_scheduled_scan still updates on the next tick after maintenance_until passes.
+      description: 'v3.1.0 - A host in effective maintenance is skipped by the dispatcher even when due, whether the maintenance is per-host (hosts.maintenance_mode=true) or per-group (member of a group with maintenance=true); enforcement resolves through the host_effective_maintenance view. The skipped host''s schedule row is not advanced, so it resumes once maintenance clears.'
       priority: high
       references_constraints: [C-05]
     - id: AC-06


### PR DESCRIPTION
## Summary

A pre-release review of the `/settings/scanning` page and the maintenance-mode buttons on `/settings/scanning`, `/hosts/<id>`, and `/groups` surfaced two real enforcement defects plus a cosmetic issue. This fixes all three.

## Defects fixed

**1. Per-host maintenance did not stop compliance scans.** The host-detail toggle writes `hosts.maintenance_mode`, but the scan dispatcher filtered a *different* column — `host_compliance_schedule.maintenance_mode` — that no code path ever set. So a host put in maintenance kept getting compliance-scanned, contradicting the button's own tooltip ("Pause scans & alerts"). The connectivity/intelligence/discovery loops honored the per-host flag; only the scan scheduler was blind to it.

**2. Per-group maintenance enforced nothing.** `POST /groups/{id}:maintenance` set `groups.maintenance`, but no scheduler or probe loop read it — the flag only moved a number on the summary tile. The migration comment claiming it "pauses scanning/alerting for a group's hosts" was aspirational.

## Approach — one source of truth

New DB view **`host_effective_maintenance(host_id, in_maintenance)`** (migration 0049) unions both scopes:
- per-host: `hosts.maintenance_mode`
- per-group: membership in any `maintenance=true` group (manual `group_members` OR auto `os_family` match — mirrors `group.Service.Summary`)

All four scheduler/probe loops now JOIN the view and skip a host when `in_maintenance`:
- compliance scan dispatcher (`internal/scheduler/service.go`) + schedule preview (`readviews.go`)
- connectivity/liveness probe (`internal/liveness/service.go`)
- intelligence scheduler (`internal/intelligence/scheduler/service.go`)
- OS discovery scheduler (`internal/intelligence/discovery/scheduler/service.go`) + manual sweep

Centralizing the predicate in one view is deliberate: the original bug came from two identically-named columns, one of them dead. Now there is exactly one definition of "effective maintenance," so per-host and per-group behave identically everywhere.

The dead `host_compliance_schedule.maintenance_mode` / `maintenance_until` columns are left in place (dropping them is a separate cleanup) but are no longer read.

## Cosmetic — "Wired" badge

The OS discovery and OS Intelligence sections on `/settings/scanning` showed a static **"Wired"** badge — a developer build-status label that never changed. Replaced with a dynamic **Running / Paused** badge driven by `maintenance_global`, matching the Compliance scanner and Connectivity monitor sections. (The two "Running" badges already there are dynamic and were left as-is.)

## SDD

- The `host_effective_maintenance` view is documented across the touched specs. Spec version bumps: `system-scheduler` 3.0.0→3.1.0 (AC-05/C-05 rewritten to effective maintenance), `system-liveness-loop` 1.3.0→1.4.0, `system-intelligence-scheduler` 1.0.0→1.1.0, `system-discovery-scheduler` 1.0.0→1.1.0, `api-groups` 1.0.0→1.1.0 (enforcement now real, context corrected), `api-system-scan-config` 1.2.0→1.3.0 (preview AC-07 excludes effective-maintenance hosts), `frontend-settings-intelligence-config` 1.1.0→1.2.0 (AC-11 + C-10), `frontend-settings-discovery-config` 1.0.0→1.1.0 (AC-09 + C-08).
- Tests: scheduler AC-05 now proves BOTH per-host and per-group skip dispatch; the intelligence loop test adds a per-group host (second independent proof of the group path); liveness source-inspection updated to assert the view JOIN; two new frontend tests assert the dynamic badge (Running/Paused, no "Wired").

## Verification

- `gofmt`, `go vet ./...`, `go build ./...` — clean
- Affected DB packages (scheduler, liveness, intelligence, group, server) pass under `-p 4`
- `specter check` (115 specs), `check --test` (0 errors), `coverage --strictness annotation` (115/115, 100%)
- Frontend `tsc --noEmit` clean; full vitest suite 353/353

## Scope note

Global maintenance (`maintenance_global`, four config surfaces) was already fully wired and is unchanged. Independent of the open Kensa-bump PR #729.
