### PR TITLE
chore(release): v0.4.0 (Eyrie)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] Eyrie — 2026-07-13
+
 ### Added
 
 - **Org-wide default compliance lens.** A scan always runs the full Kensa

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ OpenWatch is the compliance operating system for teams managing Linux infrastruc
 > Python/FastAPI implementation was archived out of the repo on 2026-06-05). The
 > Go tree lives at the **repo root**: Go 1.26 backend (`cmd/`, `internal/`),
 > React 19 + TanStack frontend (`frontend/`), PostgreSQL-only. The current
-> version is `0.2.1`, on the general-availability line that opened with `0.2.0`.
+> version is `0.4.0`, on the general-availability line that opened with `0.2.0`.
 
-![OpenWatch Host Management: a fleet of RHEL and Ubuntu hosts with per-host compliance scores against 630 Kensa rules](docs/images/host-management.png)
+![OpenWatch Host Management: a fleet of RHEL and Ubuntu hosts with per-host compliance scores against 748 Kensa rules](docs/images/host-management.png)
 
 ## The Problem with Point-in-Time Compliance
 

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.3.0"
+VERSION="0.4.0"
 CODENAME="Eyrie"


### PR DESCRIPTION
Release-prep for **v0.4.0 (Eyrie)** — minor bump (new features since v0.3.0).

Bumps `packaging/version.env` `0.3.0 -> 0.4.0` and finalizes the CHANGELOG `[Unreleased]` section as `[0.4.0] Eyrie — 2026-07-13`. Also fixes the stale root-README version line (`0.2.1 -> 0.4.0`) and rule count (`630 -> 748`).

Once merged, the GA tag `v0.4.0` is cut on the merge commit, which triggers `release.yml` (multi-arch signed RPM/DEB + SBOMs + GitHub release) and `package-smoke.yml` (per-distro install matrix).

## What ships in v0.4.0 (since v0.3.0)
- **Added:** org-wide default compliance lens; SMTP email notifications with per-severity routing; self-service profile editing.
- **Security:** Kensa v0.7.6 (patches a root command injection in remediation handlers); SMTP header-injection hardening (CWE-93).
- **Changed:** Go 1.26.5; Kensa corpus 647 -> 748 rules; three built-in scan-variable defaults moved to the STIG baseline (a host may flip pass->fail on the stricter thresholds unless an override is set).
- **Fixed:** per-host/per-group maintenance now suppresses scans everywhere; notification channel-test surfaces the real error (secret-scrubbed); host-detail "paused for maintenance" tile reflects real state.