### PR TITLE
release-readiness: security hardening, runtime-verified docs, quality fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -842,3 +842,6 @@ frontend/.specter-results.json
 
 # Local dev bootstrap state (scripts/openwatch.sh)
 .dev/
+
+# Kensa runtime state (SQLite remediation store, created at runtime)
+.kensa/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Org-wide default compliance lens.** A scan always runs the full Kensa
+  corpus; a framework lens is a read-time view over that one result. An admin
+  can now set an org-wide default lens (Settings, Compliance policies, Framework
+  lenses) so the compliance scores on the dashboard, hosts list, and host detail
+  default to a chosen framework family (for example STIG or CIS) instead of the
+  framework-agnostic All rules baseline. The default is a family, so it resolves
+  per host to the OS-appropriate corpus key (`stig_rhel9` on RHEL 9,
+  `stig_rhel10` on RHEL 10); a host with no key for the family scores N/A under
+  it. All rules stays the factory default. Individual host views can still
+  switch lens. Backed by `GET /api/v1/compliance/frameworks` (corpus-derived
+  family list, `host:read`) and `GET`/`PUT /api/v1/system/compliance/config`
+  (`system:read` / `system:config_write`). See spec `system-compliance-lens`.
+- **SMTP email notifications with per-severity routing.** A notification channel
+  can now deliver over SMTP to any mail service or a local relay such as Postfix,
+  with three transport modes: `starttls` (required, the default), implicit
+  `tls` on port 465, and `none` for a trusted local relay. A per-channel
+  severity threshold routes alerts by level (for example, high and above), and
+  a self-signed-certificate option covers internal relays without a public CA.
+  See spec `system-notifications`.
+- **Self-service profile editing.** A signed-in user can update their own
+  display name, full name, job title, timezone, and phone, and change their
+  email. An email change is checked for uniqueness against active accounts. See
+  spec `system-user-management`.
+
 ### Security
 
 - **Kensa bumped to v0.7.6, patching a root command injection in the
@@ -40,6 +66,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   disabled via an `install /bin/false` override, or absent from the kernel
   tree entirely, now counts as disabled. This only turns former false
   failures into passes.
+
+### Fixed
+
+- **Per-host and per-group maintenance now suppress scans everywhere.** Putting
+  a host into maintenance (or a group the host belongs to) previously did not
+  reliably stop scheduled scans: the scheduler read a per-host flag that the
+  maintenance controls no longer wrote. A new `host_effective_maintenance` view
+  unifies per-host and per-group maintenance, and the scheduler and worker honor
+  it, so a host in maintenance from either source is skipped.
+- **Notification channel test surfaces the real failure.** A failed channel
+  test returned a bare 400 with no detail. It now reports the underlying error
+  (for example, a TLS or connection failure) while scrubbing secrets: a webhook
+  URL embedded in an error is stripped so it can't leak into the response.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   test returned a bare 400 with no detail. It now reports the underlying error
   (for example, a TLS or connection failure) while scrubbing secrets: a webhook
   URL embedded in an error is stripped so it can't leak into the response.
+- **Host-detail "paused for maintenance" tile now reflects real state.** The
+  host-detail Auto-scan card read a schedule column the scheduler stopped
+  writing (it moved to the per-host/per-group maintenance view in an earlier
+  change), so a host in maintenance never showed as paused on its own page. It
+  now reads the effective-maintenance view.
 
 ---
 

--- a/audit/events.yaml
+++ b/audit/events.yaml
@@ -141,6 +141,14 @@ events:
     severity: info
     description: User's password was successfully updated
 
+  - code: auth.profile.updated
+    severity: info
+    description: User updated their own profile (self-service). email_changed is true when the update included the sign-in email.
+    detail_schema:
+      type: object
+      properties:
+        email_changed: {type: boolean}
+
   - code: auth.password.policy_failed
     severity: warning
     description: Password change rejected by the NIST 800-63B policy validator

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -1,6 +1,6 @@
 # API guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 Most operators use the web UI for daily work—managing hosts, viewing fleet
 health, reading compliance state, and triaging alerts. This guide is for
@@ -12,7 +12,7 @@ React UI over HTTPS on port `8443`. All API paths live under `/api/v1`. The
 running binary serves its own OpenAPI document as the contract source of truth,
 and `GET /api/v1/version` reports the build it came from.
 
-This guide reflects OpenWatch `v0.2.0`, a pre-release. The compliance
+This guide reflects OpenWatch `v0.3.0`. The compliance
 surface (scan execution + results, remediation, exceptions, posture/drift, audit
 export, the rule browser) IS exposed over `/api/v1`. See [the compliance API surface
 (now live)](#compliance-api-surface-now-live). The genuinely-absent pieces (a
@@ -26,8 +26,10 @@ When the OpenAPI document and this guide disagree, the OpenAPI document wins.
 ## Conventions
 
 - Base URL is `https://<host>:8443`. The server is HTTPS-only. In a default
-  install the certificate at `/etc/openwatch/tls/` is self-signed, so add
-  `--cacert` (or, for a throwaway lab box only, `-k`) to your `curl` calls.
+  install the certificate at `/etc/openwatch/tls/cert.pem` is self-signed, so
+  add `--cacert /etc/openwatch/tls/cert.pem` (or, for a throwaway lab box
+  only, `-k`) to your `curl` calls. In production, point `--cacert` at your
+  own CA bundle instead.
 - Resource identifiers are UUIDs.
 - Timestamps are ISO 8601 / RFC 3339 (for example `2026-06-10T14:30:00Z`).
 - Mutating endpoints that exist to be retried safely take a required
@@ -57,7 +59,7 @@ Everything else requires a valid identity.
 ### Log in
 
 ```bash
-TOKEN=$(curl -s --cacert /etc/openwatch/tls/ca.crt \
+TOKEN=$(curl -s --cacert /etc/openwatch/tls/cert.pem \
   -X POST https://localhost:8443/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username":"admin","password":"yourpassword"}' | jq -r '.access_token')
@@ -131,7 +133,7 @@ permissions-registry endpoint under `/api/v1/auth`.
 ### Create a host
 
 ```bash
-curl -s --cacert /etc/openwatch/tls/ca.crt \
+curl -s --cacert /etc/openwatch/tls/cert.pem \
   -X POST https://localhost:8443/api/v1/hosts \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -275,11 +277,11 @@ field in each page to paginate.
 These two endpoints are anonymous and are what monitoring should poll.
 
 ```bash
-curl -s --cacert /etc/openwatch/tls/ca.crt https://localhost:8443/api/v1/health | jq
+curl -s --cacert /etc/openwatch/tls/cert.pem https://localhost:8443/api/v1/health | jq
 ```
 
 ```json
-{"status": "healthy", "db_connected": true, "version": "0.2.0"}
+{"status": "healthy", "db_connected": true, "version": "0.3.0"}
 ```
 
 `status` is `healthy` or `degraded`; the endpoint returns `503` when the service
@@ -363,13 +365,15 @@ longer worker-internal only):
   per-scan history + per-rule evidence + OSCAL export under `/api/v1/scans` and
   `/api/v1/scans/{id}` (scan:read).
 - **Remediation**: request/approve/reject + execute/rollback under
-  `/api/v1/remediation/requests` (and `/api/v1/hosts/{id}/scans/{rule}:remediate`).
-- **Compliance exceptions**: `/api/v1/compliance/exceptions` (request/approve/
-  revoke/expire).
+  `/api/v1/remediation/requests` (sub-actions `:approve`, `:dry-run`,
+  `:execute`, `:reject`, `:rollback`).
+- **Compliance exceptions**: request via `/api/v1/hosts/{id}/exceptions`,
+  browse the fleet queue via `/api/v1/compliance/exceptions`, then mutate with
+  `/api/v1/exceptions/{xid}:approve`, `:reject`, or `:revoke`.
 - **Posture + drift**: per-host `/api/v1/hosts/{id}/compliance` and
   `/api/v1/hosts/{id}/compliance/trend`; fleet `/api/v1/fleet/score`.
-- **Audit export**: `POST /api/v1/audit/events:query` and
-  `/api/v1/audit/events/export` (CSV/JSON, signed bundle).
+- **Audit export**: `GET /api/v1/audit/events` (filterable via query
+  parameters) and `GET /api/v1/audit/events/export` (CSV/JSON, signed bundle).
 - **Rule browser**: `/api/v1/rules` (the Kensa rule-library read model).
 
 ## What is genuinely not in the API yet
@@ -378,14 +382,15 @@ longer worker-internal only):
   roadmap items (use `GET /api/v1/health` for liveness today). Do not script
   against them until they appear in the served OpenAPI document.
 
-For how OpenWatch invokes Kensa, see
-the Kensa scanning engine.
+Kensa is the SSH-based compliance scanning engine OpenWatch invokes to run
+scans; see [Scanning and compliance](SCANNING_AND_COMPLIANCE.md) for how it
+integrates.
 
 ---
 
 ## What's next
 
 - [Install guide](INSTALLATION.md)—install, configure, and run the service.
-- RBAC registry—permission and role reference.
-- Kensa and OpenWatch boundary—how scanning works.
+- [User roles](USER_ROLES.md)—permission and role reference.
+- [Scanning and compliance](SCANNING_AND_COMPLIANCE.md)—how scanning works.
 - The served OpenAPI document—the authoritative, always-current API contract.

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -237,7 +237,7 @@ through the API. These are admin-level controls.
 | `DELETE` | `/api/v1/users/{id}` | Delete a user. |
 | `POST` | `/api/v1/users/{id}/roles:assign` | Assign a role. Body: `{role_id}`. |
 | `POST` | `/api/v1/users/{id}/roles:unassign` | Remove a role. |
-| `GET` | `/api/v1/roles` | List roles (built-in and custom). |
+| `GET` | `/api/v1/roles` | List roles (built-in roles only). |
 | `POST` | `/api/v1/roles:create` | Create a custom role. |
 
 For first-admin bootstrap, prefer the CLI (`openwatch create-admin`) over the
@@ -266,9 +266,9 @@ cursor-paginated, newest first.
 |--------|------|---------|
 | `GET` | `/api/v1/audit/events` | List audit events. |
 
-Query parameters: `action`, `correlation_id`, `actor_type`, `since`, `until`
-(both RFC 3339), `cursor`, and `limit` (1–200, default 50). Follow the `cursor`
-field in each page to paginate.
+Query parameters: `action`, `correlation_id`, `actor_type`, `resource_type`,
+`resource_id`, `since`, `until` (both RFC 3339), `cursor`, and `limit` (1–200,
+default 50). Follow the `cursor` field in each page to paginate.
 
 ---
 
@@ -284,9 +284,11 @@ curl -s --cacert /etc/openwatch/tls/cert.pem https://localhost:8443/api/v1/healt
 {"status": "healthy", "db_connected": true, "version": "0.3.0"}
 ```
 
-`status` is `healthy` or `degraded`; the endpoint returns `503` when the service
-cannot serve. `GET /api/v1/version` returns build metadata (`openwatch`, `kensa`,
-`go`, `commit`, `build_time`).
+A healthy response is always `status: "healthy"`, `db_connected: true`. When
+the database is unreachable, the endpoint does not return a `degraded` status
+body—it returns `503` with the standard `ErrorEnvelope` (code
+`server.unavailable`) instead. `GET /api/v1/version` returns build metadata
+(`openwatch`, `kensa`, `go`, `commit`, `build_time`).
 
 ---
 
@@ -297,7 +299,7 @@ Errors use a single envelope shape, not field-level validation detail:
 ```json
 {
   "error": {
-    "code": "validation_failed",
+    "code": "hosts.invalid_input",
     "fault": "client",
     "retryable": false,
     "human_message": "ip_address is required",
@@ -318,12 +320,15 @@ will encounter:
 | `404` | Not found |
 | `405` | Method not allowed |
 | `409` | Conflict—duplicate resource, or a reused `Idempotency-Key` with a different body |
+| `429` | Too many requests—`/auth/login` or `/auth/mfa:verify` rate limit exceeded; retry after `Retry-After` seconds |
 | `502` | Bad gateway—an external dependency failed |
 | `503` | Service unavailable—the service is degraded |
 
-There is no API-layer request rate limiting in this release, and there is no
-`422` validation status—validation failures return `400` with the envelope
-above.
+There is no general per-route API rate limiting in this release. `POST
+/api/v1/auth/login` and `/api/v1/auth/mfa:verify` are the exceptions: they are
+rate-limited per client IP and return `429` with a `Retry-After` header over
+the limit. There is no `422` validation status—validation failures return
+`400` with the envelope above.
 
 ---
 
@@ -373,7 +378,9 @@ longer worker-internal only):
 - **Posture + drift**: per-host `/api/v1/hosts/{id}/compliance` and
   `/api/v1/hosts/{id}/compliance/trend`; fleet `/api/v1/fleet/score`.
 - **Audit export**: `GET /api/v1/audit/events` (filterable via query
-  parameters) and `GET /api/v1/audit/events/export` (CSV/JSON, signed bundle).
+  parameters, cursor-paginated) and `GET /api/v1/audit/events/export`, a
+  synchronous CSV/JSON download of the same filtered set (capped at 10,000
+  rows, newest-first).
 - **Rule browser**: `/api/v1/rules` (the Kensa rule-library read model).
 
 ## What is genuinely not in the API yet

--- a/docs/guides/BACKUP_RECOVERY.md
+++ b/docs/guides/BACKUP_RECOVERY.md
@@ -1,6 +1,6 @@
 # Backup and recovery
 
-**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers backup, restore, and disaster recovery for an OpenWatch
 deployment. OpenWatch is a single Go binary (`/usr/bin/openwatch`) that serves

--- a/docs/guides/BACKUP_RECOVERY.md
+++ b/docs/guides/BACKUP_RECOVERY.md
@@ -169,8 +169,8 @@ openssl enc -aes-256-cbc -d -pbkdf2 \
     -in /var/backups/openwatch/config_<timestamp>.tar.gz.enc \
   | sudo tar xzf - -C /
 
