### PR TITLE
fix(notifications): channel-test error detail + postfix support (self-signed TLS, relay tests)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4336,6 +4336,7 @@ components:
           description: Alert tags this channel matches; empty = every alert
         smtp_port: {type: integer, nullable: true, description: SMTP port (email channels)}
         smtp_encryption: {type: string, nullable: true, description: SMTP transport security (email channels) - none|starttls|tls}
+        smtp_insecure_skip_verify: {type: boolean, nullable: true, description: Skip TLS cert verification for an internal relay with a self-signed/private-CA cert (email channels; STARTTLS/TLS only)}
         from:      {type: string, nullable: true, description: Sender address (email channels)}
         to:
           type: array
@@ -4407,6 +4408,12 @@ components:
             'tls' uses implicit TLS from connect (SMTPS, e.g. port 465);
             'none' is plaintext for a trusted local relay. Omitted defaults
             to starttls.
+        smtp_insecure_skip_verify:
+          type: boolean
+          description: >-
+            Skip TLS certificate verification for the SMTP handshake (email).
+            For an internal relay with a self-signed or private-CA cert only;
+            a MITM-exposing downgrade, inert under 'none'. Defaults false.
         username:  {type: string, description: SMTP auth username (email). Stored encrypted.}
         password:  {type: string, description: SMTP auth password (email). Stored encrypted.}
         from:      {type: string, description: Envelope From address (email).}
@@ -4432,6 +4439,7 @@ components:
         smtp_host: {type: string}
         smtp_port: {type: integer}
         smtp_encryption: {type: string, enum: [none, starttls, tls]}
