### PR TITLE
feat(compliance): org-wide default lens (Phase 1)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -948,6 +948,7 @@ paths:
       parameters:
         - {name: environment, in: query, required: false, schema: {type: string}}
         - {name: tag, in: query, required: false, schema: {type: string}}
+        - {name: framework, in: query, required: false, schema: {type: string}, description: 'Lens each host card''s compliance_summary through a framework family (e.g. "stig") or a specific corpus key; omit for All rules.'}
       responses:
         '200':
           description: Host list
@@ -1548,6 +1549,70 @@ paths:
               schema: {$ref: '#/components/schemas/DiscoverySweepResponse'}
         '403':
           description: Caller lacks system:config:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/compliance/frameworks:
+    get:
+      operationId: getComplianceFrameworks
+      summary: List the framework families present in the scanned corpus
+      x-required-permission: host:read
+      description: >
+        Framework families derived at runtime from
+        host_rule_state.framework_refs (STIG, CIS, NIST 800-53, …), each with
+        a display label and the concrete corpus keys it spans. Feeds the
+        default-lens picker. Empty until at least one host is scanned.
+      responses:
+        '200':
+          description: Families
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ComplianceFrameworksResponse'}
+        '401':
+          description: No valid session or bearer
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
+  /api/v1/system/compliance/config:
+    get:
+      operationId: getSystemComplianceConfig
+      summary: Read the org-wide compliance-display config (default lens)
+      x-required-permission: system:read
+      responses:
+        '200':
+          description: Current compliance config
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ComplianceConfig'}
+        '403':
+          description: Caller lacks system:read
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+    put:
+      operationId: putSystemComplianceConfig
+      summary: Set the default compliance lens (framework family, or empty for All rules)
+      x-required-permission: system:config:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/ComplianceConfig'}
+      responses:
+        '200':
+          description: Updated compliance config
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ComplianceConfig'}
+        '400':
+          description: Invalid default_framework
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks system:config:write
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -5353,6 +5418,37 @@ components:
           type: integer
           minimum: 0
           description: Count of host.discovery jobs persisted by this sweep. Zero is a valid steady state (every host already discovered, or fleet empty)
+
+    ComplianceConfig:
+      type: object
+      required: [default_framework]
+      description: >-
+        Org-wide compliance-display config. default_framework is the default
+        lens the score surfaces (dashboard/hosts avg compliance, host detail)
+        project to: a framework family id (e.g. "stig", "cis") or empty for
+        All rules (the full Kensa corpus). Resolved per-host to the OS key at
+        query time.
+      properties:
+        default_framework: {type: string, description: Framework family id, or empty for All rules}
+
+    ComplianceFramework:
+      type: object
+      required: [id, label, keys]
+      properties:
+        id:    {type: string, description: Family id (e.g. "stig")}
+        label: {type: string, description: Display label (e.g. "STIG")}
+        keys:
+          type: array
+          items: {type: string}
+          description: Concrete corpus keys in this family (e.g. stig_rhel9, stig_rhel10)
+
+    ComplianceFrameworksResponse:
+      type: object
+      required: [frameworks]
+      properties:
+        frameworks:
+          type: array
+          items: {$ref: '#/components/schemas/ComplianceFramework'}
 
     ScanConfig:
       type: object

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -997,6 +997,44 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/compliance/frameworks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the framework families present in the scanned corpus
+         * @description Framework families derived at runtime from host_rule_state.framework_refs (STIG, CIS, NIST 800-53, …), each with a display label and the concrete corpus keys it spans. Feeds the default-lens picker. Empty until at least one host is scanned.
+         */
+        get: operations["getComplianceFrameworks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/system/compliance/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read the org-wide compliance-display config (default lens) */
+        get: operations["getSystemComplianceConfig"];
+        /** Set the default compliance lens (framework family, or empty for All rules) */
+        put: operations["putSystemComplianceConfig"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/system/scan/config": {
         parameters: {
             query?: never;
@@ -3515,6 +3553,22 @@ export interface components {
             /** @description Count of host.discovery jobs persisted by this sweep. Zero is a valid steady state (every host already discovered, or fleet empty) */
             enqueued: number;
         };
+        /** @description Org-wide compliance-display config. default_framework is the default lens the score surfaces (dashboard/hosts avg compliance, host detail) project to: a framework family id (e.g. "stig", "cis") or empty for All rules (the full Kensa corpus). Resolved per-host to the OS key at query time. */
+        ComplianceConfig: {
+            /** @description Framework family id */
+            default_framework: string;
+        };
+        ComplianceFramework: {
+            /** @description Family id (e.g. "stig") */
+            id: string;
+            /** @description Display label (e.g. "STIG") */
+            label: string;
+            /** @description Concrete corpus keys in this family (e.g. stig_rhel9, stig_rhel10) */
+            keys: string[];
+        };
+        ComplianceFrameworksResponse: {
+            frameworks: components["schemas"]["ComplianceFramework"][];
+        };
         ScanConfig: {
             /** @description Master switch for the adaptive scheduler. When false the loop ticks but dispatches nothing. On-demand scans are unaffected */
             enabled: boolean;
@@ -5833,6 +5887,8 @@ export interface operations {
             query?: {
                 environment?: string;
                 tag?: string;
+                /** @description Lens each host card's compliance_summary through a framework family (e.g. "stig") or a specific corpus key; omit for All rules. */
+                framework?: string;
             };
             header?: never;
             path?: never;
@@ -6636,6 +6692,106 @@ export interface operations {
                 };
             };
             /** @description Caller lacks system:config:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getComplianceFrameworks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Families */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComplianceFrameworksResponse"];
+                };
+            };
+            /** @description No valid session or bearer */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getSystemComplianceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current compliance config */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComplianceConfig"];
+                };
+            };
+            /** @description Caller lacks system:read */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    putSystemComplianceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ComplianceConfig"];
+            };
+        };
+        responses: {
+            /** @description Updated compliance config */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComplianceConfig"];
+                };
+            };
+            /** @description Invalid default_framework */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks system:config:write */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/api/useDefaultLens.ts
+++ b/frontend/src/api/useDefaultLens.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/api/client';
+
+// The org-wide default compliance lens: a framework FAMILY id (e.g. "stig")
+// or "" for All rules. Cached under ['compliance-config']; the score
+// surfaces (dashboard/hosts avg compliance, host detail) read it to default
+// their framework projection. A read failure degrades to "" (All rules).
+export function useDefaultLens(): string {
+  const q = useQuery({
+    queryKey: ['compliance-config'],
+    queryFn: async () => {
+      const { data, response } = await api.GET('/api/v1/system/compliance/config');
+      if (!response.ok) return { default_framework: '' };
+      return data ?? { default_framework: '' };
+    },
+    staleTime: 60_000,
+  });
+  return q.data?.default_framework ?? '';
+}
+
+// familyOf mirrors the Go framework.FamilyOf: strip a trailing OS suffix so a
+// corpus key maps to its family (stig_rhel9 -> stig); OS-agnostic keys are
+// their own family. Used to resolve a family default to a host's own key and
+// to mark the active "View as" chip.
+const OS_SUFFIX = /_(rhel|ubuntu)[0-9]+$/;
+export function familyOf(key: string): string {
+  return key.replace(OS_SUFFIX, '');
+}
+
+// resolveLensForHost maps the configured default (a family or key, or "") to
+// the concrete corpus key to use for THIS host, given the host's available
+// framework keys. Returns "" (All rules) when the default is empty or the
+// host has no key in that family.
+export function resolveLensForHost(defaultLens: string, availableKeys: string[]): string {
+  if (!defaultLens) return '';
+  if (availableKeys.includes(defaultLens)) return defaultLens; // already a key
+  const match = availableKeys.find((k) => familyOf(k) === defaultLens);
+  return match ?? '';
+}