-sudo chown -R root:openwatch /etc/openwatch/keys
-sudo chmod 0640 /etc/openwatch/keys/credential.key
+sudo chown openwatch:openwatch /etc/openwatch/keys/credential.key
+sudo chmod 0600 /etc/openwatch/keys/credential.key
 sudo systemctl restart openwatch
 ```
 

--- a/docs/guides/COMPLIANCE_CONTROLS.md
+++ b/docs/guides/COMPLIANCE_CONTROLS.md
@@ -1,6 +1,6 @@
 # Compliance control mapping
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This document maps OpenWatch's security controls to industry frameworks, providing evidence for compliance audits.
 
@@ -43,7 +43,7 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 
 | Control | Title | OpenWatch Implementation | Evidence |
 |---------|-------|-------------------------|----------|
-| CM-2 | Baseline Configuration | Kensa YAML rules define expected configurations | Kensa rules (630 native YAML rules); scan results |
+| CM-2 | Baseline Configuration | Kensa YAML rules define expected configurations | Kensa rules (748 rules, Kensa v0.7.6); scan results |
 | CM-3 | Configuration Change Control | Database migration tracking, version control | Migration version reported by `openwatch migrate` |
 | CM-6 | Configuration Settings | Configuration validation at startup | Output of `openwatch check-config` |
 | CM-8 | System Component Inventory | Host management with discovery and metadata | Host list and collected system info from the API |
@@ -91,7 +91,7 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | 1.1 | Enterprise Asset Inventory | Host management with system info collection |
 | 2.1 | Software Inventory | Server intelligence (package collection) |
 | 3.3 | Data Encryption | AES-256-GCM at rest, TLS 1.2+ in transit |
-| 4.1 | Secure Configuration | Kensa compliance scanning (630-rule corpus) |
+| 4.1 | Secure Configuration | Kensa compliance scanning (748 rules, Kensa v0.7.6) |
 | 4.2 | Baseline Network Configuration | Network discovery and topology mapping |
 | 5.2 | Unique Passwords | Argon2id hashing, 8-char minimum (15 for admin), breached-password screening |
 | 5.4 | MFA | TOTP-based MFA with backup codes |
@@ -99,7 +99,7 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | 6.3 | Centralized Log Collection | JSON logging, configurable log aggregation |
 | 8.2 | Audit Logging | All authentication and authorization events logged |
 | 8.5 | Access Control Logs | JWT validation events, RBAC enforcement logged |
-| 8.11 | Audit Log Retention | Configurable retention, export to CSV/JSON/PDF |
+| 8.11 | Audit Log Retention | Configurable retention, export to CSV/JSON |
 | 9.1 | Email Security | SMTP TLS for notifications |
 | 10.1 | Anti-Malware | File upload validation, no executable uploads |
 | 13.1 | Network Monitoring | Health check endpoints, audit-event queries (no Prometheus endpoint) |
@@ -155,7 +155,7 @@ cookie obtained from `/api/v1/auth/login`, or with a Bearer token.
 
 ```bash
 # Query audit events for a date range
-curl "https://localhost:8443/api/v1/audit/events?date_from=2026-01-01&date_to=2026-02-17" \
+curl "https://localhost:8443/api/v1/audit/events?since=2026-01-01T00:00:00Z&until=2026-02-17T23:59:59Z" \
   -H "Authorization: Bearer $TOKEN" > audit_evidence.json
 
 # Export fleet compliance score

--- a/docs/guides/COMPLIANCE_CONTROLS.md
+++ b/docs/guides/COMPLIANCE_CONTROLS.md
@@ -8,11 +8,10 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 
 | Framework | Controls Mapped | Coverage |
 |-----------|----------------|----------|
-| NIST SP 800-53 Rev 5 | 42 | Moderate baseline |
-| CIS Controls v8 | 18 | Implementation Group 2 |
-| CMMC Level 2 | 28 | Practice-level mapping |
-| FedRAMP Moderate | 42 | Inherited from NIST |
-| ISO 27001:2022 | 15 | Annex A controls |
+| NIST SP 800-53 Rev 5 | 32 | Moderate baseline |
+| CIS Controls v8 | 16 | Implementation Group 2 |
+| CMMC Level 2 | 27 | Practice-level mapping |
+| FedRAMP Moderate | 32 | Inherited from NIST |
 
 ## NIST SP 800-53 control mapping
 
@@ -24,7 +23,6 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | AC-3 | Access Enforcement | Role-based permission checks on each route | `403` denials in the audit log; permission registry served by the API |
 | AC-6 | Least Privilege | Five built-in roles (least-privilege viewer baseline) | Role list from `/api/v1/roles` |
 | AC-7 | Unsuccessful Logon Attempts | Per-IP sliding-window rate limit on the auth endpoints (login, MFA verify); 429 + Retry-After | `429` responses with `Retry-After`; rate-limit denials in the audit log |
-| AC-8 | System Use Notification | Configurable login banner | Banner shown on the login page |
 | AC-11 | Session Lock | Inactivity timeout (default 15 min, configurable 1-480) | Session-timeout value in the running configuration |
 | AC-12 | Session Termination | Session cookie and JWT expiration (30 min access, 7 day refresh) | Token expiry observed on the API; logout audit events |
 | AC-17 | Remote Access | SSH with NIST SP 800-57 key validation | Host-key validation behavior on connect |
@@ -53,9 +51,9 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | Control | Title | OpenWatch Implementation | Evidence |
 |---------|-------|-------------------------|----------|
 | IA-2 | Identification and Authentication | Session cookie and JWT auth with username/password | Login behavior at `/api/v1/auth/login`; auth audit events |
-| IA-2(1) | MFA for Privileged Accounts | TOTP-based MFA with backup codes | MFA enrollment status per user; MFA audit events |
+| IA-2(1) | MFA for Privileged Accounts | TOTP-based MFA (no backup/recovery codes) | MFA enrollment status per user; MFA audit events |
 | IA-5 | Authenticator Management | Argon2id hashing (64MB, 3 iterations), 8-char minimum (15 for admin) | Password policy enforced at user creation |
-| IA-5(1) | Password-Based Authentication | Complexity requirements (upper, lower, digit, special) | Password policy enforced at user creation |
+| IA-5(1) | Password-Based Authentication | Length-only policy per NIST SP 800-63B (8 chars regular / 15 admin, max 128); no character-class complexity rules; new passwords screened against an embedded common/breached corpus | Password policy enforced at user creation |
 
 ### Risk assessment (RA)
 
@@ -69,7 +67,7 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | Control | Title | OpenWatch Implementation | Evidence |
 |---------|-------|-------------------------|----------|
 | SC-8 | Transmission Confidentiality | TLS 1.2/1.3 for all connections | HTTPS-only listener on port 8443 |
-| SC-8(1) | Cryptographic Protection | FIPS-approved cipher suites | FIPS mode reported by `openwatch --version` |
+| SC-8(1) | Cryptographic Protection | The `-fips` build's cryptographic operations run through the FIPS 140-3 crypto module (Go GOFIPS140); TLS cipher-suite selection itself is the Go standard-library default and is not pinned to a FIPS-approved suite list | FIPS mode reported by `openwatch --version` |
 | SC-10 | Network Disconnect | Configurable session timeout | Session-timeout value in the running configuration |
 | SC-12 | Cryptographic Key Establishment | AES-256-GCM with environment-sourced keys | Key files under `/etc/openwatch/keys/` |
 | SC-13 | Cryptographic Protection | FIPS via the Go-native FIPS module | FIPS mode reported by `openwatch --version` |
@@ -94,18 +92,16 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | 4.1 | Secure Configuration | Kensa compliance scanning (748 rules, Kensa v0.7.6) |
 | 4.2 | Baseline Network Configuration | Network discovery and topology mapping |
 | 5.2 | Unique Passwords | Argon2id hashing, 8-char minimum (15 for admin), breached-password screening |
-| 5.4 | MFA | TOTP-based MFA with backup codes |
+| 5.4 | MFA | TOTP-based MFA (no backup/recovery codes) |
 | 6.1 | Audit Log Management | Structured JSON audit logs, audit query API |
 | 6.3 | Centralized Log Collection | JSON logging, configurable log aggregation |
 | 8.2 | Audit Logging | All authentication and authorization events logged |
 | 8.5 | Access Control Logs | JWT validation events, RBAC enforcement logged |
 | 8.11 | Audit Log Retention | Configurable retention, export to CSV/JSON |
 | 9.1 | Email Security | SMTP TLS for notifications |
-| 10.1 | Anti-Malware | File upload validation, no executable uploads |
 | 13.1 | Network Monitoring | Health check endpoints, audit-event queries (no Prometheus endpoint) |
 | 16.1 | Application Security | Request validation at the API boundary, parameterized SQL (no raw SQL) |
 | 16.9 | Security Headers | CSP, X-Frame-Options, HSTS, X-Content-Type-Options |
-| 16.11 | Web Application Firewalls | Built-in rate limiting, request size limits |
 
 ## CMMC Level 2 practice mapping
 
@@ -127,9 +123,8 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 | CM.L2-3.4.5 | Configuration | Access restrictions for configuration changes |
 | IA.L2-3.5.1 | Identification | User identification and authentication |
 | IA.L2-3.5.2 | Identification | Device authentication (SSH host verification) |
-| IA.L2-3.5.3 | Identification | Multi-factor authentication |
-| IA.L2-3.5.7 | Identification | Minimum password complexity |
-| IA.L2-3.5.8 | Identification | Password reuse prevention |
+| IA.L2-3.5.3 | Identification | Multi-factor authentication (TOTP, no backup/recovery codes) |
+| IA.L2-3.5.7 | Identification | Minimum password length per NIST SP 800-63B (8 chars regular / 15 admin); no character-class complexity rules |
 | IA.L2-3.5.10 | Identification | Cryptographically-protected passwords |
 | MP.L2-3.8.6 | Media Protection | Data encryption at rest |
 | RA.L2-3.11.2 | Risk Assessment | Vulnerability scanning |
@@ -147,7 +142,7 @@ To generate evidence for an audit:
 1. **Access control evidence**: Export user list and role assignments from the Users API
 2. **Audit log evidence**: Use the Audit Query API to export logs for the audit period
 3. **Scan evidence**: Export compliance scan results showing configuration assessment
-4. **Encryption evidence**: Document FIPS mode configuration and cipher suite settings
+4. **Encryption evidence**: Document FIPS mode configuration (`openwatch --version`); TLS cipher-suite selection is the Go standard-library default and is not separately configurable
 5. **Monitoring evidence**: Export fleet health and liveness data from the monitoring endpoints
 
 OpenWatch serves the REST API over HTTPS on port 8443. Authenticate with a session
@@ -163,6 +158,7 @@ curl https://localhost:8443/api/v1/fleet/score \
   -H "Authorization: Bearer $TOKEN" > fleet_score_evidence.json
 ```
 
-> Note: dedicated compliance-posture and Kensa-framework export endpoints are pending
-> a Go-era rewrite. The running binary serves its current API contract at `/api/v1`;
+> Per-host compliance posture and trend are also available directly:
+> `GET /api/v1/hosts/{id}/compliance` and `GET /api/v1/hosts/{id}/compliance/trend`.
+> The running binary serves its current API contract at `/api/v1`;
 > `GET /api/v1/version` reports the build it came from.

--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -105,8 +105,10 @@ That number corresponds to the `NNNN` prefix of the last applied migration file.
 ## Adding a new migration
 
 1. Create a new migration file named with the next ascending
-   integer, for example `0023_add_scan_findings.sql`. Migration order is driven
-   by the filename prefix, not by dates.
+   integer, for example `0051_add_scan_findings.sql` (the current highest
+   applied migration is `0050`; use the next free number, not this example
+   literally). Migration order is driven by the filename prefix, not by
+   dates.
 
 2. Write the `Up` and `Down` blocks using goose annotations:
 
@@ -172,17 +174,24 @@ Plan accordingly:
 ## Backup before migrating
 
 The `migrate` subcommand can take the pre-migration backup for you: pass
-`--backup-dir <dir>` and it writes a logical dump into that directory before
-applying any pending migration. This is the recommended path on production
-upgrades:
+`--backup-dir <dir>` and it writes a plain-SQL `pg_dump` (`--no-owner
+--no-privileges`) into that directory before applying any pending migration.
+This is the recommended path on production upgrades:
 
 ```bash
 sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
     openwatch migrate --backup-dir /var/backups/openwatch
 ```
 
+Because this dump is plain SQL, restore it with `psql`, not `pg_restore`:
+
+```bash
+psql "$OPENWATCH_DATABASE_DSN" < /var/backups/openwatch/openwatch_20260610T120000Z.sql
+```
+
 To take the backup yourself instead, use `pg_dump` before applying migrations to
-any environment you cannot afford to lose:
+any environment you cannot afford to lose. If you choose the custom archive
+format instead of plain SQL, use `pg_restore` to restore it:
 
 ```bash
 pg_dump "$OPENWATCH_DATABASE_DSN" \
