### PR TITLE
feat(settings): SMTP encryption modes + severity threshold; profile self-edit

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -121,6 +121,41 @@ paths:
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    patch:
+      operationId: patchAuthMe
+      summary: Update the calling user's own profile
+      description: >-
+        Self-service profile edit for the authenticated user. The body is a
+        partial: present fields are updated, omitted fields are unchanged.
+        Changing email (the sign-in identity) is allowed but must be unique
+        among active users (409 on conflict). Username, role, and password
+        are NOT editable here (password uses /auth/password:change).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/AuthMeUpdateRequest'}
+      responses:
+        '200':
+          description: Updated identity
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/AuthMeResponse'}
+        '400':
+          description: Malformed body or invalid field
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '401':
+          description: No valid session or bearer
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '409':
+          description: Email already in use by another active user
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
   /api/v1/users/me/preferences:
     get:
@@ -4189,6 +4224,25 @@ components:
         username: {type: string}
         email:    {type: string}
         role:     {type: string}
+        full_name:    {type: string, description: Editable profile field (may be empty)}
+        display_name: {type: string, description: Editable profile field (may be empty)}
+        job_title:    {type: string, description: Editable profile field (may be empty)}
+        timezone:     {type: string, description: IANA timezone, editable (may be empty)}
+        phone:        {type: string, description: Editable profile field (may be empty)}
+
+    AuthMeUpdateRequest:
+      type: object
+      description: >-
+        Partial self-profile update. Every field is optional; a present field
+        replaces the stored value (empty string clears it). Omitted fields are
+        left unchanged.
+      properties:
+        email:        {type: string, description: Sign-in identity; must be unique among active users}
+        full_name:    {type: string, maxLength: 256}
+        display_name: {type: string, maxLength: 256}
+        job_title:    {type: string, maxLength: 256}
+        timezone:     {type: string, maxLength: 64}
+        phone:        {type: string, maxLength: 64}
 
     # Per-user UI preferences (system-user-preferences). Every field is
     # optional: GET returns only the keys the user has set, and PATCH treats
@@ -4281,6 +4335,7 @@ components:
           additionalProperties: {type: string}
           description: Alert tags this channel matches; empty = every alert
         smtp_port: {type: integer, nullable: true, description: SMTP port (email channels)}
+        smtp_encryption: {type: string, nullable: true, description: SMTP transport security (email channels) - none|starttls|tls}
         from:      {type: string, nullable: true, description: Sender address (email channels)}
         to:
           type: array
@@ -4343,6 +4398,15 @@ components:
           description: Optional bearer token for webhook auth. Stored encrypted.
         smtp_host: {type: string, description: SMTP relay host (email). Stored encrypted.}
         smtp_port: {type: integer, description: SMTP relay port (email), e.g. 587.}
+        smtp_encryption:
+          type: string
+          enum: [none, starttls, tls]
+          description: >-
+            Transport security for the SMTP connection (email). 'starttls'
+            (default) connects plaintext then requires a STARTTLS upgrade;
+            'tls' uses implicit TLS from connect (SMTPS, e.g. port 465);
+            'none' is plaintext for a trusted local relay. Omitted defaults
+            to starttls.
         username:  {type: string, description: SMTP auth username (email). Stored encrypted.}
         password:  {type: string, description: SMTP auth password (email). Stored encrypted.}
         from:      {type: string, description: Envelope From address (email).}
@@ -4367,6 +4431,7 @@ components:
         token:     {type: string}
         smtp_host: {type: string}
         smtp_port: {type: integer}
+        smtp_encryption: {type: string, enum: [none, starttls, tls]}
         username:  {type: string}
         password:  {type: string}
         from:      {type: string}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -89,7 +89,11 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update the calling user's own profile