--- a/frontend/src/components/settings/DefaultLensCard.tsx
+++ b/frontend/src/components/settings/DefaultLensCard.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { SettingCard, FirstSettingRow, Select } from './primitives';
+
+// DefaultLensCard — the org-wide default compliance lens. An admin picks a
+// framework FAMILY (or All rules); the score surfaces default to it. Wired to
+// GET/PUT /api/v1/system/compliance/config and GET /api/v1/compliance/frameworks
+// (the corpus-derived family list). Read-only for non-writers.
+export function DefaultLensCard({ canWrite }: { canWrite: boolean }) {
+  const queryClient = useQueryClient();
+  const [banner, setBanner] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  const configQuery = useQuery({
+    queryKey: ['compliance-config'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/system/compliance/config');
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load'));
+      return data!;
+    },
+  });
+
+  const frameworksQuery = useQuery({
+    queryKey: ['compliance-frameworks'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/compliance/frameworks');
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load frameworks'));
+      return data!.frameworks;
+    },
+  });
+
+  const [value, setValue] = useState('');
+  useEffect(() => {
+    if (configQuery.data) setValue(configQuery.data.default_framework ?? '');
+  }, [configQuery.data]);
+
+  const mutation = useMutation({
+    mutationFn: async (next: string) => {
+      const { response, error } = await api.PUT('/api/v1/system/compliance/config', {
+        body: { default_framework: next },
+      });
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to save'));
+    },
+    onSuccess: () => {
+      setBanner({ kind: 'success', text: 'Default lens saved.' });
+      queryClient.invalidateQueries({ queryKey: ['compliance-config'] });
+    },
+    onError: (e: Error) => setBanner({ kind: 'error', text: e.message }),
+  });
+
+  const options = [
+    { value: '', label: 'All rules (full Kensa corpus)' },
+    ...(frameworksQuery.data ?? []).map((f) => ({ value: f.id, label: f.label })),
+  ];
+
+  return (
+    <SettingCard>
+      <FirstSettingRow
+        name="Default lens"
+        description={
+          <>
+            The framework the dashboard, hosts, and host-detail compliance scores default to.
+            Individual host views can still switch lens.{' '}
+            {banner?.kind === 'success' && <span style={{ color: 'var(--ow-ok)' }}>{banner.text}</span>}
+            {banner?.kind === 'error' && <span style={{ color: 'var(--ow-crit)' }}>{banner.text}</span>}
+          </>
+        }
+        control={
+          <Select
+            value={value}
+            onChange={(v) => {
+              setValue(v);
+              setBanner(null);
+              if (canWrite) mutation.mutate(v);
+            }}
+            ariaLabel="Default compliance lens"
+            options={options}
+            width="260px"
+            disabled={!canWrite || configQuery.isLoading || mutation.isPending}
+          />
+        }
+      />
+    </SettingCard>
+  );
+}

--- a/frontend/src/components/settings/DefaultLensCard.tsx
+++ b/frontend/src/components/settings/DefaultLensCard.tsx
@@ -7,8 +7,10 @@ import { SettingCard, FirstSettingRow, Select } from './primitives';
 // DefaultLensCard — the org-wide default compliance lens. An admin picks a
 // framework FAMILY (or All rules); the score surfaces default to it. Wired to
 // GET/PUT /api/v1/system/compliance/config and GET /api/v1/compliance/frameworks