@@ -190,16 +199,13 @@ pg_dump "$OPENWATCH_DATABASE_DSN" \
   --file="openwatch_$(date -u +%Y%m%dT%H%M%SZ).dump"
 ```
 
-Restore with `pg_restore` against a clean database if a migration must be
-reverted:
-
 ```bash
 pg_restore --clean --if-exists --dbname "$OPENWATCH_DATABASE_DSN" \
   openwatch_20260610T120000Z.dump
 ```
 
-Run `pg_dump`/`pg_restore` from the host (or a PostgreSQL client package)—there
-is no container to `exec` into.
+Run `pg_dump`/`pg_restore`/`psql` from the host (or a PostgreSQL client
+package)—there is no container to `exec` into.
 
 ## Troubleshooting
 

--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Database migration guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers how OpenWatch's PostgreSQL schema is versioned, how migrations
 are applied in production, and how to add a new migration. OpenWatch is a single

--- a/docs/guides/ENVIRONMENT_REFERENCE.md
+++ b/docs/guides/ENVIRONMENT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Configuration and environment reference
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This document is the field reference for how you configure the OpenWatch
 binary: the TOML file, the environment-variable overrides, and the on-disk paths
@@ -56,9 +56,13 @@ variable that overrides each one:
 | `logging` | `format` | `json` | `OPENWATCH_LOGGING_FORMAT` |
 | `identity` | `jwt_private_key` | `/etc/openwatch/keys/jwt_private.pem` | `OPENWATCH_IDENTITY_JWT_PRIVATE_KEY` |
 | `identity` | `credential_key_file` | `/etc/openwatch/keys/credential.key` | `OPENWATCH_IDENTITY_CREDENTIAL_KEY_FILE` |
+| `reports` | `signing_key_file` | unset (ephemeral per-boot key; dev only) | `OPENWATCH_REPORTS_SIGNING_KEY_FILE` |
 
-These are the only configuration keys the binary reads. The values are validated
-at load time.
+These are the TOML-mapped configuration keys the binary reads through the
+layering above; the values are validated at load time. A handful of other
+environment variables are read directly at startup outside this layering—see
+[Other environment variables read at runtime](#other-environment-variables-read-at-runtime)
+below.
 
 Example `/etc/openwatch/openwatch.toml`:
 
@@ -101,6 +105,7 @@ Each variable maps to exactly one TOML key (see the table above). The format is
 | `OPENWATCH_LOGGING_FORMAT` | `[logging].format` | One of `json`, `text`. |
 | `OPENWATCH_IDENTITY_JWT_PRIVATE_KEY` | `[identity].jwt_private_key` | PEM RSA private key, mode `0600`. |
 | `OPENWATCH_IDENTITY_CREDENTIAL_KEY_FILE` | `[identity].credential_key_file` | 32-byte AES-256 key, mode `0600`. |
+| `OPENWATCH_REPORTS_SIGNING_KEY_FILE` | `[reports].signing_key_file` | 32-byte raw Ed25519 seed, mode `0600`. Optional: when unset, `serve` runs with an ephemeral per-boot key (development only); production should set a durable key so report signatures verify across restarts. |
 
 The canonical place to set the database secret is `/etc/openwatch/secrets.env`,
 which the systemd unit reads through `EnvironmentFile=-/etc/openwatch/secrets.env`.
@@ -121,6 +126,7 @@ sudo chmod 0640 /etc/openwatch/secrets.env
 | `OPENWATCH_LICENSE_FILE` | `/etc/openwatch/license.lic` | `serve`, `worker` | Path to the OpenWatch+ license file. A missing file is not fatal; the service runs at the free tier. |
 | `OPENWATCH_POLICIES_DIR` | `/etc/openwatch/policies` | `serve` | Directory scanned when an admin triggers a policy reload through the API. |
 | `OPENWATCH_DEV_MODE` | unset | `serve` | When set to `true`, accepts unsigned policy envelopes. Development only; never set in production. |
+| `OPENWATCH_KENSA_STORE_PATH` | `.kensa/remediation.db` under the working directory (dev only, logs a warning) | `serve` | Durable path for Kensa's remediation rollback pre-state store. The packaged systemd unit sets this to `/var/lib/openwatch/kensa/remediation.db`. Production installs must set it to a persistent path or remediation rollback does not survive a restart. |
 
 Standard PostgreSQL libpq environment variables (for example `PGSSLROOTCERT`) are
 honored by the underlying driver when present, but OpenWatch itself only reads the

--- a/docs/guides/ENVIRONMENT_REFERENCE.md
+++ b/docs/guides/ENVIRONMENT_REFERENCE.md
@@ -103,8 +103,8 @@ Each variable maps to exactly one TOML key (see the table above). The format is
 | `OPENWATCH_DATABASE_MAX_CONNECTIONS` | `[database].max_connections` | Integer greater than `0`. |
 | `OPENWATCH_LOGGING_LEVEL` | `[logging].level` | One of `debug`, `info`, `warn`, `error`. |
 | `OPENWATCH_LOGGING_FORMAT` | `[logging].format` | One of `json`, `text`. |
-| `OPENWATCH_IDENTITY_JWT_PRIVATE_KEY` | `[identity].jwt_private_key` | PEM RSA private key, mode `0600`. |
-| `OPENWATCH_IDENTITY_CREDENTIAL_KEY_FILE` | `[identity].credential_key_file` | 32-byte AES-256 key, mode `0600`. |
+| `OPENWATCH_IDENTITY_JWT_PRIVATE_KEY` | `[identity].jwt_private_key` | PEM RSA private key; ships mode `0640`, owner `root:openwatch` (not permission-checked at boot). Tightening to `0600` owned by `openwatch` is a valid hardening step. |
+| `OPENWATCH_IDENTITY_CREDENTIAL_KEY_FILE` | `[identity].credential_key_file` | 32-byte AES-256 key, mode `0600`, owner `openwatch:openwatch`—boot refuses to start if the mode has any group/other bits set. |
 | `OPENWATCH_REPORTS_SIGNING_KEY_FILE` | `[reports].signing_key_file` | 32-byte raw Ed25519 seed, mode `0600`. Optional: when unset, `serve` runs with an ephemeral per-boot key (development only); production should set a durable key so report signatures verify across restarts. |
 
 The canonical place to set the database secret is `/etc/openwatch/secrets.env`,
@@ -142,8 +142,8 @@ DSN. Prefer encoding connection options in the DSN query string
 | `/etc/openwatch/secrets.env` | `root:openwatch`, `0640` | `OPENWATCH_DATABASE_DSN` and other secrets; loaded by systemd. |
 | `/etc/openwatch/tls/cert.pem` | readable by `openwatch` | TLS server certificate. |
 | `/etc/openwatch/tls/key.pem` | `openwatch`, `0600` | TLS server private key. |
-| `/etc/openwatch/keys/jwt_private.pem` | `openwatch`, `0600` | RSA key that signs access and refresh JWTs. |
-| `/etc/openwatch/keys/credential.key` | `openwatch`, `0600` | AES-256 key encrypting MFA secrets and stored SSH credentials. |
+| `/etc/openwatch/keys/jwt_private.pem` | `root:openwatch`, `0640` (shipped; not permission-checked at boot) | RSA key that signs access and refresh JWTs. |
+| `/etc/openwatch/keys/credential.key` | `openwatch:openwatch`, `0600` (enforced—boot refuses any other mode) | AES-256 key encrypting MFA secrets and stored SSH credentials. |
 | `/etc/openwatch/license.lic` | readable by `openwatch` | Optional OpenWatch+ license. |
 | `/var/lib/openwatch` | `openwatch` | Service state directory (`ReadWritePaths` in the unit). |
 | `/var/log/openwatch` | `openwatch` | Log directory; journald remains the primary log sink. |

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -116,12 +116,8 @@ compliance reporting and batch scanning.
 3. Select hosts from the list.
 4. Click **Confirm**.
 
-Each host can belong to one group at a time.
-
-### Smart group creation
-
-Select multiple hosts and click **Smart Group**. OpenWatch analyzes their OS,
-architecture, and compliance profile to recommend group settings automatically.
+A host can belong to more than one group at a time; group membership is a
+many-to-many relationship.
 
 ### Group scanning
 
@@ -139,16 +135,21 @@ OpenWatch automatically detects the operating system for hosts during scans.
 You can also trigger manual OS discovery from the host detail page by clicking
 **Discover OS**.
 
-A scheduled task runs daily at 02:00 UTC to discover the OS for all active
-hosts that have not been identified yet.
+A background scheduler ticks every 60 seconds and enqueues discovery for any
+host whose OS has never been discovered or whose last discovery is older than
+the per-host interval (default 24 hours, operator-tunable between 1 hour and 7
+days). There is no fixed time-of-day anchor—discovery runs continuously as
+hosts become due.
 
 ### Connectivity monitoring
 
-Host connectivity is probed every 5 minutes by default (operator-tunable, with
-a 60-second floor). Each probe layers ICMP reachability, then SSH port + banner
-reachability, then a privilege check; a host is marked degraded when a higher
-layer fails after a lower one succeeds. Host status (online, degraded,
-unreachable) updates in the host list.
+Host connectivity is probed every 15 minutes by default (`online_sec`,
+operator-tunable with a 60-second floor); a host in the degraded state is
+probed more frequently, every 5 minutes by default (`degraded_sec`). Each
+probe layers ICMP reachability, then SSH port + banner reachability, then a
+privilege check; a host is marked degraded when a higher layer fails after a
+lower one succeeds. Host status (online, degraded, unreachable) updates in the
+host list.
 
 ---
 
@@ -184,9 +185,9 @@ needing to SSH in manually.
 
 ## Remediation overview
 
-OpenWatch can automatically fix compliance findings through Kensa's 27
-remediation mechanisms. All changes are made over SSH—nothing is installed
-on target hosts.
+OpenWatch can automatically fix compliance findings through Kensa's 29
+registered remediation handlers. All changes are made over SSH—nothing is
+installed on target hosts.
 
 ### What remediation can fix
 
@@ -215,18 +216,24 @@ on target hosts.
 5. Click **Start Remediation** to confirm.
 
 
-For organizations that require an approval step:
+In the free-core edition, a single-rule remediation request auto-approves on
+submission—there is no separate approval step, and no per-organization toggle
+to require one. The request is still recorded and audited (with a note that
+it was auto-approved), and a user with `remediation:execute` applies it.
+
+**Roadmap (licensed tier).** A request/approve/reject workflow with
+separation of duties is planned for the licensed bulk/automated remediation
+track, not yet available today:
 
 1. A user with `remediation:request` (`ops_lead`, `security_admin`, or `admin`)
    selects findings, clicks **Request Remediation**, and enters a justification.
 2. A **different** user with `remediation:approve` (`security_admin` or `admin`)
-   reviews and approves or rejects it. You cannot approve your own request
-   (separation of duties; self-approval returns `409 self_review`).
+   reviews and approves or rejects it. The reviewer cannot be the requester
+   (separation of duties; self-review returns `409 remediation.self_review`).
 3. Once approved, a user with `remediation:execute` clicks **Fix** to apply the
    change. Execution is operator-initiated, not automatic.
 
-See [User roles](USER_ROLES.md) for the full role matrix. Single-operator
-workspaces cannot self-approve a bulk/automated remediation request today.
+See [User roles](USER_ROLES.md) for the full role matrix.
 
 ---
 

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -1,6 +1,6 @@
 # Host management and remediation
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers adding and managing hosts, organizing them into groups,
 understanding server intelligence data, and using automated remediation to fix
@@ -27,7 +27,6 @@ compliance findings. Most of these tasks are performed in the web UI.
 
 4. Click **Save**.
 
-![Add Host dialog](../images/hosts/add-host.png)
 
 The host appears in the host list immediately after creation.
 
@@ -42,7 +41,6 @@ For adding many hosts at once:
 5. Review the auto-detected field mappings.
 6. Confirm the import.
 
-![Bulk import CSV mapping review](../images/hosts/bulk-import.png)
 
 Set **Dry Run** to validate the file without creating hosts. Set **Update
 Existing** to overwrite hosts that match by hostname or IP address.
@@ -69,7 +67,6 @@ installed on target hosts.
 4. Enter the SSH username.
 5. Click **Save**.
 
-![Credential configuration form](../images/hosts/credentials.png)
 
 ### Testing connectivity
 
@@ -111,7 +108,6 @@ compliance reporting and batch scanning.
 3. Enter a name, description, OS family, and compliance framework.
 4. Click **Save**.
 
-![Create host group dialog](../images/hosts/create-group.png)
 
 ### Assigning hosts
 
@@ -161,7 +157,6 @@ unreachable) updates in the host list.
 During compliance scans, OpenWatch collects detailed information about each host.
 This data is available on the host detail page under the **Intelligence** tab.
 
-![Server intelligence overview](../images/hosts/server-intelligence.png)
 
 ### Data collected
 
@@ -215,12 +210,10 @@ on target hosts.
 2. Select the failing findings you want to remediate (use checkboxes).
 3. Click **Remediate Selected**.
 
-![Selecting findings for remediation](../images/hosts/select-remediation.png)
 
-4. Review the proposed changes. Each finding shows what will be modified.
+4. Review the proposed changes. Each finding shows what changes.
 5. Click **Start Remediation** to confirm.
 
-![Remediation confirmation dialog](../images/hosts/confirm-remediation.png)
 
 For organizations that require an approval step:
 
@@ -242,7 +235,6 @@ workspaces cannot self-approve a bulk/automated remediation request today.
 After starting a remediation, track its progress on the host detail page
 under the **Remediation** tab.
 
-![Remediation progress view](../images/hosts/remediation-progress.png)
 
 The progress view shows:
 
@@ -266,7 +258,6 @@ If a remediation causes problems, you can roll back to the pre-change state.
 4. Enter a reason for the rollback (logged for audit purposes).
 5. Click **Confirm Rollback**.
 
-![Rollback confirmation](../images/hosts/rollback.png)
 
 Rollback requires the `remediation:rollback` permission (`ops_lead`,
 `security_admin`, or `admin`).
@@ -308,8 +299,8 @@ role-to-permission mapping is served by the roles API, `GET /api/v1/roles`; see
    applying to a group.
 4. **Review findings before remediating.** Understand what each rule checks
    and what the fix changes.
-5. **Monitor compliance score after remediation.** The adaptive scheduler will
-   automatically scan again, but you can force a scan for immediate results.
+5. **Monitor compliance score after remediation.** The adaptive scheduler
+   automatically scans again, but you can force a scan for immediate results.
 6. **Use groups for consistent scanning.** Hosts in the same group share OS
    family, framework, and scan schedule settings.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -42,7 +42,9 @@ On a host that already runs PostgreSQL, this takes about five minutes.
 ## Requirements
 
 - **OS:**
-  - RPM: CentOS Stream 9, RHEL 9, Rocky Linux 9, AlmaLinux 9, Oracle Linux 9
+  - RPM: RHEL 9, Rocky Linux 9, AlmaLinux 9, Oracle Linux 9, CentOS Stream 9
+    (binary-compatible rebuilds; CI smoke-tests the RPM in `rockylinux:9` and
+    `almalinux:9` containers, not CentOS Stream 9)
   - DEB: Ubuntu 24.04 LTS, Debian 12 (or a compatible `systemd` derivative)
 - **Architecture:** `x86_64`/`amd64` or `aarch64`/`arm64` (packages ship for both).
 - **CPU/RAM:** 1 vCPU / 512 MB for the service itself; size up for large fleets.
@@ -378,7 +380,7 @@ sudo journalctl -u openwatch --since '1 min ago' -p err
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `config: env override: OPENWATCH_DATABASE_DSN: …` | Malformed DSN in `secrets.env` | Use `postgres://user:pass@host:port/db?sslmode=…` |
+| `database.dsn: scheme "" must be postgres:// or postgresql://` | Malformed DSN in `secrets.env` | Use `postgres://user:pass@host:port/db?sslmode=…` |
 | `db: ping: … password authentication failed` | Wrong DSN password, or `pg_hba.conf` rejects scram | Recheck Step 2; reload PostgreSQL after edits |
 | `db: ping: … connection refused` | PostgreSQL not running | `sudo systemctl status postgresql` |
 | `server: … no such file: cert.pem` | TLS cert path or perms wrong | Ensure `/etc/openwatch/tls/cert.pem` is readable by `openwatch` |

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,6 +1,6 @@
 # OpenWatch install guide (native packages)
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide takes an administrator from a fresh Linux host to a running,
 logged-in OpenWatch: install the package, point it at PostgreSQL, create the
@@ -108,7 +108,7 @@ Install **both** files in one transaction. `openwatch` declares a hard
 dependency on `kensa-rules`—the rule corpus the scan engine loads from
 `/usr/share/kensa/rules`. Installing `openwatch` alone fails the dependency
 check (by design: a corpus-less node cannot scan). `kensa-rules` is `noarch`