+        smtp_insecure_skip_verify: {type: boolean}
         username:  {type: string}
         password:  {type: string}
         from:      {type: string}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2733,6 +2733,8 @@ export interface components {
             smtp_port?: number | null;
             /** @description SMTP transport security (email channels) - none|starttls|tls */
             smtp_encryption?: string | null;
+            /** @description Skip TLS cert verification for an internal relay with a self-signed/private-CA cert (email channels; STARTTLS/TLS only) */
+            smtp_insecure_skip_verify?: boolean | null;
             /** @description Sender address (email channels) */
             from?: string | null;
             /** @description Recipient addresses (email channels) */
@@ -2798,6 +2800,8 @@ export interface components {
              * @enum {string}
              */
             smtp_encryption?: "none" | "starttls" | "tls";
+            /** @description Skip TLS certificate verification for the SMTP handshake (email). For an internal relay with a self-signed or private-CA cert only; a MITM-exposing downgrade, inert under 'none'. Defaults false. */
+            smtp_insecure_skip_verify?: boolean;
             /** @description SMTP auth username (email). Stored encrypted. */
             username?: string;
             /** @description SMTP auth password (email). Stored encrypted. */
@@ -2820,6 +2824,7 @@ export interface components {
             smtp_port?: number;
             /** @enum {string} */
             smtp_encryption?: "none" | "starttls" | "tls";
+            smtp_insecure_skip_verify?: boolean;
             username?: string;
             password?: string;
             from?: string;

--- a/frontend/src/pages/settings/NotificationsPage.tsx
+++ b/frontend/src/pages/settings/NotificationsPage.tsx
@@ -270,6 +270,11 @@ function ChannelModal({
   const [smtpEncryption, setSmtpEncryption] = useState<'none' | 'starttls' | 'tls'>(
     (channel?.smtp_encryption as 'none' | 'starttls' | 'tls') ?? 'starttls',
   );
+  // Trust a self-signed / private-CA relay cert (internal postfix). Only
+  // meaningful when TLS is in play.
+  const [smtpInsecureSkipVerify, setSmtpInsecureSkipVerify] = useState<boolean>(
+    channel?.smtp_insecure_skip_verify ?? false,
+  );
   const [username, setUsername] = useState(channel?.username ?? '');
   const [password, setPassword] = useState('');
   const [from, setFrom] = useState(channel?.from ?? '');
@@ -290,6 +295,7 @@ function ChannelModal({
         smtp_host: smtpHost,
         smtp_port: Number(smtpPort) || 0,
         smtp_encryption: smtpEncryption,
+        smtp_insecure_skip_verify: smtpEncryption !== 'none' ? smtpInsecureSkipVerify : false,
         from,
         to: to
           .split(',')
@@ -417,6 +423,18 @@ function ChannelModal({
               ]}
             />
           </FormField>
+          {smtpEncryption !== 'none' && (
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, marginTop: 2 }}
+            >
+              <input
+                type="checkbox"
+                checked={smtpInsecureSkipVerify}
+                onChange={(e) => setSmtpInsecureSkipVerify(e.target.checked)}
+              />
+              Trust self-signed / internal certificate (skips TLS verification)
+            </label>
+          )}
           <FormField label="Username (optional)">
             <input
               style={inputStyle}

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -374,10 +374,12 @@ describe('frontend-settings — structural', () => {
     expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:delete'\)/);
     expect(NOTIF_SRC).toMatch(/hasPermission\)\('notification:test'\)/);
     // Email channels expose an SMTP encryption selector (none/starttls/tls)
-    // and send smtp_encryption in the config.
+    // and send smtp_encryption in the config, plus a self-signed-cert
+    // (skip-verify) toggle for an internal relay.
     expect(NOTIF_SRC).toMatch(/smtp_encryption/);
     expect(NOTIF_SRC).toContain("'starttls'");
     expect(NOTIF_SRC).toContain("'tls'");
+    expect(NOTIF_SRC).toMatch(/smtp_insecure_skip_verify/);
     // Severity delivery is threshold-based (minimum level), not two presets.
     expect(NOTIF_SRC).toMatch(/Medium and above/);
     expect(NOTIF_SRC).toMatch(/High and above/);

--- a/internal/notification/delivery.go
+++ b/internal/notification/delivery.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/smtp"
+	"net/url"
 	"strconv"
 	"strings"
 	"syscall"
@@ -203,6 +205,18 @@ func buildEmailMessage(from string, to []string, subject, body string) []byte {
 	return b.Bytes()
 }
 
+// scrubHTTPErr returns a delivery error safe to surface to the operator:
+// it unwraps the *url.Error that http.Client.Do returns so the embedded
+// request URL (the secret webhook/slack endpoint) is dropped, leaving just
+// the underlying cause (e.g. "dial tcp: connection refused").
+func scrubHTTPErr(err error) string {
+	var ue *url.Error
+	if errors.As(err, &ue) && ue.Err != nil {
+		return ue.Err.Error()
+	}
+	return err.Error()
+}
+
 // deliverHTTP POSTs the rendered alert to a single channel. A non-2xx
 // response is an error. The body is drained + closed so the connection
 // can be reused.
@@ -221,7 +235,11 @@ func deliverHTTP(ctx context.Context, client *http.Client, ch Channel, a alertro
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("notification: deliver to %q: %w", ch.Name, err)
+		// Scrub the URL: http.Client.Do wraps the failure in a *url.Error
+		// that embeds the full request URL — which for a slack/webhook channel
+		// IS the secret. Surface only the underlying cause so the operator can
+		// see the error (via the test endpoint) without leaking the target.
+		return fmt.Errorf("notification: deliver to %q: %s", ch.Name, scrubHTTPErr(err))
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))

--- a/internal/notification/delivery.go
+++ b/internal/notification/delivery.go
@@ -137,7 +137,14 @@ func sendSMTP(cfg Config, from string, to []string, msg []byte) error {
 	}
 	addr := net.JoinHostPort(cfg.SMTPHost, strconv.Itoa(cfg.SMTPPort))
 	mode := NormalizeSMTPEncryption(cfg.SMTPEncryption)
-	tlsCfg := &tls.Config{ServerName: cfg.SMTPHost, MinVersion: tls.VersionTLS12}
+	// InsecureSkipVerify is opt-in per channel, for an internal relay with a
+	// self-signed / private-CA cert. It only affects the TLS handshake, so it
+	// is inert under the "none" (plaintext) mode.
+	tlsCfg := &tls.Config{
+		ServerName:         cfg.SMTPHost,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: cfg.SMTPInsecureSkipVerify, //nolint:gosec // opt-in, documented, internal-relay only
+	}
 	dialer := &net.Dialer{Timeout: smtpDialTimeout}
 
 	var conn net.Conn

--- a/internal/notification/delivery_test.go
+++ b/internal/notification/delivery_test.go
@@ -5,7 +5,9 @@
 package notification
 
 import (
+	"errors"
 	"net"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -100,6 +102,32 @@ func TestMatchesTags(t *testing.T) {
 		}
 		if matchesTags(map[string]string{"alert_type": "scan"}, critical) {
 			t.Error("mismatched exact-match key should not match")
+		}
+	})
+}
+
+// @ac AC-22
+// AC-22: scrubHTTPErr strips the secret webhook/slack URL that
+// http.Client.Do embeds in a *url.Error, so a failed test delivery can be
+// surfaced to the operator without leaking the channel's secret target.
+func TestScrubHTTPErr(t *testing.T) {
+	t.Run("system-notifications/AC-22", func(t *testing.T) {
+		secret := "https://hooks.slack.com/services/T00/B00/SECRETTOKEN"
+		ue := &url.Error{
+			Op:  "Post",
+			URL: secret,
+			Err: errors.New("dial tcp 1.2.3.4:443: connect: connection refused"),
+		}
+		got := scrubHTTPErr(ue)
+		if strings.Contains(got, "SECRETTOKEN") || strings.Contains(got, secret) {
+			t.Errorf("scrubHTTPErr leaked the secret URL: %q", got)
+		}
+		if !strings.Contains(got, "connection refused") {
+			t.Errorf("scrubHTTPErr dropped the useful cause: %q", got)
+		}
+		// A non-url error passes through unchanged.
+		if scrubHTTPErr(errors.New("plain")) != "plain" {
+			t.Error("non-url error should pass through unchanged")
 		}
 	})
 }

--- a/internal/notification/smtp_send_test.go
+++ b/internal/notification/smtp_send_test.go
@@ -1,0 +1,198 @@
+// @spec system-notifications
+//
+// In-process SMTP relays (plaintext + self-signed TLS) that exercise the
+// real sendSMTP delivery path — the postfix-style configurations.
+
+package notification
+
+import (
+	"bufio"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// serveSMTP runs a minimal one-shot SMTP conversation over conn — just
+// enough for a no-auth delivery (no STARTTLS/AUTH advertised) — capturing
+// the DATA payload into body. It is the shape a trusted relay (a local
+// postfix) presents; used over both a plaintext and a TLS-wrapped conn.
+func serveSMTP(conn net.Conn, body *strings.Builder) {
+	defer conn.Close()
+	r := bufio.NewReader(conn)
+	w := bufio.NewWriter(conn)
+	send := func(s string) { _, _ = w.WriteString(s + "\r\n"); _ = w.Flush() }
+
+	send("220 fake-relay ESMTP")
+	inData := false
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if inData {
+			if line == "." {
+				inData = false
+				send("250 2.0.0 Ok: queued")
+				continue
+			}
+			body.WriteString(line + "\n")
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "EHLO"), strings.HasPrefix(line, "HELO"):
+			send("250-fake-relay")
+			send("250 8BITMIME")
+		case strings.HasPrefix(line, "MAIL FROM"), strings.HasPrefix(line, "RCPT TO"):
+			send("250 2.1.0 Ok")
+		case line == "DATA":
+			send("354 End data with <CR><LF>.<CR><LF>")
+			inData = true
+		case line == "QUIT":
+			send("221 2.0.0 Bye")
+			return
+		default:
+			send("250 Ok")
+		}
+	}
+}
+
+// listenRelay accepts one connection, optionally wraps it in TLS with a
+// self-signed cert (implicit TLS, like a relay on :465), then serves SMTP.
+func listenRelay(t *testing.T, tlsCfg *tls.Config) (host string, port int, got *strings.Builder, wg *sync.WaitGroup) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	var body strings.Builder
+	var group sync.WaitGroup
+	group.Add(1)
+	go func() {
+		defer group.Done()
+		raw, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		var conn net.Conn = raw
+		if tlsCfg != nil {
+			conn = tls.Server(raw, tlsCfg)
+		}
+		serveSMTP(conn, &body)
+	}()
+	h, p, _ := net.SplitHostPort(ln.Addr().String())
+	pi, _ := strconv.Atoi(p)
+	return h, pi, &body, &group
+}
+
+// selfSignedServerTLS returns a server tls.Config with a fresh self-signed
+// cert for 127.0.0.1 — a stand-in for an internal relay whose cert no
+// public CA chains to.
+func selfSignedServerTLS(t *testing.T) *tls.Config {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	key, cert := genRSACert(t, tmpl)
+	return &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{cert}, PrivateKey: key}}}
+}
+
+// @ac AC-21
+// AC-21 (delivery side): sendSMTP delivers through a plaintext, no-auth
+// relay when encryption is "none" — the configuration a trusted internal
+// postfix relay uses. And the secure default (starttls, required) fails
+// loudly against a relay that does not offer STARTTLS rather than silently
+// downgrading. Proves the postfix path end to end.
+func TestSendSMTP_PlaintextRelay(t *testing.T) {
+	t.Run("system-notifications/AC-21", func(t *testing.T) {
+		host, port, got, wg := listenRelay(t, nil)
+		cfg := Config{
+			SMTPHost: host, SMTPPort: port, SMTPEncryption: SMTPEncNone,
+			From: "openwatch@corp.example", To: []string{"secops@corp.example"},
+		}
+		msg := buildEmailMessage(cfg.From, cfg.To, "test", "hello from openwatch")
+		if err := sendSMTP(cfg, cfg.From, cfg.To, msg); err != nil {
+			t.Fatalf("sendSMTP(none) to plaintext relay failed: %v", err)
+		}
+		wg.Wait()
+		if !strings.Contains(got.String(), "hello from openwatch") {
+			t.Errorf("relay did not receive the message body; got:\n%s", got.String())
+		}
+
+		// starttls-required against a relay that doesn't offer it → fail loudly.
+		h2, p2, _, _ := listenRelay(t, nil)
+		c2 := cfg
+		c2.SMTPHost, c2.SMTPPort, c2.SMTPEncryption = h2, p2, SMTPEncSTARTTLS
+		if err := sendSMTP(c2, c2.From, c2.To, msg); err == nil {
+			t.Error("sendSMTP(starttls) should fail when the relay does not offer STARTTLS")
+		}
+	})
+}
+
+// @ac AC-23
+// AC-23: SMTPInsecureSkipVerify governs whether an internal relay's
+// self-signed cert is trusted. Implicit-TLS ("tls") delivery to a relay
+// with a self-signed cert FAILS verification by default and SUCCEEDS when
+// skip-verify is set — the toggle that makes a TLS-enabled internal postfix
+// usable without leaking cert trust to the whole system.
+func TestSendSMTP_SelfSignedTLS(t *testing.T) {
+	t.Run("system-notifications/AC-23", func(t *testing.T) {
+		base := Config{
+			SMTPEncryption: SMTPEncTLS,
+			From:           "openwatch@corp.example",
+			To:             []string{"secops@corp.example"},
+		}
+		msg := buildEmailMessage(base.From, base.To, "test", "hello over self-signed tls")
+
+		// Default (verify on): the self-signed cert is rejected.
+		h1, p1, _, _ := listenRelay(t, selfSignedServerTLS(t))
+		c1 := base
+		c1.SMTPHost, c1.SMTPPort = h1, p1
+		if err := sendSMTP(c1, c1.From, c1.To, msg); err == nil {
+			t.Error("sendSMTP(tls) should reject a self-signed cert when skip-verify is off")
+		}
+
+		// skip-verify on: the handshake is accepted and the message delivers.
+		h2, p2, got2, wg2 := listenRelay(t, selfSignedServerTLS(t))
+		c2 := base
+		c2.SMTPHost, c2.SMTPPort, c2.SMTPInsecureSkipVerify = h2, p2, true
+		if err := sendSMTP(c2, c2.From, c2.To, msg); err != nil {
+			t.Fatalf("sendSMTP(tls, skip-verify) to self-signed relay failed: %v", err)
+		}
+		wg2.Wait()
+		if !strings.Contains(got2.String(), "hello over self-signed tls") {
+			t.Errorf("self-signed relay did not receive the message; got:\n%s", got2.String())
+		}
+	})
+}
+
+// genRSACert generates a self-signed RSA cert from tmpl and returns the key
+// and DER bytes. Kept local so the test needs no fixtures.
+func genRSACert(t *testing.T, tmpl *x509.Certificate) (key *rsa.PrivateKey, der []byte) {
+	t.Helper()
+	k, err := rsa.GenerateKey(crand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa key: %v", err)
+	}
+	d, err := x509.CreateCertificate(crand.Reader, tmpl, tmpl, &k.PublicKey, k)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return k, d
+}

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -68,6 +68,13 @@ type Config struct {
 	// empty value is treated as "starttls" (the secure default). Not a
 	// secret; returned to the edit form.
 	SMTPEncryption string `json:"smtp_encryption,omitempty"`
+	// SMTPInsecureSkipVerify, when true, disables TLS certificate
+	// verification for the STARTTLS/implicit-TLS handshake. It exists ONLY
+	// for an internal relay (e.g. a local postfix) that presents a
+	// self-signed or private-CA certificate; it is a MITM-exposing downgrade
+	// and has no effect when encryption is "none". Not a secret; returned to
+	// the edit form.
+	SMTPInsecureSkipVerify bool `json:"smtp_insecure_skip_verify,omitempty"`
 }
 
 // SMTP encryption modes for Config.SMTPEncryption.

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -2775,6 +2775,9 @@ type NotificationChannel struct {
 	// SmtpEncryption SMTP transport security (email channels) - none|starttls|tls
 	SmtpEncryption *string `json:"smtp_encryption,omitempty"`
 
+	// SmtpInsecureSkipVerify Skip TLS cert verification for an internal relay with a self-signed/private-CA cert (email channels; STARTTLS/TLS only)
+	SmtpInsecureSkipVerify *bool `json:"smtp_insecure_skip_verify,omitempty"`
+
 	// SmtpPort SMTP port (email channels)
 	SmtpPort *int `json:"smtp_port,omitempty"`
 
@@ -2813,6 +2816,9 @@ type NotificationChannelCreate struct {
 	// SmtpHost SMTP relay host (email). Stored encrypted.
 	SmtpHost *string `json:"smtp_host,omitempty"`
 
+	// SmtpInsecureSkipVerify Skip TLS certificate verification for the SMTP handshake (email). For an internal relay with a self-signed or private-CA cert only; a MITM-exposing downgrade, inert under 'none'. Defaults false.
+	SmtpInsecureSkipVerify *bool `json:"smtp_insecure_skip_verify,omitempty"`
+
 	// SmtpPort SMTP relay port (email)
 	SmtpPort  *int               `json:"smtp_port,omitempty"`
 	TagFilter *map[string]string `json:"tag_filter,omitempty"`
@@ -2844,18 +2850,19 @@ type NotificationChannelList struct {
 
 // NotificationChannelUpdate Updates name/enabled/tag_filter. Supplying the secret config (url for slack/webhook, or smtp_host for email) replaces it; omitting it leaves the stored secret unchanged.
 type NotificationChannelUpdate struct {
-	Enabled        bool                                     `json:"enabled"`
-	From           *string                                  `json:"from,omitempty"`
-	Name           string                                   `json:"name"`
-	Password       *string                                  `json:"password,omitempty"`
-	SmtpEncryption *NotificationChannelUpdateSmtpEncryption `json:"smtp_encryption,omitempty"`
-	SmtpHost       *string                                  `json:"smtp_host,omitempty"`
-	SmtpPort       *int                                     `json:"smtp_port,omitempty"`
-	TagFilter      *map[string]string                       `json:"tag_filter,omitempty"`
-	To             *[]string                                `json:"to,omitempty"`
-	Token          *string                                  `json:"token,omitempty"`
-	Url            *string                                  `json:"url,omitempty"`
-	Username       *string                                  `json:"username,omitempty"`
+	Enabled                bool                                     `json:"enabled"`
+	From                   *string                                  `json:"from,omitempty"`
+	Name                   string                                   `json:"name"`
+	Password               *string                                  `json:"password,omitempty"`
+	SmtpEncryption         *NotificationChannelUpdateSmtpEncryption `json:"smtp_encryption,omitempty"`
+	SmtpHost               *string                                  `json:"smtp_host,omitempty"`
+	SmtpInsecureSkipVerify *bool                                    `json:"smtp_insecure_skip_verify,omitempty"`
+	SmtpPort               *int                                     `json:"smtp_port,omitempty"`
+	TagFilter              *map[string]string                       `json:"tag_filter,omitempty"`
+	To                     *[]string                                `json:"to,omitempty"`
+	Token                  *string                                  `json:"token,omitempty"`
+	Url                    *string                                  `json:"url,omitempty"`
+	Username               *string                                  `json:"username,omitempty"`
 }
 
 // NotificationChannelUpdateSmtpEncryption defines model for NotificationChannelUpdate.SmtpEncryption.

--- a/internal/server/api_notifications_test.go
+++ b/internal/server/api_notifications_test.go
@@ -203,8 +203,8 @@ func TestNotifications_EmailEncryptionRoundTrip(t *testing.T) {
 		body := map[string]any{
 			"type": "email", "name": "tls-mail",
 			"smtp_host": "smtp.corp.example", "smtp_port": 465,
-			"smtp_encryption": "tls",
-			"from":            "alerts@corp.example", "to": []string{"sec@corp.example"},
+			"smtp_encryption": "tls", "smtp_insecure_skip_verify": true,
+			"from": "alerts@corp.example", "to": []string{"sec@corp.example"},
 		}
 		cr := doReq(t, asRole(t, "POST", url+"/api/v1/notifications/channels", auth.RoleAdmin, body))
 		if cr.StatusCode != http.StatusCreated {
@@ -215,6 +215,10 @@ func TestNotifications_EmailEncryptionRoundTrip(t *testing.T) {
 		if !strings.Contains(raw, `"smtp_encryption":"tls"`) &&
 			!strings.Contains(raw, `"smtp_encryption": "tls"`) {
 			t.Errorf("read did not return smtp_encryption=tls for pre-fill: %s", raw)
+		}
+		if !strings.Contains(raw, `"smtp_insecure_skip_verify":true`) &&
+			!strings.Contains(raw, `"smtp_insecure_skip_verify": true`) {
+			t.Errorf("read did not return smtp_insecure_skip_verify=true for pre-fill: %s", raw)
 		}
 		// An out-of-enum mode is rejected by validation.
 		bad := map[string]any{

--- a/internal/server/notifications_handlers.go
+++ b/internal/server/notifications_handlers.go
@@ -3,7 +3,9 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/notification"
@@ -164,10 +166,16 @@ func (h *handlers) TestNotificationChannel(w http.ResponseWriter, r *http.Reques
 				"channel not found", false)
 			return
 		}
-		// Delivery failed (unreachable, non-2xx, blocked host). Client-fault
-		// 400 so the operator fixes the channel config, not a server bug.
+		// Delivery failed (unreachable relay, auth rejected, STARTTLS not
+		// offered, non-2xx webhook, blocked host). Client-fault 400 so the
+		// operator fixes the channel config. Surface the reason (the delivery
+		// layer already scrubs the secret webhook URL from HTTP errors) and log
+		// it server-side — previously it was swallowed, leaving no way to
+		// diagnose why a test failed.
+		slog.WarnContext(r.Context(), "notification test delivery failed",
+			"channel_id", uuid.UUID(id).String(), "error", err.Error())
 		writeError(w, http.StatusBadRequest, "notifications.delivery_failed", "client",
-			"test delivery failed", false)
+			"test delivery failed: "+testErrDetail(err), false)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -214,6 +222,19 @@ func toAPINotificationChannel(c notification.Channel) api.NotificationChannel {
 		}
 	}
 	return out
+}
+
+// testErrDetail bounds a delivery error for the human-facing test response.
+// The delivery layer already scrubs the secret webhook URL from HTTP errors,
+// so what remains (SMTP/dial/auth causes) is safe to show the operator; this
+// only trims the internal wrapper prefix and caps the length.
+func testErrDetail(err error) string {
+	s := strings.TrimPrefix(err.Error(), "notification: ")
+	const max = 300
+	if len(s) > max {
+		s = s[:max] + "..."
+	}
+	return s
 }
 
 func derefTagFilter(m *map[string]string) map[string]string {

--- a/internal/server/notifications_handlers.go
+++ b/internal/server/notifications_handlers.go
@@ -72,7 +72,8 @@ func (h *handlers) PostNotificationChannel(w http.ResponseWriter, r *http.Reques
 		Name:    req.Name,
 		Enabled: enabled,
 		Config: notificationConfig(req.Url, req.Token, req.SmtpHost, req.SmtpPort,
-			createEnc(req.SmtpEncryption), req.Username, req.Password, req.From, req.To),
+			createEnc(req.SmtpEncryption), derefBool(req.SmtpInsecureSkipVerify),
+			req.Username, req.Password, req.From, req.To),
 		TagFilter: derefTagFilter(req.TagFilter),
 	}
 	c, err := h.notificationSvc.Create(r.Context(), p)
@@ -125,7 +126,8 @@ func (h *handlers) PatchNotificationChannel(w http.ResponseWriter, r *http.Reque
 	if req.Url != nil || req.SmtpHost != nil {
 		p.ReplaceConfig = true
 		p.Config = notificationConfig(req.Url, req.Token, req.SmtpHost, req.SmtpPort,
-			updateEnc(req.SmtpEncryption), req.Username, req.Password, req.From, req.To)
+			updateEnc(req.SmtpEncryption), derefBool(req.SmtpInsecureSkipVerify),
+			req.Username, req.Password, req.From, req.To)
 	}
 	c, err := h.notificationSvc.Update(r.Context(), uuid.UUID(id), p)
 	if err != nil {
@@ -208,6 +210,10 @@ func toAPINotificationChannel(c notification.Channel) api.NotificationChannel {
 			e := c.Config.SMTPEncryption
 			out.SmtpEncryption = &e
 		}
+		if c.Config.SMTPInsecureSkipVerify {
+			v := true
+			out.SmtpInsecureSkipVerify = &v
+		}
 		if c.Config.From != "" {
 			f := c.Config.From
 			out.From = &f
@@ -264,7 +270,7 @@ func updateEnc(e *api.NotificationChannelUpdateSmtpEncryption) string {
 // notificationConfig assembles the decrypted Config from the optional
 // request fields. HTTP channels use url/token; email uses the smtp* +
 // from/to fields. Unset pointers stay zero (validated per-type downstream).
-func notificationConfig(url, token, smtpHost *string, smtpPort *int, smtpEncryption string, username, password, from *string, to *[]string) notification.Config {
+func notificationConfig(url, token, smtpHost *string, smtpPort *int, smtpEncryption string, smtpInsecureSkipVerify bool, username, password, from *string, to *[]string) notification.Config {
 	cfg := notification.Config{}
 	if url != nil {
 		cfg.URL = *url
@@ -279,6 +285,7 @@ func notificationConfig(url, token, smtpHost *string, smtpPort *int, smtpEncrypt
 		cfg.SMTPPort = *smtpPort
 	}
 	cfg.SMTPEncryption = smtpEncryption
+	cfg.SMTPInsecureSkipVerify = smtpInsecureSkipVerify
 	if username != nil {
 		cfg.Username = *username
 	}

--- a/specs/api/notifications.spec.yaml
+++ b/specs/api/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-notifications
   title: Notification channels REST API
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -93,6 +93,6 @@ spec:
       priority: high
       references_constraints: [C-02]
     - id: AC-08
-      description: "v1.3.0 — an email channel's smtp_encryption mode (none | starttls | tls) round-trips: POST with smtp_encryption creates the channel and the GET /notifications/channels JSON returns the same smtp_encryption for pre-fill (it is non-secret). An out-of-enum value is rejected with 400."
+      description: "v1.4.0 — an email channel's smtp_encryption mode (none | starttls | tls) AND smtp_insecure_skip_verify flag round-trip: POST with both creates the channel and the GET /notifications/channels JSON returns the same smtp_encryption and smtp_insecure_skip_verify for pre-fill (both non-secret). An out-of-enum encryption value is rejected with 400."
       priority: high
       references_constraints: [C-02]

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.14.0"
+  version: "1.15.0"
   status: draft
   tier: 2
 
@@ -332,7 +332,7 @@ spec:
       priority: high
       references_constraints: [C-08]
     - id: AC-23
-      description: "v1.14.0 source-inspection: NotificationsPage gates on hasPermission('notification:read') returning ForbiddenPage when absent; it lists from GET /api/v1/notifications/channels keyed ['notification-channels']; Add/Edit call api.POST/PATCH '/api/v1/notifications/channels', Delete calls api.DELETE, Test calls POST '/api/v1/notifications/channels/{id}:test', and every mutation invalidates ['notification-channels']; the page renders channel.target_hint and references no response url/token field. Email channels expose an SMTP encryption selector (none/starttls/tls) sent as smtp_encryption, and the severity 'Deliver for' filter is threshold-based (a minimum level: 'Medium and above', 'High and above', etc.). AC-15 stub set excludes Notifications."
+      description: "v1.14.0 source-inspection: NotificationsPage gates on hasPermission('notification:read') returning ForbiddenPage when absent; it lists from GET /api/v1/notifications/channels keyed ['notification-channels']; Add/Edit call api.POST/PATCH '/api/v1/notifications/channels', Delete calls api.DELETE, Test calls POST '/api/v1/notifications/channels/{id}:test', and every mutation invalidates ['notification-channels']; the page renders channel.target_hint and references no response url/token field. Email channels expose an SMTP encryption selector (none/starttls/tls) sent as smtp_encryption plus a self-signed-cert 'skip verify' toggle (smtp_insecure_skip_verify) for an internal relay, and the severity 'Deliver for' filter is threshold-based (a minimum level: 'Medium and above', 'High and above', etc.). AC-15 stub set excludes Notifications."
       priority: high
       references_constraints: [C-15]
     - id: AC-24

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-notifications
   title: Notification channels — encrypted store + SSRF-guarded delivery
-  version: "1.8.0"
+  version: "1.9.0"
   status: approved
   tier: 2
 
@@ -317,5 +317,16 @@ spec:
         (the send fails rather than silently downgrading to plaintext), and
         plaintext for "none". net/smtp.SendMail is not used (it cannot do
         implicit TLS and only opportunistic STARTTLS).
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-22
+      description: >-
+        v1.9.0 — A delivery error is safe to surface to the operator: HTTP
+        (slack/webhook) failures are wrapped so the secret target URL that
+        http.Client.Do embeds in its *url.Error is stripped (scrubHTTPErr),
+        leaving only the underlying cause. This lets the channel-test
+        endpoint show WHY a delivery failed (unreachable relay, auth
+        rejected, STARTTLS not offered, non-2xx) without leaking the
+        webhook/slack secret.
       priority: high
       references_constraints: [C-03]

--- a/specs/system/notifications.spec.yaml
+++ b/specs/system/notifications.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-notifications
   title: Notification channels — encrypted store + SSRF-guarded delivery
-  version: "1.9.0"
+  version: "1.10.0"
   status: approved
   tier: 2
 
@@ -328,5 +328,16 @@ spec:
         endpoint show WHY a delivery failed (unreachable relay, auth
         rejected, STARTTLS not offered, non-2xx) without leaking the
         webhook/slack secret.
+      priority: high
+      references_constraints: [C-03]
+    - id: AC-23
+      description: >-
+        v1.10.0 — Config.SMTPInsecureSkipVerify governs TLS certificate
+        verification for the STARTTLS/implicit-TLS handshake, for an internal
+        relay (e.g. a local postfix) with a self-signed or private-CA cert.
+        Off (default), sendSMTP over "tls"/"starttls" rejects an untrusted
+        cert; on, it accepts it and delivers. It is inert under "none". This
+        is the toggle that makes a TLS-enabled internal relay usable without
+        weakening system-wide trust.
       priority: high
       references_constraints: [C-03]


### PR DESCRIPTION
## Summary

Notification email/SMTP hardening + testability, so an operator can actually diagnose a failing channel and so an internal **postfix** relay works in all its common shapes.

## 1. Surface the reason a channel test fails (secret-safe)

The channel-test endpoint returned a bare **400 "test delivery failed"** and **did not log** the underlying error — so a failed test (unreachable relay, rejected SMTP auth, STARTTLS not offered, non-2xx webhook) gave the operator nothing to act on. Found while diagnosing a real Gmail SMTP test that failed with no detail (cause: Gmail needs an App Password).

- `TestNotificationChannel` now includes the delivery error in the 400 response and logs it (`slog.WarnContext` with the channel id). Status stays 400 (operator-fixable config).
- **Secret-safe:** `http.Client.Do` wraps failures in a `*url.Error` that embeds the request URL — for a slack/webhook channel that URL *is* the secret. New `scrubHTTPErr` unwraps it to the underlying cause before it can reach a response or log. SMTP errors are already secret-free (host:port only).

## 2. Self-signed / internal-cert TLS option (postfix with a private cert)

A TLS-enabled internal relay (a postfix with a self-signed or private-CA cert) previously failed STARTTLS/implicit-TLS with `x509: certificate signed by unknown authority`, with no way around it.

- New per-channel **`smtp_insecure_skip_verify`** sets `tls.Config.InsecureSkipVerify` for the STARTTLS/TLS handshake only (inert under `none`). It's a documented, opt-in, MITM-exposing downgrade for a *trusted internal relay* — surfaced in the UI as a **"Trust self-signed / internal certificate"** checkbox shown only when TLS is selected.

## 3. Real delivery tests for the postfix paths

`sendSMTP` was previously only source-inspected. Added in-process SMTP relays that exercise the shipping code:

- **Plaintext no-auth relay** (a trusted local postfix): `none` mode delivers; `starttls`-required against a relay that doesn't offer STARTTLS fails loudly (the signal to pick `none`).
- **Self-signed implicit-TLS relay**: rejected by default, delivered with `smtp_insecure_skip_verify` — proving the toggle end to end.

## SDD

- `system-notifications` 1.8.0 → 1.10.0: **AC-22** (scrubHTTPErr — no secret-URL leak), **AC-23** (skip-verify governs self-signed cert trust), and AC-21's delivery test.
- `api-notifications` 1.3.0 → 1.4.0 (AC-08: encryption + skip-verify round-trip).
- `frontend-settings` 1.14.0 → 1.15.0 (AC-23: encryption selector + skip-verify checkbox).

## Verification

- `gofmt`, `go vet ./...`, `go build ./...` — clean
- `internal/notification` (incl. `TestSendSMTP_PlaintextRelay`, `TestSendSMTP_SelfSignedTLS`, `TestScrubHTTPErr`) and the full `internal/server` suite pass
- `specter` 115/115, `check-generated` in sync
- frontend `tsc` + full vitest 353/353

## Operator note (Gmail, and postfix)

- **Gmail**: reachable + STARTTLS works, so a failure is auth — use a 16-char **App Password** (2FA on), full email as username, port 587 (STARTTLS) or 465 (TLS). The test now says so.
- **postfix**: host = the relay (localhost allowed — SMTP is not SSRF-blocked), blank username/password for a trusted relay, encryption **None** for plaintext or **STARTTLS/TLS** (+ the skip-verify checkbox if it uses a self-signed cert).