### PR TITLE
feat(compliance): enabled-frameworks allowlist for lenses

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1562,7 +1562,16 @@ paths:
         Framework families derived at runtime from
         host_rule_state.framework_refs (STIG, CIS, NIST 800-53, …), each with
         a display label and the concrete corpus keys it spans. Feeds the
-        default-lens picker. Empty until at least one host is scanned.
+        default-lens picker. Empty until at least one host is scanned. By
+        default the list is narrowed to the enabled-frameworks allowlist (if
+        set); pass all=true to return every corpus family (for the allowlist
+        editor).
+      parameters:
+        - name: all
+          in: query
+          required: false
+          description: When true, return every corpus family, ignoring the enabled-frameworks allowlist.
+          schema: {type: boolean, default: false}
       responses:
         '200':
           description: Families
@@ -5427,9 +5436,17 @@ components:
         lens the score surfaces (dashboard/hosts avg compliance, host detail)
         project to: a framework family id (e.g. "stig", "cis") or empty for
         All rules (the full Kensa corpus). Resolved per-host to the OS key at
-        query time.
+        query time. enabled_frameworks is the allowlist of families offered as
+        lenses; empty means all corpus families are available. A non-empty
+        default_framework must be in a non-empty enabled_frameworks.
       properties:
         default_framework: {type: string, description: Framework family id, or empty for All rules}
+        enabled_frameworks:
+          type: array
+          items: {type: string}
+          description: >-
+            Allowlist of framework family ids offered as lenses. Empty (or
+            omitted) means every family found in the corpus is available.
 
     ComplianceFramework:
       type: object

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1006,7 +1006,7 @@ export interface paths {
         };
         /**
          * List the framework families present in the scanned corpus
-         * @description Framework families derived at runtime from host_rule_state.framework_refs (STIG, CIS, NIST 800-53, …), each with a display label and the concrete corpus keys it spans. Feeds the default-lens picker. Empty until at least one host is scanned.
+         * @description Framework families derived at runtime from host_rule_state.framework_refs (STIG, CIS, NIST 800-53, …), each with a display label and the concrete corpus keys it spans. Feeds the default-lens picker. Empty until at least one host is scanned. By default the list is narrowed to the enabled-frameworks allowlist (if set); pass all=true to return every corpus family (for the allowlist editor).
          */
         get: operations["getComplianceFrameworks"];
         put?: never;
@@ -3553,10 +3553,12 @@ export interface components {
             /** @description Count of host.discovery jobs persisted by this sweep. Zero is a valid steady state (every host already discovered, or fleet empty) */
             enqueued: number;
         };