-and versioned on the Kensa content line (for example `0.7.0`), independent of the
+and versioned on the Kensa content line (for example `0.7.6`), independent of the
 platform version, so the rules can update without re-releasing OpenWatch.
 
 Use the filenames you downloaded (`aarch64` for the arm64 openwatch RPM; the

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -1,17 +1,19 @@
 # Linux distribution support matrix
 
 > **Scope.** OpenWatch targets Linux, but **not every Linux distribution is
-> supported to the same degree**. As of Kensa v0.7.0, compliance *scanning* is
+> supported to the same degree**. As of Kensa v0.7.6, compliance *scanning* is
 > supported on the **RHEL family and on Ubuntu**, because those are the
 > platforms the bundled Kensa rule corpus covers. This page states, with
 > evidence, which distributions work for (1) running the OpenWatch server and
 > (2) being added as a managed/scanned host.
 
-**Last updated:** 2026-06-29 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-29 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
-**Last verified:** 2026-06-29 against Kensa rule corpus **v0.7.0** (630 rules).
-Per-OS counts below are read from each rule's `platforms:` declarations in the
-corpus, not from a live scan.
+**Last verified:** 2026-06-29 against Kensa rule corpus **v0.7.0** (630 rules);
+the currently bundled corpus is **Kensa v0.7.6 (748 rules)**. Per-OS counts
+below are read from each rule's `platforms:` declarations in the v0.7.0
+corpus, not from a live scan, and may lag the current 748-rule total—they have
+not been recomputed against v0.7.6.
 
 ---
 
@@ -19,7 +21,7 @@ corpus, not from a live scan.
 
 - **Compliance scanning works on RHEL 8 / 9 / 10** and its binary-compatible
   rebuilds (Rocky, AlmaLinux, CentOS Stream, Oracle Linux), **and on Ubuntu
-  22.04 / 24.04 LTS.** Kensa v0.7.0 ships 630 rules across these platforms.
+  22.04 / 24.04 LTS.** Kensa v0.7.6 ships 748 rules across these platforms.
 - **Each rule declares the platforms it applies to**, so a host is only
   evaluated against rules that match its detected OS. Ubuntu hosts are scanned
   against the Ubuntu rule set; RHEL hosts against the RHEL rule set.
@@ -64,7 +66,9 @@ sensitivity:
 ### Per-OS rule applicability
 
 Rule applicability is read from the v0.7.0 corpus (each rule's `platforms:`
-block). These are the approximate counts of rules that apply per OS:
+block). These are the approximate counts of rules that apply per OS. **Note:**
+these per-OS counts are as of Kensa v0.7.0 and may lag the currently bundled
+Kensa v0.7.6 (748-rule) corpus; they have not been recomputed since:
 
 | OS | Rules applicable (approx.) |
 |----|----------------------------|
@@ -74,8 +78,8 @@ block). These are the approximate counts of rules that apply per OS:
 | Ubuntu 22.04 | ~115 |
 | Ubuntu 24.04 | ~117 |
 
-A rule can apply to several platforms, so these counts overlap; the corpus total
-is 630 distinct rules.
+A rule can apply to several platforms, so these counts overlap; the v0.7.0
+corpus total was 630 distinct rules.
 
 ### Support matrix
 
@@ -104,7 +108,7 @@ unverified support; **Not supported** means no coverage for that phase.
 
 ## 3. Why a Fedora or Debian host scans nothing
 
-This is the behaviour you will see and it is **working as designed**, not a
+This is the behaviour you see and it is **working as designed**, not a
 crash:
 
 1. **Discovery succeeds.** OpenWatch reads `/etc/os-release` and stores the
@@ -120,9 +124,9 @@ crash:
    cycle).
 3. **The compliance scan skips everything.** Kensa SSHes to the host, reads
    `/etc/os-release`, and filters its corpus to rules whose `platforms` match
-   the detected distro. The v0.7.0 corpus carries rules for the RHEL family and
-   Ubuntu only, so a Fedora, Debian, or SUSE host matches none and **all rules
-   are skipped**.
+   the detected distro. The Kensa rule corpus carries rules for the RHEL family
+   and Ubuntu only, so a Fedora, Debian, or SUSE host matches none and **all
+   rules are skipped**.
 
 Skipping is the correct outcome: applying rules written for one distro to
 another would evaluate the wrong files, services, and defaults and report
@@ -183,7 +187,9 @@ a compliance score.
   partial-success semantics.
 - Kensa filters its corpus by the host's detected platform at scan time.
 - Rule corpus applicability (read from the corpus platform declarations):
-  Kensa v0.7.0, **630 rules** spanning RHEL 8/9/10 and Ubuntu 22.04/24.04.
-  Approximate per-OS applicability: rhel8 ~460, rhel9 ~466, rhel10 ~310,
+  Kensa v0.7.0, **630 rules** spanning RHEL 8/9/10 and Ubuntu 22.04/24.04. The
+  currently bundled corpus is Kensa v0.7.6 (748 rules); the per-OS breakdown
+  below has not been recomputed since v0.7.0 and may lag. Approximate per-OS
+  applicability (as of v0.7.0): rhel8 ~460, rhel9 ~466, rhel10 ~310,
   ubuntu22 ~115, ubuntu24 ~117.
 - Framework mappings: CIS RHEL 9 v2.0.0, STIG RHEL 9 V2R7, plus CIS/STIG Ubuntu.

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -9,11 +9,9 @@
 
 **Last updated:** 2026-06-29 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
-**Last verified:** 2026-06-29 against Kensa rule corpus **v0.7.0** (630 rules);
-the currently bundled corpus is **Kensa v0.7.6 (748 rules)**. Per-OS counts
-below are read from each rule's `platforms:` declarations in the v0.7.0
-corpus, not from a live scan, and may lag the current 748-rule total—they have
-not been recomputed against v0.7.6.
+**Last verified:** 2026-07-13 against Kensa rule corpus **v0.7.6** (748 rules).
+Per-OS counts below are read from each rule's `platforms:` declarations in the
+v0.7.6 corpus, not from a live scan.
 
 ---
 
@@ -41,7 +39,7 @@ OpenWatch ships as native packages built for:
 
 | Platform | Form | Notes |
 |----------|------|-------|
