### PR TITLE
feat(compliance): per-host and per-group compliance targets

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2490,6 +2490,52 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/groups/{id}:target:
+    post:
+      operationId: postGroupTarget
+      summary: Set or clear a site group's compliance target framework
+      description: |
+        Sets (or clears, when target_framework is empty) the compliance
+        target family a member host is held to. Only a site group may carry a
+        target; an os_category group is rejected with 400. RBAC: host:write.
+        Spec api-groups.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/GroupTargetRequest'}
+      responses:
+        '200':
+          description: The updated group
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Group'}
+        '400':
+          description: Target on a non-site group, or an invalid family value
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '401':
+          description: Caller is not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks host:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Group not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/groups/{id}/members:
     post:
       operationId: postGroupMember
@@ -5729,6 +5775,11 @@ components:
           type: string
           description: OS family an auto group matches on (empty for manual groups)
         maintenance: {type: boolean}
+        target_framework:
+          type: string
+          description: >-
+            Compliance target framework family a member host is held to (empty
+            for none). Only a site group may carry one.
         created_at:  {type: string, format: date-time}
         updated_at:  {type: string, format: date-time}
 
@@ -6174,6 +6225,14 @@ components:
       required: [on]
       properties:
         on: {type: boolean}
+
+    GroupTargetRequest:
+      type: object
+      required: [target_framework]
+      properties:
+        target_framework:
+          type: string
+          description: Compliance target family id, or empty to clear the target.
 
     GroupMemberRequest:
       type: object

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1531,6 +1531,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/groups/{id}:target": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set or clear a site group's compliance target framework
+         * @description Sets (or clears, when target_framework is empty) the compliance
+         *     target family a member host is held to. Only a site group may carry a
+         *     target; an os_category group is rejected with 400. RBAC: host:write.
+         *     Spec api-groups.
+         */
+        post: operations["postGroupTarget"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/groups/{id}/members": {
         parameters: {
             query?: never;
@@ -3758,6 +3781,8 @@ export interface components {
             /** @description OS family an auto group matches on (empty for manual groups) */
             match_family?: string;
             maintenance: boolean;
+            /** @description Compliance target framework family a member host is held to (empty for none). Only a site group may carry one. */
+            target_framework?: string;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -4110,6 +4135,10 @@ export interface components {
         };
         GroupMaintenanceRequest: {
             on: boolean;
+        };
+        GroupTargetRequest: {
+            /** @description Compliance target family id, or empty to clear the target. */
+            target_framework: string;
         };
         GroupMemberRequest: {
             /** Format: uuid */
@@ -7904,6 +7933,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Group"];
+                };
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Group not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postGroupTarget: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GroupTargetRequest"];
+            };
+        };
+        responses: {
+            /** @description The updated group */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Group"];
+                };
+            };
+            /** @description Target on a non-site group, or an invalid family value */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
             /** @description Caller is not authenticated */