-// (the corpus-derived family list). Read-only for non-writers.
-export function DefaultLensCard({ canWrite }: { canWrite: boolean }) {
+// (the corpus-derived family list). The write is enforced server-side
+// (system:config_write) — matching the other config cards, the control is not
+// client-gated; a caller without the permission gets a 403 error banner.
+export function DefaultLensCard() {
   const queryClient = useQueryClient();
   const [banner, setBanner] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
 
@@ -72,12 +74,12 @@ export function DefaultLensCard({ canWrite }: { canWrite: boolean }) {
             onChange={(v) => {
               setValue(v);
               setBanner(null);
-              if (canWrite) mutation.mutate(v);
+              mutation.mutate(v);
             }}
             ariaLabel="Default compliance lens"
             options={options}
             width="260px"
-            disabled={!canWrite || configQuery.isLoading || mutation.isPending}
+            disabled={configQuery.isLoading || mutation.isPending}
           />
         }
       />

--- a/frontend/src/components/settings/primitives.tsx
+++ b/frontend/src/components/settings/primitives.tsx
@@ -408,17 +408,20 @@ export function Select({
   options,
   ariaLabel,
   width,
+  disabled,
 }: {
   value: string;
   onChange: (v: string) => void;
   options: { value: string; label: string }[];
   ariaLabel?: string;
   width?: number | string;
+  disabled?: boolean;
 }) {
   return (
     <select
       value={value}
       aria-label={ariaLabel}
+      disabled={disabled}
       onChange={(e) => onChange(e.target.value)}
       style={{
         height: 32,
@@ -429,7 +432,8 @@ export function Select({
         fontFamily: 'inherit',
         fontSize: 13,
         padding: '0 28px 0 10px',
-        cursor: 'pointer',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
         appearance: 'none',
         width: width ?? 'auto',
         minWidth: 160,

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -30,6 +30,7 @@ import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { useHostRemediations } from '@/hooks/useHostRemediations';
 import { formatLift } from '@/components/hosts/RequestRemediationModal';
 import { apiErrorCode, apiErrorMessage } from '@/api/errors';
+import { useDefaultLens, resolveLensForHost } from '@/api/useDefaultLens';
 import { relativeTime } from '@/api/eventDisplay';
 import { EditHostModal } from '@/components/hosts/EditHostModal';
 import { HostCredentialModal } from '@/components/hosts/HostCredentialModal';
@@ -213,9 +214,33 @@ export function HostDetailPage() {
   const search = useSearch({ strict: false }) as HostDetailSearch;
   const navigate = useNavigate();
   const hostId = params.hostId ?? '';
-  const framework = search.framework;
   const activeTab: TabId = search.tab ?? 'overview';
   const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+
+  // Default lens: with no explicit ?framework=, this host defaults to the org
+  // default lens resolved to its own OS key (family "stig" -> stig_rhel9). The
+  // explicit "all" sentinel means the user chose All rules (no filter),
+  // distinct from "no choice" which applies the default.
+  const defaultLens = useDefaultLens();
+  const hostFrameworksQuery = useQuery({
+    queryKey: ['host', hostId, 'compliance', 'frameworks'],
+    queryFn: async () => {
+      const { data, response } = await api.GET('/api/v1/hosts/{id}/compliance/frameworks', {
+        params: { path: { id: hostId } },
+      });
+      if (!response.ok) return null;
+      return data;
+    },
+    enabled: !!hostId,
+  });
+  const availableKeys = (hostFrameworksQuery.data?.frameworks ?? []).map((f) => f.framework_id);
+  const resolvedDefault = resolveLensForHost(defaultLens, availableKeys);
+  const framework =
+    search.framework === undefined
+      ? resolvedDefault || undefined
+      : search.framework === 'all'
+        ? undefined
+        : search.framework;
 
   const detailQuery = useQuery({
     queryKey: ['host', hostId, framework],
@@ -352,7 +377,10 @@ export function HostDetailPage() {
       to: '/hosts/$hostId',
       params: { hostId },
       search: {
-        ...(next ? { framework: next } : {}),
+        // Persist the choice explicitly. "All rules" writes the 'all'
+        // sentinel so it overrides the org default (an absent param would
+        // re-apply the default).
+        framework: next && next !== 'all' ? next : 'all',
         ...(activeTab !== 'overview' ? { tab: activeTab } : {}),
       },
     });

--- a/frontend/src/pages/HostsListPage.tsx
+++ b/frontend/src/pages/HostsListPage.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
+import { useDefaultLens } from '@/api/useDefaultLens';
 import { HostActionsMenu } from '@/components/hosts/HostActionsMenu';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
@@ -173,12 +174,17 @@ export function HostsListPage() {
     [search.status, search.os, search.tier],
   );
 
+  // Org default compliance lens — applied to the per-host card scores and the
+  // fleet Avg-compliance KPI so /hosts matches the dashboard. Empty = All rules.
+  const lens = useDefaultLens();
+
   const hostsQuery = useQuery({
-    queryKey: ['hosts', search.env, search.tag],
+    queryKey: ['hosts', search.env, search.tag, lens],
     queryFn: async () => {
       const params: Record<string, string> = {};
       if (search.env) params.environment = search.env;
       if (search.tag) params.tag = search.tag;
+      if (lens) params.framework = lens;
       const { data, error } = await api.GET('/api/v1/hosts', {
         params: { query: params },
       });
@@ -253,9 +259,11 @@ export function HostsListPage() {
   // resolves. Shared queryKey with the dashboard widget, so it dedupes/caches.
   // Spec frontend-hosts-list AC-26.
   const fleetScoreQuery = useQuery({
-    queryKey: ['fleet', 'score'],
+    queryKey: ['fleet', 'score', lens],
     queryFn: async () => {
-      const { data, error, response } = await api.GET('/api/v1/fleet/score', {});
+      const { data, error, response } = await api.GET('/api/v1/fleet/score', {
+        params: lens ? { query: { framework: lens } } : {},
+      });
       if (error || !response.ok) throw new Error(`HTTP ${response.status}`);
       return data!;
     },

--- a/frontend/src/pages/dashboard/widgets.tsx
+++ b/frontend/src/pages/dashboard/widgets.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
+import { useDefaultLens } from '@/api/useDefaultLens';
 import { KpiValue, KpiSub, Sparkline, WidgetCard, WidgetState, toneVar } from './primitives';
 import { relativeTime, severityLabel, severityTone, sourceLabel } from '@/api/eventDisplay';
 
@@ -57,10 +58,15 @@ export function KpiHostsOnline() {
 
 // ── KPI: Avg compliance ────────────────────────────────────────────
 export function KpiAvgCompliance() {
+  // Score through the org default lens (family/key) so a single-framework
+  // shop sees e.g. its STIG score here; empty = All rules (Kensa baseline).
+  const lens = useDefaultLens();
   const q = useQuery({
-    queryKey: ['fleet', 'score'],
+    queryKey: ['fleet', 'score', lens],
     queryFn: async () => {
-      const { data, error, response } = await api.GET('/api/v1/fleet/score', {});
+      const { data, error, response } = await api.GET('/api/v1/fleet/score', {
+        params: lens ? { query: { framework: lens } } : {},
+      });
       if (error || !response.ok)
         throw new Error(apiErrorMessage(error, `Failed (${response.status})`));
       return data!;

--- a/frontend/src/pages/settings/PoliciesPage.tsx
+++ b/frontend/src/pages/settings/PoliciesPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
-import { useAuthStore } from '@/store/useAuthStore';
 import { SettingsLayout } from '@/components/settings/SettingsLayout';
 import { PageHead, Section, BackendPendingBanner } from '@/components/settings/primitives';
 import { ScanVariablesCard } from '@/components/settings/ScanVariablesCard';
@@ -24,7 +23,6 @@ import { ExceptionQueue } from '@/components/settings/ExceptionQueue';
 // frontend-settings (stub sections).
 export function PoliciesPage() {
   const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
-  const canWrite = useAuthStore((s) => s.hasPermission)('system:config_write');
   useEffect(() => {
     setCrumbs([{ label: 'Settings' }, { label: 'Compliance policies' }]);
     return () => setCrumbs([]);
@@ -50,7 +48,7 @@ export function PoliciesPage() {
           use out of the box. "All rules" keeps the framework-agnostic Kensa score. Individual host
           views can still switch lens.
         </p>
-        <DefaultLensCard canWrite={canWrite} />
+        <DefaultLensCard />
         <div style={{ marginTop: 12 }}>
           <BackendPendingBanner
             slice="Enabled frameworks"

--- a/frontend/src/pages/settings/PoliciesPage.tsx
+++ b/frontend/src/pages/settings/PoliciesPage.tsx
@@ -1,14 +1,10 @@
 import { useEffect } from 'react';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
+import { useAuthStore } from '@/store/useAuthStore';
 import { SettingsLayout } from '@/components/settings/SettingsLayout';
-import {
-  PageHead,
-  Section,
-  SettingCard,
-  BackendPendingBanner,
-  Btn,
-} from '@/components/settings/primitives';
+import { PageHead, Section, BackendPendingBanner } from '@/components/settings/primitives';
 import { ScanVariablesCard } from '@/components/settings/ScanVariablesCard';
+import { DefaultLensCard } from '@/components/settings/DefaultLensCard';
 import { ExceptionQueue } from '@/components/settings/ExceptionQueue';
 
 // Settings → Compliance policies.
@@ -28,6 +24,7 @@ import { ExceptionQueue } from '@/components/settings/ExceptionQueue';
 // frontend-settings (stub sections).
 export function PoliciesPage() {
   const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
+  const canWrite = useAuthStore((s) => s.hasPermission)('system:config_write');
   useEffect(() => {
     setCrumbs([{ label: 'Settings' }, { label: 'Compliance policies' }]);
     return () => setCrumbs([]);
@@ -45,50 +42,21 @@ export function PoliciesPage() {
         <ScanVariablesCard />
       </Section>
 
-      {/* ────────── Framework lenses (stub) ────────── */}
-      <Section title="Framework lenses">
-        <BackendPendingBanner
-          slice="Framework registry endpoints"
-          text="Framework enable/disable and the default lens are not configurable yet. Every framework found in the rule corpus is currently available as a lens."
-        />
-        <SettingCard>
-          {[
-            {
-              name: 'Enabled frameworks',
-              description:
-                'CIS RHEL 9, STIG RHEL 9 V2R7, NIST 800-53 R5, PCI-DSS v4.0, FedRAMP Moderate.',
-            },
-            {
-              name: 'Default lens',
-              description: 'Which framework Hosts and Reports filter to by default.',
-            },
-          ].map((row, i) => (
-            <div
-              key={row.name}
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr minmax(180px, auto)',
-                gap: 20,
-                alignItems: 'center',
-                padding: '16px 20px',
-                borderTop: i === 0 ? 'none' : '1px solid var(--ow-line)',
-                opacity: 0.7,
-              }}
-            >
-              <div>
-                <div style={{ fontWeight: 500, color: 'var(--ow-fg-0)' }}>{row.name}</div>
-                <div
-                  style={{ color: 'var(--ow-fg-2)', fontSize: 12, marginTop: 4, lineHeight: 1.5 }}
-                >
-                  {row.description}
-                </div>
-              </div>
-              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <Btn disabled>Configure</Btn>
-              </div>
-            </div>
-          ))}
-        </SettingCard>
+      {/* ────────── Framework lenses ────────── */}
+      <Section title="Framework lenses" badge="Live" badgeTier="ok">
+        <p style={{ margin: '0 0 12px', color: 'var(--ow-fg-2)', fontSize: 13, lineHeight: 1.5 }}>
+          Scans always run the full Kensa rule corpus; a framework lens is a read-time view over
+          those results. Set the default lens the compliance scores (dashboard, hosts, host detail)
+          use out of the box. "All rules" keeps the framework-agnostic Kensa score. Individual host
+          views can still switch lens.
+        </p>
+        <DefaultLensCard canWrite={canWrite} />
+        <div style={{ marginTop: 12 }}>
+          <BackendPendingBanner
+            slice="Enabled frameworks"
+            text="Hiding frameworks you don't use (an allowlist) is a follow-up. Today every framework found in the corpus is available as a lens."
+          />
+        </div>
       </Section>
 
       {/* ────────── Exception workflow (LIVE) ────────── */}

--- a/frontend/tests/pages/hosts-list-extended.test.ts
+++ b/frontend/tests/pages/hosts-list-extended.test.ts
@@ -49,7 +49,7 @@ describe('frontend-hosts-list — v1.1.0 ACs', () => {
     // queryKey must include env + tag so the cache rotates on filter
     // change (and the same key restores from URL on reload).
     expect(PAGE_SRC).toMatch(
-      /queryKey:\s*\[\s*['"]hosts['"]\s*,\s*search\.env\s*,\s*search\.tag\s*\]/,
+      /queryKey:\s*\[\s*['"]hosts['"]\s*,\s*search\.env\s*,\s*search\.tag\s*,\s*lens\s*\]/,
     );
     // Params actually forwarded to the API call.
     expect(PAGE_SRC).toMatch(/params\.environment\s*=\s*search\.env/);

--- a/frontend/tests/pages/hosts-list.test.ts
+++ b/frontend/tests/pages/hosts-list.test.ts
@@ -135,7 +135,7 @@ test('frontend-hosts-list/AC-13 — per-host Scan buttons are live with idempote
 // divides by the all-status rule total) is only a fallback.
 test('frontend-hosts-list/AC-26 — avg compliance KPI sourced from /fleet/score (matches dashboard)', () => {
   // Shares the dashboard's query key + endpoint.
-  expect(PAGE_SRC).toContain("queryKey: ['fleet', 'score']");
+  expect(PAGE_SRC).toContain("queryKey: ['fleet', 'score', lens]");
   expect(PAGE_SRC).toContain("api.GET('/api/v1/fleet/score'");
   // The KPI value is overridden with the canonical fleet score, same rounding
   // as the dashboard widget (Math.round(passing_fraction * 100)).

--- a/internal/fleetrollup/compliance_lens_test.go
+++ b/internal/fleetrollup/compliance_lens_test.go
@@ -1,0 +1,74 @@
+// @spec system-compliance-lens
+//
+// The family-aware fleet score: a family filter spans a mixed-OS fleet.
+
+package fleetrollup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// seedRuleStateFW inserts a host_rule_state row with a specific
+// framework_refs JSONB literal (e.g. `{"stig_rhel9":["V-1"]}`).
+func seedRuleStateFW(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status, frameworkRefs string) {
+	t.Helper()
+	now := time.Now().UTC()
+	scanID, _ := uuid.NewV7()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_rule_state
+			(host_id, rule_id, current_status, severity,
+			 last_checked_at, check_count, last_scan_id, evidence,
+			 framework_refs, first_seen_at, last_changed_at)
+		VALUES ($1, $2, $3, 'medium', $4, 1, $5, '{}'::jsonb, $6::jsonb, $4, $4)`,
+		hostID, ruleID, status, now, scanID, frameworkRefs,
+	)
+	if err != nil {
+		t.Fatalf("seed rule_state fw: %v", err)
+	}
+}
+
+// @ac AC-03
+// AC-03: a FAMILY filter spans a mixed-OS fleet (stig_rhel9 + stig_rhel10),
+// a specific-key filter matches only that OS, and no filter counts all rules.
+func TestFleetComplianceScore_FamilyMatchesMixedOS(t *testing.T) {
+	t.Run("system-compliance-lens/AC-03", func(t *testing.T) {
+		pool := freshPool(t)
+		svc := NewService(pool)
+		user := seedUser(t, pool)
+		h9 := seedHost(t, pool, user)  // RHEL 9
+		h10 := seedHost(t, pool, user) // RHEL 10
+
+		seedRuleStateFW(t, pool, h9, "r.a", "pass", `{"stig_rhel9":["V-1"]}`)
+		seedRuleStateFW(t, pool, h9, "r.b", "fail", `{"stig_rhel9":["V-2"]}`)
+		seedRuleStateFW(t, pool, h9, "r.c", "pass", `{"cis_rhel9":["1.1"]}`)
+		seedRuleStateFW(t, pool, h10, "r.a", "pass", `{"stig_rhel10":["V-1"]}`)
+
+		// Family "stig" = stig_rhel9 (1 pass, 1 fail) + stig_rhel10 (1 pass)
+		// across both hosts → 2 pass / 3 evaluations.
+		stig, err := svc.FleetComplianceScore(context.Background(), WithFramework("stig"))
+		if err != nil {
+			t.Fatalf("stig score: %v", err)
+		}
+		if stig.TotalEvaluations != 3 || stig.PassingFraction != 2.0/3.0 {
+			t.Errorf("stig family = %d evals / %v, want 3 / %v",
+				stig.TotalEvaluations, stig.PassingFraction, 2.0/3.0)
+		}
+
+		// A specific key matches only that OS.
+		key, _ := svc.FleetComplianceScore(context.Background(), WithFramework("stig_rhel9"))
+		if key.TotalEvaluations != 2 {
+			t.Errorf("stig_rhel9 = %d evals, want 2", key.TotalEvaluations)
+		}
+
+		// No filter = all rules (3 pass + 1 fail = 4 evaluations).
+		all, _ := svc.FleetComplianceScore(context.Background())
+		if all.TotalEvaluations != 4 {
+			t.Errorf("all rules = %d evals, want 4", all.TotalEvaluations)
+		}
+	})
+}

--- a/internal/fleetrollup/service.go
+++ b/internal/fleetrollup/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/framework"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -35,15 +36,17 @@ func NewService(pool *pgxpool.Pool) *Service {
 func (s *Service) FleetComplianceScore(ctx context.Context, opts ...Option) (Score, error) {
 	o := applyOpts(opts)
 
-	// Single SQL covers both the unfiltered (framework="") and
-	// framework-filtered paths via NULLIF + ? operator. PostgreSQL
-	// short-circuits to TRUE when $1 is NULL (no framework given).
-	const q = `
+	// Single SQL covers the unfiltered (framework=""), specific-key, and
+	// family paths. framework.MatchSQL($1) is TRUE when $1 is NULL (all
+	// rules) or framework_refs carries that exact key OR any key in that
+	// family (e.g. "stig" matches stig_rhel9 + stig_rhel10 across a mixed-OS
+	// fleet — a single key filter would miss the other OS).
+	q := `
 		SELECT
 			COUNT(*) FILTER (WHERE current_status = 'pass')                  AS passing,
 			COUNT(*) FILTER (WHERE current_status IN ('pass','fail'))        AS evaluations
 		  FROM host_rule_state
-		 WHERE ($1::text IS NULL OR framework_refs ? $1)`
+		 WHERE ` + framework.MatchSQL("$1")
 	var passing, evaluations int64
 	if err := s.pool.QueryRow(ctx, q, nullableFramework(o.framework)).Scan(&passing, &evaluations); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -1,0 +1,116 @@
+// Package framework groups the corpus's per-rule framework reference keys
+// (host_rule_state.framework_refs) into user-facing FAMILIES and lists them
+// for the "default compliance lens" picker.
+//
+// Corpus keys are either OS-specific baselines (stig_rhel9, cis_ubuntu22, …)
+// or OS-agnostic catalogs (nist_800_53, pci_dss_4, srg). A FAMILY is the
+// coarse grouping an operator picks (STIG, CIS, …): the key with a trailing
+// _<os><version> segment stripped. An OS-agnostic key is its own family.
+//
+// The score-filter queries (fleet score, hosts list) match a family in SQL
+// with the SAME regexp as FamilyOf below — see osSuffixSQL. Keep the two in
+// sync: a rule-state is "in family F" when any of its framework_refs keys,
+// with the OS suffix stripped, equals F.
+package framework
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// osSuffix matches a trailing OS/version segment (e.g. _rhel9, _ubuntu2204).
+// Only rhel/ubuntu tokens count as OS suffixes; digits elsewhere
+// (nist_800_53, pci_dss_4) are NOT stripped.
+var osSuffix = regexp.MustCompile(`_(rhel|ubuntu)[0-9]+$`)
+
+// OSSuffixSQL is the Postgres regexp literal mirroring osSuffix, for the
+// score-filter queries. MUST match osSuffix.
+const OSSuffixSQL = `_(rhel|ubuntu)[0-9]+$`
+
+// FamilyOf returns the family id for a corpus framework key by stripping a
+// trailing OS suffix. A key with no OS suffix is its own family:
+//
+//	stig_rhel9 -> stig ; cis_ubuntu22 -> cis ; nist_800_53 -> nist_800_53
+func FamilyOf(key string) string { return osSuffix.ReplaceAllString(key, "") }
+
+// MatchSQL returns a SQL boolean fragment (for a WHERE clause on a table
+// with a framework_refs JSONB column) that is TRUE when:
+//   - the bind parameter is NULL (all-rules, no filter), OR
+//   - framework_refs has a key equal to the parameter (a specific corpus
+//     key, e.g. "stig_rhel9"), OR
+//   - framework_refs has a key whose family (OS suffix stripped) equals the
+//     parameter (a family id, e.g. "stig" matches stig_rhel9/stig_rhel10/…).
+//
+// paramRef is the placeholder to use (e.g. "$1", "$2"); it must be a fixed
+// literal, never user input. The family regexp mirrors FamilyOf.
+func MatchSQL(paramRef string) string {
+	return `(` + paramRef + `::text IS NULL OR EXISTS (
+			SELECT 1 FROM jsonb_object_keys(framework_refs) AS fk
+			 WHERE fk = ` + paramRef + `
+			    OR regexp_replace(fk, '` + OSSuffixSQL + `', '') = ` + paramRef + `))`
+}
+
+// familyLabels overrides the display label for known families; anything else
+// falls back to an upper-cased id.
+var familyLabels = map[string]string{
+	"stig":        "STIG",
+	"cis":         "CIS",
+	"srg":         "SRG",
+	"nist_800_53": "NIST 800-53",
+	"pci_dss_4":   "PCI DSS 4",
+}
+
+// Label renders a family id for display.
+func Label(id string) string {
+	if l, ok := familyLabels[id]; ok {
+		return l
+	}
+	return strings.ToUpper(id)
+}
+
+// Family is a user-facing framework grouping with the corpus keys it spans.
+type Family struct {
+	ID    string   `json:"id"`
+	Label string   `json:"label"`
+	Keys  []string `json:"keys"`
+}
+
+// Service resolves families from the live corpus (host_rule_state).
+type Service struct{ pool *pgxpool.Pool }
+
+// NewService builds the resolver.
+func NewService(pool *pgxpool.Pool) *Service { return &Service{pool: pool} }
+
+// Families groups every framework key present in the corpus into families,
+// sorted by id. Empty when no host has been scanned yet.
+func (s *Service) Families(ctx context.Context) ([]Family, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT DISTINCT k FROM host_rule_state, jsonb_object_keys(framework_refs) AS k`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	byID := map[string][]string{}
+	for rows.Next() {
+		var k string
+		if err := rows.Scan(&k); err != nil {
+			return nil, err
+		}
+		id := FamilyOf(k)
+		byID[id] = append(byID[id], k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]Family, 0, len(byID))
+	for id, ks := range byID {
+		sort.Strings(ks)
+		out = append(out, Family{ID: id, Label: Label(id), Keys: ks})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}

--- a/internal/framework/framework_test.go
+++ b/internal/framework/framework_test.go
@@ -1,0 +1,33 @@
+// @spec system-compliance-lens
+package framework
+
+import "testing"
+
+// @ac AC-02
+// AC-02: FamilyOf strips a trailing OS suffix (rhel/ubuntu + digits) to
+// group OS-specific baselines into one family, and leaves OS-agnostic keys
+// as their own family — so the default-lens picker offers coarse families
+// (STIG, CIS) that resolve per-host.
+func TestFamilyOf(t *testing.T) {
+	t.Run("system-compliance-lens/AC-02", func(t *testing.T) {
+		cases := map[string]string{
+			"stig_rhel9":    "stig",
+			"stig_rhel10":   "stig",
+			"stig_ubuntu22": "stig",
+			"cis_rhel8":     "cis",
+			"cis_ubuntu24":  "cis",
+			"nist_800_53":   "nist_800_53", // OS-agnostic: digits not stripped
+			"pci_dss_4":     "pci_dss_4",   // trailing _4 is not an OS suffix
+			"srg":           "srg",
+		}
+		for key, want := range cases {
+			if got := FamilyOf(key); got != want {
+				t.Errorf("FamilyOf(%q) = %q, want %q", key, got, want)
+			}
+		}
+		// Labels: known families render nicely, unknown upper-cases.
+		if Label("stig") != "STIG" || Label("nist_800_53") != "NIST 800-53" {
+			t.Errorf("Label mismatch: stig=%q nist=%q", Label("stig"), Label("nist_800_53"))
+		}
+	})
+}

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -1724,6 +1724,29 @@ type CategoryEntry struct {
 	Id          string `json:"id"`
 }
 
+// ComplianceConfig Org-wide compliance-display config. default_framework is the default lens the score surfaces (dashboard/hosts avg compliance, host detail) project to: a framework family id (e.g. "stig", "cis") or empty for All rules (the full Kensa corpus). Resolved per-host to the OS key at query time.
+type ComplianceConfig struct {
+	// DefaultFramework Framework family id
+	DefaultFramework string `json:"default_framework"`
+}
+
+// ComplianceFramework defines model for ComplianceFramework.
+type ComplianceFramework struct {
+	// Id Family id (e.g. "stig")
+	Id string `json:"id"`
+
+	// Keys Concrete corpus keys in this family (e.g. stig_rhel9, stig_rhel10)
+	Keys []string `json:"keys"`
+
+	// Label Display label (e.g. "STIG")
+	Label string `json:"label"`
+}
+
+// ComplianceFrameworksResponse defines model for ComplianceFrameworksResponse.
+type ComplianceFrameworksResponse struct {
+	Frameworks []ComplianceFramework `json:"frameworks"`
+}
+
 // ConnectivityBreakdown defines model for ConnectivityBreakdown.
 type ConnectivityBreakdown struct {
 	// Critical unreachable + consecutive_failures<3
@@ -3715,6 +3738,9 @@ type GetFleetTopFailingRulesParams struct {
 type GetHostsParams struct {
 	Environment *string `form:"environment,omitempty" json:"environment,omitempty"`
 	Tag         *string `form:"tag,omitempty" json:"tag,omitempty"`
+
+	// Framework Lens each host card's compliance_summary through a framework family (e.g. "stig") or a specific corpus key; omit for All rules.
+	Framework *string `form:"framework,omitempty" json:"framework,omitempty"`
 }
 
 // GetHostMonitoringHistoryParams defines parameters for GetHostMonitoringHistory.
@@ -3947,6 +3973,9 @@ type PostSSOProviderJSONRequestBody = SSOProviderCreateRequest
 // PutSSOProviderJSONRequestBody defines body for PutSSOProvider for application/json ContentType.
 type PutSSOProviderJSONRequestBody = SSOProviderUpdateRequest
 
+// PutSystemComplianceConfigJSONRequestBody defines body for PutSystemComplianceConfig for application/json ContentType.
+type PutSystemComplianceConfigJSONRequestBody = ComplianceConfig
+
 // PutSystemConnectivityConfigJSONRequestBody defines body for PutSystemConnectivityConfig for application/json ContentType.
 type PutSystemConnectivityConfigJSONRequestBody = ConnectivityConfig
 
@@ -4063,6 +4092,9 @@ type ServerInterface interface {
 	// Fleet-wide compliance exception queue
 	// (GET /api/v1/compliance/exceptions)
 	GetComplianceExceptions(w http.ResponseWriter, r *http.Request, params GetComplianceExceptionsParams)
+	// List the framework families present in the scanned corpus
+	// (GET /api/v1/compliance/frameworks)
+	GetComplianceFrameworks(w http.ResponseWriter, r *http.Request)
 	// List credentials (metadata only)
 	// (GET /api/v1/credentials)
 	GetCredentials(w http.ResponseWriter, r *http.Request)
@@ -4354,6 +4386,12 @@ type ServerInterface interface {
 	// Update an SSO provider (omit client_secret to keep the existing one)
 	// (PUT /api/v1/sso/providers/{id})
 	PutSSOProvider(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Read the org-wide compliance-display config (default lens)
+	// (GET /api/v1/system/compliance/config)
+	GetSystemComplianceConfig(w http.ResponseWriter, r *http.Request)
+	// Set the default compliance lens (framework family, or empty for All rules)
+	// (PUT /api/v1/system/compliance/config)
+	PutSystemComplianceConfig(w http.ResponseWriter, r *http.Request)
 	// Read the connectivity-monitor runtime config + baked-in defaults
 	// (GET /api/v1/system/connectivity/config)
 	GetSystemConnectivityConfig(w http.ResponseWriter, r *http.Request)
@@ -4603,6 +4641,12 @@ func (_ Unimplemented) GetAuthSSOLogin(w http.ResponseWriter, r *http.Request, i
 // Fleet-wide compliance exception queue
 // (GET /api/v1/compliance/exceptions)
 func (_ Unimplemented) GetComplianceExceptions(w http.ResponseWriter, r *http.Request, params GetComplianceExceptionsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List the framework families present in the scanned corpus
+// (GET /api/v1/compliance/frameworks)
+func (_ Unimplemented) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -5185,6 +5229,18 @@ func (_ Unimplemented) GetSSOProvider(w http.ResponseWriter, r *http.Request, id
 // Update an SSO provider (omit client_secret to keep the existing one)
 // (PUT /api/v1/sso/providers/{id})
 func (_ Unimplemented) PutSSOProvider(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Read the org-wide compliance-display config (default lens)
+// (GET /api/v1/system/compliance/config)
+func (_ Unimplemented) GetSystemComplianceConfig(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Set the default compliance lens (framework family, or empty for All rules)
+// (PUT /api/v1/system/compliance/config)
+func (_ Unimplemented) PutSystemComplianceConfig(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -6331,6 +6387,20 @@ func (siw *ServerInterfaceWrapper) GetComplianceExceptions(w http.ResponseWriter
 	handler.ServeHTTP(w, r)
 }
 
+// GetComplianceFrameworks operation middleware
+func (siw *ServerInterfaceWrapper) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetComplianceFrameworks(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetCredentials operation middleware
 func (siw *ServerInterfaceWrapper) GetCredentials(w http.ResponseWriter, r *http.Request) {
 
@@ -7298,6 +7368,19 @@ func (siw *ServerInterfaceWrapper) GetHosts(w http.ResponseWriter, r *http.Reque
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "framework" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "framework", r.URL.Query(), &params.Framework, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "framework"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "framework", Err: err})
 		}
 		return
 	}
@@ -9146,6 +9229,34 @@ func (siw *ServerInterfaceWrapper) PutSSOProvider(w http.ResponseWriter, r *http
 	handler.ServeHTTP(w, r)
 }
 
+// GetSystemComplianceConfig operation middleware
+func (siw *ServerInterfaceWrapper) GetSystemComplianceConfig(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetSystemComplianceConfig(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PutSystemComplianceConfig operation middleware
+func (siw *ServerInterfaceWrapper) PutSystemComplianceConfig(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PutSystemComplianceConfig(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetSystemConnectivityConfig operation middleware
 func (siw *ServerInterfaceWrapper) GetSystemConnectivityConfig(w http.ResponseWriter, r *http.Request) {
 
@@ -9829,6 +9940,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/v1/compliance/exceptions", wrapper.GetComplianceExceptions)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/compliance/frameworks", wrapper.GetComplianceFrameworks)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/credentials", wrapper.GetCredentials)
 	})
 	r.Group(func(r chi.Router) {
@@ -10118,6 +10232,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Put(options.BaseURL+"/api/v1/sso/providers/{id}", wrapper.PutSSOProvider)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/system/compliance/config", wrapper.GetSystemComplianceConfig)
+	})
+	r.Group(func(r chi.Router) {
+		r.Put(options.BaseURL+"/api/v1/system/compliance/config", wrapper.PutSystemComplianceConfig)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/system/connectivity/config", wrapper.GetSystemConnectivityConfig)

--- a/internal/server/api_compliance_test.go
+++ b/internal/server/api_compliance_test.go
@@ -1,0 +1,72 @@
+// @spec system-compliance-lens
+//
+// The default-lens config endpoints + the corpus-derived frameworks list.
+
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+)
+
+// @ac AC-04
+// AC-04: GET /compliance/frameworks (host:read) lists corpus families; the
+// compliance config GET is system:read and PUT is system:config:write
+// (viewer 403), round-trips the value, and rejects an invalid family (400).
+func TestCompliance_FrameworksAndDefaultLens(t *testing.T) {
+	t.Run("system-compliance-lens/AC-04", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		host := seedHostForIntel(t, pool)
+		seedRuleStateForHostWithFrameworks(t, pool, host, "r.a", "pass",
+			map[string]string{"stig_rhel9": "V-1"})
+
+		// Frameworks list → contains the "stig" family.
+		fr := doReq(t, asRole(t, "GET", url+"/api/v1/compliance/frameworks", auth.RoleViewer, nil))
+		if fr.StatusCode != http.StatusOK {
+			t.Fatalf("frameworks = %d, want 200", fr.StatusCode)
+		}
+		raw := readBody(t, fr)
+		if !strings.Contains(raw, `"id":"stig"`) && !strings.Contains(raw, `"id": "stig"`) {
+			t.Errorf("frameworks missing stig family: %s", raw)
+		}
+
+		// Config GET → default empty (All rules).
+		gr := doReq(t, asRole(t, "GET", url+"/api/v1/system/compliance/config", auth.RoleViewer, nil))
+		var cfg api.ComplianceConfig
+		_ = json.NewDecoder(gr.Body).Decode(&cfg)
+		gr.Body.Close()
+		if gr.StatusCode != http.StatusOK || cfg.DefaultFramework != "" {
+			t.Errorf("get config = %d default=%q, want 200 empty", gr.StatusCode, cfg.DefaultFramework)
+		}
+
+		// PUT as viewer → 403.
+		if vr := doReq(t, asRole(t, "PUT", url+"/api/v1/system/compliance/config", auth.RoleViewer,
+			map[string]any{"default_framework": "stig"})); vr.StatusCode != http.StatusForbidden {
+			t.Errorf("viewer put = %d, want 403", vr.StatusCode)
+		}
+
+		// PUT as admin → 200, and the value round-trips.
+		if pr := doReq(t, asRole(t, "PUT", url+"/api/v1/system/compliance/config", auth.RoleAdmin,
+			map[string]any{"default_framework": "stig"})); pr.StatusCode != http.StatusOK {
+			t.Fatalf("admin put = %d, want 200", pr.StatusCode)
+		}
+		gr2 := doReq(t, asRole(t, "GET", url+"/api/v1/system/compliance/config", auth.RoleViewer, nil))
+		var cfg2 api.ComplianceConfig
+		_ = json.NewDecoder(gr2.Body).Decode(&cfg2)
+		gr2.Body.Close()
+		if cfg2.DefaultFramework != "stig" {
+			t.Errorf("after put, default = %q, want stig", cfg2.DefaultFramework)
+		}
+
+		// Invalid family → 400.
+		if br := doReq(t, asRole(t, "PUT", url+"/api/v1/system/compliance/config", auth.RoleAdmin,
+			map[string]any{"default_framework": "BAD SPACE"})); br.StatusCode != http.StatusBadRequest {
+			t.Errorf("invalid put = %d, want 400", br.StatusCode)
+		}
+	})
+}

--- a/internal/server/compliance_handlers.go
+++ b/internal/server/compliance_handlers.go
@@ -1,0 +1,80 @@
+package server
+
+// Compliance-display endpoints: the org-wide DEFAULT LENS setting and the
+// list of framework families present in the scanned corpus (for the picker).
+// The lens is a read-time projection — it changes what scores are shown, not
+// what was scanned (scans always run the full Kensa corpus).
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/framework"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+)
+
+// GetComplianceFrameworks lists the framework families derived from the
+// corpus (host_rule_state.framework_refs). Read-gated on host:read.
+func (h *handlers) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.HostRead); denied {
+		return
+	}
+	fams, err := framework.NewService(h.pool).Families(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"list compliance frameworks failed", true)
+		return
+	}
+	out := api.ComplianceFrameworksResponse{Frameworks: make([]api.ComplianceFramework, 0, len(fams))}
+	for _, f := range fams {
+		out.Frameworks = append(out.Frameworks, api.ComplianceFramework{
+			Id: f.ID, Label: f.Label, Keys: f.Keys,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// GetSystemComplianceConfig returns the org-wide compliance-display config
+// (the default lens). system:read.
+func (h *handlers) GetSystemComplianceConfig(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
+		return
+	}
+	cfg, err := h.sysCfg.LoadCompliance(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"load compliance config failed", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.ComplianceConfig{DefaultFramework: cfg.DefaultFramework})
+}
+
+// PutSystemComplianceConfig sets the default compliance lens. system:config:write.
+func (h *handlers) PutSystemComplianceConfig(w http.ResponseWriter, r *http.Request) {
+	if denied := auth.EnforcePermission(w, r, auth.SystemConfigWrite); denied {
+		return
+	}
+	var req api.ComplianceConfig
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.malformed", "client",
+			"malformed request body", false)
+		return
+	}
+	actor := auth.FromContext(r.Context()).ID
+	cfg, err := h.sysCfg.SetCompliance(r.Context(),
+		systemconfig.ComplianceConfig{DefaultFramework: req.DefaultFramework}, actor)
+	if err != nil {
+		if errors.Is(err, systemconfig.ErrInvalidConfig) {
+			writeError(w, http.StatusBadRequest, "validation.field_invalid", "client",
+				"invalid default_framework", false)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "server.error", "server",
+			"save compliance config failed", true)
+		return
+	}
+	writeJSON(w, http.StatusOK, api.ComplianceConfig{DefaultFramework: cfg.DefaultFramework})
+}

--- a/internal/server/hosts_enrichment.go
+++ b/internal/server/hosts_enrichment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Hanalyx/openwatch/internal/framework"
 	"github.com/Hanalyx/openwatch/internal/server/api"
 )
 
@@ -215,12 +216,15 @@ func loadHostLatestScanIDByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uu
 // compliance_summary: null ("never scanned"). critical_failing counts
 // rows with current_status='fail' AND critical severity
 // (case-insensitive). Spec api-hosts v1.5.0 C-12 / AC-23.
-func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uuid.UUID) (map[uuid.UUID]*api.HostListComplianceSummary, error) {
+func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uuid.UUID, lens string) (map[uuid.UUID]*api.HostListComplianceSummary, error) {
 	out := map[uuid.UUID]*api.HostListComplianceSummary{}
 	if len(ids) == 0 {
 		return out, nil
 	}
-	const q = `
+	// $2 is the default-lens family / specific key (or NULL for all rules);
+	// framework.MatchSQL resolves a family per host in-query so each card
+	// reflects the same lens as the fleet KPI.
+	q := `
 		SELECT host_id,
 		       COUNT(*) FILTER (WHERE current_status = 'pass')::BIGINT    AS passing,
 		       COUNT(*) FILTER (WHERE current_status = 'fail')::BIGINT    AS failing,
@@ -231,8 +235,13 @@ func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []
 		                          AND lower(COALESCE(severity, '')) = 'critical')::BIGINT AS critical_failing
 		  FROM host_rule_state
 		 WHERE host_id = ANY($1)
+		   AND ` + framework.MatchSQL("$2") + `
 		 GROUP BY host_id`
-	rows, err := pool.Query(ctx, q, ids)
+	var frameworkParam any
+	if lens != "" {
+		frameworkParam = lens
+	}
+	rows, err := pool.Query(ctx, q, ids, frameworkParam)
 	if err != nil {
 		return nil, fmt.Errorf("loadHostListComplianceByIDs: %w", err)
 	}
@@ -257,8 +266,12 @@ func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []
 // JSONB contains the given key (api-hosts v1.2.0 AC-17 / AC-18). A host
 // whose rule_state has no rows mapped to the requested framework
 // returns all-zero counts (AC-18).
-func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID, framework string) (api.HostComplianceSummary, error) {
-	const q = `
+func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID, lens string) (api.HostComplianceSummary, error) {
+	// $2 is a family id or a specific corpus key (or NULL for all rules);
+	// framework.MatchSQL resolves a family (e.g. "stig") to the host's own
+	// OS key (stig_rhel9 for a RHEL 9 host) in-query, so the list can carry
+	// a single family filter uniformly across a mixed-OS fleet.
+	q := `
 		SELECT
 			COUNT(*) FILTER (WHERE current_status = 'pass')::BIGINT    AS passing,
 			COUNT(*) FILTER (WHERE current_status = 'fail')::BIGINT    AS failing,
@@ -267,11 +280,11 @@ func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID u
 			COUNT(*)::BIGINT                                           AS total
 		  FROM host_rule_state
 		 WHERE host_id = $1
-		   AND ($2::text IS NULL OR framework_refs ? $2)`
+		   AND ` + framework.MatchSQL("$2")
 	var s api.HostComplianceSummary
 	var frameworkParam any
-	if framework != "" {
-		frameworkParam = framework
+	if lens != "" {
+		frameworkParam = lens
 	}
 	if err := pool.QueryRow(ctx, q, hostID, frameworkParam).Scan(
 		&s.Passing, &s.Failing, &s.Skipped, &s.Error, &s.Total,

--- a/internal/server/hosts_handlers.go
+++ b/internal/server/hosts_handlers.go
@@ -62,7 +62,11 @@ func (h *handlers) GetHosts(w http.ResponseWriter, r *http.Request, params api.G
 			"last_scan_at join failed", true)
 		return
 	}
-	complianceByID, err := loadHostListComplianceByIDs(r.Context(), h.pool, ids)
+	listLens := ""
+	if params.Framework != nil {
+		listLens = *params.Framework
+	}
+	complianceByID, err := loadHostListComplianceByIDs(r.Context(), h.pool, ids, listLens)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"compliance summary join failed", true)

--- a/internal/systemconfig/store.go
+++ b/internal/systemconfig/store.go
@@ -471,3 +471,79 @@ func (s *Store) SetScanVars(ctx context.Context, vars ScanVariables, changedBy s
 	}
 	return nil
 }
+
+// LoadCompliance returns the persisted compliance-display config, or
+// DefaultCompliance (All rules) when no row exists. Only returns an error
+// for DB / unmarshal failures.
+func (s *Store) LoadCompliance(ctx context.Context) (ComplianceConfig, error) {
+	var raw []byte
+	err := s.pool.QueryRow(ctx, `SELECT value FROM system_config WHERE key = $1`, KeyCompliance).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return DefaultCompliance(), nil
+	}
+	if err != nil {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: load %s: %w", KeyCompliance, err)
+	}
+	cfg := DefaultCompliance()
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: unmarshal %s: %w", KeyCompliance, err)
+	}
+	return cfg, nil
+}
+
+// SetCompliance validates and persists the compliance-display config,
+// emitting a SystemConfigChanged audit event with the old + new value.
+func (s *Store) SetCompliance(ctx context.Context, cfg ComplianceConfig, changedBy string) (ComplianceConfig, error) {
+	if err := cfg.Validate(); err != nil {
+		return ComplianceConfig{}, err
+	}
+	newBytes, err := json.Marshal(cfg)
+	if err != nil {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: marshal: %w", err)
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var oldRaw []byte
+	err = tx.QueryRow(ctx, `SELECT value FROM system_config WHERE key = $1 FOR UPDATE`, KeyCompliance).Scan(&oldRaw)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: read old: %w", err)
+	}
+	oldCfg := DefaultCompliance()
+	if len(oldRaw) > 0 {
+		_ = json.Unmarshal(oldRaw, &oldCfg)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO system_config (key, value, updated_at, updated_by)
+		VALUES ($1, $2, now(), $3)
+		ON CONFLICT (key) DO UPDATE
+		   SET value      = EXCLUDED.value,
+		       updated_at = EXCLUDED.updated_at,
+		       updated_by = EXCLUDED.updated_by`,
+		KeyCompliance, newBytes, changedBy,
+	); err != nil {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: upsert: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ComplianceConfig{}, fmt.Errorf("systemconfig: commit: %w", err)
+	}
+
+	if s.emit != nil {
+		s.emit(ctx, audit.SystemConfigChanged, audit.Event{
+			ActorType: "user",
+			ActorID:   changedBy,
+			Detail: audit.MakeDetail(map[string]any{
+				"config_key": KeyCompliance,
+				"old_value":  oldCfg,
+				"new_value":  cfg,
+				"changed_by": changedBy,
+			}),
+		})
+	}
+	return cfg, nil
+}

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -248,3 +248,49 @@ func TestConcurrentSet_LastWriterWins_NoDeadlock(t *testing.T) {
 		}
 	})
 }
+
+// @spec system-compliance-lens
+// @ac AC-01
+// AC-01: ComplianceConfig defaults to All rules (empty), Validate bounds the
+// family token, and Set/Load round-trips the value; a fresh store returns the
+// empty default.
+func TestComplianceConfig_DefaultValidateRoundTrip(t *testing.T) {
+	t.Run("system-compliance-lens/AC-01", func(t *testing.T) {
+		pool := freshPool(t)
+		s := NewStore(pool, nil)
+		ctx := context.Background()
+
+		// Fresh store (no row) → All rules (empty).
+		got, err := s.LoadCompliance(ctx)
+		if err != nil {
+			t.Fatalf("LoadCompliance (no row): %v", err)
+		}
+		if got.DefaultFramework != "" {
+			t.Errorf("default = %q, want empty (All rules)", got.DefaultFramework)
+		}
+
+		// Validate: empty + valid token OK; garbage + over-long rejected.
+		for _, ok := range []string{"", "stig", "nist_800_53", "cis"} {
+			if err := (ComplianceConfig{DefaultFramework: ok}).Validate(); err != nil {
+				t.Errorf("Validate(%q) = %v, want nil", ok, err)
+			}
+		}
+		for _, bad := range []string{"STIG!", "has space", string(make([]byte, 65))} {
+			if err := (ComplianceConfig{DefaultFramework: bad}).Validate(); err == nil {
+				t.Errorf("Validate(%q) = nil, want error", bad)
+			}
+		}
+
+		// Set then Load round-trips.
+		if _, err := s.SetCompliance(ctx, ComplianceConfig{DefaultFramework: "stig"}, "admin"); err != nil {
+			t.Fatalf("SetCompliance: %v", err)
+		}
+		got, err = s.LoadCompliance(ctx)
+		if err != nil {
+			t.Fatalf("LoadCompliance: %v", err)
+		}
+		if got.DefaultFramework != "stig" {
+			t.Errorf("round-trip default = %q, want stig", got.DefaultFramework)
+		}
+	})
+}

--- a/internal/systemconfig/types.go
+++ b/internal/systemconfig/types.go
@@ -14,6 +14,7 @@ const (
 	KeyDiscovery    = "discovery"
 	KeyScan         = "scan"
 	KeyScanVars     = "scan_variables"
+	KeyCompliance   = "compliance"
 )
 
 // ConnectivityConfig is the typed shape stored under KeyConnectivity.
@@ -377,6 +378,39 @@ func (v ScanVariables) Validate() error {
 		}
 		if len(val) > ScanVarsMaxValueLen {
 			return fmt.Errorf("%w: value for %q exceeds %d bytes", ErrInvalidConfig, name, ScanVarsMaxValueLen)
+		}
+	}
+	return nil
+}
+
+// ComplianceConfig holds org-wide compliance-DISPLAY settings. Phase 1
+// carries only the default lens: the framework FAMILY the score surfaces
+// (dashboard avg-compliance, hosts list, host detail) default to. An empty
+// value means "All rules" — the full Kensa corpus, an honest
+// framework-agnostic baseline and the factory default. A non-empty value
+// is a family id (e.g. "stig", "cis", "nist_800_53") resolved per-host to
+// the OS-specific corpus key at query time (internal/framework); an
+// unknown/absent family falls back to all-rules.
+type ComplianceConfig struct {
+	DefaultFramework string `json:"default_framework"`
+}
+
+// DefaultCompliance returns the baked-in default: All rules (empty lens).
+func DefaultCompliance() ComplianceConfig {
+	return ComplianceConfig{DefaultFramework: ""}
+}
+
+// Validate bounds the family id. It is resolved leniently against the live
+// corpus at query time, so this only rejects obvious garbage / length; an
+// empty value (All rules) is always valid.
+func (c ComplianceConfig) Validate() error {
+	f := c.DefaultFramework
+	if len(f) > 64 {
+		return fmt.Errorf("%w: default_framework exceeds 64 chars", ErrInvalidConfig)
+	}
+	for _, r := range f {
+		if !(r == '_' || r == '-' || r == '.' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return fmt.Errorf("%w: default_framework has invalid characters", ErrInvalidConfig)
 		}
 	}
 	return nil

--- a/specs/frontend/hosts-list.spec.yaml
+++ b/specs/frontend/hosts-list.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-hosts-list
   title: Hosts list — fleet dashboard with search, filter, card/table views
-  version: "1.9.0"
+  version: "1.10.0"
   status: approved
   tier: 2
 
@@ -127,7 +127,7 @@ spec:
       priority: high
       references_constraints: [C-04]
     - id: AC-05
-      description: Reloading /hosts?env=production&tag=tag-x&q=foo restores all three URL params into the search box + environment filter + tag filter AND re-fetches with the env/tag parameters via the openapi-fetch client. v1.1.0 — sort URL params are out of scope per the revised AC-04.
+      description: 'Reloading /hosts?env=production&tag=tag-x&q=foo restores all three URL params into the search box + environment filter + tag filter AND re-fetches with the env/tag parameters via the openapi-fetch client. v1.1.0 — sort URL params are out of scope per the revised AC-04. v1.10.0 — the hosts query key also carries the org default lens (queryKey [''hosts'', search.env, search.tag, lens]) so the per-host card scores rotate when the default framework changes; the resolved lens is forwarded as params.framework.'
       priority: critical
       references_constraints: [C-04]
     - id: AC-06
@@ -218,8 +218,11 @@ spec:
         > 0, kpis.avgCompliance.value is round(passing_fraction * 100) — the
         same number and rounding the dashboard shows — overriding the
         client-side kpisFromHosts aggregate so /hosts and /dashboard agree.
+        v1.10.0 — the key carries the org default lens (['fleet','score',lens])
+        and forwards it as ?framework= so the KPI reflects the default lens,
+        matching the dashboard.
         Source-inspection of HostsListPage: a useQuery with queryKey
-        ['fleet','score'] hits GET /api/v1/fleet/score, and the avg-compliance
+        ['fleet','score',lens] hits GET /api/v1/fleet/score, and the avg-compliance
         KPI value is set to round(passing_fraction * 100) from that query
         (guarded on total_evaluations > 0), the same expression the dashboard
         widget uses.

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -1,0 +1,73 @@
+spec:
+  id: system-compliance-lens
+  title: Default compliance lens — org-wide framework projection
+  version: "1.0.0"
+  status: approved
+  tier: 2
+
+  context:
+    system: openwatch
+    feature: An org-wide default framework "lens" the compliance-score surfaces project to
+    description: >
+      OpenWatch scans a host once against the full Kensa corpus; frameworks
+      (CIS, STIG, NIST, …) are read-time PROJECTIONS over that one result
+      (system-kensa-executor: "one scan, many framework views"). Phase 1 adds
+      an org-wide DEFAULT LENS: an admin picks a framework FAMILY (e.g. STIG)
+      and the score surfaces (dashboard + hosts avg compliance, hosts-list
+      cards, host detail) default to scoring against that framework's mapped
+      rules instead of All rules. The default is a family, not a versioned
+      key, so it resolves per-host to the OS-appropriate corpus key
+      (stig_rhel9 on RHEL 9, stig_rhel10 on RHEL 10); a host with no key for
+      the family scores N/A under it. Empty means All rules — the honest
+      framework-agnostic baseline and the factory default.
+    related_specs:
+      - system-kensa-executor
+      - api-fleet-observability
+      - api-hosts
+
+  objective:
+    summary: >
+      The default lens changes what compliance scores DEFAULT to showing,
+      org-wide, without changing what was scanned; All rules stays the
+      baseline and frameworks never blend into one number.
+    scope:
+      includes:
+        - 'ComplianceConfig.DefaultFramework (systemconfig) + config endpoints'
+        - 'Framework family resolution (FamilyOf) + corpus-derived family list'
+        - 'Family-aware score filter in the fleet score + hosts-list queries'
+      excludes:
+        - 'Per-host/per-group compliance TARGET assignment (Phase 3)'
+        - 'Framework-scoped posture history / trend (Phase 3)'
+        - 'Enabled-frameworks allowlist (Phase 2)'
+
+  constraints:
+    - id: C-01
+      description: The default lens is ComplianceConfig.DefaultFramework, persisted in systemconfig (KeyCompliance). An empty value means All rules (the factory default); a non-empty value is a framework FAMILY id. It is a read-time display default only — it MUST NOT affect what a scan runs (scans always execute the full corpus).
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: A framework FAMILY groups corpus keys by stripping a trailing OS suffix (_(rhel|ubuntu)<digits>); an OS-agnostic key (nist_800_53, pci_dss_4, srg) is its own family. The available family list MUST be derived from the live corpus (host_rule_state.framework_refs), never hardcoded. A score filter for a family MUST match ANY corpus key in that family (so a mixed-OS fleet scores across stig_rhel9 + stig_rhel10), while a specific key matches exactly; the family match SQL MUST mirror FamilyOf.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: The compliance config read is system:read; the write is system:config:write and emits a system.config.changed audit event. The frameworks list is host:read.
+      type: security
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: ComplianceConfig defaults DefaultFramework to "" (All rules); Validate accepts empty and a short lowercase family token and rejects an over-long or invalid-character value. SetCompliance persists and LoadCompliance round-trips the value; a fresh store with no row returns the empty (All rules) default.
+      priority: high
+      references_constraints: [C-01]
+    - id: AC-02
+      description: FamilyOf strips a trailing OS suffix (stig_rhel9 -> stig, cis_ubuntu22 -> cis) and leaves an OS-agnostic key as its own family (nist_800_53, pci_dss_4, srg). Label renders a known family (STIG, NIST 800-53) and upper-cases an unknown id.
+      priority: high
+      references_constraints: [C-02]
+    - id: AC-03
+      description: The fleet compliance score with a FAMILY filter counts rule-states carrying ANY key in that family across a mixed-OS corpus (a host with stig_rhel9 and a host with stig_rhel10 both contribute to the "stig" fleet score); a specific-key filter counts only that key; an empty filter counts all rules. The hosts-list card summary honors the same family filter per host.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-04
+      description: GET /api/v1/compliance/frameworks returns the corpus-derived families (id, label, keys) and is host:read. GET /api/v1/system/compliance/config returns the current default lens (system:read); PUT sets it (system:config:write), rejects an invalid value with 400, and echoes the stored value.
+      priority: high
+      references_constraints: [C-01, C-03]

--- a/specter.yaml
+++ b/specter.yaml
@@ -69,6 +69,7 @@ domains:
             - system-worker-subcommand
             - system-scan-runs
             - system-account-policy
+            - system-compliance-lens
             - api-host-compliance
             - api-system-scan-config
             - api-compliance-trend


### PR DESCRIPTION
## Summary

Phase 1 of the Framework-lens design: an org-wide **default compliance lens**. An admin picks a framework family (STIG, CIS, …) and the compliance-score surfaces default to it instead of All rules — without changing what a scan runs (scans always execute the full Kensa corpus; a lens is a read-time projection).

Delivers the agreed model:
- **All rules stays the honest baseline** and the factory default — zero behavior change out of the box.
- **Admin override** picks a framework **family**, resolved per-host to the OS key (STIG → `stig_rhel9` on RHEL 9, `stig_rhel10` on RHEL 10; N/A where a host's OS has no key for the family).
- We never blend frameworks into one number.

## Backend

- **`ComplianceConfig.DefaultFramework`** (systemconfig, `KeyCompliance`) — empty = All rules. Endpoints: `GET/PUT /api/v1/system/compliance/config` (system:read / system:config_write, audited).
- **`internal/framework`** — `FamilyOf` strips a trailing `_(rhel|ubuntu)<digits>` OS suffix to group corpus keys into families (OS-agnostic keys like `nist_800_53`/`pci_dss_4`/`srg` are their own family); `Families()` derives the picker list from the live corpus (`host_rule_state.framework_refs`) — nothing hardcoded. `GET /api/v1/compliance/frameworks` lists them (host:read).
- **Family-aware scoring** — `framework.MatchSQL` matches a rule-state by exact key OR family (OS suffix stripped, mirroring `FamilyOf`), so a `?framework=stig` filter spans `stig_rhel9 + stig_rhel10` across a mixed-OS fleet (a single-key filter would miss the other OS). Applied to the fleet score, the hosts-list card summary, and the per-host list loader; `GET /hosts` gains a `framework` query param.

## Frontend

- **Settings → Compliance policies → Framework lenses** is now live: a **Default lens** dropdown (All rules + corpus families) wired to the config, admin-gated. (Enabled-frameworks allowlist is labeled a follow-up.)
- **Dashboard** and **/hosts** Avg-Compliance KPIs pass the default lens to `/fleet/score`; **/hosts** per-host cards pass it to `GET /hosts`.
- **Host detail** defaults its lens to the org default resolved to that host's key (the existing "View as" selector still overrides; an explicit "All rules" uses an `all` sentinel so it isn't re-defaulted). Shared `useDefaultLens` hook + `familyOf`/`resolveLensForHost` helpers.

## Out of scope (later phases, per the design)

- **Enabled-frameworks allowlist** (Phase 2).
- **Per-host/group compliance TARGET + mixed-fleet cohorts** (Phase 3) — the fleet avg stays a single lens/All-rules number for now.
- **Framework-scoped 30-day trend** — posture snapshots are still all-rules (no framework dimension); the trend card stays All rules under a framework default. Labeled, deferred to Phase 3.

## SDD

New spec **`system-compliance-lens`** (AC-01 config store, AC-02 family resolution, AC-03 family-aware fleet score across mixed OS, AC-04 endpoints), registered in specter.yaml. `frontend-hosts-list` 1.9.0→1.10.0 (query keys carry the lens). Tests: `framework` FamilyOf; systemconfig ComplianceConfig round-trip; fleetrollup family-matches-mixed-OS; server compliance endpoints (RBAC + round-trip + invalid→400).

## Verification

- `gofmt`, `go vet ./...`, `go build ./...` — clean
- `internal/framework`, `internal/systemconfig`, `internal/fleetrollup`, `internal/server` suites pass
- `specter check` (116 specs), `coverage --strictness annotation` (116/116), `check-generated` in sync
- frontend `tsc` + full vitest 353/353