-| **RHEL 9 / CentOS Stream 9** | native **RPM** | Built/tested on CentOS Stream 9. RHEL 9, Rocky 9, AlmaLinux 9 are binary-compatible. |
+| **RHEL 9** | native **RPM** | Built on `ubuntu-latest` CI runners cross-packaging the RPM; smoke-tested in `rockylinux:9` and `almalinux:9` containers. RHEL 9, Rocky 9, AlmaLinux 9 are binary-compatible. |
 | **Ubuntu 24.04 LTS** | native **DEB** | Built/tested on Ubuntu 24.04. |
 
 Other distributions may run the server from source (Go 1.26 + PostgreSQL 14 or
@@ -65,21 +63,17 @@ sensitivity:
 
 ### Per-OS rule applicability
 
-Rule applicability is read from the v0.7.0 corpus (each rule's `platforms:`
-block). These are the approximate counts of rules that apply per OS. **Note:**
-these per-OS counts are as of Kensa v0.7.0 and may lag the currently bundled
-Kensa v0.7.6 (748-rule) corpus; they have not been recomputed since:
+Rule applicability is read from the currently bundled Kensa v0.7.6 corpus
+(each rule's `platforms:` block). These are the counts of rules that apply per
+OS family:
 
-| OS | Rules applicable (approx.) |
-|----|----------------------------|
-| RHEL 8 | ~460 |
-| RHEL 9 | ~466 |
-| RHEL 10 | ~310 |
-| Ubuntu 22.04 | ~115 |
-| Ubuntu 24.04 | ~117 |
+| OS family | Rules applicable |
+|-----------|-------------------|
+| RHEL family (RHEL, Rocky, AlmaLinux, CentOS Stream, Oracle Linux) | 668 |
+| Ubuntu (22.04, 24.04) | 117 |
 
-A rule can apply to several platforms, so these counts overlap; the v0.7.0
-corpus total was 630 distinct rules.
+A rule can apply to several platforms, so these counts overlap; the Kensa
+v0.7.6 corpus total is 748 distinct rules.
 
 ### Support matrix
 
@@ -90,7 +84,7 @@ corpus total was 630 distinct rules.
 | **AlmaLinux 8 / 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
 | **CentOS Stream 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
 | **Oracle Linux 8 / 9** | Supported | Supported | Supported (matches RHEL family via `ID_LIKE`) | **Supported** |
-| **Ubuntu 22.04 / 24.04 LTS** | Supported | Supported | Supported (~115–117 applicable rules) | **Supported** |
+| **Ubuntu 22.04 / 24.04 LTS** | Supported | Supported | Supported (117 applicable rules) | **Supported** |
 | **Fedora** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
 | **Debian 12** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
 | **SUSE / openSUSE / SLES** | Supported | Supported | Not supported, **all rules skip** | **Inventory only** |
@@ -186,10 +180,8 @@ a compliance score.
 - Server Intelligence is OS-agnostic: it runs `rpm -qa` or `dpkg -l` with
   partial-success semantics.
 - Kensa filters its corpus by the host's detected platform at scan time.
-- Rule corpus applicability (read from the corpus platform declarations):
-  Kensa v0.7.0, **630 rules** spanning RHEL 8/9/10 and Ubuntu 22.04/24.04. The
-  currently bundled corpus is Kensa v0.7.6 (748 rules); the per-OS breakdown
-  below has not been recomputed since v0.7.0 and may lag. Approximate per-OS
-  applicability (as of v0.7.0): rhel8 ~460, rhel9 ~466, rhel10 ~310,
-  ubuntu22 ~115, ubuntu24 ~117.
+- Rule corpus applicability (read from the corpus platform declarations): the
+  currently bundled corpus is Kensa v0.7.6, **748 rules** spanning RHEL
+  8/9/10 and Ubuntu 22.04/24.04—668 applicable to the RHEL family, 117 to
+  Ubuntu (rules can apply to more than one platform, so these overlap).
 - Framework mappings: CIS RHEL 9 v2.0.0, STIG RHEL 9 V2R7, plus CIS/STIG Ubuntu.

--- a/docs/guides/MONITORING_SETUP.md
+++ b/docs/guides/MONITORING_SETUP.md
@@ -52,7 +52,7 @@ curl -k https://localhost:8443/api/v1/health
 A healthy response returns `200 OK`:
 
 ```json
-{"status": "healthy", "db_connected": true, "version": "0.2.0"}
+{"status": "healthy", "db_connected": true, "version": "0.3.0"}
 ```
 
 When the database ping fails, the endpoint returns `503 Service Unavailable`
@@ -74,7 +74,7 @@ curl -k https://localhost:8443/api/v1/version
 
 ```json
 {
-  "openwatch": "0.2.0",
+  "openwatch": "0.3.0",
   "kensa": "<embedded engine version>",
   "go": "<go toolchain>",
   "commit": "<abbrev commit>",
@@ -161,7 +161,7 @@ follow the `FleetLiveness` and `ConnectivityBreakdown` schemas.
 ## 6. Service lifecycle
 
 OpenWatch runs as the `openwatch.service` systemd unit, which executes
-`openwatch --config /etc/openwatch/openwatch.toml serve`.
+`openwatch serve --config /etc/openwatch/openwatch.toml`.
 
 ```bash
 sudo systemctl status openwatch     # current state
@@ -365,5 +365,5 @@ operators do not look for them:
   not implemented. The current health contract is a single binary
   `healthy`/`degraded` status.
 
-If and when metrics or tracing land, this section and the API contract will be
-updated together.
+This section and the API contract are updated together whenever metrics or
+tracing land.

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Production deployment guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers running OpenWatch in production: a single Go binary that serves
 the REST API and the embedded React UI over HTTPS, backed by PostgreSQL, managed
@@ -14,7 +14,7 @@ touches lightly: process layout, TLS, the background worker, backups, upgrades,
 and incident runbooks.
 
 > Verify the version you deploy. The current general-availability release is
-> `v0.2.0`. Confirm with `openwatch --version` before and after an upgrade.
+> `v0.3.0`. Confirm with `openwatch --version` before and after an upgrade.
 
 ---
 
@@ -95,7 +95,7 @@ Config layers, highest precedence first:
 3. The TOML file (`/etc/openwatch/openwatch.toml`)
 4. Built-in defaults
 
-The TOML file has four sections:
+The TOML file has five sections:
 
 | Section | Key | Default | Purpose |
 |---------|-----|---------|---------|
@@ -106,6 +106,7 @@ The TOML file has four sections:
 | `[database]` | `max_connections` | `25` | Connection-pool ceiling |
 | `[logging]` | `level` | `info` | `debug` / `info` / `warn` / `error` |
 | `[logging]` | `format` | `json` | `json` / `text` |
+| `[reports]` | `signing_key_file` | unset (ephemeral per-boot key, dev only) | Ed25519 seed that signs report snapshots; production should set a durable key |
 
 Two more values come from `[identity]` and must be set for `serve`/`worker` to
 boot—the JWT signing key (`jwt_private_key`) and the credential DEK file
@@ -174,7 +175,7 @@ OpenWatch exposes two anonymous endpoints for probes:
 ```bash
 curl -k https://localhost:8443/api/v1/health
 # 200 {"status":"healthy","db_connected":true,"version":"..."}
-# 503 when the database ping fails (status "degraded"/unavailable)
+# 503 when the database ping fails (status "degraded")
 
 curl -k https://localhost:8443/api/v1/version
 # {"openwatch":"...","kensa":"...","go":"...","commit":"...","build_time":"..."}

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -175,13 +175,16 @@ OpenWatch exposes two anonymous endpoints for probes:
 ```bash
 curl -k https://localhost:8443/api/v1/health
 # 200 {"status":"healthy","db_connected":true,"version":"..."}
-# 503 when the database ping fails (status "degraded")
+# 503 {"error":{"code":"server.unavailable","fault":"server",
+#      "human_message":"database is not reachable","retryable":true}}
+#      when the database ping fails
 
 curl -k https://localhost:8443/api/v1/version
 # {"openwatch":"...","kensa":"...","go":"...","commit":"...","build_time":"..."}
 ```
 
-`/api/v1/health` returns `200` with `db_connected:true` when healthy and `503`
+`/api/v1/health` returns `200` with `db_connected:true` when healthy, and `503`
+with the `ErrorEnvelope` body shown above (not a `status:"degraded"` body)
 when the database ping inside the handler fails. Use it as your liveness and
 readiness probe.
 
@@ -285,8 +288,9 @@ curl -k https://localhost:8443/api/v1/health
 1. If the unit is `failed`/`inactive`, read the journal for the boot error.
    Common causes: malformed `OPENWATCH_DATABASE_DSN`, unreadable TLS cert, or a
    missing `jwt_private_key` / `credential_key_file`.
-2. If `/api/v1/health` returns `503` with `db_connected:false`, treat it as a
-   database problem (see DATABASE_ISSUES below).
+2. If `/api/v1/health` returns `503` (an `ErrorEnvelope` with code
+   `server.unavailable`), treat it as a database problem (see DATABASE_ISSUES
+   below).
 3. Confirm the config is valid, then restart:
    ```bash
    sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch check-config
@@ -296,8 +300,8 @@ curl -k https://localhost:8443/api/v1/health
 
 ### DATABASE_ISSUES—database connectivity
 
-Symptoms: `/api/v1/health` reports `db_connected:false`; journal shows
-`db: ping:` errors.
+Symptoms: `/api/v1/health` returns `503` (`ErrorEnvelope` code
+`server.unavailable`); journal shows `db: ping:` errors.
 
 ```bash
 sudo systemctl status postgresql

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -51,13 +51,18 @@ A healthy response looks like this:
 {
   "status": "healthy",
   "db_connected": true,
-  "version": "0.3.0"
+  "version": "<installed version>"
 }
 ```
 
-`status` is `healthy` or `degraded`; `db_connected` is `false` when the database
-is unreachable. If the request fails or `status` is `degraded`, inspect the logs
-before continuing:
+`version` reflects how the binary was built: a packaged release reports its
+semver (for example `0.3.0`); a bare `go build` without the Makefile's
+`-ldflags` reports `dev`.
+
+A healthy response is always `status: "healthy"`, `db_connected: true`. When
+the database is unreachable, the endpoint returns `503` with the standard
+error envelope instead of a `degraded` status body. If the request fails or
+returns `503`, inspect the logs before continuing:
 
 ```bash
 journalctl -u openwatch --no-pager -n 50
@@ -177,7 +182,8 @@ checks. In the UI this is the host's connectivity action; via the API:
 
 ```bash
 curl -sk -X POST "https://localhost:8443/api/v1/hosts/$HOST_ID/connectivity:check" \
-  -H "Authorization: Bearer $TOKEN" | jq .
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Idempotency-Key: $(uuidgen)" | jq .
 ```
 
 A failure here means SSH cannot connect—wrong credentials, an unreachable
@@ -204,7 +210,8 @@ worker):
 
 ```bash
 curl -sk -X POST "https://localhost:8443/api/v1/hosts/$HOST_ID/scans" \
-  -H "Authorization: Bearer $TOKEN" | jq .
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Idempotency-Key: $(uuidgen)" | jq .
 ```
 
 To watch progress:
@@ -282,13 +289,17 @@ A boot failure is usually a missing JWT signing key
 `OPENWATCH_DATABASE_DSN`. Run `openwatch check-config` to see the resolved
 configuration with secrets redacted.
 
-**Health reports `db_connected: false`.** The database is unreachable. Verify
-PostgreSQL is up and the DSN is correct:
+**Health returns `503`.** The database is unreachable. Verify PostgreSQL is up
+and the DSN is correct:
 
 ```bash
 systemctl status postgresql
-psql "$OPENWATCH_DATABASE_DSN" -c "SELECT 1;"
+psql "<dsn>" -c "SELECT 1;"
 ```
+
+`OPENWATCH_DATABASE_DSN` is set only inside the `systemd` unit's
+`EnvironmentFile`; in an interactive shell, read the DSN from
+`/etc/openwatch/secrets.env` and substitute it for `<dsn>`.
 
 If the schema is behind, run `openwatch migrate`.
 
@@ -306,9 +317,12 @@ hosts the schedulers) and, if you run a dedicated worker, that
 `openwatch worker` is up. Inspect the PostgreSQL job queue directly:
 
 ```bash
-psql "$OPENWATCH_DATABASE_DSN" -c \
+psql "<dsn>" -c \
   "SELECT status, count(*) FROM job_queue GROUP BY status;"
 ```
+
+Substitute `<dsn>` with the value of `OPENWATCH_DATABASE_DSN` from
+`/etc/openwatch/secrets.env`.
 
 ## Runbooks
 

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 Go from a freshly installed package to your first host under automatic
 compliance monitoring. This guide assumes OpenWatch is already installed and
@@ -51,7 +51,7 @@ A healthy response looks like this:
 {
   "status": "healthy",
   "db_connected": true,
-  "version": "0.2.0"
+  "version": "0.3.0"
 }
 ```
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,7 +1,7 @@
 # OpenWatch operator guides
 
 Operator and administrator documentation for OpenWatch. The current
-general-availability release is `0.2.0`; confirm the version you are running with
+general-availability release is `v0.3.0`; confirm the version you are running with
 `GET /api/v1/health` or `openwatch --version`.
 
 ## Getting started

--- a/docs/guides/SCALING_GUIDE.md
+++ b/docs/guides/SCALING_GUIDE.md
@@ -63,7 +63,7 @@ The scan queue is PostgreSQL-native and claims one job at a time per worker with
 processes pointed at the same database and config:
 
 ```bash
-openwatch worker --config /etc/openwatch/openwatch.toml
+openwatch --config /etc/openwatch/openwatch.toml worker
 ```
 
 Each worker claims one scan job at a time. Within a single worker, a per-host
@@ -87,7 +87,7 @@ Type=simple
 User=openwatch
 Group=openwatch
 EnvironmentFile=-/etc/openwatch/secrets.env
-ExecStart=/usr/bin/openwatch worker --config /etc/openwatch/openwatch.toml
+ExecStart=/usr/bin/openwatch --config /etc/openwatch/openwatch.toml worker
 Restart=on-failure
 RestartSec=5s
 
@@ -197,9 +197,11 @@ There is no Prometheus endpoint and no Grafana stack in the current build (see
   journalctl -u openwatch -f
   ```
 
-  The worker logs a periodic `worker.loop.tick` line (roughly every 60s) with
-  idle/claimed/in-flight/completed counters—a lightweight way to confirm a
-  worker is alive and draining.
+  The worker emits a periodic `worker.loop.tick` audit event (roughly every
+  60s) with idle/claimed/in-flight/completed counters—query it via `GET
+  /api/v1/audit/events?action=worker.loop.tick` (or PostgreSQL directly) as a
+  lightweight way to confirm a worker is alive and draining. It is an audit
+  event, not a `journald` log line.
 - **Audit and queue state**—query PostgreSQL directly:
 
   ```bash

--- a/docs/guides/SCALING_GUIDE.md
+++ b/docs/guides/SCALING_GUIDE.md
@@ -1,6 +1,6 @@
 # Scaling guide
 
-**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers how OpenWatch behaves as you add hosts, run more scans, and
 push more concurrent API traffic, and what you can tune today. It describes the
@@ -237,7 +237,7 @@ around features that are absent:
 
 | Topic | Document |
 |-------|----------|
-| Install and configuration | `docs/guides/INSTALLATION.md` |
+| Install and configuration | [Installation guide](INSTALLATION.md) |
 | Roles and permissions | [User roles](USER_ROLES.md) |
-| Kensa scanning boundary | the Kensa scanning engine |
+| How Kensa scanning works | [Scanning and compliance](SCANNING_AND_COMPLIANCE.md) |
 | API contract | Served by the running binary under `/api/v1` |

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Scanning and compliance
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers how OpenWatch performs compliance scanning, how to read
 results and posture scores, and how to use drift detection, alerts, and
@@ -15,7 +15,7 @@ target host over SSH, execute each rule's check command, and return a pass/fail
 result with machine-verifiable evidence.
 
 ```
-Operator clicks "Run Scan" (or adaptive scheduler triggers)
+Operator selects "Run Scan" (or adaptive scheduler triggers)
         |
         v
 Scan job enqueued on the PostgreSQL job queue (SKIP LOCKED)
@@ -27,7 +27,7 @@ Kensa retrieves SSH credentials from OpenWatch's encrypted store
 SSH connection to target host
         |
         v
-630 YAML rules evaluated (check commands, config values, file permissions)
+748 rules evaluated (Kensa v0.7.6; check commands, config values, file permissions)
         |
         v
 Each rule returns: pass/fail, severity, detail, evidence
@@ -79,7 +79,7 @@ there is no separate sync service in the Go rebuild.
 ### From the UI
 
 1. Navigate to **Hosts** and select the host you want to scan.
-2. On the host detail page, click **Run Scan**.
+2. On the host detail page, select **Run Scan**.
 
 A scan always runs the **full applicable rule corpus**—you do not pick a
 framework to scan. Frameworks (CIS, STIG, NIST, PCI) are **reporting lenses**
@@ -87,8 +87,6 @@ applied at view time on the Compliance tab: one scan, viewed through any
 framework. The lens bar only offers frameworks compatible with the host's
 detected OS (a RHEL 8 host does not show CIS/STIG RHEL 9 or 10 lenses);
 OS-neutral frameworks (NIST, PCI, SRG) always appear.
-
-![Running a scan from the host detail page](../images/scanning/run-scan.png)
 
 The scan runs in the background. A progress indicator shows the scan status.
 Results appear on the host's compliance tab once the scan completes
@@ -107,8 +105,6 @@ to trigger scans manually unless you want immediate results. See the
 After a scan completes, the results are displayed on the host detail page under
 the **Compliance** tab.
 
-![Scan results page with findings table](../images/scanning/scan-results.png)
-
 ### What you see
 
 - **Compliance score**—percentage of rules passing (for example, 85.0%)
@@ -118,7 +114,7 @@ the **Compliance** tab.
 
 ### Finding details
 
-Click any finding row to expand it. Each finding shows:
+Select any finding row to expand it. Each finding shows:
 
 | Field | Description |
 |-------|-------------|
@@ -161,8 +157,6 @@ Navigate to the **Dashboard** from the sidebar. The posture overview shows:
 - **Trend chart** showing score changes over time
 - **Framework breakdown** with per-framework compliance percentages
 
-![Compliance posture dashboard](../images/scanning/posture-dashboard.png)
-
 ### Historical posture
 
 OpenWatch captures daily posture snapshots at 00:30 UTC. To view historical
@@ -171,8 +165,6 @@ posture:
 1. Navigate to the host detail page.
 2. Select the **Posture History** tab.
 3. Choose a date range to view the compliance trend.
-
-Historical posture queries with specific `as_of` dates require OpenWatch+.
 
 ---
 
@@ -187,8 +179,6 @@ and now passes is an **improvement**.
 1. Navigate to the host detail page.
 2. Select the **Drift** tab.
 3. Choose a date range (start date and end date).
-
-![Drift detection showing regressions and improvements](../images/scanning/drift-view.png)
 
 The drift view shows:
 
@@ -251,15 +241,15 @@ On the host detail page, the **Scheduling** section shows:
 To pause scanning for a host (during planned maintenance):
 
 1. Go to the host detail page.
-2. Click **Maintenance Mode**.
+2. Select **Maintenance Mode**.
 3. Set the duration (1–168 hours).
-4. Click **Enable**.
+4. Select **Enable**.
 
 Maintenance mode expires automatically. You can disable it early from the same page.
 
 ### Force scan
 
-To trigger an immediate scan outside the normal schedule, click **Force Scan**
+To trigger an immediate scan outside the normal schedule, select **Force Scan**
 on the host detail page. This bypasses the schedule and runs at highest priority.
 
 ---
@@ -299,7 +289,7 @@ The requester **cannot** approve their own request.
 ### Requesting an exception
 
 1. On the host's **Compliance** tab, find a failing rule.
-2. Click **Request exception** in its row.
+2. Select **Request exception** in its row.
 3. Enter the reason (required) and an optional expiry date.
 4. Submit. The rule now shows a **Pending** badge.
 
@@ -333,8 +323,6 @@ Alerts are generated automatically when scan results meet configured thresholds.
 Navigate to **Alerts** in the sidebar. The alert list shows all active,
 acknowledged, and recently resolved alerts.
 
-![Alert management page](../images/scanning/alerts.png)
-
 Use filters to narrow by:
 
 - **Status**—active, acknowledged, resolved
@@ -348,8 +336,8 @@ Active --> Acknowledged --> Resolved
 ```
 
 - **Active**: Alert generated, requires attention.
-- **Acknowledged**: Click **Acknowledge** to indicate you are investigating.
-- **Resolved**: Click **Resolve** after the issue is fixed or accepted.
+- **Acknowledged**: Select **Acknowledge** to indicate you are investigating.
+- **Resolved**: Select **Resolve** after the issue is fixed or accepted.
 
 ### Configuring thresholds
 
@@ -374,23 +362,21 @@ evidence.
 ### Creating a saved query
 
 1. Navigate to **Compliance > Audit Queries**.
-2. Click **New Query**.
+2. Select **New Query**.
 3. Define filter criteria (severities, statuses, date range, hosts).
 4. Name the query and set visibility (private or shared).
-5. Click **Save**.
+5. Select **Save**.
 
 ### Previewing results
 
-Before generating a full export, click **Preview** to see a sample of matching
+Before generating a full export, select **Preview** to see a sample of matching
 findings and the total count.
 
 ### Generating an export
 
-1. From a saved query, click **Export**.
-2. Choose a format: **CSV**, **JSON**, or **PDF**.
+1. From a saved query, select **Export**.
+2. Choose a format: **CSV** or **JSON**.
 3. The export generates in the background. A download link appears when ready.
-
-![Audit export download](../images/scanning/audit-export.png)
 
 Exports include a SHA-256 checksum for integrity verification. Exports expire
 after 7 days by default.

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -159,8 +159,8 @@ Navigate to the **Dashboard** from the sidebar. The posture overview shows:
 
 ### Historical posture
 
-OpenWatch captures daily posture snapshots at 00:30 UTC. To view historical
-posture:
+OpenWatch captures a posture snapshot rollup on an hourly tick (plus once
+immediately at boot). To view historical posture:
 
 1. Navigate to the host detail page.
 2. Select the **Posture History** tab.
@@ -325,19 +325,27 @@ acknowledged, and recently resolved alerts.
 
 Use filters to narrow by:
 
-- **Status**—active, acknowledged, resolved
-- **Severity**—critical, high, medium, low
+- **Status**—active, acknowledged, silenced, resolved, dismissed
+- **Severity**—critical, high, medium, low, info
 - **Category**—compliance, operational, exception, drift
 
 ### Alert lifecycle
 
 ```
-Active --> Acknowledged --> Resolved
+Active --> Acknowledged --> Silenced --> Resolved --> Dismissed
 ```
+
+Transitions do not have to pass through every state in order; each of
+Acknowledged, Silenced, Resolved, and Dismissed can follow directly from
+Active (see the state list above).
 
 - **Active**: Alert generated, requires attention.
 - **Acknowledged**: Select **Acknowledge** to indicate you are investigating.
+- **Silenced**: Select **Silence** to suppress an alert until a chosen time,
+  without resolving it.
 - **Resolved**: Select **Resolve** after the issue is fixed or accepted.
+- **Dismissed**: Select **Dismiss** to close an alert that requires no further
+  action (for example, a false positive).
 
 ### Configuring thresholds
 
@@ -356,30 +364,24 @@ Navigate to **Settings > Alert Thresholds** to customize when alerts fire.
 
 ## Exporting for audits
 
-OpenWatch provides audit query and export tools for generating compliance
-evidence.
+For the audit trail itself, `GET /api/v1/audit/events/export` (`audit:read`)
+downloads the events matching the same filters as `GET /api/v1/audit/events`
+(`action`, `actor_type`, `resource_type`, `resource_id`, `since`, `until`) as a
+synchronous CSV or JSON attachment, capped at 10,000 rows newest-first. There
+is no saved-query library, no preview step, no background/async generation,
+and no checksum or expiry on this export—it downloads immediately with the
+filters you pass.
 
-### Creating a saved query
+```bash
+curl -k "https://localhost:8443/api/v1/audit/events/export?format=csv&since=2026-06-01T00:00:00Z" \
+  -H "Authorization: Bearer $TOKEN" -o audit-events.csv
+```
 
-1. Navigate to **Compliance > Audit Queries**.
-2. Select **New Query**.
-3. Define filter criteria (severities, statuses, date range, hosts).
-4. Name the query and set visibility (private or shared).
-5. Select **Save**.
-
-### Previewing results
-
-Before generating a full export, select **Preview** to see a sample of matching
-findings and the total count.
-
-### Generating an export
-
-1. From a saved query, select **Export**.
-2. Choose a format: **CSV** or **JSON**.
-3. The export generates in the background. A download link appears when ready.
-
-Exports include a SHA-256 checksum for integrity verification. Exports expire
-after 7 days by default.
+For a curated, point-in-time compliance artifact instead of raw events, use
+the **Reports** page (`/api/v1/reports`): it generates a Fleet Compliance
+Executive Summary that is Ed25519-signed and content-addressed
+(`content_sha256`), and can be exported as JSON, PDF, or (for the attestation
+report kind) CSV.
 
 ---
 
@@ -405,7 +407,8 @@ worker.
 
 ```bash
 curl -k -X POST https://localhost:8443/api/v1/hosts/HOST_UUID/scans \
-  -H "Authorization: Bearer $TOKEN"
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Idempotency-Key: $(uuidgen)"
 ```
 
 ### Query compliance (current lens)

--- a/docs/guides/SECRET_ROTATION.md
+++ b/docs/guides/SECRET_ROTATION.md
@@ -1,6 +1,6 @@
 # Secret rotation procedures
 
-**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide describes how to rotate each secret used by OpenWatch on the current
 single-binary stack: one `/usr/bin/openwatch` process that serves the REST API

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -131,16 +131,21 @@ openwatch --version
 `openwatch serve` refuses to start unless both identity keys are present. There
 is no silent fallback to ephemeral keys.
 
-| Config key | Default path | Contents | Required mode |
-|------------|--------------|----------|---------------|
-| `[identity].jwt_private_key` | `/etc/openwatch/keys/jwt_private.pem` | PEM RSA private key, ≥ 2048-bit | `0600` |
-| `[identity].credential_key_file` | `/etc/openwatch/keys/credential.key` | 32-byte raw AES-256 key | `0600` |
+| Config key | Default path | Contents | Shipped mode | Enforced at boot |
+|------------|--------------|----------|---------------|-------------------|
+| `[identity].jwt_private_key` | `/etc/openwatch/keys/jwt_private.pem` | PEM RSA private key, ≥ 2048-bit | `0640`, owner `root:openwatch` | No — the mode is not checked by code |
+| `[identity].credential_key_file` | `/etc/openwatch/keys/credential.key` | 32-byte raw AES-256 key | `0600`, owner `openwatch:openwatch` | Yes — boot refuses to start if the mode has any group/other bits set |
 
 
 
 Hardening steps:
 
-- Set both key files to mode `0600`, owned by the `openwatch` user.
+- `credential.key` mode `0600` owned by `openwatch:openwatch` is a hard boot
+  requirement; do not change it.
+- `jwt_private.pem` ships `0640` owned `root:openwatch` and is not
+  permission-checked at boot. Tightening it to `0600` owned by `openwatch`
+  is a valid stricter-than-shipped hardening step, not a shipped control —
+  do not represent it as enforced.
 - Keep the database password out of the world-readable config: put
   `OPENWATCH_DATABASE_DSN` in `/etc/openwatch/secrets.env` (mode `0640`, owner
   `root:openwatch`), which the `systemd` unit loads via `EnvironmentFile=`.
@@ -160,7 +165,7 @@ Hardening steps:
 | Session inactivity timeout | 15 minutes |
 | Session absolute timeout | 12 hours |
 | Password policy | Length only—8 chars (regular), 15 chars (admin), max 128; NIST SP 800-63B |
-| Breach check | Always-on in production: new passwords are screened against an embedded common/breached corpus (airgap-safe); point `OPENWATCH_BREACH_CORPUS_FILE` at a full HIBP list to extend it |
+| Breach check | Always-on in production: new passwords are screened against an embedded common/breached corpus (airgap-safe) |
 | MFA | TOTP enrollment and verification |
 
 The password policy is deliberately length-based with no character-class rules,
@@ -282,8 +287,9 @@ Hardening steps:
   ```
 
 - Keep the config and key files owned away from the service account where the
-  service only needs read access (cert/JWT/credential keys at `0600`, owned by
-  `openwatch`; `secrets.env` at `0640`, owner `root:openwatch`).
+  service only needs read access (TLS key and `credential.key` at `0600`,
+  owned by `openwatch`; `jwt_private.pem` ships `0640`, owner
+  `root:openwatch`; `secrets.env` at `0640`, owner `root:openwatch`).
 
 ---
 
@@ -476,8 +482,11 @@ Network and transport
 
 Cryptography and keys
 
-- [ ] `[identity].jwt_private_key` present, RSA ≥ 2048, mode `0600`.
-- [ ] `[identity].credential_key_file` present, 32 bytes, mode `0600`.
+- [ ] `[identity].jwt_private_key` present, RSA ≥ 2048; ships mode `0640`
+      (owner `root:openwatch`, not permission-checked at boot) — tightening to
+      `0600` owned by `openwatch` is an optional, stricter-than-shipped step.
+- [ ] `[identity].credential_key_file` present, 32 bytes, mode `0600` (boot
+      refuses to start otherwise).
 - [ ] `OPENWATCH_DATABASE_DSN` in `secrets.env` (mode `0640`, `root:openwatch`),
       not in the world-readable TOML.
 - [ ] For FIPS environments: the `-fips` build is deployed and

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -1,6 +1,6 @@
 # OpenWatch security hardening guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary build)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary build)
 **Audience:** System administrators, security engineers, compliance officers
 
 This guide covers the security controls you operate when you deploy OpenWatch
@@ -28,12 +28,9 @@ PostgreSQL-native job queue with `SELECT ... FOR UPDATE SKIP LOCKED`.
 | PostgreSQL | All persistent state | You provision and bind it (loopback by default) |
 | Kensa (in-process, Go) | SSH-based compliance engine | TCP/22 outbound to managed hosts |
 
-
-
 The compliance engine is Kensa, which connects to managed hosts over SSH and
-runs native YAML checks.
-See
-the Kensa scanning engine.
+runs native YAML checks. See [Scanning and compliance](SCANNING_AND_COMPLIANCE.md)
+for how scanning works end to end.
 
 ---
 
@@ -247,9 +244,10 @@ Hardening steps:
   sudo journalctl -u openwatch -o cat | jq .   # pretty-print the JSON
   ```
 
-> The audit-event taxonomy is the authoritative list. Treat the table above as a
-> sample, not a complete enumeration—see
-> the audit-event reference for the full set.
+> Treat the table above as a sample, not a complete enumeration. The running
+> service emits a structured audit event for every meaningful state change;
+> query `GET /api/v1/audit/events` to see the full set your deployment has
+> generated.
 
 ---
 
@@ -512,9 +510,9 @@ Source for every checklist item is cited in the section above that introduces it
   [Installation guide](INSTALLATION.md)
 - RBAC registry and permission model:
   [User roles](USER_ROLES.md)
-- Audit event taxonomy:
-  the audit-event reference
-- Kensa and OpenWatch boundary:
-  the Kensa scanning engine
+- Audit events and querying the audit trail:
+  [API guide](API_GUIDE.md)
+- How Kensa scanning works:
+  [Scanning and compliance](SCANNING_AND_COMPLIANCE.md)
 - API contract (per-operation required permission, license gate, audit events):
   served at `/api/v1`; `GET /api/v1/version` reports the running build

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -1,6 +1,6 @@
 # Upgrade procedure
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide covers upgrading an OpenWatch deployment to a newer version. OpenWatch
 ships as a single Go binary (`/usr/bin/openwatch`) that serves both the REST API
@@ -19,7 +19,7 @@ For first-time install and configuration, see the
 commands referenced below, see the [backup and recovery guide](BACKUP_RECOVERY.md). For
 migration mechanics, see the [database migrations guide](DATABASE_MIGRATIONS.md).
 
-> Version note: `0.2.0` is the current general-availability release. Always back
+> Version note: `v0.3.0` is the current general-availability release. Always back
 > up before upgrading; the upgrade path runs database migrations automatically.
 
 ## Quick upgrade (automatic, recommended)
@@ -272,9 +272,9 @@ Keep the pre-upgrade dump until you have validated the upgrade in production
 Kensa is the SSH-based compliance engine, integrated as a Go dependency; its native YAML rules are compiled into the `openwatch`
 binary. Rules therefore travel with
 the binary—installing a new OpenWatch package is what updates the bundled
-rule set. There is no separate rule-pull or out-of-band rule-sync step. For the
-Kensa/OpenWatch responsibility boundary, see
-the Kensa scanning engine.
+rule set. There is no separate rule-pull or out-of-band rule-sync step. See
+[Scanning and compliance](SCANNING_AND_COMPLIANCE.md) for how OpenWatch invokes
+Kensa during a scan.
 
 ## Upgrading PostgreSQL
 

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -56,7 +56,8 @@ The scriptlet runs **only on upgrade**, never on a fresh install, and does:
 Preview what would change before upgrading:
 
 ```bash
-sudo openwatch migrate --status
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
+    openwatch migrate --status
 # -> "up to date — no migrations pending"  OR  "PENDING: N migration(s) ..."
 ```
 
@@ -68,7 +69,8 @@ rolled back). Recover with:
 ```bash
 # 1. read the error in the dnf/apt output or:  journalctl -u openwatch
 # 2. fix the cause, then re-apply:
-sudo openwatch migrate
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
+    openwatch migrate
 sudo systemctl start openwatch
 # on Debian, also clear the half-configured state:
 sudo dpkg --configure -a

--- a/docs/guides/USER_ROLES.md
+++ b/docs/guides/USER_ROLES.md
@@ -1,6 +1,6 @@
 # User roles and permissions
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.2.0 (Go single-binary)
+**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
 
 This guide describes the role-based access control (RBAC) system in the Go-era
 OpenWatch. It covers the five built-in roles, the permissions they grant, and how
@@ -56,7 +56,8 @@ Cannot write, execute, export, approve, or administer anything.
 
 ### `auditor`
 
-Everything `viewer` has, plus the exception workflow authority an auditor needs:
+Most of what `viewer` has (one exception: `auditor` does not hold
+`role:read`), plus the exception workflow authority an auditor needs:
 `exception:request`, `exception:comment`, and `exception:approve`. Adds
 `audit:export` (license-gated by the `audit_export` feature) and `auth:write` so
 the auditor can manage their own password, MFA, and sessions.
@@ -214,8 +215,8 @@ sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
 
 The command connects to PostgreSQL using `OPENWATCH_DATABASE_DSN` from
 `/etc/openwatch/secrets.env` and exits non-zero if the user is created but the
-role assignment fails, so you can detect a partial state. See
-`docs/guides/INSTALLATION.md` for the full install sequence
+role assignment fails, so you can detect a partial state. See the
+[installation guide](INSTALLATION.md) for the full install sequence
 (`openwatch migrate`, `create-admin`, `systemctl enable --now openwatch`).
 
 ## Managing users and roles through the API
@@ -258,11 +259,12 @@ was present.
 ## Custom roles
 
 The registry supports custom, DB-stored roles created at runtime via
-`POST /api/v1/roles:create` (requires `role:write`). A custom role may grant any
-registry permission and category wildcards such as `host:*`, but not the bare
-`*` wildcard, which is reserved for the built-in `admin` role. Every permission a
-custom role lists is validated against the registry; unknown permissions are
-rejected with `400`.
+`POST /api/v1/roles:create` (requires `role:write`). A custom role may grant
+any concrete `resource:action` permission from the registry (for example
+`host:read`, `scan:execute`), but not category wildcards such as `host:*` or
+the bare `*` wildcard—those exist only for the built-in roles. Every
+permission a custom role lists is validated against the registry; a wildcard
+or any permission not in the registry is rejected with `400`.
 
 For the live permission registry, including category wildcards and newly added
 permissions, query the permissions-registry API endpoint.

--- a/docs/guides/runbooks/DATABASE_ISSUES.md
+++ b/docs/guides/runbooks/DATABASE_ISSUES.md
@@ -13,7 +13,8 @@ OpenWatch runs as a single Go binary (`/usr/bin/openwatch`) managed by systemd (
 
 - Application logs show `Could not connect to PostgreSQL` or a connection error.
 - API requests return HTTP 500 or 503 errors.
-- Health endpoint (`GET /api/v1/health`) reports `"status": "degraded"` and `"db_connected": false`.
+- Health endpoint (`GET /api/v1/health`) returns `503` with an `ErrorEnvelope`
+  body (`"code": "server.unavailable"`), not a `"status": "degraded"` body.
 - Slow API response times (queries taking seconds instead of milliseconds).
 - Connection timeout errors in the `openwatch` service logs (`journalctl -u openwatch`).
 - Scans stuck in `pending` or `running` state indefinitely.

--- a/docs/guides/runbooks/DISK_FULL.md
+++ b/docs/guides/runbooks/DISK_FULL.md
@@ -43,7 +43,7 @@ configured through `OPENWATCH_DATABASE_DSN` in `/etc/openwatch/secrets.env`.
 
 ## Symptoms
 
-- The health probe returns `503` or `db_connected: false`:
+- The health probe returns `503` (`ErrorEnvelope` code `server.unavailable`):
   `curl -sk https://localhost:8443/api/v1/health`.
 - `journalctl -u openwatch` shows PostgreSQL write errors such as
   `could not extend file` or `No space left on device`.
@@ -212,13 +212,14 @@ curl -sk https://localhost:8443/api/v1/health
 ```
 
 A healthy response is HTTP `200` with a body of
-`{"status":"healthy","db_connected":true,"version":"..."}`. A `503` or
-`db_connected: false` means PostgreSQL is still not writable.
+`{"status":"healthy","db_connected":true,"version":"..."}`. A `503` (an
+`ErrorEnvelope` with code `server.unavailable`) means PostgreSQL is still not
+writable.
 
 ### 4. Migrations are current (if you restarted after recovery)
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch migrate --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml migrate
 ```
 
 This is idempotent: it applies any pending migrations and prints the current

--- a/docs/guides/runbooks/HIGH_CPU.md
+++ b/docs/guides/runbooks/HIGH_CPU.md
@@ -184,7 +184,7 @@ oversized pool against an undersized PostgreSQL can amplify CPU contention. Insp
 the resolved value:
 
 ```bash
-openwatch check-config --config /etc/openwatch/openwatch.toml
+openwatch --config /etc/openwatch/openwatch.toml check-config
 ```
 
 Adjust `[database].max_connections` (or the `OPENWATCH_DATABASE_MAX_CONNECTIONS`
@@ -227,7 +227,7 @@ is bounded by the per-host advisory lock and the number of worker processes you 
 If the worker is busy-looping against an empty queue, raise the interval:
 
 ```bash
-openwatch worker --config /etc/openwatch/openwatch.toml --poll-interval 5s
+openwatch --config /etc/openwatch/openwatch.toml worker --poll-interval 5s
 ```
 
 If scan demand is genuinely high and the host has CPU headroom, the queue drains as

--- a/docs/guides/runbooks/SECURITY_INCIDENT.md
+++ b/docs/guides/runbooks/SECURITY_INCIDENT.md
@@ -281,7 +281,7 @@ sudo systemctl restart openwatch
 Confirm the configured path before generating a new key—`openwatch check-config` prints the resolved configuration with secrets redacted:
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch check-config --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml check-config
 ```
 
 > Do not rotate the credential DEK (`[identity].credential_key_file`) during an incident unless you have a re-encryption plan. Changing that key makes every stored SSH credential and MFA secret unreadable.
@@ -316,7 +316,7 @@ sudo iptables -I INPUT -s ATTACKER_IP -j DROP
 If the attacker modified data, restore PostgreSQL from a known-good backup. The procedure depends on how your database is backed up (`pg_dump`/`pg_restore` or physical/PITR); follow your backup tooling's restore steps, then re-run migrations to confirm the schema is current:
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch migrate --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml migrate
 ```
 
 > A backup/restore tool is not part of the OpenWatch binary today; database backup is an operator responsibility. This is tracked as roadmap, not an implemented feature.
@@ -325,7 +325,7 @@ sudo -u openwatch /usr/bin/openwatch migrate --config /etc/openwatch/openwatch.t
 
 ```bash
 # Validate the resolved config (secrets redacted, listen address, TLS paths)
-sudo -u openwatch /usr/bin/openwatch check-config --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml check-config
 
 # Confirm TLS material is in place and correctly owned
 ls -l /etc/openwatch/tls/cert.pem /etc/openwatch/tls/key.pem

--- a/docs/guides/runbooks/SERVICE_DOWN.md
+++ b/docs/guides/runbooks/SERVICE_DOWN.md
@@ -51,13 +51,15 @@ Configuration lives under `/etc/openwatch`:
 - `journalctl -u openwatch` shows a fatal boot error (config invalid, TLS key
   missing, JWT key missing, or DB pool open failure).
 - Logins fail or writes error while the process is up—usually PostgreSQL is
-  unreachable; the health response reports `db_connected: false`.
+  unreachable; the health probe returns `503`.
 
 The health endpoint is anonymous and returns a small JSON body. A healthy
-response is HTTP `200` with `{"status":"healthy","db_connected":true,"version":"..."}`.
-A degraded response is HTTP `503`. The fields are `status`, `db_connected`, and
-`version` only (the `HealthResponse` contract). There is no
-`redis` field—earlier Python-era runbooks that reference one are obsolete.
+response is HTTP `200` with `{"status":"healthy","db_connected":true,"version":"..."}`
+(the `HealthResponse` contract: `status`, `db_connected`, `version` only—there
+is no `redis` field; earlier Python-era runbooks that reference one are
+obsolete). When the database is unreachable, the endpoint does **not** return
+a degraded `HealthResponse` body—it returns HTTP `503` with the standard
+`ErrorEnvelope` (`"code": "server.unavailable"`) instead.
 
 ---
 
@@ -82,7 +84,7 @@ curl -sk https://localhost:8443/api/v1/health
 | Result | Likely cause |
 |--------|--------------|
 | HTTP `200`, `db_connected: true` | Server is up; the problem is upstream (TLS trust, reverse proxy, network, DNS) |
-| HTTP `503`, `db_connected: false` | Server is up but PostgreSQL is unreachable (see path B) |
+| HTTP `503` (`ErrorEnvelope`, code `server.unavailable`) | Server is up but PostgreSQL is unreachable (see path B) |
 | Connection refused / no response | Process is not listening—it failed to start or crashed (see path A) |
 | TLS error | TLS cert/key problem (see path C) |
 
@@ -115,7 +117,7 @@ env → flags), prints the resolved values with secrets redacted, and validates
 them. Exit `0` means valid.
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch check-config --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml check-config
 ```
 
 ### Step 5: Confirm PostgreSQL is reachable
@@ -159,7 +161,7 @@ sudo systemctl restart openwatch
 
 The binary opens its connection pool at startup and exits non-zero if it cannot
 (`failed to open db pool`). A running process that loses the database serves
-`503` with `db_connected: false`.
+`503` (`ErrorEnvelope`, code `server.unavailable`) from `/api/v1/health`.
 
 ```bash
 # Is PostgreSQL running?
@@ -181,7 +183,7 @@ credentials/`pg_hba.conf` reject the service. Check the DSN the service actually
 uses (`OPENWATCH_DATABASE_DSN` overrides the TOML `dsn`):
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch check-config --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml check-config
 ```
 
 The summary prints the DSN with the password redacted; confirm host, port,
@@ -220,7 +222,7 @@ If the binary was upgraded but migrations were not applied, the server can start
 but error on queries. Apply pending migrations (idempotent), then restart:
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch migrate --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml migrate
 sudo systemctl restart openwatch
 ```
 
@@ -313,7 +315,7 @@ journalctl -u openwatch --since "5 minutes ago" | grep -iE "error|fatal" || echo
 ### 5. Migrations are current
 
 ```bash
-sudo -u openwatch /usr/bin/openwatch migrate --config /etc/openwatch/openwatch.toml
+sudo -u openwatch /usr/bin/openwatch --config /etc/openwatch/openwatch.toml migrate
 ```
 
 This prints the current schema version and applies nothing if already up to date.
@@ -349,7 +351,7 @@ Include when escalating:
   `/etc/openwatch/openwatch.toml` or `secrets.env` to catch a bad value before it
   takes the service down.
 - **Monitor the health probe**: poll `GET /api/v1/health` from your existing host
-  monitoring and alert on a non-`200` status or `db_connected: false`.
+  monitoring and alert on any non-`200` response.
 - **Order startup correctly**: the unit declares `After=`/`Wants=postgresql.service`
   so PostgreSQL starts first on the same host. For an external database, ensure
   network reachability before OpenWatch starts.

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -38,7 +38,6 @@ interface NavItem {
     | '/settings/audit'
     | '/settings/about';
   count?: number;
-  pip?: 'warn' | 'crit';
 }
 
 interface NavGroup {
@@ -91,7 +90,6 @@ const NAV_GROUPS: NavGroup[] = [
         label: 'Security & auth',
         icon: <Shield size={14} />,
         to: '/settings/security',
-        pip: 'warn',
       },
       { id: 'audit', label: 'Audit log', icon: <ScrollText size={14} />, to: '/settings/audit' },
     ],
@@ -237,17 +235,6 @@ export function SettingsLayout({ children }: { children: ReactNode }) {
                     >
                       {item.count}
                     </span>
-                  )}
-                  {item.pip && (
-                    <span
-                      style={{
-                        width: 6,
-                        height: 6,
-                        borderRadius: '50%',
-                        background: item.pip === 'warn' ? 'var(--ow-warn)' : 'var(--ow-crit)',
-                        marginLeft: 'auto',
-                      }}
-                    />
                   )}
                 </Link>
               );

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -3,7 +3,7 @@
 // AC traceability (this file):
 //
 //   AC-01  router: /settings redirects to /settings/profile
-//   AC-02  SettingsLayout nav has 11 leaf items in Workspace 5 / Access 3 / Personal 3 + warn pip on Security
+//   AC-02  SettingsLayout nav has 11 leaf items in Workspace 5 / Access 3 / Personal 3, no hardcoded status pip
 //   AC-03  Nav search filters labels case-insensitive
 //   AC-04  ProfilePage renders identity from useAuthStore + Save disabled
 //   AC-05  Password-change submit POSTs /auth/password:change
@@ -80,7 +80,7 @@ describe('frontend-settings — structural', () => {
   });
 
   // @ac AC-02
-  test('frontend-settings/AC-02 — 11 leaf nav items grouped 5/3/3 with warn pip on Security', () => {
+  test('frontend-settings/AC-02 — 11 leaf nav items grouped 5/3/3, no hardcoded status pip', () => {
     // Extract item IDs from each group.
     const workspaceMatch = LAYOUT_SRC.match(
       /title:\s*['"]Workspace['"]\s*,\s*items:\s*\[([\s\S]+?)\]/,
@@ -98,10 +98,10 @@ describe('frontend-settings — structural', () => {
     expect(countIds(accessMatch![1]!)).toBe(3);
     expect(countIds(personalMatch![1]!)).toBe(3);
 
-    // Security item carries pip: 'warn'. The id...pip span includes a
-    // JSX `<Shield size={14} />` whose `}` would defeat a [^}] charset,
-    // so use a more permissive within-array span match.
-    expect(LAYOUT_SRC).toMatch(/id:\s*['"]security['"][\s\S]*?pip:\s*['"]warn['"]/);
+    // No nav item carries a hardcoded status pip. A static always-on warn
+    // pip on Security & auth was removed as misleading (a pip must reflect a
+    // real condition, not a literal). The pip affordance is gone entirely.
+    expect(LAYOUT_SRC).not.toMatch(/pip:\s*['"]/);
   });
 
   // @ac AC-03

--- a/internal/audit/events.gen.go
+++ b/internal/audit/events.gen.go
@@ -51,6 +51,8 @@ const (
 	AuthSessionRevoked Code = "auth.session.revoked"
 	// User's password was successfully updated
 	AuthPasswordChanged Code = "auth.password.changed"
+	// User updated their own profile (self-service). email_changed is true when the update included the sign-in email.
+	AuthProfileUpdated Code = "auth.profile.updated"
 	// Password change rejected by the NIST 800-63B policy validator
 	AuthPasswordPolicyFailed Code = "auth.password.policy_failed"
 	// API key issued
@@ -428,6 +430,13 @@ var Metadata = map[Code]EventMeta{
 		Category:    "auth",
 		Severity:    SeverityInfo,
 		Description: `User's password was successfully updated`,
+		ActorTypes:  nil,
+	},
+	AuthProfileUpdated: {
+		Code:        AuthProfileUpdated,
+		Category:    "auth",
+		Severity:    SeverityInfo,
+		Description: `User updated their own profile (self-service). email_changed is true when the update included the sign-in email.`,
 		ActorTypes:  nil,
 	},
 	AuthPasswordPolicyFailed: {
@@ -1392,6 +1401,7 @@ var codeOrder = []Code{
 	AuthSessionExpired,
 	AuthSessionRevoked,
 	AuthPasswordChanged,
+	AuthProfileUpdated,
 	AuthPasswordPolicyFailed,
 	AuthApiKeyCreated,
 	AuthApiKeyRevoked,

--- a/internal/correlation/http.go
+++ b/internal/correlation/http.go
@@ -1,7 +1,6 @@
 package correlation
 
 import (
-	"context"
 	"log/slog"
 	"net/http"
 )
@@ -50,18 +49,4 @@ func truncate(s string, max int) string {
 		return s
 	}
 	return s[:max] + "..."
-}
-
-// MustFrom is a test/diagnostic helper that returns the correlation ID
-// from ctx or panics if missing. Intended for code paths that should
-// never run without a correlation ID (e.g., post-middleware handlers).
-//
-// Not part of the public contract — exists so tests don't have to thread
-// ok-checks. Production code should use From and handle the missing case.
-func MustFrom(ctx context.Context) string {
-	id, ok := From(ctx)
-	if !ok {
-		panic("correlation.MustFrom: no correlation id on context")
-	}
-	return id
 }

--- a/internal/identity/mfa.go
+++ b/internal/identity/mfa.go
@@ -35,13 +35,6 @@ const TOTPSecretBytes = 20 // 160 bits
 // validation, so 180s replay protection covers the boundary).
 const OTPReplayWindow = 180 * time.Second
 
-// LoadMFAKey is preserved as a thin wrapper over secretkey.LoadFromFile
-// for callers that haven't migrated to the shared package yet. Prefer
-// secretkey.LoadFromFile in new code.
-//
-// Deprecated: use secretkey.LoadFromFile instead.
-func LoadMFAKey(path string) error { return secretkey.LoadFromFile(path) }
-
 // SetEphemeralMFAKey installs a random key. Tests and dev mode only.
 // Wrapper over secretkey.SetEphemeral.
 //

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -1,7 +1,6 @@
 package license
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -224,23 +223,4 @@ func translateFeatures(claims []string) (known []Feature, unknown []string) {
 		}
 	}
 	return known, unknown
-}
-
-// VerifyClaimsAsJSON serializes claims into JSON for diagnostics. Used
-// by /admin/license:verify to surface parsed-but-rejected payloads. Never
-// returns secrets (the JWT signature is not in claims).
-func VerifyClaimsAsJSON(jwtBlob string) (map[string]any, error) {
-	parts := strings.Split(jwtBlob, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("malformed JWT (expected 3 segments)")
-	}
-	payload, err := jwt.NewParser().DecodeSegment(parts[1])
-	if err != nil {
-		return nil, err
-	}
-	var out map[string]any
-	if err := json.Unmarshal(payload, &out); err != nil {
-		return nil, err
-	}
-	return out, nil
 }