--- a/internal/db/migrations/0051_compliance_targets.sql
+++ b/internal/db/migrations/0051_compliance_targets.sql
@@ -1,0 +1,56 @@
+-- 0051_compliance_targets.sql
+--
+-- Per-host and per-group compliance TARGET: durable operator intent about which
+-- framework family a host is held to (its default lens, and the basis for
+-- cohort scoring). Mirrors host_effective_maintenance (0049): a nullable
+-- target-family value at two scopes, resolved into one row per host by
+-- precedence.
+--
+--   * Per-host  — hosts.target_framework, set from the host-detail page. The
+--     override; wins over any group.
+--   * Per-group — groups.target_framework, set on a SITE group only (D1: an
+--     auto os_category group is an OS grouping, not a statement of compliance
+--     intent; the service rejects a target on a non-site group). A host in
+--     several site groups with different targets resolves to the OLDEST
+--     membership (D2: group_members.added_at ASC, then group id).
+--
+-- The org-wide default (systemconfig ComplianceConfig.DefaultFramework) is the
+-- final fallback and is applied by the Go caller (it lives in a JSONB config
+-- row a view should not reach into), so this view returns NULL when neither a
+-- host nor a site-group target is set. NULL means "inherit the org default".
+--
+-- A framework family with no matching corpus key for a host scores N/A, never
+-- 0% (D3) — enforced at query time by framework.MatchSQL, not here.
+--
+-- Deleted hosts are intentionally NOT filtered here (mirroring 0049) — each
+-- consuming query keeps its own deleted_at predicate, so the view stays a pure
+-- target resolver.
+--
+-- Spec: system-compliance-lens, api-hosts, api-groups.
+
+-- +goose Up
+ALTER TABLE hosts ADD COLUMN target_framework TEXT;
+ALTER TABLE groups ADD COLUMN target_framework TEXT;
+
+CREATE VIEW host_effective_target AS
+SELECT
+    h.id AS host_id,
+    COALESCE(
+        h.target_framework,
+        (
+            SELECT g.target_framework
+              FROM group_members gm
+              JOIN groups g ON g.id = gm.group_id
+             WHERE gm.host_id = h.id
+               AND g.kind = 'site'
+               AND g.target_framework IS NOT NULL
+             ORDER BY gm.added_at ASC, g.id ASC
+             LIMIT 1
+        )
+    ) AS target_framework
+FROM hosts h;
+
+-- +goose Down
+DROP VIEW IF EXISTS host_effective_target;
+ALTER TABLE groups DROP COLUMN IF EXISTS target_framework;
+ALTER TABLE hosts DROP COLUMN IF EXISTS target_framework;

--- a/internal/framework/effective_target_db_test.go
+++ b/internal/framework/effective_target_db_test.go
@@ -1,0 +1,101 @@
+// @spec system-compliance-lens
+//
+// host_effective_target view precedence + framework.EffectiveTarget resolver
+// (Phase 3 compliance-targets, migration 0051).
+
+package framework
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+)
+
+// @ac AC-07
+// AC-07: host_effective_target resolves host target > oldest site-group target
+// > NULL; EffectiveTarget applies the org default as the final fallback.
+func TestEffectiveTarget_Precedence(t *testing.T) {
+	t.Run("system-compliance-lens/AC-07", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+		s := NewService(pool)
+
+		var uid uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (id, username, email, password_hash)
+			 VALUES (gen_random_uuid(), 'tgt-u', 'tgt-u@x', 'h') RETURNING id`).Scan(&uid); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		mkHost := func(name string, target *string) uuid.UUID {
+			var id uuid.UUID
+			if err := pool.QueryRow(ctx,
+				`INSERT INTO hosts (id, hostname, ip_address, created_by, target_framework)
+				 VALUES (gen_random_uuid(), $1, '10.0.0.1', $2, $3) RETURNING id`,
+				name, uid, target).Scan(&id); err != nil {
+				t.Fatalf("seed host %s: %v", name, err)
+			}
+			return id
+		}
+		mkSiteGroup := func(name, target string) uuid.UUID {
+			var gid uuid.UUID
+			if err := pool.QueryRow(ctx,
+				`INSERT INTO groups (id, name, kind, membership, target_framework)
+				 VALUES (gen_random_uuid(), $1, 'site', 'manual', $2) RETURNING id`,
+				name, target).Scan(&gid); err != nil {
+				t.Fatalf("seed group %s: %v", name, err)
+			}
+			return gid
+		}
+		addMember := func(gid, hid uuid.UUID, addedAt time.Time) {
+			if _, err := pool.Exec(ctx,
+				`INSERT INTO group_members (group_id, host_id, added_at) VALUES ($1, $2, $3)`,
+				gid, hid, addedAt); err != nil {
+				t.Fatalf("seed membership: %v", err)
+			}
+		}
+		strp := func(s string) *string { return &s }
+
+		// host override wins over a site-group target.
+		hOwn := mkHost("h-own", strp("cis"))
+		gStig := mkSiteGroup("site-stig", "stig")
+		addMember(gStig, hOwn, time.Unix(1000, 0))
+
+		// no own target, one site-group target -> the group's.
+		hGroup := mkHost("h-group", nil)
+		addMember(gStig, hGroup, time.Unix(1000, 0))
+
+		// no own target, no group -> org default fallback.
+		hNone := mkHost("h-none", nil)
+
+		// two site groups, different targets -> oldest membership wins.
+		hTie := mkHost("h-tie", nil)
+		gCis := mkSiteGroup("site-cis", "cis")
+		addMember(gStig, hTie, time.Unix(1000, 0)) // older -> stig
+		addMember(gCis, hTie, time.Unix(2000, 0))  // newer -> cis
+
+		cases := []struct {
+			name string
+			host uuid.UUID
+			org  string
+			want string
+		}{
+			{"host override", hOwn, "srg", "cis"},
+			{"site-group target", hGroup, "srg", "stig"},
+			{"org-default fallback", hNone, "srg", "srg"},
+			{"oldest membership wins", hTie, "srg", "stig"},
+		}
+		for _, tc := range cases {
+			got, err := s.EffectiveTarget(ctx, tc.host, tc.org)
+			if err != nil {
+				t.Fatalf("%s: EffectiveTarget: %v", tc.name, err)
+			}
+			if got != tc.want {
+				t.Errorf("%s: EffectiveTarget = %q, want %q", tc.name, got, tc.want)
+			}
+		}
+	})
+}

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -15,10 +15,13 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -84,6 +87,27 @@ type Service struct{ pool *pgxpool.Pool }
 
 // NewService builds the resolver.
 func NewService(pool *pgxpool.Pool) *Service { return &Service{pool: pool} }
+
+// EffectiveTarget returns the host's effective compliance-target family: its
+// host_effective_target value (the host override, else the oldest site-group
+// target — migration 0051), falling back to orgDefault when neither is set.
+// An empty result means All rules. This is the per-host default lens: a host's
+// score defaults to its target instead of the org default.
+func (s *Service) EffectiveTarget(ctx context.Context, hostID uuid.UUID, orgDefault string) (string, error) {
+	var target *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT target_framework FROM host_effective_target WHERE host_id = $1`, hostID).Scan(&target)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return orgDefault, nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if target != nil && *target != "" {
+		return *target, nil
+	}
+	return orgDefault, nil
+}
 
 // Families groups every framework key present in the corpus into families,
 // sorted by id. Empty when no host has been scanned yet.

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -21,6 +21,8 @@ var (
 	ErrSiteMustBeManual  = errors.New("group: a site must use manual membership")
 	ErrDuplicateFamily   = errors.New("group: an auto group already exists for that OS family")
 	ErrEmptyName         = errors.New("group: name is required")
+	ErrTargetOnlyOnSite  = errors.New("group: only a site group may carry a compliance target")
+	ErrInvalidTarget     = errors.New("group: target_framework is too long or has invalid characters")
 )
 
 // Service owns group CRUD, membership, and the per-group rollups.