+         * @description Self-service profile edit for the authenticated user. The body is a partial: present fields are updated, omitted fields are unchanged. Changing email (the sign-in identity) is allowed but must be unique among active users (409 on conflict). Username, role, and password are NOT editable here (password uses /auth/password:change).
+         */
+        patch: operations["patchAuthMe"];
         trace?: never;
     };
     "/api/v1/users/me/preferences": {
@@ -2642,6 +2646,26 @@ export interface components {
             username: string;
             email: string;
             role: string;
+            /** @description Editable profile field (may be empty) */
+            full_name?: string;
+            /** @description Editable profile field (may be empty) */
+            display_name?: string;
+            /** @description Editable profile field (may be empty) */
+            job_title?: string;
+            /** @description IANA timezone */
+            timezone?: string;
+            /** @description Editable profile field (may be empty) */
+            phone?: string;
+        };
+        /** @description Partial self-profile update. Every field is optional; a present field replaces the stored value (empty string clears it). Omitted fields are left unchanged. */
+        AuthMeUpdateRequest: {
+            /** @description Sign-in identity; must be unique among active users */
+            email?: string;
+            full_name?: string;
+            display_name?: string;
+            job_title?: string;
+            timezone?: string;
+            phone?: string;
         };
         UserPreferences: {
             /** @enum {string} */
@@ -2707,6 +2731,8 @@ export interface components {
             };
             /** @description SMTP port (email channels) */
             smtp_port?: number | null;
+            /** @description SMTP transport security (email channels) - none|starttls|tls */
+            smtp_encryption?: string | null;
             /** @description Sender address (email channels) */
             from?: string | null;
             /** @description Recipient addresses (email channels) */
@@ -2767,6 +2793,11 @@ export interface components {
             smtp_host?: string;
             /** @description SMTP relay port (email) */
             smtp_port?: number;
+            /**
+             * @description Transport security for the SMTP connection (email). 'starttls' (default) connects plaintext then requires a STARTTLS upgrade; 'tls' uses implicit TLS from connect (SMTPS, e.g. port 465); 'none' is plaintext for a trusted local relay. Omitted defaults to starttls.
+             * @enum {string}
+             */
+            smtp_encryption?: "none" | "starttls" | "tls";
             /** @description SMTP auth username (email). Stored encrypted. */
             username?: string;
             /** @description SMTP auth password (email). Stored encrypted. */
@@ -2787,6 +2818,8 @@ export interface components {
             token?: string;
             smtp_host?: string;
             smtp_port?: number;
+            /** @enum {string} */
+            smtp_encryption?: "none" | "starttls" | "tls";
             username?: string;
             password?: string;
             from?: string;
@@ -4539,6 +4572,57 @@ export interface operations {
             };
             /** @description No valid session or bearer */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    patchAuthMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthMeUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated identity */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthMeResponse"];
+                };
+            };
+            /** @description Malformed body or invalid field */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description No valid session or bearer */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Email already in use by another active user */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/pages/settings/NotificationsPage.tsx
+++ b/frontend/src/pages/settings/NotificationsPage.tsx
@@ -25,7 +25,7 @@ type Channel = components['schemas']['NotificationChannel'];
 // Settings -> Notifications.
 //
 // CRUD + test for operator-managed alert-delivery channels (Slack /
-// webhook) over /api/v1/notifications/channels. Secrets (url/token) are
+// webhook / email-SMTP) over /api/v1/notifications/channels. Secrets are
 // write-only: the API never returns them, so the list shows the
 // non-secret target_hint. Gated on notification:read; write/delete/test
 // controls gate on their own permissions.
@@ -45,10 +45,14 @@ const inputStyle = {
   width: '100%',
 } as const;
 
+// Threshold semantics: the value is the MINIMUM severity delivered — the
+// backend (matchesTags) delivers that level and everything more severe.
 const SEVERITY_OPTIONS = [
   { value: '', label: 'All alerts (no filter)' },
-  { value: 'critical', label: 'Critical only' },
+  { value: 'low', label: 'Low and above' },
+  { value: 'medium', label: 'Medium and above' },
   { value: 'high', label: 'High and above' },
+  { value: 'critical', label: 'Critical only' },
 ];
 
 export function NotificationsPage() {
@@ -83,7 +87,7 @@ export function NotificationsPage() {
     <SettingsLayout>
       <PageHead
         title="Notifications"
-        description="Deliver fired alerts to Slack or a webhook. Targets are stored encrypted and never shown again."
+        description="Deliver fired alerts to Slack, a webhook, or email (SMTP). Scope each channel by minimum severity. Targets are stored encrypted and never shown again."
         actions={
           <Btn variant="primary" disabled={!canWrite} onClick={() => setAddOpen(true)}>
             <Plus size={14} /> Add channel
@@ -101,7 +105,7 @@ export function NotificationsPage() {
             </div>
           ) : channels.length === 0 ? (
             <div style={{ ...pad, textAlign: 'center' }}>
-              No channels yet. Add a Slack or webhook channel to start receiving alerts.
+              No channels yet. Add a Slack, webhook, or email channel to start receiving alerts.
             </div>
           ) : (
             channels.map((c, i) => (
@@ -262,6 +266,10 @@ function ChannelModal({
   const isEmail = channel?.type === 'email';
   const [smtpHost, setSmtpHost] = useState(isEmail ? (channel?.target_hint ?? '') : '');
   const [smtpPort, setSmtpPort] = useState(channel?.smtp_port ? String(channel.smtp_port) : '587');
+  // Transport security. Empty/legacy channels default to STARTTLS.
+  const [smtpEncryption, setSmtpEncryption] = useState<'none' | 'starttls' | 'tls'>(
+    (channel?.smtp_encryption as 'none' | 'starttls' | 'tls') ?? 'starttls',
+  );
   const [username, setUsername] = useState(channel?.username ?? '');
   const [password, setPassword] = useState('');
   const [from, setFrom] = useState(channel?.from ?? '');
@@ -281,6 +289,7 @@ function ChannelModal({
       return {
         smtp_host: smtpHost,
         smtp_port: Number(smtpPort) || 0,
+        smtp_encryption: smtpEncryption,
         from,
         to: to
           .split(',')
@@ -396,6 +405,18 @@ function ChannelModal({
               </FormField>
             </div>
           </div>
+          <FormField label="Encryption">
+            <Select
+              value={smtpEncryption}
+              onChange={(v) => setSmtpEncryption(v as 'none' | 'starttls' | 'tls')}
+              ariaLabel="SMTP encryption"
+              options={[
+                { value: 'starttls', label: 'STARTTLS (upgrade on 25 / 587)' },
+                { value: 'tls', label: 'TLS (implicit, port 465)' },
+                { value: 'none', label: 'None (plaintext relay)' },
+              ]}
+            />
+          </FormField>
           <FormField label="Username (optional)">
             <input
               style={inputStyle}

--- a/frontend/src/pages/settings/ProfilePage.tsx
+++ b/frontend/src/pages/settings/ProfilePage.tsx
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { SettingsLayout } from '@/components/settings/SettingsLayout';
@@ -24,15 +25,13 @@ import {
 // Settings → Profile (wired to backend).
 //
 // Backend wires:
-//   • GET /api/v1/auth/me              — profile read
+//   • GET   /api/v1/auth/me             — profile read (prefills the form)
+//   • PATCH /api/v1/auth/me             — profile edit (full name, display
+//                                         name, email, job title, timezone,
+//                                         phone). Email must be unique (409).
 //   • POST /api/v1/auth/password:change — password update
-//   • POST /api/v1/auth/mfa:enroll     — MFA enrollment start
-//   • POST /api/v1/auth/mfa:verify     — MFA enrollment confirmation
-//
-// Profile-edit fields (full name, display name, job title, timezone,
-// phone) are RENDERED but not POSTed — backend has no
-// PATCH /auth/me endpoint yet. Edits stay in local form state; a
-// follow-up wires PATCH when the endpoint lands.
+//   • POST /api/v1/auth/mfa:enroll      — MFA enrollment start
+//   • POST /api/v1/auth/mfa:verify      — MFA enrollment confirmation
 
 const passwordSchema = z
   .object({
@@ -82,15 +81,71 @@ export function ProfilePage() {
 }
 
 function ProfileSection() {
+  const queryClient = useQueryClient();
   const identity = useAuthStore((s) => s.identity);
-  const [fullName, setFullName] = useState(identity?.username ?? '');
-  const [displayName, setDisplayName] = useState(identity?.username ?? '');
-  const [email, setEmail] = useState(identity?.email ?? '');
+  const setIdentity = useAuthStore((s) => s.setIdentity);
+  const [banner, setBanner] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  const meQuery = useQuery({
+    queryKey: ['auth-me'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/auth/me');
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load profile'));
+      return data!;
+    },
+  });
+  const me = meQuery.data;
+
+  const [fullName, setFullName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
   const [jobTitle, setJobTitle] = useState('');
   const [tz, setTz] = useState('UTC');
   const [phone, setPhone] = useState('');
 
-  const initials = (identity?.username ?? identity?.email ?? '?')
+  // Sync the form from server truth on load and after a save.
+  useEffect(() => {
+    if (!me) return;
+    setFullName(me.full_name ?? '');
+    setDisplayName(me.display_name ?? '');
+    setEmail(me.email ?? '');
+    setJobTitle(me.job_title ?? '');
+    setTz(me.timezone || 'UTC');
+    setPhone(me.phone ?? '');
+  }, [me]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const { data, error, response } = await api.PATCH('/api/v1/auth/me', {
+        body: {
+          email,
+          full_name: fullName,
+          display_name: displayName,
+          job_title: jobTitle,
+          timezone: tz,
+          phone,
+        },
+      });
+      if (!response.ok) {
+        const code = (error as { error?: { code?: string } } | undefined)?.error?.code;
+        if (code === 'users.email_taken') {
+          throw new Error('That email is already in use by another account.');
+        }
+        throw new Error(apiErrorMessage(error, 'Failed to save profile'));
+      }
+      return data!;
+    },
+    onSuccess: (data) => {
+      setBanner({ kind: 'success', text: 'Profile saved.' });
+      queryClient.setQueryData(['auth-me'], data);
+      // Keep the app shell's identity (avatar/email) in step.
+      if (identity) setIdentity({ ...identity, email: data.email });
+    },
+    onError: (e: Error) => setBanner({ kind: 'error', text: e.message }),
+  });
+
+  const displayNameForHeader = me?.username ?? identity?.username ?? '—';
+  const initials = (me?.username ?? me?.email ?? '?')
     .split(/[\s._-]/)
     .map((s) => s[0]?.toUpperCase() ?? '')
     .slice(0, 2)
@@ -124,13 +179,13 @@ function ProfileSection() {
             {initials}
           </div>
           <div style={{ flex: 1 }}>
-            <div style={{ fontWeight: 600, fontSize: 16 }}>{identity?.username ?? '—'}</div>
+            <div style={{ fontWeight: 600, fontSize: 16 }}>{displayNameForHeader}</div>
             <div style={{ color: 'var(--ow-fg-2)', fontSize: 13, marginTop: 2 }}>
-              {identity?.email ?? ''}
-              {identity?.role && (
+              {me?.email ?? identity?.email ?? ''}
+              {me?.role && (
                 <>
                   <span style={{ color: 'var(--ow-fg-3)', margin: '0 6px' }}>·</span>
-                  <span style={{ textTransform: 'capitalize' }}>{identity.role}</span>
+                  <span style={{ textTransform: 'capitalize' }}>{me.role}</span>
                 </>
               )}
             </div>
@@ -181,16 +236,31 @@ function ProfileSection() {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            color: 'var(--ow-fg-3)',
             fontSize: 12,
           }}
         >
-          <span>
-            Profile edits aren't saved yet — backend{' '}
-            <code style={{ fontFamily: 'var(--ow-font-mono)' }}>PATCH /auth/me</code> pending.
+          <span
+            role={banner ? 'status' : undefined}
+            style={{
+              color:
+                banner?.kind === 'success'
+                  ? 'var(--ow-ok)'
+                  : banner?.kind === 'error'
+                    ? 'var(--ow-crit)'
+                    : 'var(--ow-fg-3)',
+            }}
+          >
+            {banner?.text ?? 'Changes apply to your account and are visible to other members.'}
           </span>
-          <Btn variant="primary" disabled>
-            Save changes
+          <Btn
+            variant="primary"
+            disabled={!me || meQuery.isLoading || mutation.isPending}
+            onClick={() => {
+              setBanner(null);
+              mutation.mutate();
+            }}
+          >
+            {mutation.isPending ? 'Saving…' : 'Save changes'}
           </Btn>
         </div>
       </SettingCard>

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -112,13 +112,13 @@ describe('frontend-settings — structural', () => {
   });
 
   // @ac AC-04
-  test('frontend-settings/AC-04 — Profile reads identity from useAuthStore + Save aria-disabled', () => {
+  test('frontend-settings/AC-04 — Profile prefills from GET /auth/me and saves via PATCH /auth/me', () => {
     expect(PROFILE_SRC).toMatch(/useAuthStore/);
-    expect(PROFILE_SRC).toMatch(/identity/);
-    // The Save-changes button is disabled because PATCH /auth/me is
-    // not wired yet. The disabled prop and "Save changes" label sit on
-    // adjacent lines — match across whitespace.
-    expect(PROFILE_SRC).toMatch(/disabled\s*>\s*Save changes/);
+    // Prefill from GET /auth/me and persist edits via PATCH /auth/me.
+    expect(PROFILE_SRC).toMatch(/api\.GET\(\s*['"]\/api\/v1\/auth\/me['"]/);
+    expect(PROFILE_SRC).toMatch(/api\.PATCH\(\s*['"]\/api\/v1\/auth\/me['"]/);
+    // Save is no longer a permanently-disabled stub.
+    expect(PROFILE_SRC).not.toMatch(/disabled\s*>\s*Save changes/);
   });
 
   // @ac AC-05
@@ -373,6 +373,14 @@ describe('frontend-settings — structural', () => {
     expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:write'\)/);
     expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:delete'\)/);
     expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:test'\)/);
+    // Email channels expose an SMTP encryption selector (none/starttls/tls)
+    // and send smtp_encryption in the config.
+    expect(NOTIF_SRC).toMatch(/smtp_encryption/);
+    expect(NOTIF_SRC).toContain("'starttls'");
+    expect(NOTIF_SRC).toContain("'tls'");
+    // Severity delivery is threshold-based (minimum level), not two presets.
+    expect(NOTIF_SRC).toMatch(/Medium and above/);
+    expect(NOTIF_SRC).toMatch(/High and above/);
   });
 
   // @ac AC-24

--- a/internal/db/migrations/0050_user_profile_fields.sql
+++ b/internal/db/migrations/0050_user_profile_fields.sql
@@ -1,0 +1,30 @@
+-- 0050_user_profile_fields.sql
+--
+-- Self-service profile fields on the users table. The Settings -> Profile
+-- page renders full name, display name, job title, timezone, and phone, but
+-- until now had nowhere to store them (the users table held only the
+-- sign-in identity + auth material), so the "Save changes" button was a
+-- no-op. These columns back the new PATCH /api/v1/auth/me endpoint.
+--
+-- All are non-secret free text, nullable-by-default via an empty-string
+-- default (keeps the columns NOT NULL so reads never see NULL). Email stays
+-- where it is (it is the sign-in identity with its own unique index); the
+-- PATCH endpoint updates users.email directly with a uniqueness check.
+--
+-- Spec: api-auth (patchAuthMe) + system-user-management.
+
+-- +goose Up
+ALTER TABLE users
+    ADD COLUMN full_name    TEXT NOT NULL DEFAULT '',
+    ADD COLUMN display_name TEXT NOT NULL DEFAULT '',
+    ADD COLUMN job_title    TEXT NOT NULL DEFAULT '',
+    ADD COLUMN timezone     TEXT NOT NULL DEFAULT '',
+    ADD COLUMN phone        TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE users
+    DROP COLUMN full_name,
+    DROP COLUMN display_name,
+    DROP COLUMN job_title,
+    DROP COLUMN timezone,
+    DROP COLUMN phone;

--- a/internal/notification/delivery.go
+++ b/internal/notification/delivery.go
@@ -102,23 +102,91 @@ func deliver(ctx context.Context, client *http.Client, ch Channel, a alertrouter
 	return deliverHTTP(ctx, client, ch, a)
 }
 
-// deliverEmail sends the alert via SMTP. smtp.SendMail upgrades to
-// STARTTLS when the relay offers it, and PlainAuth refuses to send the
-// credential over an unencrypted connection to a non-localhost host — the
-// secure default. Auth is omitted when no username is configured.
+// deliverEmail sends the alert via SMTP using the channel's configured
+// encryption mode (see sendSMTP). Auth is omitted when no username is set.
 func deliverEmail(ch Channel, a alertrouter.Alert) error {
-	cfg := ch.Config
-	addr := net.JoinHostPort(cfg.SMTPHost, strconv.Itoa(cfg.SMTPPort))
-	var auth smtp.Auth
-	if cfg.Username != "" {
-		auth = smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.SMTPHost)
-	}
 	subject := fmt.Sprintf("[OpenWatch] [%s] %s", a.Severity, a.Title)
-	msg := buildEmailMessage(cfg.From, cfg.To, subject, a.Body)
-	if err := smtp.SendMail(addr, auth, cfg.From, cfg.To, msg); err != nil {
+	msg := buildEmailMessage(ch.Config.From, ch.Config.To, subject, a.Body)
+	if err := sendSMTP(ch.Config, ch.Config.From, ch.Config.To, msg); err != nil {
 		return fmt.Errorf("notification: email send via %q: %w", ch.Name, err)
 	}
 	return nil
+}
+
+// smtpDialTimeout bounds the TCP connect + TLS handshake for a relay.
+const smtpDialTimeout = 10 * time.Second
+
+// sendSMTP delivers a pre-rendered RFC 5322 message to the relay in cfg,
+// honoring cfg.SMTPEncryption:
+//
+//   - "tls":      implicit TLS from connect (SMTPS, typically port 465).
+//   - "starttls": connect plaintext, then REQUIRE a STARTTLS upgrade — the
+//     send fails rather than silently downgrading to plaintext.
+//     This is the default when the mode is empty.
+//   - "none":     plaintext, no encryption (a trusted local relay).
+//
+// PlainAuth is used only when a username is set. The relay host is NOT
+// SSRF-restricted (internal relays are legitimate); TLS + auth protect the
+// credential. net/smtp.SendMail is deliberately not used: it cannot do
+// implicit TLS (465) and only does opportunistic (downgradeable) STARTTLS.
+func sendSMTP(cfg Config, from string, to []string, msg []byte) error {
+	if len(to) == 0 {
+		return fmt.Errorf("smtp: no recipients")
+	}
+	addr := net.JoinHostPort(cfg.SMTPHost, strconv.Itoa(cfg.SMTPPort))
+	mode := NormalizeSMTPEncryption(cfg.SMTPEncryption)
+	tlsCfg := &tls.Config{ServerName: cfg.SMTPHost, MinVersion: tls.VersionTLS12}
+	dialer := &net.Dialer{Timeout: smtpDialTimeout}
+
+	var conn net.Conn
+	var err error
+	if mode == SMTPEncTLS {
+		conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsCfg)
+	} else {
+		conn, err = dialer.Dial("tcp", addr)
+	}
+	if err != nil {
+		return fmt.Errorf("smtp: dial %s: %w", addr, err)
+	}
+	client, err := smtp.NewClient(conn, cfg.SMTPHost)
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("smtp: client: %w", err)
+	}
+	defer client.Close()
+
+	if mode == SMTPEncSTARTTLS {
+		if ok, _ := client.Extension("STARTTLS"); !ok {
+			return fmt.Errorf("smtp: relay %s does not offer STARTTLS (set encryption to 'none' to allow plaintext)", cfg.SMTPHost)
+		}
+		if err := client.StartTLS(tlsCfg); err != nil {
+			return fmt.Errorf("smtp: starttls: %w", err)
+		}
+	}
+	if cfg.Username != "" {
+		if err := client.Auth(smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.SMTPHost)); err != nil {
+			return fmt.Errorf("smtp: auth: %w", err)
+		}
+	}
+	if err := client.Mail(from); err != nil {
+		return fmt.Errorf("smtp: mail from: %w", err)
+	}
+	for _, rcpt := range to {
+		if err := client.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("smtp: rcpt %s: %w", rcpt, err)
+		}
+	}
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("smtp: data: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("smtp: write: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("smtp: close data: %w", err)
+	}
+	return client.Quit()
 }
 
 // buildEmailMessage assembles a minimal RFC 5322 message.
@@ -163,13 +231,28 @@ func deliverHTTP(ctx context.Context, client *http.Client, ch Channel, a alertro
 	return nil
 }
 
-// matchesTags mirrors alertrouter.ChannelRegistration.matches: an empty
-// filter is a wildcard; otherwise every key/value must be present.
+// matchesTags decides whether a channel receives an alert. An empty
+// filter is a wildcard. The reserved "severity" key uses THRESHOLD
+// semantics — the channel receives the alert when its severity is at
+// least as high as the filter value (e.g. filter "high" delivers both
+// high and critical) — via alertrouter.SeverityOrder (critical=0 is most
+// severe). Every other key is an exact match. This is what lets an email
+// channel be scoped to "this level and above" rather than one exact level.
 func matchesTags(filter, alertTags map[string]string) bool {
 	if len(filter) == 0 {
 		return true
 	}
 	for k, v := range filter {
+		if k == "severity" {
+			ar, aok := alertrouter.SeverityOrder[alertrouter.Severity(alertTags[k])]
+			fr, fok := alertrouter.SeverityOrder[alertrouter.Severity(v)]
+			if aok && fok {
+				if ar > fr { // alert is LESS severe than the threshold
+					return false
+				}
+				continue
+			}
+		}
 		if alertTags[k] != v {
 			return false
 		}

--- a/internal/notification/delivery_test.go
+++ b/internal/notification/delivery_test.go
@@ -6,6 +6,7 @@ package notification
 
 import (
 	"net"
+	"os"
 	"strings"
 	"testing"
 
@@ -70,25 +71,72 @@ func TestIsBlockedIPAndDialControl(t *testing.T) {
 // @ac AC-05
 func TestMatchesTags(t *testing.T) {
 	t.Run("system-notifications/AC-05", func(t *testing.T) {
-		alertTags := map[string]string{"severity": "critical", "alert_type": "drift"}
-		// Empty filter = wildcard.
-		if !matchesTags(map[string]string{}, alertTags) {
+		critical := map[string]string{"severity": "critical", "alert_type": "drift"}
+		medium := map[string]string{"severity": "medium", "alert_type": "drift"}
+		// Empty/nil filter = wildcard.
+		if !matchesTags(map[string]string{}, critical) {
 			t.Error("empty filter should match")
 		}
-		if !matchesTags(nil, alertTags) {
+		if !matchesTags(nil, critical) {
 			t.Error("nil filter should match")
 		}
-		// Matching subset.
-		if !matchesTags(map[string]string{"severity": "critical"}, alertTags) {
-			t.Error("matching subset should match")
+		// The reserved "severity" key is a THRESHOLD (this level and above),
+		// not exact-match: a lower/equal threshold delivers a more-severe alert.
+		if !matchesTags(map[string]string{"severity": "critical"}, critical) {
+			t.Error("critical threshold should match a critical alert")
 		}
-		// Non-matching value.
-		if matchesTags(map[string]string{"severity": "info"}, alertTags) {
-			t.Error("non-matching value should not match")
+		if !matchesTags(map[string]string{"severity": "info"}, critical) {
+			t.Error("info threshold ('info and above') should match a critical alert")
 		}
-		// Key absent in alert.
-		if matchesTags(map[string]string{"team": "secops"}, alertTags) {
-			t.Error("absent key should not match")
+		if !matchesTags(map[string]string{"severity": "high"}, critical) {
+			t.Error("high threshold should match the more-severe critical alert")
+		}
+		if matchesTags(map[string]string{"severity": "critical"}, medium) {
+			t.Error("critical threshold should NOT match the less-severe medium alert")
+		}
+		// Non-severity keys stay EXACT match.
+		if matchesTags(map[string]string{"team": "secops"}, critical) {
+			t.Error("absent exact-match key should not match")
+		}
+		if matchesTags(map[string]string{"alert_type": "scan"}, critical) {
+			t.Error("mismatched exact-match key should not match")
+		}
+	})
+}
+
+// @ac AC-21
+// AC-21: SMTP encryption modes. NormalizeSMTPEncryption maps empty/unknown
+// to the secure STARTTLS default and passes through none/tls; sendSMTP
+// implements implicit TLS (tls.DialWithDialer) for "tls", a REQUIRED
+// STARTTLS upgrade for "starttls" (no silent plaintext downgrade), and
+// plaintext for "none".
+func TestSMTPEncryptionModes(t *testing.T) {
+	t.Run("system-notifications/AC-21", func(t *testing.T) {
+		cases := map[string]string{
+			"":              SMTPEncSTARTTLS,
+			"bogus":         SMTPEncSTARTTLS,
+			SMTPEncNone:     SMTPEncNone,
+			SMTPEncTLS:      SMTPEncTLS,
+			SMTPEncSTARTTLS: SMTPEncSTARTTLS,
+		}
+		for in, want := range cases {
+			if got := NormalizeSMTPEncryption(in); got != want {
+				t.Errorf("NormalizeSMTPEncryption(%q) = %q, want %q", in, got, want)
+			}
+		}
+		src, err := os.ReadFile("delivery.go")
+		if err != nil {
+			t.Fatalf("read delivery.go: %v", err)
+		}
+		s := string(src)
+		for _, needle := range []string{
+			"tls.DialWithDialer",      // implicit TLS (port 465)
+			"client.StartTLS",         // STARTTLS upgrade
+			"does not offer STARTTLS", // required — fail rather than downgrade
+		} {
+			if !strings.Contains(s, needle) {
+				t.Errorf("sendSMTP must contain %q for encryption-mode handling", needle)
+			}
 		}
 	})
 }

--- a/internal/notification/report_email.go
+++ b/internal/notification/report_email.go
@@ -14,10 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"mime/multipart"
-	"net"
-	"net/smtp"
 	"net/textproto"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -42,12 +39,9 @@ func (s *Service) SendReportEmail(ctx context.Context, channelID uuid.UUID, subj
 		return fmt.Errorf("notification: email channel %q has no recipients", ch.Name)
 	}
 	msg := buildReportEmail(cfg.From, cfg.To, subject, body, filename, attachment)
-	addr := net.JoinHostPort(cfg.SMTPHost, strconv.Itoa(cfg.SMTPPort))
-	var auth smtp.Auth
-	if cfg.Username != "" {
-		auth = smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.SMTPHost)
-	}
-	if err := smtp.SendMail(addr, auth, cfg.From, cfg.To, msg); err != nil {
+	// Shares delivery.go's sendSMTP, so report emails honor the channel's
+	// encryption mode (none/starttls/tls) the same as alert emails.
+	if err := sendSMTP(cfg, cfg.From, cfg.To, msg); err != nil {
 		return fmt.Errorf("notification: report email via %q: %w", ch.Name, err)
 	}
 	return nil

--- a/internal/notification/store.go
+++ b/internal/notification/store.go
@@ -60,6 +60,12 @@ func validateEmail(cfg Config) (string, error) {
 	if cfg.SMTPPort <= 0 || cfg.SMTPPort > 65535 {
 		return "", fmt.Errorf("%w: smtp port out of range", ErrInvalidConfig)
 	}
+	switch cfg.SMTPEncryption {
+	case "", SMTPEncNone, SMTPEncSTARTTLS, SMTPEncTLS:
+		// empty is accepted and treated as starttls at send time
+	default:
+		return "", fmt.Errorf("%w: invalid smtp encryption %q", ErrInvalidConfig, cfg.SMTPEncryption)
+	}
 	if strings.TrimSpace(cfg.From) == "" {
 		return "", fmt.Errorf("%w: from address required", ErrInvalidConfig)
 	}

--- a/internal/notification/store_test.go
+++ b/internal/notification/store_test.go
@@ -165,8 +165,8 @@ func TestDispatch_SelectsEnabledMatching(t *testing.T) {
 			}
 		}
 		mk("wild", true, nil)
-		mk("match", true, map[string]string{"severity": "critical"})
-		mk("nomatch", true, map[string]string{"severity": "info"})
+		mk("min-high", true, map[string]string{"severity": "high"})         // "high and above"
+		mk("min-critical", true, map[string]string{"severity": "critical"}) // "critical only"
 		mk("disabled", false, nil)
 
 		enabled, err := svc.listEnabledDecrypted(ctx)
@@ -177,16 +177,18 @@ func TestDispatch_SelectsEnabledMatching(t *testing.T) {
 		if len(enabled) != 3 {
 			t.Fatalf("enabled count = %d, want 3 (disabled excluded)", len(enabled))
 		}
-		alert := alertrouter.Alert{Severity: "critical", Tags: map[string]string{"severity": "critical"}}
+		// A HIGH alert: the wildcard and the "high and above" channel match;
+		// the "critical only" channel does NOT (its threshold is more severe
+		// than the alert). This exercises the threshold semantics of AC-05.
+		alert := alertrouter.Alert{Severity: "high", Tags: map[string]string{"severity": "high"}}
 		selected := 0
 		for _, ch := range enabled {
 			if matchesTags(ch.TagFilter, alert.Tags) {
 				selected++
 			}
 		}
-		// wild + match select; nomatch does not.
 		if selected != 2 {
-			t.Errorf("selected = %d, want 2 (wild + match)", selected)
+			t.Errorf("selected = %d, want 2 (wild + min-high; min-critical excluded)", selected)
 		}
 	})
 }

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -61,6 +61,32 @@ type Config struct {
 	Password string   `json:"password,omitempty"`
 	From     string   `json:"from,omitempty"`
 	To       []string `json:"to,omitempty"`
+	// SMTPEncryption selects the transport security for the SMTP
+	// connection: "none" (plaintext, for a trusted local relay),
+	// "starttls" (connect plaintext then require a STARTTLS upgrade), or
+	// "tls" (implicit TLS from connect — SMTPS, typically port 465). An
+	// empty value is treated as "starttls" (the secure default). Not a
+	// secret; returned to the edit form.
+	SMTPEncryption string `json:"smtp_encryption,omitempty"`
+}
+
+// SMTP encryption modes for Config.SMTPEncryption.
+const (
+	SMTPEncNone     = "none"
+	SMTPEncSTARTTLS = "starttls"
+	SMTPEncTLS      = "tls"
+)
+
+// NormalizeSMTPEncryption maps an empty/unknown mode to the secure
+// default (STARTTLS, required). Callers persist and act on the result so
+// legacy rows (no mode) behave predictably.
+func NormalizeSMTPEncryption(mode string) string {
+	switch mode {
+	case SMTPEncNone, SMTPEncTLS:
+		return mode
+	default:
+		return SMTPEncSTARTTLS
+	}
 }
 
 // Channel is a stored delivery channel. Config is populated only on the

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -893,6 +893,27 @@ func (e NotificationChannelType) Valid() bool {
 	}
 }
 
+// Defines values for NotificationChannelCreateSmtpEncryption.
+const (
+	NotificationChannelCreateSmtpEncryptionNone     NotificationChannelCreateSmtpEncryption = "none"
+	NotificationChannelCreateSmtpEncryptionStarttls NotificationChannelCreateSmtpEncryption = "starttls"
+	NotificationChannelCreateSmtpEncryptionTls      NotificationChannelCreateSmtpEncryption = "tls"
+)
+
+// Valid indicates whether the value is a known member of the NotificationChannelCreateSmtpEncryption enum.
+func (e NotificationChannelCreateSmtpEncryption) Valid() bool {
+	switch e {
+	case NotificationChannelCreateSmtpEncryptionNone:
+		return true
+	case NotificationChannelCreateSmtpEncryptionStarttls:
+		return true
+	case NotificationChannelCreateSmtpEncryptionTls:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for NotificationChannelCreateType.
 const (
 	NotificationChannelCreateTypeEmail   NotificationChannelCreateType = "email"
@@ -908,6 +929,27 @@ func (e NotificationChannelCreateType) Valid() bool {
 	case NotificationChannelCreateTypeSlack:
 		return true
 	case NotificationChannelCreateTypeWebhook:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for NotificationChannelUpdateSmtpEncryption.
+const (
+	NotificationChannelUpdateSmtpEncryptionNone     NotificationChannelUpdateSmtpEncryption = "none"
+	NotificationChannelUpdateSmtpEncryptionStarttls NotificationChannelUpdateSmtpEncryption = "starttls"
+	NotificationChannelUpdateSmtpEncryptionTls      NotificationChannelUpdateSmtpEncryption = "tls"
+)
+
+// Valid indicates whether the value is a known member of the NotificationChannelUpdateSmtpEncryption enum.
+func (e NotificationChannelUpdateSmtpEncryption) Valid() bool {
+	switch e {
+	case NotificationChannelUpdateSmtpEncryptionNone:
+		return true
+	case NotificationChannelUpdateSmtpEncryptionStarttls:
+		return true
+	case NotificationChannelUpdateSmtpEncryptionTls:
 		return true
 	default:
 		return false
@@ -1612,10 +1654,36 @@ type AuthMePermissionsResponse struct {
 
 // AuthMeResponse defines model for AuthMeResponse.
 type AuthMeResponse struct {
-	Email    string             `json:"email"`
+	// DisplayName Editable profile field (may be empty)
+	DisplayName *string `json:"display_name,omitempty"`
+	Email       string  `json:"email"`
+
+	// FullName Editable profile field (may be empty)
+	FullName *string            `json:"full_name,omitempty"`
 	Id       openapi_types.UUID `json:"id"`
-	Role     string             `json:"role"`
-	Username string             `json:"username"`
+
+	// JobTitle Editable profile field (may be empty)
+	JobTitle *string `json:"job_title,omitempty"`
+
+	// Phone Editable profile field (may be empty)
+	Phone *string `json:"phone,omitempty"`
+	Role  string  `json:"role"`
+
+	// Timezone IANA timezone
+	Timezone *string `json:"timezone,omitempty"`
+	Username string  `json:"username"`
+}
+
+// AuthMeUpdateRequest Partial self-profile update. Every field is optional; a present field replaces the stored value (empty string clears it). Omitted fields are left unchanged.
+type AuthMeUpdateRequest struct {
+	DisplayName *string `json:"display_name,omitempty"`
+
+	// Email Sign-in identity; must be unique among active users
+	Email    *string `json:"email,omitempty"`
+	FullName *string `json:"full_name,omitempty"`
+	JobTitle *string `json:"job_title,omitempty"`
+	Phone    *string `json:"phone,omitempty"`
+	Timezone *string `json:"timezone,omitempty"`
 }
 
 // AuthPasswordChangeRequest defines model for AuthPasswordChangeRequest.
@@ -2704,6 +2772,9 @@ type NotificationChannel struct {
 	Id   openapi_types.UUID `json:"id"`
 	Name string             `json:"name"`
 
+	// SmtpEncryption SMTP transport security (email channels) - none|starttls|tls
+	SmtpEncryption *string `json:"smtp_encryption,omitempty"`
+
 	// SmtpPort SMTP port (email channels)
 	SmtpPort *int `json:"smtp_port,omitempty"`
 
@@ -2736,6 +2807,9 @@ type NotificationChannelCreate struct {
 	// Password SMTP auth password (email). Stored encrypted.
 	Password *string `json:"password,omitempty"`
 
+	// SmtpEncryption Transport security for the SMTP connection (email). 'starttls' (default) connects plaintext then requires a STARTTLS upgrade; 'tls' uses implicit TLS from connect (SMTPS, e.g. port 465); 'none' is plaintext for a trusted local relay. Omitted defaults to starttls.
+	SmtpEncryption *NotificationChannelCreateSmtpEncryption `json:"smtp_encryption,omitempty"`
+
 	// SmtpHost SMTP relay host (email). Stored encrypted.
 	SmtpHost *string `json:"smtp_host,omitempty"`
 
@@ -2757,6 +2831,9 @@ type NotificationChannelCreate struct {
 	Username *string `json:"username,omitempty"`
 }
 
+// NotificationChannelCreateSmtpEncryption Transport security for the SMTP connection (email). 'starttls' (default) connects plaintext then requires a STARTTLS upgrade; 'tls' uses implicit TLS from connect (SMTPS, e.g. port 465); 'none' is plaintext for a trusted local relay. Omitted defaults to starttls.
+type NotificationChannelCreateSmtpEncryption string
+
 // NotificationChannelCreateType defines model for NotificationChannelCreate.Type.
 type NotificationChannelCreateType string
 
@@ -2767,18 +2844,22 @@ type NotificationChannelList struct {
 
 // NotificationChannelUpdate Updates name/enabled/tag_filter. Supplying the secret config (url for slack/webhook, or smtp_host for email) replaces it; omitting it leaves the stored secret unchanged.
 type NotificationChannelUpdate struct {
-	Enabled   bool               `json:"enabled"`
-	From      *string            `json:"from,omitempty"`
-	Name      string             `json:"name"`
-	Password  *string            `json:"password,omitempty"`
-	SmtpHost  *string            `json:"smtp_host,omitempty"`
-	SmtpPort  *int               `json:"smtp_port,omitempty"`
-	TagFilter *map[string]string `json:"tag_filter,omitempty"`
-	To        *[]string          `json:"to,omitempty"`
-	Token     *string            `json:"token,omitempty"`
-	Url       *string            `json:"url,omitempty"`
-	Username  *string            `json:"username,omitempty"`
+	Enabled        bool                                     `json:"enabled"`
+	From           *string                                  `json:"from,omitempty"`
+	Name           string                                   `json:"name"`
+	Password       *string                                  `json:"password,omitempty"`
+	SmtpEncryption *NotificationChannelUpdateSmtpEncryption `json:"smtp_encryption,omitempty"`
+	SmtpHost       *string                                  `json:"smtp_host,omitempty"`
+	SmtpPort       *int                                     `json:"smtp_port,omitempty"`
+	TagFilter      *map[string]string                       `json:"tag_filter,omitempty"`
+	To             *[]string                                `json:"to,omitempty"`
+	Token          *string                                  `json:"token,omitempty"`
+	Url            *string                                  `json:"url,omitempty"`
+	Username       *string                                  `json:"username,omitempty"`
 }
+
+// NotificationChannelUpdateSmtpEncryption defines model for NotificationChannelUpdate.SmtpEncryption.
+type NotificationChannelUpdateSmtpEncryption string
 
 // NotificationFeed defines model for NotificationFeed.
 type NotificationFeed struct {
@@ -3754,6 +3835,9 @@ type PutAuthPolicyJSONRequestBody = AuthPolicyUpdateRequest
 // PostAuthLoginJSONRequestBody defines body for PostAuthLogin for application/json ContentType.
 type PostAuthLoginJSONRequestBody = AuthLoginRequest
 
+// PatchAuthMeJSONRequestBody defines body for PatchAuthMe for application/json ContentType.
+type PatchAuthMeJSONRequestBody = AuthMeUpdateRequest
+
 // PostAuthMFAVerifyJSONRequestBody defines body for PostAuthMFAVerify for application/json ContentType.
 type PostAuthMFAVerifyJSONRequestBody = AuthMFAVerifyRequest
 
@@ -3939,6 +4023,9 @@ type ServerInterface interface {
 	// Return the calling identity
 	// (GET /api/v1/auth/me)
 	GetAuthMe(w http.ResponseWriter, r *http.Request)
+	// Update the calling user's own profile
+	// (PATCH /api/v1/auth/me)
+	PatchAuthMe(w http.ResponseWriter, r *http.Request)
 	// Effective permissions for the calling identity
 	// (GET /api/v1/auth/me/permissions)
 	GetAuthMePermissions(w http.ResponseWriter, r *http.Request)
@@ -4443,6 +4530,12 @@ func (_ Unimplemented) PostAuthLogout(w http.ResponseWriter, r *http.Request) {
 // Return the calling identity
 // (GET /api/v1/auth/me)
 func (_ Unimplemented) GetAuthMe(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update the calling user's own profile
+// (PATCH /api/v1/auth/me)
+func (_ Unimplemented) PatchAuthMe(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -5954,6 +6047,20 @@ func (siw *ServerInterfaceWrapper) GetAuthMe(w http.ResponseWriter, r *http.Requ
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAuthMe(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PatchAuthMe operation middleware
+func (siw *ServerInterfaceWrapper) PatchAuthMe(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PatchAuthMe(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -9680,6 +9787,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/auth/me", wrapper.GetAuthMe)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/api/v1/auth/me", wrapper.PatchAuthMe)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/auth/me/permissions", wrapper.GetAuthMePermissions)

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -314,6 +314,62 @@ func TestAuthLogout_RevokesSession(t *testing.T) {
 	})
 }
 
+// @ac AC-14
+// AC-14: PATCH /auth/me applies a partial self-profile update and returns
+// the updated identity; changing email to one another active user already
+// holds returns 409. /auth/* is CSRF-exempt, so the cookie alone authorizes.
+func TestAuthPatchMe_UpdatesProfileAndEmailConflict(t *testing.T) {
+	t.Run("api-auth/AC-14", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		usrSvc := users.NewService(pool, nil)
+		u := seedAuthUser(t, usrSvc, "ac14", false)
+		_ = usrSvc.AssignRole(context.Background(), u.ID, "viewer", nil)
+		other := seedAuthUser(t, usrSvc, "ac14other", false)
+
+		resp := login(t, url, map[string]string{"username": u.Username, "password": u.Password})
+		cookie := pickSessionCookie(resp)
+		resp.Body.Close()
+		if cookie == nil {
+			t.Fatal("no session cookie")
+		}
+
+		// Partial profile update → 200 with the new fields echoed, email intact.
+		body, _ := json.Marshal(map[string]any{"full_name": "AC Fourteen", "job_title": "SecOps", "timezone": "UTC"})
+		req, _ := http.NewRequest("PATCH", url+"/api/v1/auth/me", bytes.NewReader(body))
+		req.AddCookie(cookie)
+		req.Header.Set("Content-Type", "application/json")
+		resp = doReq(t, req)
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			t.Fatalf("patch status = %d, want 200", resp.StatusCode)
+		}
+		var me struct {
+			FullName string `json:"full_name"`
+			JobTitle string `json:"job_title"`
+			Email    string `json:"email"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&me)
+		resp.Body.Close()
+		if me.FullName != "AC Fourteen" || me.JobTitle != "SecOps" {
+			t.Errorf("profile not updated: %+v", me)
+		}
+		if me.Email != u.Email {
+			t.Errorf("email changed unexpectedly to %q", me.Email)
+		}
+
+		// Email collision with the other active user → 409.
+		body, _ = json.Marshal(map[string]any{"email": other.Email})
+		req, _ = http.NewRequest("PATCH", url+"/api/v1/auth/me", bytes.NewReader(body))
+		req.AddCookie(cookie)
+		req.Header.Set("Content-Type", "application/json")
+		resp = doReq(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Errorf("email-conflict status = %d, want 409", resp.StatusCode)
+		}
+	})
+}
+
 // @ac AC-08
 // AC-08: Refresh rotates; old refresh token is invalid for subsequent calls.
 func TestAuthRefresh_Rotates(t *testing.T) {

--- a/internal/server/api_notifications_test.go
+++ b/internal/server/api_notifications_test.go
@@ -194,6 +194,41 @@ func TestNotifications_EmailListExposesNonSecretConfig(t *testing.T) {
 	})
 }
 
+// @ac AC-08
+// AC-08: an email channel's smtp_encryption mode round-trips (create ->
+// read) and an invalid mode is rejected with 400.
+func TestNotifications_EmailEncryptionRoundTrip(t *testing.T) {
+	t.Run("api-notifications/AC-08", func(t *testing.T) {
+		url, _ := freshAPIServer(t)
+		body := map[string]any{
+			"type": "email", "name": "tls-mail",
+			"smtp_host": "smtp.corp.example", "smtp_port": 465,
+			"smtp_encryption": "tls",
+			"from":            "alerts@corp.example", "to": []string{"sec@corp.example"},
+		}
+		cr := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin, body))
+		if cr.StatusCode != http.StatusCreated {
+			t.Fatalf("create = %d", cr.StatusCode)
+		}
+		lr := doReq(t, asRole(t, "GET", url+"/api/v1/notifications/channels", auth.RoleAdmin, nil))
+		raw := readBody(t, lr)
+		if !strings.Contains(raw, `"smtp_encryption":"tls"`) &&
+			!strings.Contains(raw, `"smtp_encryption": "tls"`) {
+			t.Errorf("read did not return smtp_encryption=tls for pre-fill: %s", raw)
+		}
+		// An out-of-enum mode is rejected by validation.
+		bad := map[string]any{
+			"type": "email", "name": "bad-enc",
+			"smtp_host": "smtp.corp.example", "smtp_port": 587,
+			"smtp_encryption": "bogus",
+			"from":            "a@x.com", "to": []string{"b@x.com"},
+		}
+		if br := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin, bad)); br.StatusCode != http.StatusBadRequest {
+			t.Errorf("invalid encryption = %d, want 400", br.StatusCode)
+		}
+	})
+}
+
 // @ac AC-03
 func TestNotifications_UpdateDeleteRBAC(t *testing.T) {
 	t.Run("api-notifications/AC-03", func(t *testing.T) {

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -498,11 +498,68 @@ func (h *handlers) PostAuthPasswordChange(w http.ResponseWriter, r *http.Request
 // surfaced.
 func userToMe(u users.User, role string) api.AuthMeResponse {
 	return api.AuthMeResponse{
-		Id:       openapitypes.UUID(u.ID),
-		Username: u.Username,
-		Email:    u.Email,
-		Role:     role,
+		Id:          openapitypes.UUID(u.ID),
+		Username:    u.Username,
+		Email:       u.Email,
+		Role:        role,
+		FullName:    &u.FullName,
+		DisplayName: &u.DisplayName,
+		JobTitle:    &u.JobTitle,
+		Timezone:    &u.Timezone,
+		Phone:       &u.Phone,
 	}
+}
+
+// PatchAuthMe applies a partial self-profile update for the calling user.
+// Spec api-auth AC (patchAuthMe): present fields update, omitted stay;
+// email must be unique among active users (409). Username/role/password
+// are not editable here.
+func (h *handlers) PatchAuthMe(w http.ResponseWriter, r *http.Request) {
+	id := auth.FromContext(r.Context())
+	if id.IsAnonymous {
+		writeError(w, http.StatusUnauthorized, "auth.required", "client",
+			"authentication required", false)
+		return
+	}
+	userID, err := uuid.Parse(id.ID)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "auth.required", "client",
+			"identity id is not a UUID", false)
+		return
+	}
+	var req api.AuthMeUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.malformed", "client",
+			"malformed request body", false)
+		return
+	}
+	u, err := h.users.UpdateProfile(r.Context(), userID, users.ProfileUpdate{
+		Email:       req.Email,
+		FullName:    req.FullName,
+		DisplayName: req.DisplayName,
+		JobTitle:    req.JobTitle,
+		Timezone:    req.Timezone,
+		Phone:       req.Phone,
+	})
+	switch {
+	case errors.Is(err, users.ErrEmailTaken):
+		writeError(w, http.StatusConflict, "users.email_taken", "client",
+			"that email is already in use by another account", false)
+		return
+	case errors.Is(err, users.ErrInvalidProfile):
+		writeError(w, http.StatusBadRequest, "validation.field_invalid", "client",
+			"invalid profile field", false)
+		return
+	case errors.Is(err, users.ErrUserNotFound):
+		writeError(w, http.StatusUnauthorized, "auth.required", "client",
+			"identity user not found", false)
+		return
+	case err != nil:
+		writeError(w, http.StatusInternalServerError, "internal.error", "server",
+			"failed to update profile", false)
+		return
+	}
+	writeJSON(w, http.StatusOK, userToMe(u, string(id.RoleID)))
 }
 
 // mfaEnrolled returns whether the user has a VERIFIED MFA secret. A secret

--- a/internal/server/notifications_handlers.go
+++ b/internal/server/notifications_handlers.go
@@ -70,7 +70,7 @@ func (h *handlers) PostNotificationChannel(w http.ResponseWriter, r *http.Reques
 		Name:    req.Name,
 		Enabled: enabled,
 		Config: notificationConfig(req.Url, req.Token, req.SmtpHost, req.SmtpPort,
-			req.Username, req.Password, req.From, req.To),
+			createEnc(req.SmtpEncryption), req.Username, req.Password, req.From, req.To),
 		TagFilter: derefTagFilter(req.TagFilter),
 	}
 	c, err := h.notificationSvc.Create(r.Context(), p)
@@ -123,7 +123,7 @@ func (h *handlers) PatchNotificationChannel(w http.ResponseWriter, r *http.Reque
 	if req.Url != nil || req.SmtpHost != nil {
 		p.ReplaceConfig = true
 		p.Config = notificationConfig(req.Url, req.Token, req.SmtpHost, req.SmtpPort,
-			req.Username, req.Password, req.From, req.To)
+			updateEnc(req.SmtpEncryption), req.Username, req.Password, req.From, req.To)
 	}
 	c, err := h.notificationSvc.Update(r.Context(), uuid.UUID(id), p)
 	if err != nil {
@@ -196,6 +196,10 @@ func toAPINotificationChannel(c notification.Channel) api.NotificationChannel {
 			p := c.Config.SMTPPort
 			out.SmtpPort = &p
 		}
+		if c.Config.SMTPEncryption != "" {
+			e := c.Config.SMTPEncryption
+			out.SmtpEncryption = &e
+		}
 		if c.Config.From != "" {
 			f := c.Config.From
 			out.From = &f
@@ -219,10 +223,27 @@ func derefTagFilter(m *map[string]string) map[string]string {
 	return *m
 }
 
+// createEnc / updateEnc flatten the generated per-request SMTP-encryption
+// enum pointers to a plain string ("" when absent → the store treats empty
+// as the STARTTLS default).
+func createEnc(e *api.NotificationChannelCreateSmtpEncryption) string {
+	if e == nil {
+		return ""
+	}
+	return string(*e)
+}
+
+func updateEnc(e *api.NotificationChannelUpdateSmtpEncryption) string {
+	if e == nil {
+		return ""
+	}
+	return string(*e)
+}
+
 // notificationConfig assembles the decrypted Config from the optional
 // request fields. HTTP channels use url/token; email uses the smtp* +
 // from/to fields. Unset pointers stay zero (validated per-type downstream).
-func notificationConfig(url, token, smtpHost *string, smtpPort *int, username, password, from *string, to *[]string) notification.Config {
+func notificationConfig(url, token, smtpHost *string, smtpPort *int, smtpEncryption string, username, password, from *string, to *[]string) notification.Config {
 	cfg := notification.Config{}
 	if url != nil {
 		cfg.URL = *url
@@ -236,6 +257,7 @@ func notificationConfig(url, token, smtpHost *string, smtpPort *int, username, p
 	if smtpPort != nil {
 		cfg.SMTPPort = *smtpPort
 	}
+	cfg.SMTPEncryption = smtpEncryption
 	if username != nil {
 		cfg.Username = *username
 	}

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/auth"
@@ -33,6 +34,13 @@ var (
 	// ErrCannotDisableSelf guards an admin from disabling their own account
 	// (lockout prevention).
 	ErrCannotDisableSelf = errors.New("users: cannot disable your own account")
+	// ErrEmailTaken is returned by UpdateProfile when the requested email is
+	// already used by another active user (the sign-in identity must be
+	// unique). Maps to HTTP 409.
+	ErrEmailTaken = errors.New("users: email already in use")
+	// ErrInvalidProfile is returned for a malformed profile update (e.g. an
+	// empty email). Maps to HTTP 400.
+	ErrInvalidProfile = errors.New("users: invalid profile update")
 )
 
 // User is the safe shape returned by every read API. PasswordHash is
@@ -59,6 +67,15 @@ type User struct {
 	// Populated by ListUsers via an aggregate; other lookups (login path,
 	// GetUserByID) leave it nil since they do not need the membership join.
 	Roles []string
+
+	// Self-service profile fields (migration 0050). Free text, may be
+	// empty. Populated by the queryOne lookups (GetUserByID / by-username);
+	// the login-path scan leaves them empty since login does not need them.
+	FullName    string
+	DisplayName string
+	JobTitle    string
+	Timezone    string
+	Phone       string
 }
 
 // CreateParams is the input to CreateUser. Plaintext password is hashed
@@ -195,7 +212,8 @@ func (s *Service) CreateFederatedUser(ctx context.Context, username, email strin
 // Spec AC-04.
 func (s *Service) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 	const stmt = `
-		SELECT id, username, email, last_password_change_at, created_at, updated_at, disabled_at
+		SELECT id, username, email, last_password_change_at, created_at, updated_at, disabled_at,
+		       full_name, display_name, job_title, timezone, phone
 		FROM users
 		WHERE id = $1 AND deleted_at IS NULL`
 	return s.queryOne(ctx, stmt, id)
@@ -207,10 +225,73 @@ func (s *Service) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 // Spec AC-05.
 func (s *Service) GetUserByUsername(ctx context.Context, username string) (User, error) {
 	const stmt = `
-		SELECT id, username, email, last_password_change_at, created_at, updated_at, disabled_at
+		SELECT id, username, email, last_password_change_at, created_at, updated_at, disabled_at,
+		       full_name, display_name, job_title, timezone, phone
 		FROM users
 		WHERE username = $1 AND deleted_at IS NULL`
 	return s.queryOne(ctx, stmt, username)
+}
+
+// ProfileUpdate is a partial self-profile edit: a nil field is left
+// unchanged, a non-nil field replaces the stored value (an empty string
+// clears it, except Email which may not be empty).
+type ProfileUpdate struct {
+	Email       *string
+	FullName    *string
+	DisplayName *string
+	JobTitle    *string
+	Timezone    *string
+	Phone       *string
+}
+
+// UpdateProfile applies a partial profile edit for the user's own account
+// (PATCH /auth/me). Email is the sign-in identity: it is trimmed, must be
+// non-empty, and must be unique among active users — ErrEmailTaken (409)
+// otherwise. Username, role, and password are not editable here. Returns
+// the updated user.
+func (s *Service) UpdateProfile(ctx context.Context, id uuid.UUID, p ProfileUpdate) (User, error) {
+	var emailArg *string
+	if p.Email != nil {
+		email := strings.TrimSpace(*p.Email)
+		if email == "" || !strings.Contains(email, "@") {
+			return User{}, fmt.Errorf("%w: email must be a non-empty address", ErrInvalidProfile)
+		}
+		var taken bool
+		if err := s.pool.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM users WHERE email = $1 AND deleted_at IS NULL AND id <> $2)`,
+			email, id).Scan(&taken); err != nil {
+			return User{}, fmt.Errorf("users: email uniqueness check: %w", err)
+		}
+		if taken {
+			return User{}, ErrEmailTaken
+		}
+		emailArg = &email
+	}
+
+	const stmt = `
+		UPDATE users SET
+			email        = COALESCE($2, email),
+			full_name    = COALESCE($3, full_name),
+			display_name = COALESCE($4, display_name),
+			job_title    = COALESCE($5, job_title),
+			timezone     = COALESCE($6, timezone),
+			phone        = COALESCE($7, phone),
+			updated_at   = now()
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, username, email, last_password_change_at, created_at, updated_at, disabled_at,
+		          full_name, display_name, job_title, timezone, phone`
+	var u User
+	err := s.pool.QueryRow(ctx, stmt, id, emailArg, p.FullName, p.DisplayName, p.JobTitle, p.Timezone, p.Phone).Scan(
+		&u.ID, &u.Username, &u.Email, &u.LastPasswordChangeAt, &u.CreatedAt, &u.UpdatedAt, &u.DisabledAt,
+		&u.FullName, &u.DisplayName, &u.JobTitle, &u.Timezone, &u.Phone,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, fmt.Errorf("users: update profile: %w", err)
+	}
+	return u, nil
 }
 
 // VerifyUserPassword is the login-path helper. Looks up the hash and
@@ -456,6 +537,7 @@ func (s *Service) queryOne(ctx context.Context, stmt string, arg any) (User, err
 	err := s.pool.QueryRow(ctx, stmt, arg).Scan(
 		&u.ID, &u.Username, &u.Email,
 		&u.LastPasswordChangeAt, &u.CreatedAt, &u.UpdatedAt, &u.DisabledAt,
+		&u.FullName, &u.DisplayName, &u.JobTitle, &u.Timezone, &u.Phone,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -32,6 +32,62 @@ func freshService(t *testing.T, corpus identity.BreachCorpus) (*Service, *pgxpoo
 // strongPW returns a long-enough, not-breached password for tests.
 func strongPW() string { return "test-passphrase-strong-zZ" }
 
+// @ac AC-14
+// AC-14: UpdateProfile applies a PARTIAL self-profile edit (nil field
+// unchanged, present field replaces), and treats email as the sign-in
+// identity — unique among active users (ErrEmailTaken) and non-empty
+// (ErrInvalidProfile).
+func TestUpdateProfile_PartialAndEmailUniqueness(t *testing.T) {
+	t.Run("system-user-management/AC-14", func(t *testing.T) {
+		svc, _ := freshService(t, nil)
+		ctx := context.Background()
+		a, err := svc.CreateUser(ctx, CreateParams{Username: "alice", Email: "alice@example.com", Password: strongPW()})
+		if err != nil {
+			t.Fatalf("create alice: %v", err)
+		}
+		if _, err := svc.CreateUser(ctx, CreateParams{Username: "bob", Email: "bob@example.com", Password: strongPW()}); err != nil {
+			t.Fatalf("create bob: %v", err)
+		}
+
+		// Partial: set full_name + timezone; email + others unchanged.
+		fn, tz := "Alice Ann", "America/New_York"
+		u, err := svc.UpdateProfile(ctx, a.ID, ProfileUpdate{FullName: &fn, Timezone: &tz})
+		if err != nil {
+			t.Fatalf("UpdateProfile: %v", err)
+		}
+		if u.FullName != fn || u.Timezone != tz {
+			t.Errorf("fields not applied: %+v", u)
+		}
+		if u.Email != "alice@example.com" {
+			t.Errorf("email changed unexpectedly to %q", u.Email)
+		}
+		if u.DisplayName != "" {
+			t.Errorf("display_name should stay empty, got %q", u.DisplayName)
+		}
+
+		// Email change to an unused address succeeds.
+		ne := "alice2@example.com"
+		u, err = svc.UpdateProfile(ctx, a.ID, ProfileUpdate{Email: &ne})
+		if err != nil {
+			t.Fatalf("email change: %v", err)
+		}
+		if u.Email != ne {
+			t.Errorf("email = %q, want %q", u.Email, ne)
+		}
+
+		// Collision with bob's email → ErrEmailTaken.
+		taken := "bob@example.com"
+		if _, err := svc.UpdateProfile(ctx, a.ID, ProfileUpdate{Email: &taken}); !errors.Is(err, ErrEmailTaken) {
+			t.Errorf("expected ErrEmailTaken, got %v", err)
+		}
+		// Empty email → ErrInvalidProfile.
+		empty := ""
+		if _, err := svc.UpdateProfile(ctx, a.ID, ProfileUpdate{Email: &empty}); !errors.Is(err, ErrInvalidProfile) {
+			t.Errorf("expected ErrInvalidProfile, got %v", err)
+		}
+	})
+}
+
 // @ac AC-01
 // AC-01: CreateUser persists a row with Argon2id hash; returned User
 // has NO PasswordHash field.

--- a/specs/api/auth.spec.yaml
+++ b/specs/api/auth.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-auth
   title: Auth HTTP surface (login, MFA, refresh, me, password change)
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -115,3 +115,7 @@ spec:
     - id: AC-13
       description: POST /auth/login for a user with an UNVERIFIED MFA enrollment (a secret row exists but last_verified_at IS NULL — enrollment was begun via mfa:enroll but never confirmed via mfa:verify) does NOT require an OTP; it returns 200 and signs the user in. Only a verified secret gates login, so an abandoned enrollment cannot lock a user out.
       priority: high
+    - id: AC-14
+      description: 'v1.2.0 - PATCH /api/v1/auth/me applies a PARTIAL self-profile update for the authenticated caller (full_name, display_name, email, job_title, timezone, phone) and returns the updated AuthMeResponse; omitted fields are unchanged. Changing email to one another active user already holds returns 409 (users.email_taken). The path is under /api/v1/auth/* so it is CSRF-exempt (the session cookie or bearer authorizes). Username, role, and password are not editable here.'
+      priority: high
+      references_constraints: [C-03]

--- a/specs/api/notifications.spec.yaml
+++ b/specs/api/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-notifications
   title: Notification channels REST API
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -90,5 +90,9 @@ spec:
       references_constraints: [C-02, C-03]
     - id: AC-07
       description: "v1.2.0 — the list/read path returns an email channel's NON-secret config so the edit form can pre-fill: smtp_port, from, to, username appear in the GET /notifications/channels JSON, but the password NEVER does. A PATCH that re-sends the non-secret email fields WITHOUT a password keeps the stored password (the channel still validates and the updated recipients persist)."
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-08
+      description: "v1.3.0 — an email channel's smtp_encryption mode (none | starttls | tls) round-trips: POST with smtp_encryption creates the channel and the GET /notifications/channels JSON returns the same smtp_encryption for pre-fill (it is non-secret). An out-of-enum value is rejected with 400."
       priority: high
       references_constraints: [C-02]

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.13.0"
+  version: "1.14.0"
   status: draft
   tier: 2
 
@@ -256,7 +256,7 @@ spec:
       priority: high
       references_constraints: [C-11]
     - id: AC-04
-      description: Profile page renders the username and email returned by /auth/me. The big-avatar initials match the first 1-2 tokens of the username. The Save-changes button has aria-disabled=true.
+      description: 'v1.14.0 - The Profile page prefills its edit fields from GET /api/v1/auth/me (full_name, display_name, email, job_title, timezone, phone) and persists changes via PATCH /api/v1/auth/me. The big-avatar initials match the first 1-2 tokens of the username. The Save-changes button is wired (no longer a permanently-disabled stub) and is disabled only while loading/saving.'
       priority: critical
       references_constraints: [C-03]
     - id: AC-05
@@ -332,7 +332,7 @@ spec:
       priority: high
       references_constraints: [C-08]
     - id: AC-23
-      description: "v1.5.0 source-inspection: NotificationsPage gates on hasPermission('notification:read') returning ForbiddenPage when absent; it lists from GET /api/v1/notifications/channels keyed ['notification-channels']; Add/Edit call api.POST/PATCH '/api/v1/notifications/channels', Delete calls api.DELETE, Test calls POST '/api/v1/notifications/channels/{id}:test', and every mutation invalidates ['notification-channels']; the page renders channel.target_hint and references no response url/token field. AC-15 stub set excludes Notifications."
+      description: "v1.14.0 source-inspection: NotificationsPage gates on hasPermission('notification:read') returning ForbiddenPage when absent; it lists from GET /api/v1/notifications/channels keyed ['notification-channels']; Add/Edit call api.POST/PATCH '/api/v1/notifications/channels', Delete calls api.DELETE, Test calls POST '/api/v1/notifications/channels/{id}:test', and every mutation invalidates ['notification-channels']; the page renders channel.target_hint and references no response url/token field. Email channels expose an SMTP encryption selector (none/starttls/tls) sent as smtp_encryption, and the severity 'Deliver for' filter is threshold-based (a minimum level: 'Medium and above', 'High and above', etc.). AC-15 stub set excludes Notifications."
       priority: high
       references_constraints: [C-15]
     - id: AC-24

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-notifications
   title: Notification channels — encrypted store + SSRF-guarded delivery
-  version: "1.7.0"
+  version: "1.8.0"
   status: approved
   tier: 2
 
@@ -181,7 +181,7 @@ spec:
       priority: critical
       references_constraints: [C-02]
     - id: AC-05
-      description: DispatchChannel.Send delivers to an enabled wildcard channel and to a channel whose tag filter matches the alert tags, and skips a disabled channel and a non-matching tag filter; matchesTags treats an empty filter as a wildcard.
+      description: 'v1.8.0 - DispatchChannel.Send delivers to an enabled wildcard channel and to a channel whose tag filter matches the alert tags, and skips a disabled channel and a non-matching tag filter; matchesTags treats an empty filter as a wildcard. The reserved "severity" key uses THRESHOLD semantics (via alertrouter.SeverityOrder): a filter value delivers that severity and every more-severe one (e.g. "high" delivers high and critical), so a channel can be scoped to a minimum level. Every other tag key stays exact-match.'
       priority: high
       references_constraints: [C-03]
     - id: AC-06
@@ -306,3 +306,16 @@ spec:
         read rather than re-surfacing unread each day.
       priority: high
       references_constraints: [C-09]
+    - id: AC-21
+      description: >-
+        v1.8.0 — Email SMTP encryption is operator-selectable via
+        Config.SMTPEncryption. NormalizeSMTPEncryption maps an empty or
+        unknown value to the secure default "starttls" and passes through
+        "none"/"tls". sendSMTP (shared by alert + report email) implements
+        implicit TLS from connect for "tls" (SMTPS, e.g. port 465, via
+        tls.DialWithDialer), a REQUIRED STARTTLS upgrade for "starttls"
+        (the send fails rather than silently downgrading to plaintext), and
+        plaintext for "none". net/smtp.SendMail is not used (it cannot do
+        implicit TLS and only opportunistic STARTTLS).
+      priority: high
+      references_constraints: [C-03]

--- a/specs/system/user-management.spec.yaml
+++ b/specs/system/user-management.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-user-management
   title: User accounts and role assignment
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -113,3 +113,7 @@ spec:
       description: ListUsers returns each non-deleted user with its assigned role ids aggregated into User.Roles (a non-nil empty slice when the user has no roles); a user with {viewer, ops_lead} lists both ids, and a soft-deleted user does not appear at all.
       priority: high
       references_constraints: [C-05]
+    - id: AC-14
+      description: 'v1.1.0 - UpdateProfile applies a PARTIAL self-profile edit (full_name, display_name, job_title, timezone, phone via migration 0050): a nil field is left unchanged, a present field replaces the stored value. Email is the sign-in identity — it must be non-empty (ErrInvalidProfile) and unique among active users, excluding self (ErrEmailTaken); username, role, and password are not editable through this path.'
+      priority: high
+      references_constraints: [C-01]


### PR DESCRIPTION
## Summary

Two settings features from the pre-release review, implemented in SDD discipline:

1. **Notifications — email/SMTP hardening** (`/settings/notifications`)
2. **Profile self-edit** (`/settings/profile`)

Independent of each other; grouped in one branch for a single review/CI cycle.

## 1. Notifications: SMTP encryption modes + severity threshold

The email channel existed but couldn't reach "any SMTP service" and offered no encryption control; the severity filter was also silently broken.

- **Encryption is now operator-selectable** per email channel — `none` / `starttls` / `tls`:
  - `tls` = **implicit TLS from connect (SMTPS, port 465)** — previously impossible (`net/smtp.SendMail` can't do it).
  - `starttls` = connect plaintext then **require** a STARTTLS upgrade (fails rather than silently downgrading to plaintext). Default for new + legacy channels.
  - `none` = plaintext, for a trusted local relay (e.g. postfix).
  - Both the alert path (`delivery.go`) and the report-email path (`report_email.go`) now share one `sendSMTP` helper, so both honor the mode.
- **Severity delivery is now a real threshold.** The `severity` tag filter was **exact-match** — "High and above" only matched exactly `high`, missing `critical`. `matchesTags` now treats `severity` as a minimum via `alertrouter.SeverityOrder` (delivers that level and everything more severe). The UI "Deliver for" gains Low/Medium and-above options. Other tag keys stay exact-match.
- **Stale copy fixed:** the page said "Slack or a webhook"; email has been supported and is now named.
- No DB migration — the channel config is an encrypted JSON blob; `smtp_encryption` rides in it. `net/smtp.SendMail` is retired.

**Requirements coverage:** (a) any SMTP — now including 465-only providers via implicit TLS; (b) postfix relay — unauthenticated `none`/`starttls` on :25; (c) encrypted or plaintext — explicitly selectable, STARTTLS required by default.

## 2. Profile self-edit (PATCH /auth/me)

The Profile page rendered editable fields (full name, display name, email, job title, timezone, phone) but "Save changes" was a permanently-disabled stub — no columns, no endpoint.

- **Migration 0050** adds `full_name, display_name, job_title, timezone, phone` to `users` (empty-string defaults).
- **`PATCH /api/v1/auth/me`** — partial self-update (present fields replace, omitted unchanged). **Email is editable** (it's the sign-in identity) with a **uniqueness check → 409** when another active user holds it; empty email → 400. Username/role/password are not editable here (password stays on `/auth/password:change`). Under `/api/v1/auth/*`, so CSRF-exempt.
- `GET /auth/me` now returns the profile fields; the form prefills from it and re-syncs after save.
- Frontend: the Save button is wired (disabled only while loading/saving), with success + 409 error banners.

## SDD

- Specs bumped: `system-notifications` 1.7.0→1.8.0 (AC-05 threshold rewrite + AC-21 encryption modes), `api-notifications` 1.2.0→1.3.0 (AC-08 encryption round-trip), `api-auth` 1.1.0→1.2.0 (AC-14 patchAuthMe), `system-user-management` 1.0.0→1.1.0 (AC-14 UpdateProfile + email uniqueness), `frontend-settings` 1.13.0→1.14.0 (AC-04 profile PATCH + AC-23 encryption/severity selectors).
- Tests: `matchesTags` threshold + `NormalizeSMTPEncryption`/`sendSMTP` mode inspection; `UpdateProfile` partial + email-uniqueness (DB); `PATCH /auth/me` 200 + 409 (DB); email encryption round-trip + invalid-mode 400 (DB). Two existing severity tests updated from exact-match to threshold semantics.

## Verification

- `gofmt`, `go vet ./...`, `go build ./...` — clean
- `internal/notification`, `internal/users`, `internal/db` pass; `internal/server` pass (full suite)
- `specter check` (115), `coverage --strictness annotation` (115/115), `check-generated` in sync
- Frontend `tsc` clean; full vitest 353/353

## Out of scope

Email **re-verification** on change (no email-verification infra yet), photo upload, session listing/revoke, and Framework-lens configuration (the third review item — deferred per your note).