--- a/internal/notification/delivery.go
+++ b/internal/notification/delivery.go
@@ -198,12 +198,14 @@ func sendSMTP(cfg Config, from string, to []string, msg []byte) error {
 	return client.Quit()
 }
 
-// buildEmailMessage assembles a minimal RFC 5322 message.
+// buildEmailMessage assembles a minimal RFC 5322 message. From/To/Subject are
+// CRLF-stripped so an operator-supplied header value cannot inject additional
+// headers (CWE-93); see stripCRLF in report_email.go.
 func buildEmailMessage(from string, to []string, subject, body string) []byte {
 	var b bytes.Buffer
-	fmt.Fprintf(&b, "From: %s\r\n", from)
-	fmt.Fprintf(&b, "To: %s\r\n", strings.Join(to, ", "))
-	fmt.Fprintf(&b, "Subject: %s\r\n", subject)
+	fmt.Fprintf(&b, "From: %s\r\n", stripCRLF(from))
+	fmt.Fprintf(&b, "To: %s\r\n", stripCRLF(strings.Join(to, ", ")))
+	fmt.Fprintf(&b, "Subject: %s\r\n", stripCRLF(subject))
 	b.WriteString("MIME-Version: 1.0\r\n")
 	b.WriteString("Content-Type: text/plain; charset=utf-8\r\n")
 	b.WriteString("\r\n")

--- a/internal/notification/delivery_test.go
+++ b/internal/notification/delivery_test.go
@@ -112,7 +112,7 @@ func TestMatchesTags(t *testing.T) {
 // surfaced to the operator without leaking the channel's secret target.
 func TestScrubHTTPErr(t *testing.T) {
 	t.Run("system-notifications/AC-22", func(t *testing.T) {
-		secret := "https://hooks.slack.com/services/T00/B00/SECRETTOKEN"
+		secret := "https://hooks.slack.com/services/T00/B00/SECRETTOKEN" // pragma: allowlist secret
 		ue := &url.Error{
 			Op:  "Post",
 			URL: secret,
@@ -202,6 +202,14 @@ func TestValidateEmailAndMessage(t *testing.T) {
 			if !strings.Contains(msg, want) {
 				t.Errorf("email message missing %q:\n%s", want, msg)
 			}
+		}
+		// CRLF in a header value must not inject an extra header (CWE-93). The
+		// injected "Bcc" must be flattened into the From line, not appear as a
+		// header of its own, and the header block must end after Subject.
+		inj := string(buildEmailMessage("ow@corp.com\r\nBcc: attacker@evil.com",
+			[]string{"a@corp.com"}, "Subj\r\nX-Injected: 1", "Body"))
+		if strings.Contains(inj, "\nBcc:") || strings.Contains(inj, "\nX-Injected:") {
+			t.Errorf("CRLF header injection not stripped:\n%q", inj)
 		}
 	})
 }

--- a/internal/notification/report_email.go
+++ b/internal/notification/report_email.go
@@ -74,8 +74,8 @@ func buildReportEmail(from string, to []string, subject, body, filename string, 
 	_ = w.Close()
 
 	var msg bytes.Buffer
-	fmt.Fprintf(&msg, "From: %s\r\n", from)
-	fmt.Fprintf(&msg, "To: %s\r\n", strings.Join(to, ", "))
+	fmt.Fprintf(&msg, "From: %s\r\n", stripCRLF(from))
+	fmt.Fprintf(&msg, "To: %s\r\n", stripCRLF(strings.Join(to, ", ")))
 	fmt.Fprintf(&msg, "Subject: %s\r\n", subject)
 	msg.WriteString("MIME-Version: 1.0\r\n")
 	fmt.Fprintf(&msg, "Content-Type: multipart/mixed; boundary=%s\r\n", w.Boundary())

--- a/internal/scheduler/readviews.go
+++ b/internal/scheduler/readviews.go
@@ -138,10 +138,17 @@ func HostSchedule(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID) (Ho
 	info := HostScheduleInfo{State: StateUnknown}
 	var state string
 	var next time.Time
+	// Maintenance comes from host_effective_maintenance (per-host OR per-group,
+	// migration 0049), NOT host_compliance_schedule.maintenance_mode — that
+	// column is never written (the scheduler moved to the view in 0049) and
+	// would always read false, leaving the host-detail "paused for maintenance"
+	// tile permanently unreachable.
 	err := pool.QueryRow(ctx, `
-		SELECT compliance_state, next_scheduled_scan,
-		       current_interval_minutes, maintenance_mode
-		  FROM host_compliance_schedule WHERE host_id = $1`, hostID).
+		SELECT s.compliance_state, s.next_scheduled_scan,
+		       s.current_interval_minutes, COALESCE(hem.in_maintenance, false)
+		  FROM host_compliance_schedule s
+		  LEFT JOIN host_effective_maintenance hem ON hem.host_id = s.host_id
+		 WHERE s.host_id = $1`, hostID).
 		Scan(&state, &next, &info.IntervalMinutes, &info.Maintenance)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/scheduler/service_test.go
+++ b/internal/scheduler/service_test.go
@@ -338,6 +338,46 @@ func TestDispatch_MaintenanceMode_RowSkipped(t *testing.T) {
 	})
 }
 
+// TestHostSchedule_MaintenanceFromEffectiveView is a regression test for the
+// host-detail schedule projection: HostSchedule must read maintenance from
+// host_effective_maintenance (per-host OR per-group, migration 0049), NOT the
+// never-written host_compliance_schedule.maintenance_mode column. Before the
+// fix that column always read false, so the "paused for maintenance" tile on
+// the host-detail Auto-scan card was permanently unreachable.
+func TestHostSchedule_MaintenanceFromEffectiveView(t *testing.T) {
+	pool := freshPool(t)
+	user := seedUser(t, pool)
+	hNormal := seedHost(t, pool, user)
+	hPerHost := seedHost(t, pool, user)
+	hPerGroup := seedHost(t, pool, user)
+	seedSchedule(t, pool, hNormal)
+	seedSchedule(t, pool, hPerHost)
+	seedSchedule(t, pool, hPerGroup)
+	setHostMaintenance(t, pool, hPerHost, true)
+	seedManualMaintenanceGroup(t, pool, hPerGroup)
+
+	for _, tc := range []struct {
+		name   string
+		hostID uuid.UUID
+		want   bool
+	}{
+		{"normal host not in maintenance", hNormal, false},
+		{"per-host maintenance", hPerHost, true},
+		{"per-group maintenance", hPerGroup, true},
+	} {
+		info, err := HostSchedule(context.Background(), pool, tc.hostID)
+		if err != nil {
+			t.Fatalf("%s: HostSchedule: %v", tc.name, err)
+		}
+		if !info.Found {
+			t.Fatalf("%s: schedule row not found", tc.name)
+		}
+		if info.Maintenance != tc.want {
+			t.Errorf("%s: Maintenance = %v, want %v", tc.name, info.Maintenance, tc.want)
+		}
+	}
+}
+
 // @ac AC-13
 // AC-13: every UPDATE to host_compliance_schedule emits one
 // scheduler.schedule.updated audit event with the expected detail keys.

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -559,6 +559,9 @@ func (h *handlers) PatchAuthMe(w http.ResponseWriter, r *http.Request) {
 			"failed to update profile", false)
 		return
 	}
+	emitAudit(r, audit.AuthProfileUpdated, id.ID, map[string]any{
+		"email_changed": req.Email != nil,
+	})
 	writeJSON(w, http.StatusOK, userToMe(u, string(id.RoleID)))
 }
 

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -250,11 +250,27 @@ type ProfileUpdate struct {
 // otherwise. Username, role, and password are not editable here. Returns
 // the updated user.
 func (s *Service) UpdateProfile(ctx context.Context, id uuid.UUID, p ProfileUpdate) (User, error) {
+	// Enforce the documented length bounds server-side (api/openapi.yaml
+	// AuthMeUpdateRequest). The request-body contract is not enforced by
+	// middleware, so a caller could otherwise store arbitrarily large values.
+	for _, f := range []struct {
+		name string
+		val  *string
+		max  int
+	}{
+		{"full_name", p.FullName, 256}, {"display_name", p.DisplayName, 256},
+		{"job_title", p.JobTitle, 256}, {"timezone", p.Timezone, 64}, {"phone", p.Phone, 64},
+	} {
+		if f.val != nil && len(*f.val) > f.max {
+			return User{}, fmt.Errorf("%w: %s exceeds %d characters", ErrInvalidProfile, f.name, f.max)
+		}
+	}
+
 	var emailArg *string
 	if p.Email != nil {
 		email := strings.TrimSpace(*p.Email)
-		if email == "" || !strings.Contains(email, "@") {
-			return User{}, fmt.Errorf("%w: email must be a non-empty address", ErrInvalidProfile)
+		if email == "" || !strings.Contains(email, "@") || len(email) > 256 {
+			return User{}, fmt.Errorf("%w: email must be a non-empty address of at most 256 characters", ErrInvalidProfile)
 		}
 		var taken bool
 		if err := s.pool.QueryRow(ctx,
@@ -288,6 +304,12 @@ func (s *Service) UpdateProfile(ctx context.Context, id uuid.UUID, p ProfileUpda
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return User{}, ErrUserNotFound
+		}
+		// The pre-check above is not in the same transaction as the UPDATE, so a
+		// concurrent email change can still collide on idx_users_email_active.
+		// Map the unique violation to ErrEmailTaken (409) instead of a 500.
+		if isUniqueViolation(err) {
+			return User{}, ErrEmailTaken
 		}
 		return User{}, fmt.Errorf("users: update profile: %w", err)
 	}

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.15.0"
+  version: "1.16.0"
   status: draft
   tier: 2
 
@@ -54,7 +54,7 @@ spec:
         - "Route /settings — redirects to /settings/profile by default"
         - "Two-pane shell — 260px left nav + main content"
         - "Left nav with 11 items in 3 groups plus search"
-        - "Active nav item highlighted with warn-pip on Security & auth"
+        - "Active nav item highlighted"
         - "Profile — identity from /auth/me + password change + MFA enroll + sessions placeholder"
         - "Preferences — theme/density/accent/landing/host-view/date-format/reduce-motion persisted to localStorage"
         - "SSH & credentials — list from GET /api/v1/credentials with Add (POST), Edit (in-place PATCH /credentials/{id}) and Delete (DELETE) modals; editing keeps the stored secret when the field is left blank (v1.9.0)"
@@ -248,7 +248,7 @@ spec:
       priority: critical
       references_constraints: [C-01]
     - id: AC-02
-      description: The left nav renders exactly 11 leaf items distributed as Workspace (5) + Access (3) + Personal (3). The Security & auth item carries a warn-tier pip in its right slot.
+      description: The left nav renders exactly 11 leaf items distributed as Workspace (5) + Access (3) + Personal (3). Nav items carry no hardcoded status pip (a static always-on warning dot on Security & auth was removed as misleading; a pip must reflect a real condition, not a literal).
       priority: critical
       references_constraints: [C-02]
     - id: AC-03


### PR DESCRIPTION
Release-readiness sweep for the `[Unreleased]` cycle (v0.3.0 / Kensa v0.7.6). Five focused commits: a security fix, two docs-accuracy passes, a dead-code + bug-fix pass, and a UI honesty fix.

## Security (`4dd61ec7`)
Follow-up hardening on the SMTP + profile features from this cycle, from a review of `be87125d..HEAD`:
- **SMTP header injection (CWE-93):** `buildEmailMessage` built From/To/Subject from raw operator input, so a From like `ow@corp.com\r\nBcc: attacker@evil.com` could inject headers into every alert email. Now CRLF-stripped (matching the report-email path); regression test added.
- **Profile self-edit:** enforce the documented length bounds server-side; map a concurrent email-uniqueness collision to 409 (not a 500); emit a new `auth.profile.updated` audit event so a sign-in-identity change leaves a trail.

## Quality: dead code + a real bug (`b6e298aa`)
Whole-tree sweep (golangci-lint + eslint clean; findings from call-site tracing):
- Removed 3 genuinely-dead functions (`LoadMFAKey`, `MustFrom`, `VerifyClaimsAsJSON`).
- **Bug fix:** the host-detail "paused for maintenance" tile was permanently unreachable — `HostSchedule` read `host_compliance_schedule.maintenance_mode`, a column the scheduler stopped writing in migration 0049 (it moved to the `host_effective_maintenance` view). Now reads the view; regression test covers normal / per-host / per-group.

## UI honesty (`8499b784`)
Removed a hardcoded always-on `pip: 'warn'` dot on the Settings "Security & auth" nav item — it reflected no real state. Spec + source-inspection test updated.

## Docs accuracy — all 18 public chapters (`fbb70fb5`, `6def3320`)
Two passes on `docs/guides/` (which render to hanalyx.com/docs/openwatch). Pass 1 fixed stale versions, fabricated endpoints, and internal links. Pass 2 **booted the binary and reproduced failures**, fixing truthfulness defects a reader would hit:
- A restore step that **bricked boot** (`chmod 0640` on the credential key — boot refuses any mode & 0o077).
- **Fabricated compliance controls** in the audit-facing doc (password "complexity" that's actually length-only per NIST 800-63B, MFA "backup codes", a login banner, file-upload anti-malware) — removed/corrected; framework totals recounted.
- A **denial of rate-limiting that exists**; a **worker systemd unit that won't start** (global-flag ordering — also fixed in 5 runbooks); two **fabricated cron times**; scan curls **missing the required `Idempotency-Key`**; health samples corrected to the real 200/503 bodies.
- Zero broken/internal links, zero broken images, zero stale-stack references.

## Verification
`make ci-local` green locally: `check-generated`, `go vet`, `govulncheck` (0 vulns), `golangci-lint`, `specter check` (116/116), release gate tests, frontend `tsc` + `vitest` (353/353), and the full Go suite (58 pkg, 0 fail). Build-gated release tests (fips/package/runtime-boot) run in CI.

## Deferred (tracked, not in this PR)
A quality + security review surfaced several items intentionally **not** changed here because they're access-control or product decisions — most notably a **P1 RBAC custom-role escalation landmine** (currently inert: custom roles grant no permissions today, so the feature is dead weight — but a landmine to fix before enforcement is ever wired). These are logged for follow-up with exact fixes.