@@ -34,16 +36,19 @@ func NewService(pool *pgxpool.Pool) *Service {
 
 func scanGroup(row pgx.Row) (Group, error) {
 	var g Group
-	var matchFamily *string
+	var matchFamily, targetFramework *string
 	err := row.Scan(&g.ID, &g.Name, &g.Kind, &g.Subtype, &g.Color, &g.Membership,
-		&matchFamily, &g.Maintenance, &g.CreatedAt, &g.UpdatedAt)
+		&matchFamily, &g.Maintenance, &targetFramework, &g.CreatedAt, &g.UpdatedAt)
 	if matchFamily != nil {
 		g.MatchFamily = *matchFamily
+	}
+	if targetFramework != nil {
+		g.TargetFramework = *targetFramework
 	}
 	return g, err
 }
 
-const groupCols = `id, name, kind, subtype, color, membership, match_family, maintenance, created_at, updated_at`
+const groupCols = `id, name, kind, subtype, color, membership, match_family, maintenance, target_framework, created_at, updated_at`
 
 // Create validates and inserts a group.
 func (s *Service) Create(ctx context.Context, in CreateInput) (Group, error) {
@@ -130,6 +135,50 @@ func (s *Service) SetMaintenance(ctx context.Context, id uuid.UUID, on bool) (Gr
 		return Group{}, ErrNotFound
 	}
 	return g, err
+}
+
+// SetTarget sets (or clears, when family is "") the group's compliance target
+// framework. Only a site group may carry a target (D1): an os_category group
+// is an automatic OS grouping, not a statement of compliance intent, so a
+// target on one is rejected with ErrTargetOnlyOnSite.
+func (s *Service) SetTarget(ctx context.Context, id uuid.UUID, family string) (Group, error) {
+	if !validTargetFramework(family) {
+		return Group{}, ErrInvalidTarget
+	}
+	g, err := s.Get(ctx, id)
+	if err != nil {
+		return Group{}, err // ErrNotFound
+	}
+	if g.Kind != KindSite {
+		return Group{}, ErrTargetOnlyOnSite
+	}
+	var arg *string
+	if family != "" {
+		arg = &family
+	}
+	row := s.pool.QueryRow(ctx, `
+		UPDATE groups SET target_framework = $2, updated_at = now()
+		WHERE id = $1 RETURNING `+groupCols, id, arg)
+	g, err = scanGroup(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Group{}, ErrNotFound
+	}
+	return g, err
+}
+
+// validTargetFramework bounds a compliance-target family token: empty (clear)
+// or <=64 lowercase alnum plus _-. It is resolved leniently against the live
+// corpus at query time, so this only blocks garbage / length.
+func validTargetFramework(f string) bool {
+	if len(f) > 64 {
+		return false
+	}
+	for _, r := range f {
+		if !(r == '_' || r == '-' || r == '.' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
 }
 
 // Delete removes a group (group_members cascade).

--- a/internal/group/set_target_db_test.go
+++ b/internal/group/set_target_db_test.go
@@ -1,0 +1,64 @@
+// @spec system-compliance-lens
+//
+// Group compliance-target (Phase 3 compliance-targets): SetTarget's D1 rule
+// (site groups only) and set/clear/validate. Kept in its own file so its
+// @spec does not re-attribute the api-groups tests in service_db_test.go.
+
+package group
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// @ac AC-07
+// D1: only a site group may carry a compliance target. SetTarget on an
+// os_category group is rejected; a site group sets, clears, and validates.
+func TestSetTarget_SiteOnly(t *testing.T) {
+	t.Run("system-compliance-lens/AC-07", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		svc := NewService(pool)
+
+		site, err := svc.Create(ctx, CreateInput{Name: "Prod", Kind: KindSite, Membership: MembershipManual})
+		if err != nil {
+			t.Fatalf("create site: %v", err)
+		}
+		auto, err := svc.Create(ctx, CreateInput{
+			Name: "RHEL", Kind: KindOSCategory, Membership: MembershipAuto, MatchFamily: "rhel",
+		})
+		if err != nil {
+			t.Fatalf("create auto: %v", err)
+		}
+
+		// D1: target on an os_category group is rejected.
+		if _, err := svc.SetTarget(ctx, auto.ID, "stig"); err != ErrTargetOnlyOnSite {
+			t.Errorf("SetTarget(auto) err = %v, want ErrTargetOnlyOnSite", err)
+		}
+		// Site group: set then clear.
+		g, err := svc.SetTarget(ctx, site.ID, "stig")
+		if err != nil {
+			t.Fatalf("SetTarget(site): %v", err)
+		}
+		if g.TargetFramework != "stig" {
+			t.Errorf("target = %q, want stig", g.TargetFramework)
+		}
+		g, err = svc.SetTarget(ctx, site.ID, "")
+		if err != nil {
+			t.Fatalf("clear target: %v", err)
+		}
+		if g.TargetFramework != "" {
+			t.Errorf("cleared target = %q, want empty", g.TargetFramework)
+		}
+		// Invalid family value rejected.
+		if _, err := svc.SetTarget(ctx, site.ID, "BAD SPACE"); err != ErrInvalidTarget {
+			t.Errorf("SetTarget(bad) err = %v, want ErrInvalidTarget", err)
+		}
+		// Unknown group -> ErrNotFound.
+		if _, err := svc.SetTarget(ctx, uuid.New(), "stig"); err != ErrNotFound {
+			t.Errorf("SetTarget(unknown) err = %v, want ErrNotFound", err)
+		}
+	})
+}

--- a/internal/group/set_target_db_test.go
+++ b/internal/group/set_target_db_test.go
@@ -1,8 +1,8 @@
 // @spec system-compliance-lens
 //
 // Group compliance-target (Phase 3 compliance-targets): SetTarget's D1 rule
-// (site groups only) and set/clear/validate. Kept in its own file so its
-// @spec does not re-attribute the api-groups tests in service_db_test.go.
+// (site groups only) and set/clear/validate. Kept in its own file so its spec
+// annotation does not re-attribute the api-groups tests in service_db_test.go.
 
 package group
 

--- a/internal/group/types.go
+++ b/internal/group/types.go
@@ -43,8 +43,12 @@ type Group struct {
 	Membership  Membership
 	MatchFamily string // "" for manual groups
 	Maintenance bool
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// TargetFramework is the compliance TARGET family a member host is held to
+	// (Phase 3). "" means no group target. Only a site group may carry one
+	// (D1); the service rejects a target on an os_category group.
+	TargetFramework string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // MemberChip is a compact member-host descriptor for the card preview.

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -2206,8 +2206,11 @@ type Group struct {
 	Name        string          `json:"name"`
 
 	// Subtype Free-form sub-classifier (may be empty)
-	Subtype   string    `json:"subtype"`
-	UpdatedAt time.Time `json:"updated_at"`
+	Subtype string `json:"subtype"`
+
+	// TargetFramework Compliance target framework family a member host is held to (empty for none). Only a site group may carry one.
+	TargetFramework *string   `json:"target_framework,omitempty"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // GroupKind defines model for Group.Kind.
@@ -2281,6 +2284,12 @@ type GroupSummary struct {
 	Ungrouped        int  `json:"ungrouped"`
 }
 
+// GroupTargetRequest defines model for GroupTargetRequest.
+type GroupTargetRequest struct {
+	// TargetFramework Compliance target family id, or empty to clear the target.
+	TargetFramework string `json:"target_framework"`
+}
+
 // GroupUpdate defines model for GroupUpdate.
 type GroupUpdate struct {
 	Color   *string `json:"color,omitempty"`
@@ -2304,8 +2313,11 @@ type GroupWithRollup struct {
 	Rollup      GroupRollup               `json:"rollup"`
 
 	// Subtype Free-form sub-classifier (may be empty)
-	Subtype   string    `json:"subtype"`
-	UpdatedAt time.Time `json:"updated_at"`
+	Subtype string `json:"subtype"`
+
+	// TargetFramework Compliance target framework family a member host is held to (empty for none). Only a site group may carry one.
+	TargetFramework *string   `json:"target_framework,omitempty"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // GroupWithRollupKind defines model for GroupWithRollup.Kind.
@@ -3937,6 +3949,9 @@ type PostGroupMemberJSONRequestBody = GroupMemberRequest
 // PostGroupMaintenanceJSONRequestBody defines body for PostGroupMaintenance for application/json ContentType.
 type PostGroupMaintenanceJSONRequestBody = GroupMaintenanceRequest
 
+// PostGroupTargetJSONRequestBody defines body for PostGroupTarget for application/json ContentType.
+type PostGroupTargetJSONRequestBody = GroupTargetRequest
+
 // PostHostsJSONRequestBody defines body for PostHosts for application/json ContentType.
 type PostHostsJSONRequestBody = HostCreateRequest
 
@@ -4200,6 +4215,9 @@ type ServerInterface interface {
 	// Toggle a group's maintenance flag
 	// (POST /api/v1/groups/{id}:maintenance)
 	PostGroupMaintenance(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Set or clear a site group's compliance target framework
+	// (POST /api/v1/groups/{id}:target)
+	PostGroupTarget(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// Liveness + readiness probe (anonymous)
 	// (GET /api/v1/health)
 	GetHealth(w http.ResponseWriter, r *http.Request)
@@ -4848,6 +4866,12 @@ func (_ Unimplemented) DeleteGroupMember(w http.ResponseWriter, r *http.Request,
 // Toggle a group's maintenance flag
 // (POST /api/v1/groups/{id}:maintenance)
 func (_ Unimplemented) PostGroupMaintenance(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Set or clear a site group's compliance target framework
+// (POST /api/v1/groups/{id}:target)
+func (_ Unimplemented) PostGroupTarget(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -7342,6 +7366,32 @@ func (siw *ServerInterfaceWrapper) PostGroupMaintenance(w http.ResponseWriter, r
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.PostGroupMaintenance(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostGroupTarget operation middleware
+func (siw *ServerInterfaceWrapper) PostGroupTarget(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostGroupTarget(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -10065,6 +10115,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/api/v1/groups/{id}:maintenance", wrapper.PostGroupMaintenance)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/groups/{id}:target", wrapper.PostGroupTarget)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/health", wrapper.GetHealth)

--- a/internal/server/group_handlers.go
+++ b/internal/server/group_handlers.go
@@ -39,7 +39,33 @@ func toAPIGroup(g group.Group) api.Group {
 		mf := g.MatchFamily
 		out.MatchFamily = &mf
 	}
+	if g.TargetFramework != "" {
+		tf := g.TargetFramework
+		out.TargetFramework = &tf
+	}
 	return out
+}
+
+// PostGroupTarget sets or clears a site group's compliance target framework.
+// Spec api-groups.
+func (h *handlers) PostGroupTarget(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.HostWrite); denied {
+		return
+	}
+	if !h.groupSvcReady(w) {
+		return
+	}
+	var req api.GroupTargetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"malformed request body", false)
+		return
+	}
+	g, err := h.groupSvc.SetTarget(r.Context(), uuid.UUID(id), req.TargetFramework)
+	if mapGroupErr(w, err) {
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPIGroup(g))
 }
 
 // toAPIRollup maps a service rollup to the wire shape.
@@ -127,6 +153,12 @@ func mapGroupErr(w http.ResponseWriter, err error) bool {
 	case errors.Is(err, group.ErrSiteMustBeManual):
 		writeError(w, http.StatusBadRequest, "validation.invalid", "client",
 			"a site must use manual membership", false)
+	case errors.Is(err, group.ErrTargetOnlyOnSite):
+		writeError(w, http.StatusBadRequest, "validation.invalid", "client",
+			"only a site group may carry a compliance target", false)
+	case errors.Is(err, group.ErrInvalidTarget):
+		writeError(w, http.StatusBadRequest, "validation.invalid", "client",
+			"target_framework is too long or has invalid characters", false)
 	default:
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"group operation failed", true)

--- a/internal/server/hosts_handlers.go
+++ b/internal/server/hosts_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/eventbus"
+	"github.com/Hanalyx/openwatch/internal/framework"
 	"github.com/Hanalyx/openwatch/internal/host"
 	"github.com/Hanalyx/openwatch/internal/intelligence/discovery"
 	"github.com/Hanalyx/openwatch/internal/queue"
@@ -218,12 +219,19 @@ func (h *handlers) GetHostByID(w http.ResponseWriter, r *http.Request, id openap
 		return
 	}
 	// v1.2.0: optional ?framework= filters the compliance_summary;
-	// liveness is unaffected (spec C-07).
-	var framework string
+	// liveness is unaffected (spec C-07). Phase 3 (compliance-targets): when no
+	// explicit lens is requested, the summary defaults to the host's EFFECTIVE
+	// TARGET (per-host or site-group target, else the org default) instead of
+	// All rules, so a targeted host's score reflects its standard by default.
+	var lens string
 	if params.Framework != nil {
-		framework = *params.Framework
+		lens = *params.Framework
+	} else if cfg, cerr := h.sysCfg.LoadCompliance(ctx); cerr == nil {
+		if eff, eerr := framework.NewService(h.pool).EffectiveTarget(ctx, hostID, cfg.DefaultFramework); eerr == nil {
+			lens = eff
+		}
 	}
-	summary, err := loadHostComplianceSummary(ctx, h.pool, hostID, framework)
+	summary, err := loadHostComplianceSummary(ctx, h.pool, hostID, lens)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"compliance summary lookup failed", true)

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-compliance-lens
   title: Default compliance lens — org-wide framework projection
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -57,6 +57,21 @@ spec:
       description: ComplianceConfig.EnabledFrameworks is the Phase 2 allowlist of framework FAMILY ids offered as lenses, persisted in the same systemconfig row. Empty means every corpus family is available (the factory default and backward-compatible for existing rows). When non-empty and DefaultFramework is non-empty, DefaultFramework MUST be one of EnabledFrameworks (an admin cannot default the org to a hidden family). GET /compliance/frameworks narrows its result to the allowlist by default; all=true returns the full corpus list (for the allowlist editor). The allowlist is a DISPLAY filter, not a security boundary — it never changes what a scan runs.
       type: technical
       enforcement: error
+    - id: C-05
+      description: >
+        A compliance TARGET is durable operator intent about the framework
+        family a host is held to, at two scopes (migration 0051): hosts.target_framework
+        (the override) and groups.target_framework (a SITE group only — D1: an
+        os_category group may not carry a target). The host_effective_target view
+        resolves them per host by precedence: host target, else the OLDEST
+        site-group membership's target (D2: group_members.added_at ASC, then group
+        id), else NULL. framework.EffectiveTarget applies the org-default
+        (ComplianceConfig.DefaultFramework) as the final fallback and becomes the
+        host's default lens: a host's compliance summary defaults to its effective
+        target instead of All rules when no explicit lens is requested. A target
+        family with no matching corpus key for a host scores N/A, never 0% (D3).
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -83,3 +98,16 @@ spec:
       description: GET /api/v1/compliance/frameworks narrows the returned families to EnabledFrameworks when the allowlist is non-empty, returns all corpus families when the allowlist is empty, and returns all corpus families (ignoring the allowlist) when all=true is passed.
       priority: high
       references_constraints: [C-04]
+    - id: AC-07
+      description: >
+        The host_effective_target view resolves a host's target by precedence:
+        a host with its own target_framework resolves to that; a host with no
+        own target but a site-group target resolves to the group's; with two
+        site groups carrying different targets, the OLDEST membership wins; a
+        host with neither resolves to NULL. framework.EffectiveTarget returns
+        the resolved target, falling back to the given org default when the view
+        yields NULL, and empty when neither is set. A group target set on an
+        os_category group is rejected (only a site group may carry one, D1); a
+        target on a site group sets and clears via SetTarget.
+      priority: high
+      references_constraints: [C-05]


### PR DESCRIPTION
First backend slice of Phase 3 of the compliance-lens roadmap (`docs/engineering/compliance_lens_phase2_phase3_plan.md`): a durable **compliance target** — which framework family a host is held to — resolved into a per-host default lens.

## What's here
- **Migration 0051:** `hosts.target_framework`, `groups.target_framework`, and the `host_effective_target` view — mirrors `host_effective_maintenance` (0049). Resolves a host's target by precedence: **host override → oldest site-group membership → NULL**.
- **Group target API:** `POST /api/v1/groups/{id}:target` (`host:write`) via `group.SetTarget`. **Only a site group may carry a target** (D1 — an `os_category` group is rejected 400); sets, clears, and validates the family token.
- **Resolver + wiring:** `framework.EffectiveTarget` reads the view and falls back to the org default (`ComplianceConfig.DefaultFramework`). The single-host compliance summary now **defaults to the host's effective target** instead of All rules when no explicit `?framework=` is given — so a targeted host's score reflects its standard. A target family with no matching corpus key scores **N/A, never 0%** (D3).

## Decisions (locked with product)
D1 site-only targets · D2 oldest-membership tiebreak · D3 N/A-not-0% · **open-core** (targets are free, not license-gated).

## SDD + verification
Spec `system-compliance-lens` → v1.2.0 (C-05 + AC-07: view precedence, resolver fallback, D1). DB tests: `EffectiveTarget` precedence (4 cases incl. the oldest-membership tiebreak) and `SetTarget` D1/set/clear/validate. Green locally: `go build`/`vet`/`gofmt`, `specter check` 116/116 + 100% annotation coverage, `check-generated`, `tsc`.

## Following slices (not in this PR)
- Host-level target override API + the host-detail "Compliance target" control and the Groups-page target selector (UI).
- **3b cohorts** (`ComplianceCohorts` + `MatchSQLColumn` — score each cohort against its own target, never blend).
- **3c framework-scoped trend** (Option A: store the effective-target score).