-        /** @description Org-wide compliance-display config. default_framework is the default lens the score surfaces (dashboard/hosts avg compliance, host detail) project to: a framework family id (e.g. "stig", "cis") or empty for All rules (the full Kensa corpus). Resolved per-host to the OS key at query time. */
+        /** @description Org-wide compliance-display config. default_framework is the default lens the score surfaces (dashboard/hosts avg compliance, host detail) project to: a framework family id (e.g. "stig", "cis") or empty for All rules (the full Kensa corpus). Resolved per-host to the OS key at query time. enabled_frameworks is the allowlist of families offered as lenses; empty means all corpus families are available. A non-empty default_framework must be in a non-empty enabled_frameworks. */
         ComplianceConfig: {
             /** @description Framework family id */
             default_framework: string;
+            /** @description Allowlist of framework family ids offered as lenses. Empty (or omitted) means every family found in the corpus is available. */
+            enabled_frameworks?: string[];
         };
         ComplianceFramework: {
             /** @description Family id (e.g. "stig") */
@@ -6704,7 +6706,10 @@ export interface operations {
     };
     getComplianceFrameworks: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description When true, return every corpus family, ignoring the enabled-frameworks allowlist. */
+                all?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/frontend/src/components/settings/DefaultLensCard.tsx
+++ b/frontend/src/components/settings/DefaultLensCard.tsx
@@ -64,8 +64,12 @@ export function DefaultLensCard() {
           <>
             The framework the dashboard, hosts, and host-detail compliance scores default to.
             Individual host views can still switch lens.{' '}
-            {banner?.kind === 'success' && <span style={{ color: 'var(--ow-ok)' }}>{banner.text}</span>}
-            {banner?.kind === 'error' && <span style={{ color: 'var(--ow-crit)' }}>{banner.text}</span>}
+            {banner?.kind === 'success' && (
+              <span style={{ color: 'var(--ow-ok)' }}>{banner.text}</span>
+            )}
+            {banner?.kind === 'error' && (
+              <span style={{ color: 'var(--ow-crit)' }}>{banner.text}</span>
+            )}
           </>
         }
         control={

--- a/frontend/src/components/settings/EnabledFrameworksCard.tsx
+++ b/frontend/src/components/settings/EnabledFrameworksCard.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { SettingCard, FirstSettingRow, SettingRow, Toggle } from './primitives';
+
+// EnabledFrameworksCard — the Phase 2 enabled-frameworks allowlist. An admin
+// restricts which framework families are offered as lenses. Wired to
+// GET /api/v1/compliance/frameworks?all=true (the full corpus family list) and
+// GET/PUT /api/v1/system/compliance/config (enabled_frameworks). An empty
+// allowlist means every family is available (the factory default); the master
+// toggle expresses that. The current default lens must stay enabled, so its
+// row is locked on (the backend enforces the same invariant). The write is
+// server-enforced (system:config_write) — not client-gated.
+export function EnabledFrameworksCard() {
+  const queryClient = useQueryClient();
+  const [banner, setBanner] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+
+  const configQuery = useQuery({
+    queryKey: ['compliance-config'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/system/compliance/config');
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load'));
+      return data!;
+    },
+  });
+
+  // The full corpus family list (all=true bypasses the allowlist filter).
+  const allFrameworksQuery = useQuery({
+    queryKey: ['compliance-frameworks-all'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/compliance/frameworks', {
+        params: { query: { all: true } },
+      });
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load frameworks'));
+      return data!.frameworks;
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (next: { default_framework: string; enabled_frameworks: string[] }) => {
+      const { response, error } = await api.PUT('/api/v1/system/compliance/config', { body: next });
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to save'));
+    },
+    onSuccess: () => {
+      setBanner({ kind: 'success', text: 'Enabled frameworks saved.' });
+      // The narrowed picker list (['compliance-frameworks']) also changes.
+      queryClient.invalidateQueries({ queryKey: ['compliance-config'] });
+      queryClient.invalidateQueries({ queryKey: ['compliance-frameworks'] });
+    },
+    onError: (e: Error) => setBanner({ kind: 'error', text: e.message }),
+  });
+
+  const cfg = configQuery.data;
+  const allFrameworks = allFrameworksQuery.data ?? [];
+  const enabled = cfg?.enabled_frameworks ?? [];
+  const defaultFramework = cfg?.default_framework ?? '';
+  const restrict = enabled.length > 0;
+  const busy = mutation.isPending || configQuery.isLoading || allFrameworksQuery.isLoading;
+
+  const save = (enabledNext: string[]) => {
+    setBanner(null);
+    mutation.mutate({ default_framework: defaultFramework, enabled_frameworks: enabledNext });
+  };
+
+  const setRestrict = (on: boolean) => {
+    // On: seed with every family (explicit) so it's a no-op until trimmed.
+    // Off: empty list means every family is available.
+    save(on ? allFrameworks.map((f) => f.id) : []);
+  };
+
+  const toggleFamily = (id: string, on: boolean) => {
+    save(on ? [...enabled, id] : enabled.filter((x) => x !== id));
+  };
+
+  return (
+    <SettingCard>
+      <FirstSettingRow
+        name="Limit lens options"
+        description={
+          <>
+            Restrict which framework families are offered as compliance lenses. Off means every
+            framework found in the corpus is available.{' '}
+            {banner?.kind === 'success' && (
+              <span style={{ color: 'var(--ow-ok)' }}>{banner.text}</span>
+            )}
+            {banner?.kind === 'error' && (
+              <span style={{ color: 'var(--ow-crit)' }}>{banner.text}</span>
+            )}
+          </>
+        }
+        control={
+          <Toggle
+            value={restrict}
+            onChange={setRestrict}
+            ariaLabel="Limit lens options"
+            disabled={busy}
+          />
+        }
+      />
+      {restrict &&
+        allFrameworks.map((f) => {
+          const isDefault = f.id === defaultFramework;
+          return (
+            <SettingRow
+              key={f.id}
+              name={f.label}
+              description={isDefault ? 'The current default lens must stay enabled.' : undefined}
+              control={
+                <Toggle
+                  value={enabled.includes(f.id)}
+                  onChange={(on) => toggleFamily(f.id, on)}
+                  ariaLabel={f.label}
+                  disabled={busy || isDefault}
+                />
+              }
+            />
+          );
+        })}
+    </SettingCard>
+  );
+}

--- a/frontend/src/pages/settings/PoliciesPage.tsx
+++ b/frontend/src/pages/settings/PoliciesPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
 import { useBreadcrumbStore } from '@/store/useBreadcrumbStore';
 import { SettingsLayout } from '@/components/settings/SettingsLayout';
-import { PageHead, Section, BackendPendingBanner } from '@/components/settings/primitives';
+import { PageHead, Section } from '@/components/settings/primitives';
 import { ScanVariablesCard } from '@/components/settings/ScanVariablesCard';
 import { DefaultLensCard } from '@/components/settings/DefaultLensCard';
+import { EnabledFrameworksCard } from '@/components/settings/EnabledFrameworksCard';
 import { ExceptionQueue } from '@/components/settings/ExceptionQueue';
 
 // Settings → Compliance policies.
@@ -50,10 +51,7 @@ export function PoliciesPage() {
         </p>
         <DefaultLensCard />
         <div style={{ marginTop: 12 }}>
-          <BackendPendingBanner
-            slice="Enabled frameworks"
-            text="Hiding frameworks you don't use (an allowlist) is a follow-up. Today every framework found in the corpus is available as a lens."
-          />
+          <EnabledFrameworksCard />
         </div>
       </Section>
 

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -223,15 +223,17 @@ describe('frontend-settings — structural', () => {
     // About graduated too: it renders live version + license, not a
     // BackendPendingBanner. It still lives in this file but is not a stub.
     expect(STUBBED_SRC).toContain('export function AboutPage');
-    // PoliciesPage left the stub file: it lives in its own page with the
-    // live scan-variables section and per-section banners on the
-    // remaining stubs (frontend-settings-scan-config AC-06).
+    // PoliciesPage left the stub file: it lives in its own page and has now
+    // fully graduated — scan variables, framework lenses (default lens +
+    // enabled-frameworks allowlist), and the exception workflow are all live,
+    // so it carries no BackendPendingBanner.
     expect(STUBBED_SRC).not.toContain('PoliciesPage');
     const policies = readFileSync(
       resolve(process.cwd(), 'src/pages/settings/PoliciesPage.tsx'),
       'utf8',
     );
-    expect(policies).toContain('BackendPendingBanner');
+    expect(policies).not.toContain('BackendPendingBanner');
+    expect(policies).toContain('EnabledFrameworksCard');
     expect(ROUTER_SRC).toContain("from '@/pages/settings/PoliciesPage'");
   });
 

--- a/internal/fleetrollup/service.go
+++ b/internal/fleetrollup/service.go
@@ -158,11 +158,15 @@ func (s *Service) TopFailingRules(ctx context.Context, limit int, opts ...Option
 		return []RuleFailureRollup{}, nil
 	}
 	o := applyOpts(opts)
-	const q = `
+	// framework.MatchSQL($2) is family-aware (matches any corpus key in the
+	// family, e.g. "stig" spans stig_rhel9 + stig_rhel10) and handles the
+	// NULL/all-rules case; a bare framework_refs ? $2 would only match an
+	// exact key. Kept consistent with FleetComplianceScore.
+	q := `
 		SELECT rule_id, COUNT(*)::BIGINT AS failing_host_count
 		  FROM host_rule_state
 		 WHERE current_status = 'fail'
-		   AND ($2::text IS NULL OR framework_refs ? $2)
+		   AND ` + framework.MatchSQL("$2") + `
 		 GROUP BY rule_id
 		 ORDER BY failing_host_count DESC, rule_id ASC
 		 LIMIT $1`
@@ -197,11 +201,11 @@ func (s *Service) TopFailingHosts(ctx context.Context, limit int, opts ...Option
 		return []HostFailureRollup{}, nil
 	}
 	o := applyOpts(opts)
-	const q = `
+	q := `
 		SELECT host_id, COUNT(*)::BIGINT AS failing_rule_count
 		  FROM host_rule_state
 		 WHERE current_status = 'fail'
-		   AND ($2::text IS NULL OR framework_refs ? $2)
+		   AND ` + framework.MatchSQL("$2") + `
 		 GROUP BY host_id
 		 ORDER BY failing_rule_count DESC, host_id ASC
 		 LIMIT $1`
@@ -240,11 +244,11 @@ func (s *Service) RecentChanges(ctx context.Context, since time.Time, limit int,
 	o := applyOpts(opts)
 	// The "$2::timestamptz IS NULL" idiom lets us encode "no cursor"
 	// without branching the SQL. Same trick for framework via $3::text.
-	const q = `
+	q := `
 		SELECT id, host_id, rule_id, status, COALESCE(severity, ''), change_kind, occurred_at
 		  FROM transactions
 		 WHERE ($2::timestamptz IS NULL OR occurred_at > $2)
-		   AND ($3::text IS NULL OR framework_refs ? $3)
+		   AND ` + framework.MatchSQL("$3") + `
 		 ORDER BY occurred_at DESC
 		 LIMIT $1`
 	var sinceParam any

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -1724,10 +1724,13 @@ type CategoryEntry struct {
 	Id          string `json:"id"`
 }
 
-// ComplianceConfig Org-wide compliance-display config. default_framework is the default lens the score surfaces (dashboard/hosts avg compliance, host detail) project to: a framework family id (e.g. "stig", "cis") or empty for All rules (the full Kensa corpus). Resolved per-host to the OS key at query time.
+// ComplianceConfig Org-wide compliance-display config. default_framework is the default lens the score surfaces (dashboard/hosts avg compliance, host detail) project to: a framework family id (e.g. "stig", "cis") or empty for All rules (the full Kensa corpus). Resolved per-host to the OS key at query time. enabled_frameworks is the allowlist of families offered as lenses; empty means all corpus families are available. A non-empty default_framework must be in a non-empty enabled_frameworks.
 type ComplianceConfig struct {
 	// DefaultFramework Framework family id
 	DefaultFramework string `json:"default_framework"`
+
+	// EnabledFrameworks Allowlist of framework family ids offered as lenses. Empty (or omitted) means every family found in the corpus is available.
+	EnabledFrameworks *[]string `json:"enabled_frameworks,omitempty"`
 }
 
 // ComplianceFramework defines model for ComplianceFramework.
@@ -3672,6 +3675,12 @@ type GetComplianceExceptionsParams struct {
 // GetComplianceExceptionsParamsStatus defines parameters for GetComplianceExceptions.
 type GetComplianceExceptionsParamsStatus string
 
+// GetComplianceFrameworksParams defines parameters for GetComplianceFrameworks.
+type GetComplianceFrameworksParams struct {
+	// All When true, return every corpus family, ignoring the enabled-frameworks allowlist.
+	All *bool `form:"all,omitempty" json:"all,omitempty"`
+}
+
 // PostDiagnosticsEchoParams defines parameters for PostDiagnosticsEcho.
 type PostDiagnosticsEchoParams struct {
 	IdempotencyKey string  `json:"Idempotency-Key"`
@@ -4094,7 +4103,7 @@ type ServerInterface interface {
 	GetComplianceExceptions(w http.ResponseWriter, r *http.Request, params GetComplianceExceptionsParams)
 	// List the framework families present in the scanned corpus
 	// (GET /api/v1/compliance/frameworks)
-	GetComplianceFrameworks(w http.ResponseWriter, r *http.Request)
+	GetComplianceFrameworks(w http.ResponseWriter, r *http.Request, params GetComplianceFrameworksParams)
 	// List credentials (metadata only)
 	// (GET /api/v1/credentials)
 	GetCredentials(w http.ResponseWriter, r *http.Request)
@@ -4646,7 +4655,7 @@ func (_ Unimplemented) GetComplianceExceptions(w http.ResponseWriter, r *http.Re
 
 // List the framework families present in the scanned corpus
 // (GET /api/v1/compliance/frameworks)
-func (_ Unimplemented) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request) {
+func (_ Unimplemented) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request, params GetComplianceFrameworksParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -6390,8 +6399,27 @@ func (siw *ServerInterfaceWrapper) GetComplianceExceptions(w http.ResponseWriter
 // GetComplianceFrameworks operation middleware
 func (siw *ServerInterfaceWrapper) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request) {
 
+	var err error
+	_ = err
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetComplianceFrameworksParams
+
+	// ------------- Optional query parameter "all" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "all", r.URL.Query(), &params.All, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "all"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "all", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetComplianceFrameworks(w, r)
+		siw.Handler.GetComplianceFrameworks(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {

--- a/internal/server/api_compliance_test.go
+++ b/internal/server/api_compliance_test.go
@@ -70,3 +70,45 @@ func TestCompliance_FrameworksAndDefaultLens(t *testing.T) {
 		}
 	})
 }
+
+// @ac AC-06
+// AC-06: GET /compliance/frameworks narrows to the enabled-frameworks
+// allowlist by default; all=true returns the full corpus list.
+func TestCompliance_FrameworksAllowlistFilter(t *testing.T) {
+	t.Run("system-compliance-lens/AC-06", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		host := seedHostForIntel(t, pool)
+		seedRuleStateForHostWithFrameworks(t, pool, host, "r.stig", "pass",
+			map[string]string{"stig_rhel9": "V-1"})
+		seedRuleStateForHostWithFrameworks(t, pool, host, "r.cis", "pass",
+			map[string]string{"cis_rhel9": "1.1"})
+
+		hasFam := func(raw, id string) bool {
+			return strings.Contains(raw, `"id":"`+id+`"`) || strings.Contains(raw, `"id": "`+id+`"`)
+		}
+
+		// No allowlist → both families present.
+		raw := readBody(t, doReq(t, asRole(t, "GET", url+"/api/v1/compliance/frameworks", auth.RoleViewer, nil)))
+		if !hasFam(raw, "stig") || !hasFam(raw, "cis") {
+			t.Fatalf("unfiltered frameworks missing a family: %s", raw)
+		}
+
+		// Restrict the allowlist to stig.
+		if pr := doReq(t, asRole(t, "PUT", url+"/api/v1/system/compliance/config", auth.RoleAdmin,
+			map[string]any{"default_framework": "", "enabled_frameworks": []string{"stig"}})); pr.StatusCode != http.StatusOK {
+			t.Fatalf("put allowlist = %d, want 200", pr.StatusCode)
+		}
+
+		// Default list → stig only (cis filtered out).
+		raw = readBody(t, doReq(t, asRole(t, "GET", url+"/api/v1/compliance/frameworks", auth.RoleViewer, nil)))
+		if !hasFam(raw, "stig") || hasFam(raw, "cis") {
+			t.Errorf("filtered frameworks = %s, want stig only", raw)
+		}
+
+		// all=true → full corpus list again.
+		raw = readBody(t, doReq(t, asRole(t, "GET", url+"/api/v1/compliance/frameworks?all=true", auth.RoleViewer, nil)))
+		if !hasFam(raw, "stig") || !hasFam(raw, "cis") {
+			t.Errorf("all=true frameworks = %s, want both", raw)
+		}
+	})
+}

--- a/internal/server/compliance_handlers.go
+++ b/internal/server/compliance_handlers.go
@@ -17,8 +17,10 @@ import (
 )
 
 // GetComplianceFrameworks lists the framework families derived from the
-// corpus (host_rule_state.framework_refs). Read-gated on host:read.
-func (h *handlers) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request) {
+// corpus (host_rule_state.framework_refs). Read-gated on host:read. By
+// default the list is narrowed to the enabled-frameworks allowlist (Phase 2);
+// pass all=true to return every corpus family (for the allowlist editor).
+func (h *handlers) GetComplianceFrameworks(w http.ResponseWriter, r *http.Request, params api.GetComplianceFrameworksParams) {
 	if denied := auth.EnforcePermission(w, r, auth.HostRead); denied {
 		return
 	}
@@ -27,6 +29,25 @@ func (h *handlers) GetComplianceFrameworks(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"list compliance frameworks failed", true)
 		return
+	}
+	// Narrow to the enabled-frameworks allowlist unless the caller asked for
+	// all (the editor) or no allowlist is set. This is a display filter, not a
+	// security boundary: a config-load error degrades to showing all families.
+	all := params.All != nil && *params.All
+	if !all {
+		if cfg, cerr := h.sysCfg.LoadCompliance(r.Context()); cerr == nil && len(cfg.EnabledFrameworks) > 0 {
+			enabled := make(map[string]bool, len(cfg.EnabledFrameworks))
+			for _, f := range cfg.EnabledFrameworks {
+				enabled[f] = true
+			}
+			filtered := make([]framework.Family, 0, len(fams))
+			for _, f := range fams {
+				if enabled[f.ID] {
+					filtered = append(filtered, f)
+				}
+			}
+			fams = filtered
+		}
 	}
 	out := api.ComplianceFrameworksResponse{Frameworks: make([]api.ComplianceFramework, 0, len(fams))}
 	for _, f := range fams {
@@ -49,7 +70,19 @@ func (h *handlers) GetSystemComplianceConfig(w http.ResponseWriter, r *http.Requ
 			"load compliance config failed", true)
 		return
 	}
-	writeJSON(w, http.StatusOK, api.ComplianceConfig{DefaultFramework: cfg.DefaultFramework})
+	writeJSON(w, http.StatusOK, toAPIComplianceConfig(cfg))
+}
+
+// toAPIComplianceConfig maps the stored config to the API shape. An empty
+// allowlist is emitted as an absent enabled_frameworks (omitempty), matching
+// "empty means all families available".
+func toAPIComplianceConfig(cfg systemconfig.ComplianceConfig) api.ComplianceConfig {
+	out := api.ComplianceConfig{DefaultFramework: cfg.DefaultFramework}
+	if len(cfg.EnabledFrameworks) > 0 {
+		ef := cfg.EnabledFrameworks
+		out.EnabledFrameworks = &ef
+	}
+	return out
 }
 
 // PutSystemComplianceConfig sets the default compliance lens. system:config:write.
@@ -63,18 +96,22 @@ func (h *handlers) PutSystemComplianceConfig(w http.ResponseWriter, r *http.Requ
 			"malformed request body", false)
 		return
 	}
+	var enabled []string
+	if req.EnabledFrameworks != nil {
+		enabled = *req.EnabledFrameworks
+	}
 	actor := auth.FromContext(r.Context()).ID
 	cfg, err := h.sysCfg.SetCompliance(r.Context(),
-		systemconfig.ComplianceConfig{DefaultFramework: req.DefaultFramework}, actor)
+		systemconfig.ComplianceConfig{DefaultFramework: req.DefaultFramework, EnabledFrameworks: enabled}, actor)
 	if err != nil {
 		if errors.Is(err, systemconfig.ErrInvalidConfig) {
 			writeError(w, http.StatusBadRequest, "validation.field_invalid", "client",
-				"invalid default_framework", false)
+				"invalid compliance config", false)
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"save compliance config failed", true)
 		return
 	}
-	writeJSON(w, http.StatusOK, api.ComplianceConfig{DefaultFramework: cfg.DefaultFramework})
+	writeJSON(w, http.StatusOK, toAPIComplianceConfig(cfg))
 }

--- a/internal/systemconfig/store_test.go
+++ b/internal/systemconfig/store_test.go
@@ -294,3 +294,63 @@ func TestComplianceConfig_DefaultValidateRoundTrip(t *testing.T) {
 		}
 	})
 }
+
+// @spec system-compliance-lens
+// @ac AC-05
+// AC-05: EnabledFrameworks allowlist defaults empty, Validate bounds it and
+// enforces the default-must-be-enabled invariant, and Set/Load round-trips it.
+func TestComplianceConfig_EnabledFrameworksAllowlist(t *testing.T) {
+	t.Run("system-compliance-lens/AC-05", func(t *testing.T) {
+		pool := freshPool(t)
+		s := NewStore(pool, nil)
+		ctx := context.Background()
+
+		// Fresh store → empty allowlist (all families available).
+		got, err := s.LoadCompliance(ctx)
+		if err != nil {
+			t.Fatalf("LoadCompliance (no row): %v", err)
+		}
+		if len(got.EnabledFrameworks) != 0 {
+			t.Errorf("enabled = %v, want empty", got.EnabledFrameworks)
+		}
+
+		// Empty + valid lists accepted.
+		for _, okList := range [][]string{nil, {"stig"}, {"stig", "cis", "nist_800_53"}} {
+			if err := (ComplianceConfig{EnabledFrameworks: okList}).Validate(); err != nil {
+				t.Errorf("Validate(enabled=%v) = %v, want nil", okList, err)
+			}
+		}
+		// Over-long list rejected.
+		big := make([]string, ComplianceMaxEnabledFrameworks+1)
+		for i := range big {
+			big[i] = "stig"
+		}
+		if err := (ComplianceConfig{EnabledFrameworks: big}).Validate(); err == nil {
+			t.Error("Validate(over-long allowlist) = nil, want error")
+		}
+		// Invalid entry rejected.
+		if err := (ComplianceConfig{EnabledFrameworks: []string{"STIG!"}}).Validate(); err == nil {
+			t.Error("Validate(invalid entry) = nil, want error")
+		}
+		// Invariant: a non-empty default must be one of a non-empty allowlist.
+		if err := (ComplianceConfig{DefaultFramework: "stig", EnabledFrameworks: []string{"cis"}}).Validate(); err == nil {
+			t.Error("Validate(default not in allowlist) = nil, want error")
+		}
+		if err := (ComplianceConfig{DefaultFramework: "stig", EnabledFrameworks: []string{"stig", "cis"}}).Validate(); err != nil {
+			t.Errorf("Validate(default in allowlist) = %v, want nil", err)
+		}
+
+		// Set then Load round-trips the allowlist.
+		if _, err := s.SetCompliance(ctx,
+			ComplianceConfig{DefaultFramework: "stig", EnabledFrameworks: []string{"stig", "cis"}}, "admin"); err != nil {
+			t.Fatalf("SetCompliance: %v", err)
+		}
+		got, err = s.LoadCompliance(ctx)
+		if err != nil {
+			t.Fatalf("LoadCompliance: %v", err)
+		}
+		if len(got.EnabledFrameworks) != 2 || got.EnabledFrameworks[0] != "stig" || got.EnabledFrameworks[1] != "cis" {
+			t.Errorf("round-trip allowlist = %v, want [stig cis]", got.EnabledFrameworks)
+		}
+	})
+}

--- a/internal/systemconfig/types.go
+++ b/internal/systemconfig/types.go
@@ -393,24 +393,68 @@ func (v ScanVariables) Validate() error {
 // unknown/absent family falls back to all-rules.
 type ComplianceConfig struct {
 	DefaultFramework string `json:"default_framework"`
+	// EnabledFrameworks is the Phase 2 allowlist: the framework FAMILY ids an
+	// admin has opted the org into. Empty means ALL families found in the
+	// corpus are available as lenses (the factory default and every existing
+	// stored row). A non-empty list restricts the lens picker + the frameworks
+	// endpoint to these families.
+	EnabledFrameworks []string `json:"enabled_frameworks,omitempty"`
 }
 
-// DefaultCompliance returns the baked-in default: All rules (empty lens).
+// DefaultCompliance returns the baked-in default: All rules (empty lens),
+// all families enabled.
 func DefaultCompliance() ComplianceConfig {
-	return ComplianceConfig{DefaultFramework: ""}
+	return ComplianceConfig{DefaultFramework: "", EnabledFrameworks: nil}
 }
 
-// Validate bounds the family id. It is resolved leniently against the live
-// corpus at query time, so this only rejects obvious garbage / length; an
-// empty value (All rules) is always valid.
-func (c ComplianceConfig) Validate() error {
-	f := c.DefaultFramework
+// ComplianceMaxEnabledFrameworks caps the allowlist. The corpus has a handful
+// of families (stig, cis, nist_800_53, pci_dss_4, srg); 32 is far above any
+// real use and just blocks an abuse shape.
+const ComplianceMaxEnabledFrameworks = 32
+
+// validFamilyToken bounds a framework family id: <=64 chars, lowercase
+// alnum plus _-. It is resolved leniently against the live corpus at query
+// time, so this only rejects obvious garbage / length.
+func validFamilyToken(f string) bool {
 	if len(f) > 64 {
-		return fmt.Errorf("%w: default_framework exceeds 64 chars", ErrInvalidConfig)
+		return false
 	}
 	for _, r := range f {
 		if !(r == '_' || r == '-' || r == '.' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
-			return fmt.Errorf("%w: default_framework has invalid characters", ErrInvalidConfig)
+			return false
+		}
+	}
+	return true
+}
+
+// Validate bounds the default family id and the enabled-frameworks allowlist.
+// An empty default (All rules) is always valid. When the allowlist is
+// non-empty, a non-empty default MUST be one of the enabled families, so an
+// admin cannot default the org to a hidden family.
+func (c ComplianceConfig) Validate() error {
+	if !validFamilyToken(c.DefaultFramework) {
+		return fmt.Errorf("%w: default_framework invalid (>64 chars or bad characters)", ErrInvalidConfig)
+	}
+	if len(c.EnabledFrameworks) > ComplianceMaxEnabledFrameworks {
+		return fmt.Errorf("%w: enabled_frameworks has %d entries, max %d",
+			ErrInvalidConfig, len(c.EnabledFrameworks), ComplianceMaxEnabledFrameworks)
+	}
+	for _, f := range c.EnabledFrameworks {
+		if f == "" || !validFamilyToken(f) {
+			return fmt.Errorf("%w: enabled_frameworks entry %q is empty or invalid", ErrInvalidConfig, f)
+		}
+	}
+	if c.DefaultFramework != "" && len(c.EnabledFrameworks) > 0 {
+		found := false
+		for _, f := range c.EnabledFrameworks {
+			if f == c.DefaultFramework {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("%w: default_framework %q must be one of enabled_frameworks",
+				ErrInvalidConfig, c.DefaultFramework)
 		}
 	}
 	return nil

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.16.0"
+  version: "1.17.0"
   status: draft
   tier: 2
 
@@ -300,7 +300,7 @@ spec:
       priority: critical
       references_constraints: [C-08]
     - id: AC-15
-      description: v1.6.0 — The remaining stubbed Settings page (Integrations — the only full stub now that Notifications, Audit log, About are wired, Security hosts a live API-tokens section, and Compliance policies hosts the live scan-variables section) renders a single BackendPendingBanner naming the slice. Visible controls render disabled. PoliciesPage lives in its own file with per-section banners on its remaining stub sections.
+      description: v1.6.0 — The remaining stubbed Settings page (Integrations — the only full stub now that Notifications, Audit log, About are wired, Security hosts a live API-tokens section, and Compliance policies hosts the live scan-variables section) renders a single BackendPendingBanner naming the slice. Visible controls render disabled. v1.17.0 — PoliciesPage lives in its own file and has fully graduated. Scan variables, framework lenses (default lens plus the enabled-frameworks allowlist), and the exception workflow are all live, so it carries no BackendPendingBanner.
       priority: high
       references_constraints: [C-09]
     - id: AC-16

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-compliance-lens
   title: Default compliance lens — org-wide framework projection
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -35,10 +35,10 @@ spec:
         - 'ComplianceConfig.DefaultFramework (systemconfig) + config endpoints'
         - 'Framework family resolution (FamilyOf) + corpus-derived family list'
         - 'Family-aware score filter in the fleet score + hosts-list queries'
+        - 'Enabled-frameworks allowlist (Phase 2): restrict which families are offered as lenses'
       excludes:
         - 'Per-host/per-group compliance TARGET assignment (Phase 3)'
         - 'Framework-scoped posture history / trend (Phase 3)'
-        - 'Enabled-frameworks allowlist (Phase 2)'
 
   constraints:
     - id: C-01
@@ -52,6 +52,10 @@ spec:
     - id: C-03
       description: The compliance config read is system:read; the write is system:config:write and emits a system.config.changed audit event. The frameworks list is host:read.
       type: security
+      enforcement: error
+    - id: C-04
+      description: ComplianceConfig.EnabledFrameworks is the Phase 2 allowlist of framework FAMILY ids offered as lenses, persisted in the same systemconfig row. Empty means every corpus family is available (the factory default and backward-compatible for existing rows). When non-empty and DefaultFramework is non-empty, DefaultFramework MUST be one of EnabledFrameworks (an admin cannot default the org to a hidden family). GET /compliance/frameworks narrows its result to the allowlist by default; all=true returns the full corpus list (for the allowlist editor). The allowlist is a DISPLAY filter, not a security boundary — it never changes what a scan runs.
+      type: technical
       enforcement: error
 
   acceptance_criteria:
@@ -71,3 +75,11 @@ spec:
       description: GET /api/v1/compliance/frameworks returns the corpus-derived families (id, label, keys) and is host:read. GET /api/v1/system/compliance/config returns the current default lens (system:read); PUT sets it (system:config:write), rejects an invalid value with 400, and echoes the stored value.
       priority: high
       references_constraints: [C-01, C-03]
+    - id: AC-05
+      description: ComplianceConfig.EnabledFrameworks defaults to empty (all families). Validate accepts an empty allowlist and a list of valid family tokens, rejects an over-long list (>32) or an entry with invalid characters, and rejects a non-empty DefaultFramework that is not one of a non-empty EnabledFrameworks. SetCompliance persists the allowlist and LoadCompliance round-trips it (empty on a fresh store).
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-06
+      description: GET /api/v1/compliance/frameworks narrows the returned families to EnabledFrameworks when the allowlist is non-empty, returns all corpus families when the allowlist is empty, and returns all corpus families (ignoring the allowlist) when all=true is passed.
+      priority: high
+      references_constraints: [C-04]


### PR DESCRIPTION
Implements the **enabled-frameworks allowlist** — the next slice of the compliance-lens roadmap (`docs/engineering/compliance_lens_phase2_phase3_plan.md`). An admin can now restrict which framework families are offered as compliance lenses, so an org that only does STIG isn't shown CIS/PCI/SRG.

## Backend
- `ComplianceConfig` gains `EnabledFrameworks []string`. Empty = all families available (backward-compatible — every existing stored row and the factory default deserialize to this). No migration (the `compliance` config is a JSONB row).
- `Validate()` bounds the list (≤32, valid family tokens) and enforces the invariant that a non-empty `default_framework` must be one of a non-empty allowlist (an admin can't default the org to a hidden family).
- `GET /api/v1/compliance/frameworks` narrows to the allowlist by default; `?all=true` returns the full corpus list (for the editor). Every existing lens picker auto-narrows with no change.
- **Bug fixed en route:** the config PUT handler previously dropped `enabled_frameworks` — the AC-06 test caught it.

## Frontend
- New `EnabledFrameworksCard`: a master "Limit lens options" toggle (off = all available) plus per-family toggles; the current default lens's family is locked enabled. Replaces the pending-banner stub on Settings → Compliance policies, which has now **fully graduated**.

## Fold-in (plan debt #1)
`TopFailingRules` / `TopFailingHosts` / `RecentChanges` are now family-aware via `framework.MatchSQL` (a `stig` filter spans `stig_rhel9` + `stig_rhel10`), matching `FleetComplianceScore`. Previously they used exact-key matching.

## SDD + verification
Specs: `system-compliance-lens` → v1.1.0 (AC-05 allowlist validate/round-trip, AC-06 frameworks intersection + `all`); `frontend-settings` → v1.17.0 (PoliciesPage graduated). Green locally: `go build`/`vet`/`gofmt`, `specter check` 116/116 + annotation coverage 100%, `check-generated`, `tsc`, `vitest` 353/353.

Out of scope: Phase 3 (per-host/group targets, cohorts, framework-scoped trend) — blocked on the six open decisions in the plan.