### PR TITLE
feat(compliance): host target UI, interactive trend chart, and v0.5.0 release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,8 +40,12 @@ container and executes:
 - `make vet`
 - `make lint` (golangci-lint, built from source to match the runner toolchain)
 - `make vuln` (govulncheck)
-- `make test-race` (race detector plus the integration suite against PostgreSQL)
-- `go test -json` and frontend `vitest`, ingested by `specter` for spec AC coverage
+- a single `go test -race -json -timeout 600s -p 4 ./...` run: the race detector
+  plus the full integration suite against PostgreSQL, emitting the JSON that
+  `specter` ingests. This is one pass, not two — it replaced the former separate
+  `make test-race` + non-race `go test -json` runs (which walked the DB-bound
+  suite twice)
+- frontend `vitest` (JUnit), also ingested by `specter` for spec AC coverage
 - `specter sync` to enforce coverage thresholds
 
 The DSN is supplied via `OPENWATCH_TEST_DSN`; module resolution is pinned read-only
@@ -74,7 +78,7 @@ The workflow then:
 Distribution is via GitHub Releases. Operators install with
 `sudo dnf install ./openwatch-*.rpm` or `sudo apt install ./openwatch_*.deb`. A tag
 with a pre-release suffix (for example `-rc.5`) is marked as a pre-release; a bare
-`vX.Y.Z` is GA. The current version (`0.2.1`) is a GA release. See
+`vX.Y.Z` is GA. The current version (`0.4.0`, Eyrie) is a GA release. See
 `specs/system/supply-chain.spec.yaml`, `specs/release/package-build.spec.yaml`, and
 `docs/runbooks/RELEASING.md`.
 
@@ -91,9 +95,17 @@ verifies that:
 - the `openwatch` system user is created
 - `openwatch --version` and `openwatch check-config` run
 
-This is amd64 only (GitHub runners are amd64); arm64 correctness is covered by the
-cross-build in `release.yml`. Service start and functional E2E against a real fleet
-remain a manual RC step (see `docs/runbooks/RELEASING.md`).
+A third job, **Package upgrade (`rpm -U` auto-migrate)**, covers the path the
+per-distro `smoke` job (a fresh install) does not: in a `rockylinux:9` container it
+builds an old + new RPM, installs the old one, stands up PostgreSQL, rolls the schema
+back one migration, then `rpm -U`s the new package and asserts the `%post` scriptlet
+migrates the DB to head, takes a pre-upgrade backup, and stop/starts the service. It
+runs via `packaging/tests/run-upgrade-container-test.sh` (uses `--network host` and a
+throwaway Postgres on port `55432`).
+
+The smoke matrix is amd64 only (GitHub runners are amd64); arm64 correctness is
+covered by the cross-build in `release.yml`. Service start and functional E2E against
+a real fleet remain a manual RC step (see `docs/runbooks/RELEASING.md`).
 
 ## Repository automation
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -138,7 +138,7 @@ jobs:
         env:
           # Pinned so CI is reproducible. Bump in lockstep with any
           # spec-schema change required by specs/. 0.14.0 matches the
-          # local toolchain; all 75 specs validated against it.
+          # local toolchain; all 116 specs validated against it.
           SPECTER_VERSION: "0.14.0"
         run: |
           curl -fsSL "https://github.com/Hanalyx/specter/releases/download/v${SPECTER_VERSION}/specter_${SPECTER_VERSION}_linux_amd64.tar.gz" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] Eyrie — 2026-07-14
+
+### Added
+
+- **Per-host and per-group compliance targets (UI + host override).** Building on
+  the per-host and per-group target foundation, a host or a site group can now be
+  assigned a target framework family from the UI (the host Compliance tab and the
+  Groups page). A host's own target wins over its site group's, which wins over
+  the org default; a host's compliance summary and default lens follow that
+  effective target. Set via `POST /api/v1/hosts/{id}:target` and
+  `POST /api/v1/groups/{id}:target` (`host:write`). See spec
+  `system-compliance-lens`.
+- **Interactive compliance trend chart.** The host Compliance-trend card and the
+  dashboard fleet-trend widget now share one interactive chart. Hover any point
+  to read its date and score (the fleet chart also shows host count, failing
+  rules, and hosts with critical findings). The chart uses a fixed 0 to 100
+  scale with an 80% target line, and a date-positioned axis so a day with no
+  snapshot shows as a real gap rather than an interpolated line.
+
+### Fixed
+
+- **The framework-lens allowlist now applies to the per-host lens bar.**
+  Disabling a framework family under Settings, Compliance policies, Limit lens
+  options now also removes it from a host's "View as" chips, not just the
+  org-level picker. Deep links to a disabled family still work; the allowlist is
+  a display filter, not a security boundary.
+- **The Limit lens options toggle no longer silently reverts,** and changing the
+  default lens no longer clears the enabled-frameworks allowlist (the config
+  write is a full replace, so the default-lens control now preserves the
+  allowlist).
+- **Compliance exceptions handle a lapsed request correctly.** A pending request
+  whose expiry has already passed is now moved to expired by the hourly sweep
+  instead of sitting pending forever, and approving a lapsed request is refused
+  with a clear error rather than creating an immediately-dead waiver.
+
 ## [0.4.0] Eyrie — 2026-07-13
 
 ### Added

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1774,6 +1774,51 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/hosts/{id}:target:
+    post:
+      operationId: postHostTarget
+      summary: Set or clear a host's compliance target framework
+      description: |
+        Sets (or clears, when target_framework is empty) the host's own
+        compliance target family - the per-host override that wins over any
+        site-group target in the effective-target resolution. A host may always
+        carry its own target (no site-only constraint). RBAC: host:write.
+        Spec api-hosts, system-compliance-lens.
+      x-required-permission: host:write
+      parameters:
+        - {name: id, in: path, required: true, schema: {type: string, format: uuid}}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/HostTargetRequest'}
+      responses:
+        '200':
+          description: The updated host
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/HostResponse'}
+        '400':
+          description: An invalid target family value
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '401':
+          description: Caller is not authenticated
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks host:write permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '404':
+          description: Host not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/hosts/{id}/exceptions:
     get:
       operationId: getHostExceptions
@@ -4791,6 +4836,10 @@ components:
         architecture:        {type: string, nullable: true, description: 'e.g. x86_64, aarch64'}
         platform_identifier: {type: string, nullable: true, description: 'e.g. platform:el9'}
         os_discovered_at:    {type: string, format: date-time, nullable: true}
+        # Phase 3 (compliance-targets) — the host's OWN target framework
+        # (nil = inherit the site-group target, else the org default). The
+        # per-host override; wins over any group target. Spec api-hosts.
+        target_framework:    {type: string, description: "Host's own compliance target framework family (absent when unset/inheriting)."}
 
     # Per-host enrichment (spec api-hosts v1.1.0 C-05).
     # Populated on GET /hosts/{id} when host_liveness has a row for the host.
@@ -6233,6 +6282,14 @@ components:
         target_framework:
           type: string
           description: Compliance target family id, or empty to clear the target.
+
+    HostTargetRequest:
+      type: object
+      required: [target_framework]
+      properties:
+        target_framework:
+          type: string
+          description: Compliance target family id, or empty to clear the host's own target.
 
     GroupMemberRequest:
       type: object

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -1,6 +1,6 @@
 # API guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 Most operators use the web UI for daily work—managing hosts, viewing fleet
 health, reading compliance state, and triaging alerts. This guide is for
@@ -12,7 +12,7 @@ React UI over HTTPS on port `8443`. All API paths live under `/api/v1`. The
 running binary serves its own OpenAPI document as the contract source of truth,
 and `GET /api/v1/version` reports the build it came from.
 
-This guide reflects OpenWatch `v0.3.0`. The compliance
+This guide reflects OpenWatch `v0.5.0`. The compliance
 surface (scan execution + results, remediation, exceptions, posture/drift, audit
 export, the rule browser) IS exposed over `/api/v1`. See [the compliance API surface
 (now live)](#compliance-api-surface-now-live). The genuinely-absent pieces (a
@@ -124,7 +124,7 @@ permissions-registry endpoint under `/api/v1/auth`.
 | `PATCH` | `/api/v1/hosts/{id}` | `host:write` | Update mutable host fields. |
 | `DELETE` | `/api/v1/hosts/{id}` | `host:delete` | Soft-delete a host (`204`; sets `deleted_at`). |
 | `GET` | `/api/v1/hosts/{host_id}/monitoring/history` | `host:read` | Monitoring history. |
-| `POST` | `/api/v1/hosts/{host_id}/maintenance` | `host:write` | Toggle maintenance mode. |
+| `PUT` | `/api/v1/hosts/{host_id}/maintenance` | `host:write` | Pause or resume liveness probes for the host (maintenance mode). |
 | `POST` | `/api/v1/hosts/{id}/connectivity:check` | `host:write` | Run a connectivity check (idempotent). |
 | `GET` | `/api/v1/hosts/{id}/system-info` | `host:read` | Latest collected system intelligence. |
 | `POST` | `/api/v1/hosts/{id}/discovery:run` | `host:write` | Run host discovery (idempotent). |
@@ -281,7 +281,7 @@ curl -s --cacert /etc/openwatch/tls/cert.pem https://localhost:8443/api/v1/healt
 ```
 
 ```json
-{"status": "healthy", "db_connected": true, "version": "0.3.0"}
+{"status": "healthy", "db_connected": true, "version": "0.5.0"}
 ```
 
 A healthy response is always `status: "healthy"`, `db_connected: true`. When

--- a/docs/guides/BACKUP_RECOVERY.md
+++ b/docs/guides/BACKUP_RECOVERY.md
@@ -1,6 +1,6 @@
 # Backup and recovery
 
-**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 This guide covers backup, restore, and disaster recovery for an OpenWatch
 deployment. OpenWatch is a single Go binary (`/usr/bin/openwatch`) that serves

--- a/docs/guides/COMPLIANCE_CONTROLS.md
+++ b/docs/guides/COMPLIANCE_CONTROLS.md
@@ -1,6 +1,6 @@
 # Compliance control mapping
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This document maps OpenWatch's security controls to industry frameworks, providing evidence for compliance audits.
 
@@ -19,11 +19,11 @@ This document maps OpenWatch's security controls to industry frameworks, providi
 
 | Control | Title | OpenWatch Implementation | Evidence |
 |---------|-------|-------------------------|----------|
-| AC-2 | Account Management | User CRUD with RBAC (5 roles: viewer, auditor, ops_lead, security_admin, admin) | User list from the Users API; user audit events |
+| AC-2 | Account Management | User CRUD with RBAC (five roles: viewer, auditor, ops_lead, security_admin, admin) | User list from the Users API; user audit events |
 | AC-3 | Access Enforcement | Role-based permission checks on each route | `403` denials in the audit log; permission registry served by the API |
 | AC-6 | Least Privilege | Five built-in roles (least-privilege viewer baseline) | Role list from `/api/v1/roles` |
 | AC-7 | Unsuccessful Logon Attempts | Per-IP sliding-window rate limit on the auth endpoints (login, MFA verify); 429 + Retry-After | `429` responses with `Retry-After`; rate-limit denials in the audit log |
-| AC-11 | Session Lock | Inactivity timeout (default 15 min, configurable 1-480) | Session-timeout value in the running configuration |
+| AC-11 | Session Lock | Inactivity timeout (default 15 minutes, configurable from 5 minutes to 24 hours) | Session-timeout value in the running configuration |
 | AC-12 | Session Termination | Session cookie and JWT expiration (30 min access, 7 day refresh) | Token expiry observed on the API; logout audit events |
 | AC-17 | Remote Access | SSH with NIST SP 800-57 key validation | Host-key validation behavior on connect |
 

--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Database migration guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This guide covers how OpenWatch's PostgreSQL schema is versioned, how migrations
 are applied in production, and how to add a new migration. OpenWatch is a single
@@ -61,7 +61,7 @@ The DSN comes from `OPENWATCH_DATABASE_DSN` in `/etc/openwatch/secrets.env` (or
 in `goose_db_version`), and prints the version transition:
 
 ```
-migrations applied — version 47 -> 48
+migrations applied — version 50 -> 51
 ```
 
 When the schema is already current it reports that no migrations were pending
@@ -105,8 +105,8 @@ That number corresponds to the `NNNN` prefix of the last applied migration file.
 ## Adding a new migration
 
 1. Create a new migration file named with the next ascending
-   integer, for example `0051_add_scan_findings.sql` (the current highest
-   applied migration is `0050`; use the next free number, not this example
+   integer, for example `0052_add_scan_findings.sql` (the current highest
+   applied migration is `0051`; use the next free number, not this example
    literally). Migration order is driven by the filename prefix, not by
    dates.
 

--- a/docs/guides/ENVIRONMENT_REFERENCE.md
+++ b/docs/guides/ENVIRONMENT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Configuration and environment reference
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This document is the field reference for how you configure the OpenWatch
 binary: the TOML file, the environment-variable overrides, and the on-disk paths
@@ -127,6 +127,7 @@ sudo chmod 0640 /etc/openwatch/secrets.env
 | `OPENWATCH_POLICIES_DIR` | `/etc/openwatch/policies` | `serve` | Directory scanned when an admin triggers a policy reload through the API. |
 | `OPENWATCH_DEV_MODE` | unset | `serve` | When set to `true`, accepts unsigned policy envelopes. Development only; never set in production. |
 | `OPENWATCH_KENSA_STORE_PATH` | `.kensa/remediation.db` under the working directory (dev only, logs a warning) | `serve` | Durable path for Kensa's remediation rollback pre-state store. The packaged systemd unit sets this to `/var/lib/openwatch/kensa/remediation.db`. Production installs must set it to a persistent path or remediation rollback does not survive a restart. |
+| `OPENWATCH_KENSA_RULES_DIR` | unset | `serve`, `worker` | Development-only override for the Kensa rule corpus directory. When set, both processes log a startup warning. Production installs the signed `kensa-rules` package and must not set this; scans and remediation fail if no corpus is available. |
 
 Standard PostgreSQL libpq environment variables (for example `PGSSLROOTCERT`) are
 honored by the underlying driver when present, but OpenWatch itself only reads the

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -1,6 +1,6 @@
 # Host management and remediation
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This guide covers adding and managing hosts, organizing them into groups,
 understanding server intelligence data, and using automated remediation to fix
@@ -13,7 +13,7 @@ compliance findings. Most of these tasks are performed in the web UI.
 ### From the UI
 
 1. Navigate to **Hosts** in the left sidebar.
-2. Click **Add Host**.
+2. Select **Add Host**.
 3. Fill in the host details:
 
 | Field | Required | Example |
@@ -25,7 +25,7 @@ compliance findings. Most of these tasks are performed in the web UI.
 | Operating System | No | `RHEL 9` |
 | Environment | No | `production` |
 
-4. Click **Save**.
+4. Select **Save**.
 
 
 The host appears in the host list immediately after creation.
@@ -34,7 +34,7 @@ The host appears in the host list immediately after creation.
 
 For adding many hosts at once:
 
-1. Navigate to **Hosts** and click **Bulk Import**.
+1. Navigate to **Hosts** and select **Bulk Import**.
 2. Download the CSV template.
 3. Fill in the template with your host data.
 4. Upload the CSV file.
@@ -65,12 +65,12 @@ installed on target hosts.
 | **System Default** | Uses the credential configured in Settings > System Credentials. |
 
 4. Enter the SSH username.
-5. Click **Save**.
+5. Select **Save**.
 
 
 ### Testing connectivity
 
-After saving credentials, click **Test Connection** to verify that OpenWatch
+After saving credentials, select **Test Connection** to verify that OpenWatch
 can reach the host via SSH. The test checks:
 
 - Network reachability
@@ -104,24 +104,24 @@ compliance reporting and batch scanning.
 ### Creating a group
 
 1. Navigate to **Host Groups** in the sidebar.
-2. Click **Create Group**.
+2. Select **Create Group**.
 3. Enter a name, description, OS family, and compliance framework.
-4. Click **Save**.
+4. Select **Save**.
 
 
 ### Assigning hosts
 
 1. Open the group detail page.
-2. Click **Add Hosts**.
+2. Select **Add Hosts**.
 3. Select hosts from the list.
-4. Click **Confirm**.
+4. Select **Confirm**.
 
 A host can belong to more than one group at a time; group membership is a
 many-to-many relationship.
 
 ### Group scanning
 
-From the group detail page, click **Scan Group** to start a compliance scan
+From the group detail page, select **Scan Group** to start a compliance scan
 for all hosts in the group simultaneously. Monitor progress on the group's
 scan session page.
 
@@ -132,7 +132,7 @@ scan session page.
 ### OS detection
 
 OpenWatch automatically detects the operating system for hosts during scans.
-You can also trigger manual OS discovery from the host detail page by clicking
+You can also trigger manual OS discovery from the host detail page by selecting
 **Discover OS**.
 
 A background scheduler ticks every 60 seconds and enqueues discovery for any
@@ -209,11 +209,11 @@ installed on target hosts.
 
 1. Navigate to the host detail page and view the scan results.
 2. Select the failing findings you want to remediate (use checkboxes).
-3. Click **Remediate Selected**.
+3. Select **Remediate Selected**.
 
 
 4. Review the proposed changes. Each finding shows what changes.
-5. Click **Start Remediation** to confirm.
+5. Select **Start Remediation** to confirm.
 
 
 In the free-core edition, a single-rule remediation request auto-approves on
@@ -226,11 +226,11 @@ separation of duties is planned for the licensed bulk/automated remediation
 track, not yet available today:
 
 1. A user with `remediation:request` (`ops_lead`, `security_admin`, or `admin`)
-   selects findings, clicks **Request Remediation**, and enters a justification.
+   selects findings, chooses **Request Remediation**, and enters a justification.
 2. A **different** user with `remediation:approve` (`security_admin` or `admin`)
    reviews and approves or rejects it. The reviewer cannot be the requester
    (separation of duties; self-review returns `409 remediation.self_review`).
-3. Once approved, a user with `remediation:execute` clicks **Fix** to apply the
+3. Once approved, a user with `remediation:execute` selects **Fix** to apply the
    change. Execution is operator-initiated, not automatic.
 
 See [User roles](USER_ROLES.md) for the full role matrix.
@@ -261,9 +261,9 @@ If a remediation causes problems, you can roll back to the pre-change state.
 
 1. Go to the **Remediation** tab on the host detail page.
 2. Find the remediation job you want to roll back.
-3. Click **Rollback**.
+3. Select **Rollback**.
 4. Enter a reason for the rollback (logged for audit purposes).
-5. Click **Confirm Rollback**.
+5. Select **Confirm Rollback**.
 
 
 Rollback requires the `remediation:rollback` permission (`ops_lead`,

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,6 +1,6 @@
 # OpenWatch install guide (native packages)
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 This guide takes an administrator from a fresh Linux host to a running,
 logged-in OpenWatch: install the package, point it at PostgreSQL, create the
@@ -359,7 +359,7 @@ Recognized environment variables:
 
 | Variable | Effect |
 |----------|--------|
-| `OPENWATCH_SERVER_LISTEN` | Override `[server].listen` (default `:8443`) |
+| `OPENWATCH_SERVER_LISTEN` | Override `[server].listen` (default `0.0.0.0:8443`) |
 | `OPENWATCH_SERVER_TLS_CERT` | Override `[server].tls_cert` |
 | `OPENWATCH_SERVER_TLS_KEY` | Override `[server].tls_key` |
 | `OPENWATCH_DATABASE_DSN` | Override `[database].dsn` |

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -7,7 +7,7 @@
 > evidence, which distributions work for (1) running the OpenWatch server and
 > (2) being added as a managed/scanned host.
 
-**Last updated:** 2026-06-29 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 **Last verified:** 2026-07-13 against Kensa rule corpus **v0.7.6** (748 rules).
 Per-OS counts below are read from each rule's `platforms:` declarations in the
@@ -39,11 +39,13 @@ OpenWatch ships as native packages built for:
 
 | Platform | Form | Notes |
 |----------|------|-------|
-| **RHEL 9** | native **RPM** | Built on `ubuntu-latest` CI runners cross-packaging the RPM; smoke-tested in `rockylinux:9` and `almalinux:9` containers. RHEL 9, Rocky 9, AlmaLinux 9 are binary-compatible. |
-| **Ubuntu 24.04 LTS** | native **DEB** | Built/tested on Ubuntu 24.04. |
+| **RHEL 9** | native **RPM** | The RPM install is smoke-tested in `rockylinux:9`, `almalinux:9`, `oraclelinux:9`, and `fedora:41` containers. RHEL 9, Rocky 9, AlmaLinux 9, and Oracle Linux 9 are binary-compatible. |
+| **Ubuntu 24.04 LTS** | native **DEB** | The DEB install is smoke-tested in `ubuntu:24.04` and `debian:12` containers. |
 
-Other distributions may run the server from source (Go 1.26 + PostgreSQL 14 or
-newer), but only the above are packaged, tested, and released.
+RHEL 9 and Ubuntu 24.04 LTS are the released, supported server platforms; the
+other RPM and DEB distributions above are covered by the package install
+smoke test. Any distribution may run the server from source (Go 1.26 +
+PostgreSQL 14 or newer).
 
 > The server OS is **independent** of the managed-host OS. You can run the
 > OpenWatch server on Ubuntu and scan RHEL hosts, or vice-versa.

--- a/docs/guides/MONITORING_SETUP.md
+++ b/docs/guides/MONITORING_SETUP.md
@@ -1,6 +1,6 @@
 # OpenWatch monitoring and operations guide
 
-**Last updated**: 2026-06-26
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 This guide describes how you monitor a running OpenWatch deployment and how you
 respond to common operational incidents. OpenWatch ships as a single Go binary
@@ -52,7 +52,7 @@ curl -k https://localhost:8443/api/v1/health
 A healthy response returns `200 OK`:
 
 ```json
-{"status": "healthy", "db_connected": true, "version": "0.3.0"}
+{"status": "healthy", "db_connected": true, "version": "0.5.0"}
 ```
 
 When the database ping fails, the endpoint returns `503 Service Unavailable`
@@ -60,8 +60,10 @@ with an error envelope. Treat a non-`200` status, or a connection failure, as
 service-down.
 
 The response schema (`status`, `db_connected`, `version`) is defined by the
-`HealthResponse` contract. The current contract reports only a
-binary `healthy`/`degraded` status driven by database reachability.
+`HealthResponse` contract. On a `200` the `status` field is always `healthy`;
+when the database ping fails the endpoint returns `503` with an error envelope
+rather than a `degraded` status body. The signal is driven by database
+reachability.
 
 ### Version metadata
 
@@ -74,7 +76,7 @@ curl -k https://localhost:8443/api/v1/version
 
 ```json
 {
-  "openwatch": "0.3.0",
+  "openwatch": "0.5.0",
   "kensa": "<embedded engine version>",
   "go": "<go toolchain>",
   "commit": "<abbrev commit>",
@@ -362,8 +364,9 @@ operators do not look for them:
 - **Distributed tracing**—not implemented. Correlation IDs in the JSON logs
   are the current mechanism for following a request across log lines.
 - **Detailed authenticated health endpoints** (per-service, content, history)—
-  not implemented. The current health contract is a single binary
-  `healthy`/`degraded` status.
+  not implemented. The current health contract is a single `200`
+  (`status: healthy`) or `503` (error envelope) signal driven by database
+  reachability.
 
 This section and the API contract are updated together whenever metrics or
 tracing land.

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Production deployment guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 This guide covers running OpenWatch in production: a single Go binary that serves
 the REST API and the embedded React UI over HTTPS, backed by PostgreSQL, managed
@@ -14,7 +14,7 @@ touches lightly: process layout, TLS, the background worker, backups, upgrades,
 and incident runbooks.
 
 > Verify the version you deploy. The current general-availability release is
-> `v0.3.0`. Confirm with `openwatch --version` before and after an upgrade.
+> `v0.5.0`. Confirm with `openwatch --version` before and after an upgrade.
 
 ---
 
@@ -44,7 +44,7 @@ step today (write a unit that runs `ExecStart=/usr/bin/openwatch worker`).
 | API + UI | `https://<host>:8443/` | UI embedded via `go:embed`; API under `/api/v1/` |
 | Database | PostgreSQL 14+ | The only datastore. Not provisioned by the package. |
 | Job queue | PostgreSQL table, `SKIP LOCKED` | No external broker. Drained by `serve`/`worker`. |
-| Compliance engine | Kensa (Go), in-process | SSH-based, native YAML rules. See the boundary doc. |
+| Compliance engine | Kensa (Go), in-process | SSH-based checks against native YAML rules; runs inside the `serve`/`worker` process. |
 
 
 ---

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 Go from a freshly installed package to your first host under automatic
 compliance monitoring. This guide assumes OpenWatch is already installed and
@@ -56,7 +56,7 @@ A healthy response looks like this:
 ```
 
 `version` reflects how the binary was built: a packaged release reports its
-semver (for example `0.3.0`); a bare `go build` without the Makefile's
+semver (for example `0.5.0`); a bare `go build` without the Makefile's
 `-ldflags` reports `dev`.
 
 A healthy response is always `status: "healthy"`, `db_connected: true`. When
@@ -268,7 +268,7 @@ counts to a single framework key.
 |------|-------|
 | Full install and configuration reference | [Installation](INSTALLATION.md) |
 | Roles and permissions | [User roles](USER_ROLES.md) |
-| Kensa and OpenWatch boundary | the Kensa scanning engine |
+| How compliance scanning works | [Scanning and compliance](SCANNING_AND_COMPLIANCE.md) |
 | API contract (source of truth) | the served `/api/v1` OpenAPI document |
 
 ## Troubleshooting

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,40 +1,40 @@
 # OpenWatch operator guides
 
 Operator and administrator documentation for OpenWatch. The current
-general-availability release is `v0.3.0`; confirm the version you are running with
+general-availability release is `v0.5.0`; confirm the version you are running with
 `GET /api/v1/health` or `openwatch --version`.
 
 ## Getting started
 
-- [Quickstart](QUICKSTART.md) — install and reach a working server fast.
-- [Install guide](INSTALLATION.md) — native RPM and DEB packages, step by step.
-- [Linux distribution support](LINUX_DISTRIBUTION_SUPPORT.md) — tested targets.
+- [Quickstart](QUICKSTART.md): install and reach a working server fast.
+- [Install guide](INSTALLATION.md): native RPM and DEB packages, step by step.
+- [Linux distribution support](LINUX_DISTRIBUTION_SUPPORT.md): tested targets.
 
 ## Deploy and operate
 
-- [Production deployment](PRODUCTION_DEPLOYMENT.md) — hardened production setup.
-- [Configuration and environment reference](ENVIRONMENT_REFERENCE.md) — every setting.
-- [Monitoring and operations](MONITORING_SETUP.md) — health, metrics, day-2 ops.
-- [Backup and recovery](BACKUP_RECOVERY.md) — back up and restore data.
-- [Upgrade procedure](UPGRADE_PROCEDURE.md) — move between releases safely.
-- [Database migrations](DATABASE_MIGRATIONS.md) — how schema changes are applied.
-- [Scaling guide](SCALING_GUIDE.md) — grow with fleet size.
+- [Production deployment](PRODUCTION_DEPLOYMENT.md): hardened production setup.
+- [Configuration and environment reference](ENVIRONMENT_REFERENCE.md): every setting.
+- [Monitoring and operations](MONITORING_SETUP.md): health, metrics, day-2 ops.
+- [Backup and recovery](BACKUP_RECOVERY.md): back up and restore data.
+- [Upgrade procedure](UPGRADE_PROCEDURE.md): move between releases safely.
+- [Database migrations](DATABASE_MIGRATIONS.md): how schema changes are applied.
+- [Scaling guide](SCALING_GUIDE.md): grow with fleet size.
 
 ## Security
 
-- [Security hardening](SECURITY_HARDENING.md) — lock down a deployment.
-- [Secret rotation](SECRET_ROTATION.md) — rotate keys and credentials.
-- [User roles and permissions](USER_ROLES.md) — the RBAC model.
+- [Security hardening](SECURITY_HARDENING.md): lock down a deployment.
+- [Secret rotation](SECRET_ROTATION.md): rotate keys and credentials.
+- [User roles and permissions](USER_ROLES.md): the RBAC model.
 
 ## Compliance and scanning
 
-- [Scanning and compliance](SCANNING_AND_COMPLIANCE.md) — run scans, read results.
-- [Compliance control mapping](COMPLIANCE_CONTROLS.md) — frameworks and controls.
-- [Host management and remediation](HOSTS_AND_REMEDIATION.md) — manage hosts, apply fixes.
+- [Scanning and compliance](SCANNING_AND_COMPLIANCE.md): run scans, read results.
+- [Compliance control mapping](COMPLIANCE_CONTROLS.md): frameworks and controls.
+- [Host management and remediation](HOSTS_AND_REMEDIATION.md): manage hosts, apply fixes.
 
 ## API
 
-- [API guide](API_GUIDE.md) — the REST API surface and usage.
+- [API guide](API_GUIDE.md): the REST API surface and usage.
 
 ## Runbooks
 

--- a/docs/guides/SCALING_GUIDE.md
+++ b/docs/guides/SCALING_GUIDE.md
@@ -1,6 +1,6 @@
 # Scaling guide
 
-**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 This guide covers how OpenWatch behaves as you add hosts, run more scans, and
 push more concurrent API traffic, and what you can tune today. It describes the

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Scanning and compliance
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This guide covers how OpenWatch performs compliance scanning, how to read
 results and posture scores, and how to use drift detection, alerts, and
@@ -238,14 +238,18 @@ On the host detail page, the **Scheduling** section shows:
 
 ### Maintenance mode
 
-To pause scanning for a host (during planned maintenance):
+Maintenance mode is a manual on/off flag that pauses scheduled scans, alerts,
+and connectivity probes for a host during planned maintenance. It has no timer
+and does not expire on its own: it stays on until you turn it off.
+
+To pause a host:
 
 1. Go to the host detail page.
-2. Select **Maintenance Mode**.
-3. Set the duration (1–168 hours).
-4. Select **Enable**.
+2. Turn on the **Maintenance** toggle in the host action row.
 
-Maintenance mode expires automatically. You can disable it early from the same page.
+To resume, turn the toggle off. On-demand **Run Scan** still works while a host
+is in maintenance. You can also set maintenance for a whole group from the group
+detail page.
 
 ### Force scan
 

--- a/docs/guides/SECRET_ROTATION.md
+++ b/docs/guides/SECRET_ROTATION.md
@@ -1,6 +1,6 @@
 # Secret rotation procedures
 
-**Last updated:** 2026-06-22 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This guide describes how to rotate each secret used by OpenWatch on the current
 single-binary stack: one `/usr/bin/openwatch` process that serves the REST API

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -1,6 +1,6 @@
 # OpenWatch security hardening guide
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary build)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary build)
 **Audience:** System administrators, security engineers, compliance officers
 
 This guide covers the security controls you operate when you deploy OpenWatch
@@ -133,8 +133,8 @@ is no silent fallback to ephemeral keys.
 
 | Config key | Default path | Contents | Shipped mode | Enforced at boot |
 |------------|--------------|----------|---------------|-------------------|
-| `[identity].jwt_private_key` | `/etc/openwatch/keys/jwt_private.pem` | PEM RSA private key, ≥ 2048-bit | `0640`, owner `root:openwatch` | No — the mode is not checked by code |
-| `[identity].credential_key_file` | `/etc/openwatch/keys/credential.key` | 32-byte raw AES-256 key | `0600`, owner `openwatch:openwatch` | Yes — boot refuses to start if the mode has any group/other bits set |
+| `[identity].jwt_private_key` | `/etc/openwatch/keys/jwt_private.pem` | PEM RSA private key, ≥ 2048-bit | `0640`, owner `root:openwatch` | No, the mode is not checked by code |
+| `[identity].credential_key_file` | `/etc/openwatch/keys/credential.key` | 32-byte raw AES-256 key | `0600`, owner `openwatch:openwatch` | Yes, boot refuses to start if the mode has any group/other bits set |
 
 
 
@@ -188,7 +188,7 @@ Authorization is a permission registry, not free-form strings. Every protected
 operation declares its required permission; the handler middleware checks the
 caller's effective permission set; built-in roles grant permissions from the
 same registry. The effective registry is served at runtime by the
-permissions-registry API endpoint. Design doc:
+permissions-registry API endpoint. See
 [User roles](USER_ROLES.md).
 
 Built-in roles, least to most privileged:
@@ -483,7 +483,7 @@ Network and transport
 Cryptography and keys
 
 - [ ] `[identity].jwt_private_key` present, RSA ≥ 2048; ships mode `0640`
-      (owner `root:openwatch`, not permission-checked at boot) — tightening to
+      (owner `root:openwatch`, not permission-checked at boot). Tightening to
       `0600` owned by `openwatch` is an optional, stricter-than-shipped step.
 - [ ] `[identity].credential_key_file` present, 32 bytes, mode `0600` (boot
       refuses to start otherwise).

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -1,6 +1,6 @@
 # Upgrade procedure
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Eyrie, Go single-binary)
 
 This guide covers upgrading an OpenWatch deployment to a newer version. OpenWatch
 ships as a single Go binary (`/usr/bin/openwatch`) that serves both the REST API
@@ -19,7 +19,7 @@ For first-time install and configuration, see the
 commands referenced below, see the [backup and recovery guide](BACKUP_RECOVERY.md). For
 migration mechanics, see the [database migrations guide](DATABASE_MIGRATIONS.md).
 
-> Version note: `v0.3.0` is the current general-availability release. Always back
+> Version note: `v0.5.0` is the current general-availability release. Always back
 > up before upgrading; the upgrade path runs database migrations automatically.
 
 ## Quick upgrade (automatic, recommended)

--- a/docs/guides/USER_ROLES.md
+++ b/docs/guides/USER_ROLES.md
@@ -1,6 +1,6 @@
 # User roles and permissions
 
-**Last updated:** 2026-06-25 · **Applies to:** OpenWatch v0.3.0 (Go single-binary)
+**Last updated:** 2026-07-14 · **Applies to:** OpenWatch v0.5.0 (Go single-binary)
 
 This guide describes the role-based access control (RBAC) system in the Go-era
 OpenWatch. It covers the five built-in roles, the permissions they grant, and how

--- a/docs/guides/runbooks/DATABASE_ISSUES.md
+++ b/docs/guides/runbooks/DATABASE_ISSUES.md
@@ -256,8 +256,9 @@ psql -U openwatch -d openwatch -c "VACUUM VERBOSE;"
 For more aggressive space reclamation (requires exclusive table lock):
 
 ```bash
-# VACUUM FULL rewrites the entire table - use with caution during off-hours
-psql -U openwatch -d openwatch -c "VACUUM FULL scan_findings;"
+# VACUUM FULL rewrites the entire table - use with caution during off-hours.
+# Replace scan_results with the actual large table from Step 6; confirm it exists first.
+psql -U openwatch -d openwatch -c "VACUUM FULL scan_results;"
 ```
 
 Also see the [disk space runbook](DISK_FULL.md) for broader disk cleanup.
@@ -268,7 +269,7 @@ If queries return incorrect results or logs show index-related errors:
 
 ```bash
 # Reindex a specific table
-psql -U openwatch -d openwatch -c "REINDEX TABLE scan_findings;"
+psql -U openwatch -d openwatch -c "REINDEX TABLE scan_results;"
 
 # Reindex the entire database (takes longer, but thorough)
 psql -U openwatch -d openwatch -c "REINDEX DATABASE openwatch;"
@@ -370,8 +371,8 @@ Escalate if any of the following conditions are met:
 - **Connection limit per user**: Consider setting `ALTER ROLE openwatch CONNECTION LIMIT 80;` to leave headroom for administrative connections.
 - **Regular maintenance**: Schedule weekly `ANALYZE` on large tables to keep query planner statistics current:
   ```sql
-  ANALYZE scan_findings;
-  ANALYZE scans;
+  ANALYZE scan_results;
+  ANALYZE scan_runs;
   ANALYZE hosts;
-  ANALYZE audit_logs;
+  ANALYZE audit_events;
   ```

--- a/docs/guides/runbooks/DISK_FULL.md
+++ b/docs/guides/runbooks/DISK_FULL.md
@@ -277,8 +277,8 @@ retention planning.
 
 ## Not yet implemented
 
-OpenWatch is currently `v0.2.0`, a pre-release. The following do not exist in
-the current code and must not be relied on:
+As of OpenWatch `v0.5.0`, the following do not exist in the current code and
+must not be relied on:
 
 - **Automated retention / pruning jobs** for `audit_events` or other tables.
   Cleanup is manual (path C). This is roadmap work.

--- a/docs/guides/runbooks/SERVICE_DOWN.md
+++ b/docs/guides/runbooks/SERVICE_DOWN.md
@@ -363,8 +363,8 @@ Include when escalating:
 
 ## Not yet implemented
 
-OpenWatch is currently `v0.2.0`, a pre-release. The following do not exist in
-the current code and must not be relied on in this runbook:
+As of OpenWatch `v0.5.0`, the following do not exist in the current code and
+must not be relied on in this runbook:
 
 - **A packaged systemd unit for the scan worker.** Only `openwatch.service`
   (running `serve`) ships today. Running `openwatch worker` under systemd is the

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1155,6 +1155,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/hosts/{id}:target": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set or clear a host's compliance target framework
+         * @description Sets (or clears, when target_framework is empty) the host's own
+         *     compliance target family - the per-host override that wins over any
+         *     site-group target in the effective-target resolution. A host may always
+         *     carry its own target (no site-only constraint). RBAC: host:write.
+         *     Spec api-hosts, system-compliance-lens.
+         */
+        post: operations["postHostTarget"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/hosts/{id}/exceptions": {
         parameters: {
             query?: never;
@@ -3080,6 +3104,8 @@ export interface components {
             platform_identifier?: string | null;
             /** Format: date-time */
             os_discovered_at?: string | null;
+            /** @description Host's own compliance target framework family (absent when unset/inheriting). */
+            target_framework?: string;
         };
         HostLiveness: {
             /** @enum {string} */
@@ -4138,6 +4164,10 @@ export interface components {
         };
         GroupTargetRequest: {
             /** @description Compliance target family id, or empty to clear the target. */
+            target_framework: string;
+        };
+        HostTargetRequest: {
+            /** @description Compliance target family id, or empty to clear the host's own target. */
             target_framework: string;
         };
         GroupMemberRequest: {
@@ -7011,6 +7041,68 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             /** @description Caller lacks system:config:write permission */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    postHostTarget: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HostTargetRequest"];
+            };
+        };
+        responses: {
+            /** @description The updated host */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HostResponse"];
+                };
+            };
+            /** @description An invalid target family value */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Caller lacks host:write permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Host not found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/components/charts/TrendChart.tsx
+++ b/frontend/src/components/charts/TrendChart.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+
+// TrendChart is the shared interactive compliance-trend chart used by the host
+// Compliance-trend card and the dashboard fleet-trend widget, so the two never
+// diverge again. Design decisions (all deliberate):
+//
+//   - Fixed 0..100 score domain with an 80% target line. Auto min/max scaling
+//     is banned: it exaggerates a 2% move into a cliff, which is misleading on a
+//     compliance score.
+//   - Date-positioned x-axis over the requested window (ending today), NOT an
+//     index axis. A day with no snapshot (a host that was offline = not
+//     compliant) MUST read as a real gap, so the line is broken wherever two
+//     snapshots are more than one calendar day apart, and a missing recent
+//     snapshot shows as empty space on the right.
+//   - Hover anywhere reveals the nearest data point: a guide line, an enlarged
+//     marker, and a tooltip with the point's date, score, and any extra lines
+//     the caller supplies (fleet passes hosts / failing / critical).
+//
+// Pure SVG + one relative wrapper for the tooltip; no chart dependency.
+
+export interface TrendPoint {
+  date: string; // YYYY-MM-DD (the snapshot_date)
+  scorePct: number; // 0..100
+  // Tooltip lines shown on hover; line 0 renders muted (the date), the rest
+  // emphasized. Callers assemble these so host vs fleet can differ.
+  tooltip: string[];
+}
+
+const DAY_MS = 86400000;
+const parseDay = (d: string) => Date.parse(d + 'T00:00:00Z');
+
+export function TrendChart({
+  points,
+  windowDays,
+  height = 72,
+  targetPct = 80,
+  color = 'var(--ow-info)',
+}: {
+  points: TrendPoint[];
+  windowDays: number;
+  height?: number;
+  targetPct?: number;
+  color?: string;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+
+  const W = 300;
+  const PAD = 4;
+  const innerW = W - 2 * PAD;
+  const innerH = height - 2 * PAD;
+
+  // Right edge = today, so a missing recent snapshot is visible as trailing gap.
+  const todayUTC = Math.floor(Date.now() / DAY_MS) * DAY_MS;
+  const windowStart = todayUTC - (windowDays - 1) * DAY_MS;
+  const dayIndex = (d: string) => Math.round((parseDay(d) - windowStart) / DAY_MS);
+
+  const xFrac = (d: string) => (windowDays <= 1 ? 0.5 : dayIndex(d) / (windowDays - 1));
+  const x = (d: string) => PAD + xFrac(d) * innerW;
+  const y = (score: number) => PAD + (1 - Math.max(0, Math.min(100, score)) / 100) * innerH;
+
+  // Break the polyline at gaps: two points join only when exactly one calendar
+  // day apart. A gap leaves a real break instead of an interpolated line.
+  const segments: TrendPoint[][] = [];
+  for (let i = 0; i < points.length; i++) {
+    const gapFromPrev = i === 0 || dayIndex(points[i]!.date) - dayIndex(points[i - 1]!.date) !== 1;
+    if (gapFromPrev) segments.push([]);
+    segments[segments.length - 1]!.push(points[i]!);
+  }
+
+  const onMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (points.length === 0) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const f = (e.clientX - rect.left) / rect.width;
+    let best = 0;
+    let bestDist = Infinity;
+    points.forEach((p, i) => {
+      const dist = Math.abs(xFrac(p.date) - f);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = i;
+      }
+    });
+    setHover(best);
+  };
+
+  const hp = hover !== null ? points[hover] : null;
+  // Clamp the tooltip so it does not overflow the card edges.
+  const hf = hp ? xFrac(hp.date) : 0.5;
+  const tipTransform =
+    hf < 0.2
+      ? 'translate(0, -100%)'
+      : hf > 0.8
+        ? 'translate(-100%, -100%)'
+        : 'translate(-50%, -100%)';
+
+  return (
+    <div style={{ marginTop: 10 }}>
+      <div
+        style={{ position: 'relative' }}
+        onMouseMove={onMove}
+        onMouseLeave={() => setHover(null)}
+      >
+        <svg
+          viewBox={`0 0 ${W} ${height}`}
+          style={{ width: '100%', height, display: 'block' }}
+          role="img"
+          aria-label={ariaSummary(points, targetPct)}
+        >
+          <line
+            x1={PAD}
+            x2={W - PAD}
+            y1={y(targetPct)}
+            y2={y(targetPct)}
+            stroke="var(--ow-line)"
+            strokeDasharray="3 3"
+          />
+          {segments.map((seg, si) =>
+            seg.length > 1 ? (
+              <polyline
+                key={si}
+                points={seg.map((p) => `${x(p.date)},${y(p.scorePct)}`).join(' ')}
+                fill="none"
+                stroke={color}
+                strokeWidth={2}
+              />
+            ) : null,
+          )}
+          {points.map((p, i) => (
+            <circle
+              key={p.date}
+              cx={x(p.date)}
+              cy={y(p.scorePct)}
+              r={hover === i ? 3.5 : 2}
+              fill={color}
+            />
+          ))}
+          {hp && (
+            <line
+              x1={x(hp.date)}
+              x2={x(hp.date)}
+              y1={PAD}
+              y2={height - PAD}
+              stroke="var(--ow-fg-3)"
+              strokeWidth={1}
+              strokeDasharray="2 2"
+            />
+          )}
+        </svg>
+        {hp && (
+          <div
+            role="status"
+            style={{
+              position: 'absolute',
+              left: `${hf * 100}%`,
+              top: -2,
+              transform: tipTransform,
+              background: 'var(--ow-bg-2)',
+              border: '1px solid var(--ow-line)',
+              borderRadius: 6,
+              padding: '5px 8px',
+              fontSize: 11,
+              lineHeight: 1.45,
+              color: 'var(--ow-fg-1)',
+              whiteSpace: 'nowrap',
+              pointerEvents: 'none',
+              zIndex: 5,
+            }}
+          >
+            {hp.tooltip.map((line, i) => (
+              <div
+                key={i}
+                style={{
+                  color: i === 0 ? 'var(--ow-fg-3)' : 'var(--ow-fg-0)',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {line}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          fontSize: 10,
+          color: 'var(--ow-fg-3)',
+          marginTop: 2,
+        }}
+      >
+        <span>{isoDay(windowStart)}</span>
+        <span>{isoDay(todayUTC)}</span>
+      </div>
+    </div>
+  );
+}
+
+// isoDay renders a UTC ms timestamp as YYYY-MM-DD (matches snapshot_date).
+function isoDay(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// ariaSummary gives non-visual users the same headline the chart shows.
+function ariaSummary(points: TrendPoint[], targetPct: number): string {
+  if (points.length === 0) return 'Compliance score trend: no data';
+  const last = points[points.length - 1]!;
+  const first = points[0]!;
+  return (
+    `Compliance score trend, target ${targetPct}%. ` +
+    `${points.length} snapshots from ${first.date} to ${last.date}. ` +
+    `Latest ${last.scorePct}%.`
+  );
+}

--- a/frontend/src/components/hosts/HostTargetControl.tsx
+++ b/frontend/src/components/hosts/HostTargetControl.tsx
@@ -22,10 +22,16 @@ export function HostTargetControl({
   const queryClient = useQueryClient();
   const [banner, setBanner] = useState<string | null>(null);
 
+  // The full corpus family list (all=true), NOT the enabled-frameworks
+  // allowlist. A host may hold a target family the org later removes from the
+  // allowlist; the picker must still offer it so the current value has a
+  // matching option and is never silently misrepresented as "Inherit".
   const frameworksQuery = useQuery({
-    queryKey: ['compliance-frameworks'],
+    queryKey: ['compliance-frameworks-all'],
     queryFn: async () => {
-      const { data, error, response } = await api.GET('/api/v1/compliance/frameworks');
+      const { data, error, response } = await api.GET('/api/v1/compliance/frameworks', {
+        params: { query: { all: true } },
+      });
       if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load frameworks'));
       return data!.frameworks;
     },

--- a/frontend/src/components/hosts/HostTargetControl.tsx
+++ b/frontend/src/components/hosts/HostTargetControl.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import { Select } from '@/components/settings/primitives';
+
+// HostTargetControl — the host's durable COMPLIANCE TARGET: the framework
+// family this host is held to. It is the per-host override that wins over any
+// site-group target and becomes the host's default lens
+// (framework.EffectiveTarget). Empty means "inherit" (a site-group target, else
+// the org default). Writes POST /api/v1/hosts/{id}:target (host:write, enforced
+// server-side; matching the config cards the control is not client-gated — a
+// caller without the permission gets a 403 banner). Families come from the same
+// corpus-derived list as the org default lens (GET /compliance/frameworks).
+export function HostTargetControl({
+  hostId,
+  currentTarget,
+}: {
+  hostId: string;
+  currentTarget?: string | null;
+}) {
+  const queryClient = useQueryClient();
+  const [banner, setBanner] = useState<string | null>(null);
+
+  const frameworksQuery = useQuery({
+    queryKey: ['compliance-frameworks'],
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/compliance/frameworks');
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to load frameworks'));
+      return data!.frameworks;
+    },
+  });
+
+  const [value, setValue] = useState(currentTarget ?? '');
+  useEffect(() => setValue(currentTarget ?? ''), [currentTarget]);
+
+  const mutation = useMutation({
+    mutationFn: async (next: string) => {
+      const { response, error } = await api.POST('/api/v1/hosts/{id}:target', {
+        params: { path: { id: hostId } },
+        body: { target_framework: next },
+      });
+      if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to save target'));
+    },
+    onSuccess: () => {
+      setBanner(null);
+      // Refresh every host-scoped query (the lens summary + the framework-
+      // agnostic target self-query) so the score and the default lens reflect
+      // the new target.
+      queryClient.invalidateQueries({ queryKey: ['host', hostId] });
+    },
+    onError: (e: Error) => setBanner(e.message),
+  });
+
+  const options = [
+    { value: '', label: 'Inherit (group or org default)' },
+    ...(frameworksQuery.data ?? []).map((f) => ({ value: f.id, label: f.label })),
+  ];
+
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+      <span
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--ow-fg-3)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+        }}
+      >
+        Compliance target
+      </span>
+      <Select
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          setBanner(null);
+          mutation.mutate(v);
+        }}
+        ariaLabel="Host compliance target"
+        options={options}
+        width="240px"
+        disabled={frameworksQuery.isLoading || mutation.isPending}
+      />
+      {banner && (
+        <span role="alert" style={{ color: 'var(--ow-crit)', fontSize: 11 }}>
+          {banner}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/settings/DefaultLensCard.tsx
+++ b/frontend/src/components/settings/DefaultLensCard.tsx
@@ -40,7 +40,13 @@ export function DefaultLensCard() {
   const mutation = useMutation({
     mutationFn: async (next: string) => {
       const { response, error } = await api.PUT('/api/v1/system/compliance/config', {
-        body: { default_framework: next },
+        // The endpoint is a full replace: preserve the current enabled-frameworks
+        // allowlist, or omitting it would wipe the restriction every time the
+        // default lens changes.
+        body: {
+          default_framework: next,
+          enabled_frameworks: configQuery.data?.enabled_frameworks ?? [],
+        },
       });
       if (!response.ok) throw new Error(apiErrorMessage(error, 'Failed to save'));
     },

--- a/frontend/src/components/settings/EnabledFrameworksCard.tsx
+++ b/frontend/src/components/settings/EnabledFrameworksCard.tsx
@@ -57,6 +57,12 @@ export function EnabledFrameworksCard() {
   const defaultFramework = cfg?.default_framework ?? '';
   const restrict = enabled.length > 0;
   const busy = mutation.isPending || configQuery.isLoading || allFrameworksQuery.isLoading;
+  // A corpus with no framework families (never scanned, or the all=true query
+  // errored) means there is nothing to restrict. Turning the toggle on would
+  // seed an empty allowlist, which is indistinguishable from off, so the toggle
+  // would silently snap back. Guard against that: disable the toggle and show a
+  // note rather than persisting an empty (== off) list.
+  const noFamilies = allFrameworks.length === 0;
 
   const save = (enabledNext: string[]) => {
     setBanner(null);
@@ -65,7 +71,10 @@ export function EnabledFrameworksCard() {
 
   const setRestrict = (on: boolean) => {
     // On: seed with every family (explicit) so it's a no-op until trimmed.
-    // Off: empty list means every family is available.
+    // Off: empty list means every family is available. Never persist an empty
+    // list on "on" (it reads as off) — the toggle is disabled in that state,
+    // but guard here too against a race.
+    if (on && noFamilies) return;
     save(on ? allFrameworks.map((f) => f.id) : []);
   };
 
@@ -81,6 +90,12 @@ export function EnabledFrameworksCard() {
           <>
             Restrict which framework families are offered as compliance lenses. Off means every
             framework found in the corpus is available.{' '}
+            {!busy && noFamilies && (
+              <span style={{ color: 'var(--ow-fg-3)' }}>
+                No framework families in the scanned corpus yet. Scan a host, then this can be
+                limited.
+              </span>
+            )}
             {banner?.kind === 'success' && (
               <span style={{ color: 'var(--ow-ok)' }}>{banner.text}</span>
             )}
@@ -94,7 +109,7 @@ export function EnabledFrameworksCard() {
             value={restrict}
             onChange={setRestrict}
             ariaLabel="Limit lens options"
-            disabled={busy}
+            disabled={busy || noFamilies}
           />
         }
       />

--- a/frontend/src/components/settings/ExceptionQueue.tsx
+++ b/frontend/src/components/settings/ExceptionQueue.tsx
@@ -70,7 +70,12 @@ export function ExceptionQueue() {
       });
       if (error || !response.ok) {
         if (response.status === 409) {
-          throw new Error('This exception already changed state (refresh the queue).');
+          // Prefer the server's specific 409 reason (state already changed,
+          // separation-of-duties, or a lapsed-expiry request) so the approver
+          // sees why; fall back to the generic hint if the envelope is empty.
+          throw new Error(
+            apiErrorMessage(error, 'This exception already changed state (refresh the queue).'),
+          );
         }
         throw new Error(apiErrorMessage(error, `Action failed (${response.status})`));
       }
@@ -215,6 +220,15 @@ export function ExceptionQueue() {
               </div>
               <div style={{ color: 'var(--ow-fg-3)', fontSize: 12 }}>
                 {e.expires_at ? new Date(e.expires_at).toLocaleDateString() : 'No expiry'}
+                {/* A pending row past its requested expiry is lapsed: it cannot be
+                    approved (server 409) and the sweep will expire it. */}
+                {e.status === 'requested' &&
+                  e.expires_at &&
+                  new Date(e.expires_at).getTime() <= Date.now() && (
+                    <span style={{ color: 'var(--ow-warn)', marginLeft: 6, fontSize: 11 }}>
+                      (lapsed)
+                    </span>
+                  )}
               </div>
               <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
                 {e.status === 'requested' && canApprove && (

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -44,6 +44,7 @@ import { stripKernelDistroSuffix } from '@/utils/kernelVersion';
 import { CardServerIntel } from '@/pages/host-detail/CardServerIntel';
 import { ComplianceTab } from '@/pages/host-detail/ComplianceTab';
 import { SeverityPill } from '@/pages/host-detail/SeverityPill';
+import { TrendChart } from '@/components/charts/TrendChart';
 import {
   PackagesTab,
   ServicesTab,
@@ -2504,71 +2505,23 @@ function CardComplianceTrend({ hostId }: { hostId: string }) {
               }}
             >
               {diff > 0 ? '+' : ''}
-              {diff}% over {days.length} days
+              {diff}% since {first.date}
             </span>
           )}
         </div>
-        <TrendSparkline days={days} />
+        <TrendChart
+          points={days.map((d) => ({
+            date: d.date,
+            scorePct: d.score_pct,
+            tooltip: [d.date, `${d.score_pct}% compliant`, `${d.passing}/${d.total} passing`],
+          }))}
+          windowDays={30}
+        />
       </>
     );
   }
 
   return <Card title="Compliance trend · last 30 days">{body}</Card>;
-}
-
-// TrendSparkline draws the score line (0..100 domain) over the
-// snapshot points. Pure SVG, no chart dependency: the card needs one
-// readable line, not an axis system.
-function TrendSparkline({ days }: { days: { date: string; score_pct: number }[] }) {
-  const W = 280;
-  const H = 64;
-  const PAD = 4;
-  const n = days.length;
-  const x = (i: number) => (n === 1 ? W / 2 : PAD + (i * (W - 2 * PAD)) / (n - 1));
-  const y = (score: number) => PAD + (1 - score / 100) * (H - 2 * PAD);
-  const points = days.map((d, i) => `${x(i)},${y(d.score_pct)}`).join(' ');
-  return (
-    <div style={{ marginTop: 10 }}>
-      <svg
-        viewBox={`0 0 ${W} ${H}`}
-        style={{ width: '100%', height: 64, display: 'block' }}
-        role="img"
-        aria-label="Compliance score trend"
-      >
-        {/* Target line at 80%. */}
-        <line
-          x1={PAD}
-          x2={W - PAD}
-          y1={y(80)}
-          y2={y(80)}
-          stroke="var(--ow-line)"
-          strokeDasharray="3 3"
-        />
-        {n > 1 && <polyline points={points} fill="none" stroke="var(--ow-info)" strokeWidth={2} />}
-        {days.map((d, i) => (
-          <circle
-            key={d.date}
-            cx={x(i)}
-            cy={y(d.score_pct)}
-            r={n === 1 ? 3 : 2}
-            fill="var(--ow-info)"
-          />
-        ))}
-      </svg>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          fontSize: 10,
-          color: 'var(--ow-fg-3)',
-          marginTop: 2,
-        }}
-      >
-        <span>{days[0]!.date}</span>
-        <span>{days[days.length - 1]!.date}</span>
-      </div>
-    </div>
-  );
 }
 
 // RECENT_LIMIT caps the overview card at the most-recent N rows.

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -102,6 +102,9 @@ interface HostResponse {
   architecture?: string | null;
   platform_identifier?: string | null;
   os_discovered_at?: string | null;
+  // Phase 3 (compliance-targets) — the host's own target framework family
+  // (absent = inherit a site-group target, else the org default).
+  target_framework?: string;
 }
 
 type MonitoringBand = 'online' | 'degraded' | 'critical' | 'down' | 'maintenance' | 'unknown';
@@ -217,11 +220,29 @@ export function HostDetailPage() {
   const activeTab: TabId = search.tab ?? 'overview';
   const setCrumbs = useBreadcrumbStore((s) => s.setCrumbs);
 
-  // Default lens: with no explicit ?framework=, this host defaults to the org
-  // default lens resolved to its own OS key (family "stig" -> stig_rhel9). The
+  // Default lens: with no explicit ?framework=, this host defaults to its
+  // effective compliance TARGET resolved to its own OS key (family "stig" ->
+  // stig_rhel9). The host's OWN target takes precedence over the org default;
+  // when the host has none, this falls back to the org default lens. The
   // explicit "all" sentinel means the user chose All rules (no filter),
   // distinct from "no choice" which applies the default.
   const defaultLens = useDefaultLens();
+  // The host's own durable target is a host property, not a lens view, so it is
+  // fetched framework-agnostically under a distinct cache key. Keeping it out of
+  // the detail queryKey preserves the ['host', hostId, framework] shape the
+  // detail query is pinned to (frontend-host-detail AC-08), and a lens switch
+  // never refetches it. Invalidated by HostTargetControl on a target change.
+  const hostTargetQuery = useQuery({
+    queryKey: ['host', hostId, 'self'],
+    queryFn: async () => {
+      const { data, response } = await api.GET('/api/v1/hosts/{id}', {
+        params: { path: { id: hostId } },
+      });
+      return response.ok ? (data ?? null) : null;
+    },
+    enabled: !!hostId,
+  });
+  const hostOwnTarget = hostTargetQuery.data?.host?.target_framework ?? '';
   const hostFrameworksQuery = useQuery({
     queryKey: ['host', hostId, 'compliance', 'frameworks'],
     queryFn: async () => {
@@ -234,7 +255,8 @@ export function HostDetailPage() {
     enabled: !!hostId,
   });
   const availableKeys = (hostFrameworksQuery.data?.frameworks ?? []).map((f) => f.framework_id);
-  const resolvedDefault = resolveLensForHost(defaultLens, availableKeys);
+  // Prefer the host's own target over the org default (Phase 3 compliance-targets).
+  const resolvedDefault = resolveLensForHost(hostOwnTarget || defaultLens, availableKeys);
   const framework =
     search.framework === undefined
       ? resolvedDefault || undefined
@@ -494,6 +516,7 @@ export function HostDetailPage() {
               hostId={detailQuery.data.host.id}
               framework={framework}
               onFrameworkChange={onFrameworkChange}
+              targetFramework={detailQuery.data.host.target_framework ?? null}
             />
           ) : activeTab === 'packages' ? (
             <PackagesTab

--- a/frontend/src/pages/dashboard/widgets.tsx
+++ b/frontend/src/pages/dashboard/widgets.tsx
@@ -3,8 +3,9 @@ import { Link } from '@tanstack/react-router';
 import api from '@/api/client';
 import { apiErrorMessage } from '@/api/errors';
 import { useDefaultLens } from '@/api/useDefaultLens';
-import { KpiValue, KpiSub, Sparkline, WidgetCard, WidgetState, toneVar } from './primitives';
+import { KpiValue, KpiSub, WidgetCard, WidgetState, toneVar } from './primitives';
 import { relativeTime, severityLabel, severityTone, sourceLabel } from '@/api/eventDisplay';
+import { TrendChart } from '@/components/charts/TrendChart';
 
 // Dashboard widgets — each is a lens into a fleet endpoint, owning its
 // own query so loading/empty/error states are independent. All read-only
@@ -148,20 +149,28 @@ export function WidgetComplianceTrend() {
       ) : (
         (() => {
           const days = q.data.days;
-          const series = days.map((d) => d.avg_score_pct);
           // Guarded by days.length < 2 above, so both ends exist.
           const first = days[0]!;
           const last = days[days.length - 1]!;
           const up = last.avg_score_pct >= first.avg_score_pct;
           return (
             <>
-              <div style={{ marginTop: 2 }}>
-                <Sparkline
-                  data={series}
-                  color={up ? 'var(--ow-ok)' : 'var(--ow-crit)'}
-                  height={70}
-                />
-              </div>
+              <TrendChart
+                points={days.map((d) => ({
+                  date: d.date,
+                  scorePct: d.avg_score_pct,
+                  tooltip: [
+                    d.date,
+                    `${Math.round(d.avg_score_pct)}% avg compliant`,
+                    `${d.hosts} hosts`,
+                    `${d.failing} failing rules`,
+                    `${d.critical_hosts} with critical`,
+                  ],
+                }))}
+                windowDays={30}
+                color={up ? 'var(--ow-ok)' : 'var(--ow-crit)'}
+                height={70}
+              />
               <div
                 style={{
                   display: 'flex',
@@ -171,11 +180,9 @@ export function WidgetComplianceTrend() {
                   color: 'var(--ow-fg-3)',
                 }}
               >
-                <span>
-                  {days.length}d ago · {Math.round(first.avg_score_pct)}%
-                </span>
+                <span>oldest {Math.round(first.avg_score_pct)}%</span>
                 <span style={{ color: up ? 'var(--ow-ok)' : 'var(--ow-crit)' }}>
-                  today · {Math.round(last.avg_score_pct)}%
+                  latest {Math.round(last.avg_score_pct)}%
                 </span>
               </div>
             </>

--- a/frontend/src/pages/groups/GroupsPage.tsx
+++ b/frontend/src/pages/groups/GroupsPage.tsx
@@ -626,16 +626,25 @@ function GroupCard({ group, canWrite }: { group: GroupWithRollup; canWrite: bool
 // family its member hosts are held to (unless a host sets its own override).
 // Writes POST /api/v1/groups/{id}:target (host:write, enforced server-side; the
 // backend rejects a target on an os_category group, D1). Families come from the
-// same corpus-derived list as the org default lens (GET /compliance/frameworks).
-// Read-only callers see the current target as text.
+// full corpus list (GET /compliance/frameworks?all=true) so a target outside the
+// enabled-frameworks allowlist still appears. Read-only callers see it as text.
 function GroupTargetControl({ group, canWrite }: { group: GroupWithRollup; canWrite: boolean }) {
   const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
 
+  // Full corpus family list (all=true), not the enabled-frameworks allowlist: a
+  // group may hold a target the org later drops from the allowlist, so the
+  // picker must still offer it or the current value would show as "None".
   const frameworksQuery = useQuery({
-    queryKey: ['compliance-frameworks'],
+    queryKey: ['compliance-frameworks-all'],
     queryFn: async () => {
-      const { data, error: e, response } = await api.GET('/api/v1/compliance/frameworks');
+      const {
+        data,
+        error: e,
+        response,
+      } = await api.GET('/api/v1/compliance/frameworks', {
+        params: { query: { all: true } },
+      });
       if (!response.ok) throw new Error(apiErrorMessage(e, 'Failed to load frameworks'));
       return data!.frameworks;
     },

--- a/frontend/src/pages/groups/GroupsPage.tsx
+++ b/frontend/src/pages/groups/GroupsPage.tsx
@@ -571,6 +571,9 @@ function GroupCard({ group, canWrite }: { group: GroupWithRollup; canWrite: bool
         </div>
       )}
 
+      {/* compliance target (site groups only, D1) */}
+      {group.kind === 'site' && <GroupTargetControl group={group} canWrite={canWrite} />}
+
       {/* foot: maintenance toggle */}
       <div
         style={{
@@ -615,6 +618,88 @@ function GroupCard({ group, canWrite }: { group: GroupWithRollup; canWrite: bool
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// GroupTargetControl: a SITE group's durable COMPLIANCE TARGET, the framework
+// family its member hosts are held to (unless a host sets its own override).
+// Writes POST /api/v1/groups/{id}:target (host:write, enforced server-side; the
+// backend rejects a target on an os_category group, D1). Families come from the
+// same corpus-derived list as the org default lens (GET /compliance/frameworks).
+// Read-only callers see the current target as text.
+function GroupTargetControl({ group, canWrite }: { group: GroupWithRollup; canWrite: boolean }) {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const frameworksQuery = useQuery({
+    queryKey: ['compliance-frameworks'],
+    queryFn: async () => {
+      const { data, error: e, response } = await api.GET('/api/v1/compliance/frameworks');
+      if (!response.ok) throw new Error(apiErrorMessage(e, 'Failed to load frameworks'));
+      return data!.frameworks;
+    },
+    enabled: canWrite,
+  });
+
+  const [value, setValue] = useState(group.target_framework ?? '');
+  useEffect(() => setValue(group.target_framework ?? ''), [group.target_framework]);
+
+  const mutation = useMutation({
+    mutationFn: async (next: string) => {
+      const { response, error: e } = await api.POST('/api/v1/groups/{id}:target', {
+        params: { path: { id: group.id } },
+        body: { target_framework: next },
+      });
+      if (!response.ok)
+        throw new Error(apiErrorMessage(e, `Failed to set target (HTTP ${response.status})`));
+    },
+    onSuccess: () => {
+      setError(null);
+      queryClient.invalidateQueries({ queryKey: ['groups'] });
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  const label = (id: string) =>
+    frameworksQuery.data?.find((f) => f.id === id)?.label ?? id.toUpperCase();
+
+  if (!canWrite) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+        <span style={{ color: 'var(--ow-fg-3)' }}>Compliance target</span>
+        <span style={{ color: 'var(--ow-fg-1)' }}>
+          {group.target_framework ? label(group.target_framework) : 'None'}
+        </span>
+      </div>
+    );
+  }
+
+  const options = [
+    { value: '', label: 'None (org default)' },
+    ...(frameworksQuery.data ?? []).map((f) => ({ value: f.id, label: f.label })),
+  ];
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+      <span style={{ color: 'var(--ow-fg-3)', fontSize: 12 }}>Compliance target</span>
+      <Select
+        value={value}
+        onChange={(v) => {
+          setValue(v);
+          setError(null);
+          mutation.mutate(v);
+        }}
+        ariaLabel={`Compliance target for ${group.name}`}
+        options={options}
+        width="200px"
+        disabled={frameworksQuery.isLoading || mutation.isPending}
+      />
+      {error && (
+        <span role="alert" style={{ color: 'var(--ow-crit)', fontSize: 11 }}>
+          {error}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/host-detail/ComplianceTab.tsx
+++ b/frontend/src/pages/host-detail/ComplianceTab.tsx
@@ -51,6 +51,7 @@ import { RuleDetailPanel } from '@/pages/scans/RuleDetailPanel';
 import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { useHostRemediations } from '@/hooks/useHostRemediations';
 import { RequestRemediationModal } from '@/components/hosts/RequestRemediationModal';
+import { HostTargetControl } from '@/components/hosts/HostTargetControl';
 import { SeverityPill } from '@/pages/host-detail/SeverityPill';
 
 type LensResponse = components['schemas']['HostComplianceLensResponse'];
@@ -73,10 +74,15 @@ export function ComplianceTab({
   hostId,
   framework,
   onFrameworkChange,
+  targetFramework,
 }: {
   hostId: string;
   framework?: string;
   onFrameworkChange: (next: string | undefined) => void;
+  // The host's OWN durable compliance target (null = inherit). Drives the
+  // Compliance target control; the active lens above it may still differ when
+  // the user switches "View as".
+  targetFramework?: string | null;
 }) {
   // Lens response — keyed under the ['host', hostId] prefix (free
   // scan.completed refresh) and embedding the framework so the cache
@@ -241,11 +247,22 @@ export function ComplianceTab({
         policyVersion={lensQuery.data?.scan_context.policy_version ?? ''}
         scanState={lensQuery.data?.scan_context.scan_state ?? null}
       />
-      <LensBar
-        framework={framework}
-        options={frameworksQuery.data}
-        onFrameworkChange={onFrameworkChange}
-      />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <LensBar
+          framework={framework}
+          options={frameworksQuery.data}
+          onFrameworkChange={onFrameworkChange}
+        />
+        <HostTargetControl hostId={hostId} currentTarget={targetFramework} />
+      </div>
       {body}
       {requestRule && (
         <RequestExceptionModal

--- a/frontend/tests/pages/dashboard.test.ts
+++ b/frontend/tests/pages/dashboard.test.ts
@@ -5,6 +5,7 @@
 //   AC-02  each widget GETs its named live fleet/activity endpoint via useQuery
 //   AC-03  every widget renders loading + error states (WidgetState)
 //   AC-04  read-only (no api.POST/PUT/DELETE) + no em-dash copy
+//   AC-05  compliance trend uses the shared interactive TrendChart
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -17,6 +18,10 @@ const PAGE_SRC = readFileSync(
 );
 const WIDGETS_SRC = readFileSync(resolve(process.cwd(), 'src/pages/dashboard/widgets.tsx'), 'utf8');
 const PRIM_SRC = readFileSync(resolve(process.cwd(), 'src/pages/dashboard/primitives.tsx'), 'utf8');
+const TREND_SRC = readFileSync(
+  resolve(process.cwd(), 'src/components/charts/TrendChart.tsx'),
+  'utf8',
+);
 
 function stripComments(s: string): string {
   return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
@@ -84,5 +89,22 @@ describe('frontend-dashboard — fleet overview', () => {
       expect(src).not.toMatch(/api\.(POST|PUT|DELETE)/);
       expect(stripComments(src)).not.toContain('—');
     }
+  });
+
+  // @ac AC-05
+  test('frontend-dashboard/AC-05 — compliance trend uses the shared interactive TrendChart', () => {
+    // The widget renders TrendChart (not the auto-scaled Sparkline) with a
+    // fleet tooltip and trend-direction color.
+    expect(WIDGETS_SRC).toContain('TrendChart');
+    expect(WIDGETS_SRC).not.toMatch(/<Sparkline/);
+    expect(WIDGETS_SRC).toContain('avg compliant');
+    expect(WIDGETS_SRC).toContain('failing rules');
+    expect(WIDGETS_SRC).toContain('with critical');
+    // No more misleading endpoint labels.
+    expect(WIDGETS_SRC).not.toContain('d ago');
+    expect(WIDGETS_SRC).not.toContain('today ·');
+    // Shared chart enforces the 0..100 domain + 80% target + hover.
+    expect(TREND_SRC).toMatch(/targetPct/);
+    expect(TREND_SRC).toContain('onMouseMove');
   });
 });

--- a/frontend/tests/pages/host-detail-shell.test.ts
+++ b/frontend/tests/pages/host-detail-shell.test.ts
@@ -419,7 +419,7 @@ describe('frontend-host-detail v1.4.0 — live compliance trend card', () => {
   test('frontend-host-detail/AC-38 — trend card queries the snapshot endpoint with the host-prefixed key; honest states', () => {
     const card = PAGE_SRC.slice(
       PAGE_SRC.indexOf('function CardComplianceTrend'),
-      PAGE_SRC.indexOf('function TrendSparkline'),
+      PAGE_SRC.indexOf('// RECENT_LIMIT'),
     );
     expect(card.length).toBeGreaterThan(0);
     expect(card).toContain("queryKey: ['host', hostId, 'compliance_trend']");
@@ -430,9 +430,10 @@ describe('frontend-host-detail v1.4.0 — live compliance trend card', () => {
     // Honest empty state names the rollup, no fabricated zero line.
     expect(card).toContain('No snapshots yet');
     expect(card).toMatch(/hourly rollup/);
-    // Chart renders latest score + over-window delta when data exists.
-    expect(card).toContain('<TrendSparkline days={days} />');
-    expect(card).toMatch(/over \{days\.length\} days/);
+    // Chart renders latest score + first-snapshot-relative delta (the shared
+    // interactive TrendChart; the old index-axis TrendSparkline is gone).
+    expect(card).toContain('<TrendChart');
+    expect(card).toMatch(/since \{first\.date\}/);
     // The page passes the host id into the card.
     expect(PAGE_SRC).toContain('<CardComplianceTrend hostId={hostId} />');
   });

--- a/frontend/tests/pages/host-detail.test.ts
+++ b/frontend/tests/pages/host-detail.test.ts
@@ -17,6 +17,10 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const PAGE_SRC = readFileSync(resolve(process.cwd(), 'src/pages/HostDetailPage.tsx'), 'utf8');
+const TREND_SRC = readFileSync(
+  resolve(process.cwd(), 'src/components/charts/TrendChart.tsx'),
+  'utf8',
+);
 
 describe('frontend-host-detail — structural', () => {
   // @ac AC-02
@@ -127,6 +131,24 @@ describe('frontend-host-detail — structural', () => {
     expect(cardSlice).not.toMatch(/evidence/i);
     // No dead Remediate action before Phase 7.
     expect(cardSlice).not.toContain('Remediate');
+  });
+
+  // @ac AC-46
+  test('frontend-host-detail/AC-46 — Compliance trend uses the shared interactive TrendChart', () => {
+    // Host card wires the shared chart with a per-point tooltip and a
+    // first-snapshot-relative delta label (not a point count).
+    expect(PAGE_SRC).toContain('TrendChart');
+    expect(PAGE_SRC).toContain('scorePct: d.score_pct');
+    expect(PAGE_SRC).toContain('passing`');
+    expect(PAGE_SRC).toContain('% since {first.date}');
+    // Shared chart: fixed 0..100 domain (score/100), 80% target line, hover
+    // state + tooltip, and a gap-broken line (dayIndex delta != 1).
+    expect(TREND_SRC).toContain('useState');
+    expect(TREND_SRC).toContain('onMouseMove');
+    expect(TREND_SRC).toMatch(/targetPct/);
+    expect(TREND_SRC).toMatch(/\/\s*100/); // 0..100 domain
+    expect(TREND_SRC).toMatch(/!==\s*1/); // gap-break: not exactly one day apart
+    expect(TREND_SRC).toContain('tooltip');
   });
 
   // @ac AC-14

--- a/frontend/tests/pages/settings-exception-queue.test.ts
+++ b/frontend/tests/pages/settings-exception-queue.test.ts
@@ -4,6 +4,7 @@
 //   AC-01  query key + endpoints + invalidation
 //   AC-02  permission-gated actions
 //   AC-03  409 inline + host link + stub removed
+//   AC-04  lapsed indicator on a past-expiry pending row
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -54,5 +55,13 @@ describe('frontend-settings-exception-queue — source inspection', () => {
     expect(POLICIES).toContain('<ExceptionQueue />');
     const section = POLICIES.slice(POLICIES.indexOf('Exception workflow (LIVE)'), POLICIES.length);
     expect(section).not.toContain('BackendPendingBanner');
+  });
+
+  // @ac AC-04
+  test('frontend-settings-exception-queue/AC-04 — lapsed indicator on a past-expiry pending row', () => {
+    // A requested row whose expires_at is already in the past is marked lapsed.
+    expect(SRC).toContain("e.status === 'requested'");
+    expect(SRC).toMatch(/new Date\(e\.expires_at\)\.getTime\(\) <= Date\.now\(\)/);
+    expect(SRC).toContain('(lapsed)');
   });
 });

--- a/frontend/tests/pages/settings.test.ts
+++ b/frontend/tests/pages/settings.test.ts
@@ -71,6 +71,14 @@ const PREFS_STORE_SRC = readFileSync(
   resolve(process.cwd(), 'src/store/usePreferencesStore.ts'),
   'utf8',
 );
+const ENABLED_FRAMEWORKS_SRC = readFileSync(
+  resolve(process.cwd(), 'src/components/settings/EnabledFrameworksCard.tsx'),
+  'utf8',
+);
+const DEFAULT_LENS_SRC = readFileSync(
+  resolve(process.cwd(), 'src/components/settings/DefaultLensCard.tsx'),
+  'utf8',
+);
 
 describe('frontend-settings — structural', () => {
   // @ac AC-01
@@ -546,5 +554,26 @@ describe('frontend-settings — structural', () => {
     expect(AUDIT_SRC).toMatch(/setExportError/);
     // Reading remains GET-only.
     expect(AUDIT_SRC).not.toMatch(/api\.(POST|PATCH|PUT|DELETE)\(/);
+  });
+
+  // @ac AC-33
+  test('frontend-settings/AC-33 — Limit lens options toggle never persists an empty allowlist', () => {
+    // The toggle is disabled when there are no corpus families to restrict.
+    expect(ENABLED_FRAMEWORKS_SRC).toMatch(/allFrameworks\.length === 0/);
+    expect(ENABLED_FRAMEWORKS_SRC).toMatch(/disabled=\{busy \|\| noFamilies\}/);
+    // Turning it on with no families returns early (no empty save).
+    expect(ENABLED_FRAMEWORKS_SRC).toMatch(/if \(on && noFamilies\) return/);
+    // An explanatory note is shown when the corpus has no families.
+    expect(ENABLED_FRAMEWORKS_SRC).toContain('No framework families in the scanned corpus yet');
+  });
+
+  // @ac AC-34
+  test('frontend-settings/AC-34 — DefaultLensCard preserves the enabled-frameworks allowlist', () => {
+    // The default-lens PUT carries enabled_frameworks from the current config
+    // so changing the default never wipes the allowlist.
+    expect(DEFAULT_LENS_SRC).toMatch(
+      /enabled_frameworks:\s*configQuery\.data\?\.enabled_frameworks/,
+    );
+    expect(DEFAULT_LENS_SRC).toContain('default_framework: next');
   });
 });

--- a/internal/exception/service.go
+++ b/internal/exception/service.go
@@ -121,7 +121,7 @@ func (s *Service) Request(ctx context.Context, hostID uuid.UUID, ruleID, reason 
 // Emits compliance.exception.approved.
 func (s *Service) Approve(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
 	e, err := s.review(ctx, id, reviewedBy, note, StatusRequested, StatusApproved,
-		audit.ComplianceExceptionApproved, true)
+		audit.ComplianceExceptionApproved, true, true)
 	if err == nil {
 		s.notifyDecided(ctx, e, true)
 	}
@@ -133,7 +133,7 @@ func (s *Service) Approve(ctx context.Context, id, reviewedBy uuid.UUID, note st
 // compliance.exception.rejected.
 func (s *Service) Reject(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
 	e, err := s.review(ctx, id, reviewedBy, note, StatusRequested, StatusRejected,
-		audit.ComplianceExceptionRejected, true)
+		audit.ComplianceExceptionRejected, true, false)
 	if err == nil {
 		s.notifyDecided(ctx, e, false)
 	}
@@ -145,7 +145,7 @@ func (s *Service) Reject(ctx context.Context, id, reviewedBy uuid.UUID, note str
 // not a self-review concern). Emits compliance.exception.revoked.
 func (s *Service) Revoke(ctx context.Context, id, reviewedBy uuid.UUID, note string) (Exception, error) {
 	return s.review(ctx, id, reviewedBy, note, StatusApproved, StatusRevoked,
-		audit.ComplianceExceptionRevoked, false)
+		audit.ComplianceExceptionRevoked, false, false)
 }
 
 // review performs a guarded state transition fromState -> toState. The
@@ -153,19 +153,21 @@ func (s *Service) Revoke(ctx context.Context, id, reviewedBy uuid.UUID, note str
 // cannot double-transition; a zero-row update means the row was
 // missing or already moved.
 func (s *Service) review(ctx context.Context, id, reviewedBy uuid.UUID, note string,
-	fromState, toState Status, code audit.Code, blockSelfReview bool) (Exception, error) {
+	fromState, toState Status, code audit.Code, blockSelfReview, enforceNotExpired bool) (Exception, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return Exception{}, fmt.Errorf("exception: review begin: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Lock the row and read the requester for the self-review check.
+	// Lock the row and read the requester for the self-review check plus
+	// expires_at for the lapsed-request guard.
 	var status string
 	var requestedBy uuid.UUID
+	var expiresAt *time.Time
 	err = tx.QueryRow(ctx, `
-		SELECT status, requested_by FROM compliance_exceptions
-		 WHERE id = $1 FOR UPDATE`, id).Scan(&status, &requestedBy)
+		SELECT status, requested_by, expires_at FROM compliance_exceptions
+		 WHERE id = $1 FOR UPDATE`, id).Scan(&status, &requestedBy, &expiresAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Exception{}, ErrNotFound
 	}
@@ -177,6 +179,11 @@ func (s *Service) review(ctx context.Context, id, reviewedBy uuid.UUID, note str
 	}
 	if blockSelfReview && requestedBy == reviewedBy {
 		return Exception{}, ErrSelfReview
+	}
+	// A lapsed request cannot be approved into an immediately-dead waiver.
+	// Only Approve enforces this (enforceNotExpired); Reject/Revoke do not.
+	if enforceNotExpired && expiresAt != nil && !expiresAt.After(time.Now()) {
+		return Exception{}, ErrExpired
 	}
 
 	row := tx.QueryRow(ctx, `
@@ -283,14 +290,21 @@ func (s *Service) ActiveRuleIDsForHost(ctx context.Context, hostID uuid.UUID) (m
 	return out, rows.Err()
 }
 
-// ExpireSweep flips approved exceptions whose expires_at has passed to
-// 'expired' and emits compliance.exception.expired for each. Returns
-// the count expired. Idempotent: a second run finds nothing.
+// ExpireSweep flips any OPEN exception (approved OR requested) whose
+// expires_at has passed to 'expired' and emits compliance.exception.expired
+// for each. Returns the count expired. Idempotent: a second run finds nothing.
+//
+// A requested row is expired too: its expires_at is the requested waiver end,
+// so once that has passed there is nothing left to approve — leaving it pending
+// forever would strand it and block a fresh request for the same host+rule
+// (the open-uniqueness rule, C-02). Approve independently rejects a lapsed
+// request (ErrExpired), so the two guards agree.
 func (s *Service) ExpireSweep(ctx context.Context) (int, error) {
 	rows, err := s.pool.Query(ctx, `
 		UPDATE compliance_exceptions
 		   SET status = 'expired', updated_at = now()
-		 WHERE status = 'approved' AND expires_at IS NOT NULL AND expires_at <= now()
+		 WHERE status IN ('approved', 'requested')
+		   AND expires_at IS NOT NULL AND expires_at <= now()
 		RETURNING `+selectCols)
 	if err != nil {
 		return 0, fmt.Errorf("exception: expire sweep: %w", err)

--- a/internal/exception/service_test.go
+++ b/internal/exception/service_test.go
@@ -9,6 +9,7 @@
 //	AC-04  TestActiveQueries_OverlayNeverMutatesRuleState
 //	AC-05  TestExpireSweep_FlipsAndIdempotent
 //	AC-07  TestListHostNameJoin
+//	AC-08  TestApprove_RejectsLapsedRequest
 package exception
 
 import (
@@ -268,28 +269,88 @@ func TestExpireSweep_FlipsAndIdempotent(t *testing.T) {
 
 		past := time.Now().Add(-time.Hour)
 		future := time.Now().Add(time.Hour)
-		e1, _ := svc.Request(ctx, hostID, "rule-1", "reason", requester, &past)
-		_, _ = svc.Approve(ctx, e1.ID, reviewer, "ok")
-		e2, _ := svc.Request(ctx, hostID, "rule-2", "reason", requester, &future)
-		_, _ = svc.Approve(ctx, e2.ID, reviewer, "ok")
-		e3, _ := svc.Request(ctx, hostID, "rule-3", "reason", requester, nil) // no expiry
-		_, _ = svc.Approve(ctx, e3.ID, reviewer, "ok")
+
+		// approved + past: approve with a FUTURE expiry, then age it into the
+		// past via SQL. (Approve now rejects a past expiry, AC-08, so we cannot
+		// request-past-then-approve to build this row.)
+		eAppPast, _ := svc.Request(ctx, hostID, "rule-app-past", "reason", requester, &future)
+		if _, err := svc.Approve(ctx, eAppPast.ID, reviewer, "ok"); err != nil {
+			t.Fatalf("approve rule-app-past: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`UPDATE compliance_exceptions SET expires_at = $2 WHERE id = $1`, eAppPast.ID, past); err != nil {
+			t.Fatalf("age approved row: %v", err)
+		}
+		// requested + past: a request whose requested end passed while pending.
+		if _, err := svc.Request(ctx, hostID, "rule-req-past", "reason", requester, &past); err != nil {
+			t.Fatalf("request rule-req-past: %v", err)
+		}
+		// approved + future and approved + null: both must survive the sweep.
+		eFut, _ := svc.Request(ctx, hostID, "rule-fut", "reason", requester, &future)
+		_, _ = svc.Approve(ctx, eFut.ID, reviewer, "ok")
+		eNull, _ := svc.Request(ctx, hostID, "rule-null", "reason", requester, nil)
+		_, _ = svc.Approve(ctx, eNull.ID, reviewer, "ok")
 
 		calls = nil
 		n, err := svc.ExpireSweep(ctx)
-		if err != nil || n != 1 {
-			t.Fatalf("ExpireSweep = %d (err %v), want 1 (only the past-expiry row)", n, err)
+		if err != nil || n != 2 {
+			t.Fatalf("ExpireSweep = %d (err %v), want 2 (approved-past + requested-past)", n, err)
 		}
-		if len(calls) != 1 || calls[0].Code != audit.ComplianceExceptionExpired {
-			t.Errorf("sweep audit = %+v, want one expired", calls)
+		if len(calls) != 2 {
+			t.Fatalf("sweep audit = %+v, want two expired", calls)
 		}
-		// future + null expiry untouched.
+		for _, c := range calls {
+			if c.Code != audit.ComplianceExceptionExpired {
+				t.Errorf("sweep audit code = %v, want expired", c.Code)
+			}
+		}
+		// future + null expiry (both approved) untouched.
 		if c, _ := svc.ActiveCountForHost(ctx, hostID); c != 2 {
 			t.Errorf("active after sweep = %d, want 2", c)
 		}
 		// idempotent.
 		if n2, _ := svc.ExpireSweep(ctx); n2 != 0 {
 			t.Errorf("second sweep = %d, want 0", n2)
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: a lapsed request cannot be approved into an immediately-dead waiver.
+func TestApprove_RejectsLapsedRequest(t *testing.T) {
+	t.Run("api-compliance-exceptions/AC-08", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		requester := seedUser(t, pool, "req")
+		reviewer := seedUser(t, pool, "rev")
+		hostID := seedHost(t, pool, requester)
+		svc := NewService(pool, nil)
+
+		// A request whose expires_at is already in the past (it lapsed while
+		// pending). Approve must refuse it and leave the row unchanged.
+		past := time.Now().Add(-time.Hour)
+		e, err := svc.Request(ctx, hostID, "rule-lapsed", "reason", requester, &past)
+		if err != nil {
+			t.Fatalf("Request: %v", err)
+		}
+		if _, err := svc.Approve(ctx, e.ID, reviewer, "ok"); !errors.Is(err, ErrExpired) {
+			t.Fatalf("Approve(lapsed) err = %v, want ErrExpired", err)
+		}
+		var status string
+		if err := pool.QueryRow(ctx,
+			`SELECT status FROM compliance_exceptions WHERE id = $1`, e.ID).Scan(&status); err != nil {
+			t.Fatalf("read status: %v", err)
+		}
+		if Status(status) != StatusRequested {
+			t.Errorf("status after refused approve = %q, want requested", status)
+		}
+
+		// A future-dated request approves fine: the guard is specific to a
+		// past expiry, not to having an expiry at all.
+		future := time.Now().Add(time.Hour)
+		e2, _ := svc.Request(ctx, hostID, "rule-ok", "reason", requester, &future)
+		if _, err := svc.Approve(ctx, e2.ID, reviewer, "ok"); err != nil {
+			t.Errorf("Approve(future) err = %v, want nil", err)
 		}
 	})
 }

--- a/internal/exception/types.go
+++ b/internal/exception/types.go
@@ -78,4 +78,9 @@ var (
 	ErrSelfReview = errors.New("exception: requester cannot review their own request")
 	// ErrInvalidInput is returned for empty rule_id/reason etc.
 	ErrInvalidInput = errors.New("exception: invalid input")
+	// ErrExpired is returned when Approve is called on a requested row whose
+	// expires_at has already passed: the requested waiver end is in the past,
+	// so approving it would create an immediately-dead exception. The
+	// requester must submit a fresh request with a future expiry.
+	ErrExpired = errors.New("exception: the request's expiry has already passed")
 )

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -25,6 +25,7 @@ var (
 	ErrInvalidHost    = errors.New("host: invalid input")
 	ErrDuplicateHost  = errors.New("host: hostname already exists in this environment")
 	ErrInvalidCreator = errors.New("host: created_by user does not exist")
+	ErrInvalidTarget  = errors.New("host: target_framework is too long or has invalid characters")
 )
 
 // Host is the safe shape returned by every read API.
@@ -55,6 +56,14 @@ type Host struct {
 	Architecture       *string
 	PlatformIdentifier *string
 	OSDiscoveredAt     *time.Time
+
+	// Phase 3 (compliance-targets) — the host's own durable target
+	// framework: operator intent about which framework family this host is
+	// held to (its default lens, and the per-host override that wins over
+	// any site-group target in host_effective_target). nil = inherit
+	// (site-group target, else the org default). Set via SetTarget; read
+	// by GetByID/UpdateHost. Spec system-compliance-lens, api-hosts.
+	TargetFramework *string
 }
 
 // CreateParams is the input to CreateHost. Validation enforces the
@@ -190,7 +199,8 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (Host, error) {
 		       environment, tags, group_id, COALESCE(username, ''),
 		       created_by, created_at, updated_at,
 		       maintenance_mode, check_priority,
-		       os_family, os_version, architecture, platform_identifier, os_discovered_at
+		       os_family, os_version, architecture, platform_identifier, os_discovered_at,
+		       target_framework
 		FROM hosts WHERE id = $1 AND deleted_at IS NULL`
 	var h Host
 	err := s.pool.QueryRow(ctx, stmt, id).Scan(
@@ -200,6 +210,7 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (Host, error) {
 		&h.CreatedBy, &h.CreatedAt, &h.UpdatedAt,
 		&h.MaintenanceMode, &h.CheckPriority,
 		&h.OSFamily, &h.OSVersion, &h.Architecture, &h.PlatformIdentifier, &h.OSDiscoveredAt,
+		&h.TargetFramework,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -208,6 +219,66 @@ func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (Host, error) {
 		return Host{}, fmt.Errorf("host: query: %w", err)
 	}
 	return h, nil
+}
+
+// SetTarget sets (or clears, when family is "") the host's own compliance
+// target framework. This is the per-host override: in host_effective_target it
+// wins over any site-group target. Unlike a group target there is no site-only
+// constraint (D1) — a host may always carry its own target. The family token is
+// resolved leniently against the live corpus at query time, so this only
+// bounds garbage/length (D3 handles a target with no matching corpus key as
+// N/A, not 0%). Spec system-compliance-lens, api-hosts.
+func (s *Service) SetTarget(ctx context.Context, id uuid.UUID, family string) (Host, error) {
+	if !validTargetFramework(family) {
+		return Host{}, ErrInvalidTarget
+	}
+	var arg *string
+	if family != "" {
+		arg = &family
+	}
+	const stmt = `
+		UPDATE hosts SET target_framework = $2, updated_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+		RETURNING id, hostname, host(ip_address), port,
+		          COALESCE(display_name, ''), COALESCE(description, ''),
+		          environment, tags, group_id, COALESCE(username, ''),
+		          created_by, created_at, updated_at,
+		          maintenance_mode, check_priority,
+		          os_family, os_version, architecture, platform_identifier, os_discovered_at,
+		          target_framework`
+	var h Host
+	err := s.pool.QueryRow(ctx, stmt, id, arg).Scan(
+		&h.ID, &h.Hostname, &h.IPAddress, &h.Port,
+		&h.DisplayName, &h.Description,
+		&h.Environment, &h.Tags, &h.GroupID, &h.Username,
+		&h.CreatedBy, &h.CreatedAt, &h.UpdatedAt,
+		&h.MaintenanceMode, &h.CheckPriority,
+		&h.OSFamily, &h.OSVersion, &h.Architecture, &h.PlatformIdentifier, &h.OSDiscoveredAt,
+		&h.TargetFramework,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Host{}, ErrHostNotFound
+		}
+		return Host{}, fmt.Errorf("host: set target: %w", err)
+	}
+	return h, nil
+}
+
+// validTargetFramework bounds a compliance-target family token: empty (clear)
+// or <=64 chars of lowercase alnum plus _-. It mirrors the group service's
+// validator; the token is resolved leniently against the live corpus at query
+// time, so this only blocks garbage / length.
+func validTargetFramework(f string) bool {
+	if len(f) > 64 {
+		return false
+	}
+	for _, r := range f {
+		if !(r == '_' || r == '-' || r == '.' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
 }
 
 // UpdateHost applies the supplied patch fields and bumps updated_at.
@@ -271,7 +342,8 @@ func (s *Service) UpdateHost(ctx context.Context, id uuid.UUID, p UpdateParams) 
 		          environment, tags, group_id, COALESCE(username, ''),
 		          created_by, created_at, updated_at,
 		          maintenance_mode, check_priority,
-		          os_family, os_version, architecture, platform_identifier, os_discovered_at`,
+		          os_family, os_version, architecture, platform_identifier, os_discovered_at,
+		          target_framework`,
 		strings.Join(sets, ", "), idPlaceholder)
 
 	var h Host
@@ -282,6 +354,7 @@ func (s *Service) UpdateHost(ctx context.Context, id uuid.UUID, p UpdateParams) 
 		&h.CreatedBy, &h.CreatedAt, &h.UpdatedAt,
 		&h.MaintenanceMode, &h.CheckPriority,
 		&h.OSFamily, &h.OSVersion, &h.Architecture, &h.PlatformIdentifier, &h.OSDiscoveredAt,
+		&h.TargetFramework,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/host/set_target_db_test.go
+++ b/internal/host/set_target_db_test.go
@@ -1,0 +1,76 @@
+// @spec system-compliance-lens
+//
+// Host compliance-target (Phase 3 compliance-targets): host.SetTarget's
+// set/clear/validate/not-found and GetByID surfacing the stored value. The
+// per-host target is the override that wins in host_effective_target; unlike a
+// group target it carries no site-only constraint. Kept in its own file so its
+// spec annotation does not re-attribute the system-host-inventory tests in
+// host_test.go.
+
+package host
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// @ac AC-08
+// AC-08: host.SetTarget sets/clears/validates the host's own target_framework,
+// returns ErrHostNotFound for an unknown host, and GetByID surfaces the value.
+func TestSetTarget_HostOverride(t *testing.T) {
+	t.Run("system-compliance-lens/AC-08", func(t *testing.T) {
+		svc, _, createdBy := freshService(t)
+		ctx := context.Background()
+
+		h, err := svc.CreateHost(ctx, CreateParams{
+			Hostname: "target.example.com", IPAddress: "192.0.2.20",
+			Environment: "production", CreatedBy: createdBy,
+		})
+		if err != nil {
+			t.Fatalf("CreateHost: %v", err)
+		}
+		// A fresh host has no own target.
+		if h.TargetFramework != nil {
+			t.Errorf("new host TargetFramework = %v, want nil", h.TargetFramework)
+		}
+
+		// Set a valid family.
+		got, err := svc.SetTarget(ctx, h.ID, "stig")
+		if err != nil {
+			t.Fatalf("SetTarget(stig): %v", err)
+		}
+		if got.TargetFramework == nil || *got.TargetFramework != "stig" {
+			t.Errorf("target = %v, want stig", got.TargetFramework)
+		}
+		// GetByID surfaces the stored value.
+		reread, err := svc.GetByID(ctx, h.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if reread.TargetFramework == nil || *reread.TargetFramework != "stig" {
+			t.Errorf("GetByID target = %v, want stig", reread.TargetFramework)
+		}
+
+		// Clear it (empty family) -> nil.
+		cleared, err := svc.SetTarget(ctx, h.ID, "")
+		if err != nil {
+			t.Fatalf("SetTarget(clear): %v", err)
+		}
+		if cleared.TargetFramework != nil {
+			t.Errorf("cleared target = %v, want nil", cleared.TargetFramework)
+		}
+
+		// Invalid family value rejected.
+		if _, err := svc.SetTarget(ctx, h.ID, "BAD SPACE"); !errors.Is(err, ErrInvalidTarget) {
+			t.Errorf("SetTarget(bad) err = %v, want ErrInvalidTarget", err)
+		}
+
+		// Unknown host -> ErrHostNotFound.
+		if _, err := svc.SetTarget(ctx, uuid.New(), "stig"); !errors.Is(err, ErrHostNotFound) {
+			t.Errorf("SetTarget(unknown) err = %v, want ErrHostNotFound", err)
+		}
+	})
+}

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -2641,11 +2641,14 @@ type HostResponse struct {
 	OsVersion *string `json:"os_version,omitempty"`
 
 	// PlatformIdentifier e.g. platform:el9
-	PlatformIdentifier *string    `json:"platform_identifier,omitempty"`
-	Port               int        `json:"port"`
-	Tags               *[]string  `json:"tags,omitempty"`
-	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
-	Username           *string    `json:"username,omitempty"`
+	PlatformIdentifier *string   `json:"platform_identifier,omitempty"`
+	Port               int       `json:"port"`
+	Tags               *[]string `json:"tags,omitempty"`
+
+	// TargetFramework Host's own compliance target framework family (absent when unset/inheriting).
+	TargetFramework *string    `json:"target_framework,omitempty"`
+	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
+	Username        *string    `json:"username,omitempty"`
 }
 
 // HostScanContext defines model for HostScanContext.
@@ -2704,6 +2707,12 @@ type HostSystemInfo struct {
 	// SelinuxStatus Enforcing | Permissive | Disabled | empty if not present
 	SelinuxStatus *string `json:"selinux_status,omitempty"`
 	SwapTotalMb   *int    `json:"swap_total_mb,omitempty"`
+}
+
+// HostTargetRequest defines model for HostTargetRequest.
+type HostTargetRequest struct {
+	// TargetFramework Compliance target family id, or empty to clear the host's own target.
+	TargetFramework string `json:"target_framework"`
 }
 
 // HostUpdateRequest defines model for HostUpdateRequest.
@@ -3964,6 +3973,9 @@ type PatchHostByIDJSONRequestBody = HostUpdateRequest
 // PostHostExceptionJSONRequestBody defines body for PostHostException for application/json ContentType.
 type PostHostExceptionJSONRequestBody = ExceptionRequest
 
+// PostHostTargetJSONRequestBody defines body for PostHostTarget for application/json ContentType.
+type PostHostTargetJSONRequestBody = HostTargetRequest
+
 // PostNotificationChannelJSONRequestBody defines body for PostNotificationChannel for application/json ContentType.
 type PostNotificationChannelJSONRequestBody = NotificationChannelCreate
 
@@ -4278,6 +4290,9 @@ type ServerInterface interface {
 	// Read the latest Discovery facts for one host
 	// (GET /api/v1/hosts/{id}/system-info)
 	GetHostSystemInfo(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
+	// Set or clear a host's compliance target framework
+	// (POST /api/v1/hosts/{id}:target)
+	PostHostTarget(w http.ResponseWriter, r *http.Request, id openapi_types.UUID)
 	// List OS Intelligence change events
 	// (GET /api/v1/intelligence/events)
 	GetIntelligenceEvents(w http.ResponseWriter, r *http.Request, params GetIntelligenceEventsParams)
@@ -4992,6 +5007,12 @@ func (_ Unimplemented) PostHostScan(w http.ResponseWriter, r *http.Request, id o
 // Read the latest Discovery facts for one host
 // (GET /api/v1/hosts/{id}/system-info)
 func (_ Unimplemented) GetHostSystemInfo(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Set or clear a host's compliance target framework
+// (POST /api/v1/hosts/{id}:target)
+func (_ Unimplemented) PostHostTarget(w http.ResponseWriter, r *http.Request, id openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -8123,6 +8144,32 @@ func (siw *ServerInterfaceWrapper) GetHostSystemInfo(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// PostHostTarget operation middleware
+func (siw *ServerInterfaceWrapper) PostHostTarget(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostHostTarget(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetIntelligenceEvents operation middleware
 func (siw *ServerInterfaceWrapper) GetIntelligenceEvents(w http.ResponseWriter, r *http.Request) {
 
@@ -10178,6 +10225,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/hosts/{id}/system-info", wrapper.GetHostSystemInfo)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/hosts/{id}:target", wrapper.PostHostTarget)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/intelligence/events", wrapper.GetIntelligenceEvents)

--- a/internal/server/api_host_compliance_test.go
+++ b/internal/server/api_host_compliance_test.go
@@ -23,6 +23,7 @@
 //	       TestFrameworkCompatibleWithOS_Table (non-DSN)
 //	       TestFirstSentence_TrimsCatalogProse (non-DSN)
 //	AC-17  TestHostComplianceLens_ScanStateReflectsInFlightRun
+//	AC-18  TestHostComplianceFrameworks_AllowlistNarrowing
 package server
 
 import (
@@ -1078,6 +1079,81 @@ func TestHostComplianceFrameworks_OSAwareFiltering(t *testing.T) {
 		status, body := getLens(t, url, auth.RoleViewer, rhel8.String(), "?framework=cis_rhel9")
 		if status != http.StatusOK || len(body.Rules) != 1 {
 			t.Errorf("deep-linked cis_rhel9 lens: status=%d rules=%d, want 200/1", status, len(body.Rules))
+		}
+	})
+}
+
+// @ac AC-18
+// AC-18: the per-host lens bar narrows to the enabled-frameworks allowlist.
+func TestHostComplianceFrameworks_AllowlistNarrowing(t *testing.T) {
+	t.Run("api-host-compliance/AC-18", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+
+		// os_family NULL (seedHostForIntel) disables the OS-aware filter, so
+		// this exercises the allowlist filter in isolation.
+		hostID := seedHostForIntel(t, pool)
+		seedRuleStateForHostWithFrameworks(t, pool, hostID, "r.multi", "pass",
+			map[string]string{
+				"cis_rhel9": "1.1", "nist_800_53": "AC-6", "pci_dss_4": "2.2",
+				"srg": "SRG-1", "stig_rhel9": "V-1",
+			})
+
+		setAllowlist := func(list []string) {
+			t.Helper()
+			pr := doReq(t, asRole(t, "PUT", url+"/api/v1/system/compliance/config", auth.RoleAdmin,
+				map[string]any{"default_framework": "", "enabled_frameworks": list}))
+			if pr.StatusCode != http.StatusOK {
+				t.Fatalf("set allowlist %v = %d, want 200", list, pr.StatusCode)
+			}
+			pr.Body.Close()
+		}
+		fetch := func() []string {
+			t.Helper()
+			resp := doReq(t, asRole(t, "GET",
+				url+"/api/v1/hosts/"+hostID.String()+"/compliance/frameworks", auth.RoleViewer, nil))
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("frameworks status = %d, want 200", resp.StatusCode)
+			}
+			var body struct {
+				Frameworks []struct {
+					FrameworkID string `json:"framework_id"`
+				} `json:"frameworks"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			out := make([]string, 0, len(body.Frameworks))
+			for _, f := range body.Frameworks {
+				out = append(out, f.FrameworkID)
+			}
+			return out
+		}
+
+		// Allowlist {cis, nist_800_53, stig} → pci_dss_4 + srg dropped by family.
+		setAllowlist([]string{"cis", "nist_800_53", "stig"})
+		got := fetch()
+		want := []string{"cis_rhel9", "nist_800_53", "stig_rhel9"}
+		if len(got) != len(want) {
+			t.Fatalf("narrowed lenses = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("narrowed lenses[%d] = %s, want %s", i, got[i], want[i])
+			}
+		}
+
+		// Empty allowlist → all five families list again.
+		setAllowlist([]string{})
+		if got := fetch(); len(got) != 5 {
+			t.Errorf("empty-allowlist lenses = %v, want all 5", got)
+		}
+
+		// A disabled family stays viewable by direct link (only the picker filters).
+		setAllowlist([]string{"cis", "nist_800_53", "stig"})
+		status, body := getLens(t, url, auth.RoleViewer, hostID.String(), "?framework=pci_dss_4")
+		if status != http.StatusOK || len(body.Rules) != 1 {
+			t.Errorf("deep-linked pci_dss_4 lens: status=%d rules=%d, want 200/1", status, len(body.Rules))
 		}
 	})
 }

--- a/internal/server/exception_handlers.go
+++ b/internal/server/exception_handlers.go
@@ -101,6 +101,9 @@ func mapExceptionErr(w http.ResponseWriter, err error) bool {
 	case errors.Is(err, exception.ErrSelfReview):
 		writeError(w, http.StatusConflict, "exceptions.self_review", "client",
 			"the requester cannot review their own exception", false)
+	case errors.Is(err, exception.ErrExpired):
+		writeError(w, http.StatusConflict, "exceptions.expired", "client",
+			"the request's expiry has already passed; ask the requester to resubmit with a future expiry", false)
 	case errors.Is(err, exception.ErrInvalidInput):
 		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
 			"rule_id and reason are required", false)

--- a/internal/server/group_handlers.go
+++ b/internal/server/group_handlers.go
@@ -91,17 +91,18 @@ func toAPIRollup(r group.Rollup) api.GroupRollup {
 // toAPIGroupWithRollup maps a service group+rollup to the wire shape.
 func toAPIGroupWithRollup(g group.GroupWithRollup) api.GroupWithRollup {
 	return api.GroupWithRollup{
-		Id:          openapitypes.UUID(g.ID),
-		Name:        g.Name,
-		Kind:        api.GroupWithRollupKind(g.Kind),
-		Subtype:     g.Subtype,
-		Color:       g.Color,
-		Membership:  api.GroupWithRollupMembership(g.Membership),
-		Maintenance: g.Maintenance,
-		CreatedAt:   g.CreatedAt,
-		UpdatedAt:   g.UpdatedAt,
-		MatchFamily: matchFamilyPtr(g.MatchFamily),
-		Rollup:      toAPIRollup(g.Rollup),
+		Id:              openapitypes.UUID(g.ID),
+		Name:            g.Name,
+		Kind:            api.GroupWithRollupKind(g.Kind),
+		Subtype:         g.Subtype,
+		Color:           g.Color,
+		Membership:      api.GroupWithRollupMembership(g.Membership),
+		Maintenance:     g.Maintenance,
+		CreatedAt:       g.CreatedAt,
+		UpdatedAt:       g.UpdatedAt,
+		MatchFamily:     matchFamilyPtr(g.MatchFamily),
+		TargetFramework: matchFamilyPtr(g.TargetFramework),
+		Rollup:          toAPIRollup(g.Rollup),
 	}
 }
 

--- a/internal/server/host_compliance_lens_handler.go
+++ b/internal/server/host_compliance_lens_handler.go
@@ -30,6 +30,7 @@ import (
 	openapitypes "github.com/oapi-codegen/runtime/types"
 
 	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/framework"
 	"github.com/Hanalyx/openwatch/internal/host"
 	"github.com/Hanalyx/openwatch/internal/scanruns"
 	"github.com/Hanalyx/openwatch/internal/server/api"
@@ -305,6 +306,21 @@ func (h *handlers) GetHostComplianceFrameworks(
 	}
 	defer rows.Close()
 
+	// Enabled-frameworks allowlist (system-compliance-lens C-04): the lens
+	// bar offers only the framework FAMILIES the org enabled. Empty allowlist =
+	// every family (unchanged). A config-load error degrades to showing all —
+	// this is a display filter, not a security boundary, exactly like the
+	// org-level GET /compliance/frameworks. The ?framework= deep link and the
+	// overall aggregate stay unfiltered (a disabled family is still viewable by
+	// direct link; only the offered chips are narrowed).
+	var enabledFamilies map[string]bool
+	if cfg, cerr := h.sysCfg.LoadCompliance(ctx); cerr == nil && len(cfg.EnabledFrameworks) > 0 {
+		enabledFamilies = make(map[string]bool, len(cfg.EnabledFrameworks))
+		for _, f := range cfg.EnabledFrameworks {
+			enabledFamilies[f] = true
+		}
+	}
+
 	resp := api.HostComplianceFrameworksResponse{Frameworks: []api.HostComplianceFramework{}}
 	for rows.Next() {
 		var item api.HostComplianceFramework
@@ -320,6 +336,10 @@ func (h *handlers) GetHostComplianceFrameworks(
 		// exist because shared rules carry refs for several framework
 		// versions; offering a RHEL 9 lens on a RHEL 8 host is noise.
 		if !frameworkCompatibleWithOS(item.FrameworkId, osFamily, osVersion) {
+			continue
+		}
+		// Allowlist narrowing: drop a family the org disabled as a lens.
+		if enabledFamilies != nil && !enabledFamilies[framework.FamilyOf(item.FrameworkId)] {
 			continue
 		}
 		item.Passing = int(passing)

--- a/internal/server/hosts_handlers.go
+++ b/internal/server/hosts_handlers.go
@@ -312,6 +312,39 @@ func (h *handlers) PatchHostByID(w http.ResponseWriter, r *http.Request, id open
 	writeJSON(w, http.StatusOK, hostResponse(updated))
 }
 
+// PostHostTarget sets or clears the host's own compliance target framework
+// (the per-host override that wins over any site-group target). host:write.
+// Spec api-hosts, system-compliance-lens.
+func (h *handlers) PostHostTarget(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.HostWrite); denied {
+		return
+	}
+	var req api.HostTargetRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "validation.field_required", "client",
+			"malformed request body", false)
+		return
+	}
+	updated, err := h.hosts.SetTarget(r.Context(), uuid.UUID(id), req.TargetFramework)
+	if err != nil {
+		switch {
+		case errors.Is(err, host.ErrInvalidTarget):
+			writeError(w, http.StatusBadRequest, "hosts.invalid_input", "client",
+				"target_framework is too long or has invalid characters", false)
+		case errors.Is(err, host.ErrHostNotFound):
+			writeError(w, http.StatusNotFound, "hosts.not_found", "client",
+				"host not found", false)
+		default:
+			writeError(w, http.StatusInternalServerError, "server.error", "server",
+				err.Error(), true)
+		}
+		return
+	}
+	emitAudit(r, audit.HostUpdated, updated.ID.String(), nil)
+	h.publishHostChange(r.Context(), updated.ID, eventbus.HostChangeUpdated)
+	writeJSON(w, http.StatusOK, hostResponse(updated))
+}
+
 // DeleteHostByID soft-deletes a host.
 // Spec api-hosts AC-11, AC-12.
 func (h *handlers) DeleteHostByID(w http.ResponseWriter, r *http.Request, id openapitypes.UUID) {
@@ -372,6 +405,9 @@ func hostResponse(h host.Host) api.HostResponse {
 		Architecture:       h.Architecture,
 		PlatformIdentifier: h.PlatformIdentifier,
 		OsDiscoveredAt:     h.OSDiscoveredAt,
+		// Phase 3 (compliance-targets) — the host's own target framework
+		// (nil = inherit). omitempty: absent when unset. Spec api-hosts.
+		TargetFramework: h.TargetFramework,
 	}
 }
 

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.4.0"
+VERSION="0.5.0"
 CODENAME="Eyrie"

--- a/specs/api/compliance-exceptions.spec.yaml
+++ b/specs/api/compliance-exceptions.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-compliance-exceptions
   title: Compliance exception governance - operator rule waivers (request/approve/revoke lifecycle)
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -93,7 +93,7 @@ spec:
       type: security
       enforcement: error
     - id: C-06
-      description: '"Active" (suppressing) is status=approved AND (expires_at IS NULL OR expires_at > now()). ActiveCountForHost and ActiveRuleIDsForHost apply this predicate so they are correct even before the expiry sweep runs. ExpireSweep flips approved+past-expiry to expired and emits compliance.exception.expired per row; it is idempotent'
+      description: '"Active" (suppressing) is status=approved AND (expires_at IS NULL OR expires_at > now()). ActiveCountForHost and ActiveRuleIDsForHost apply this predicate so they are correct even before the expiry sweep runs. ExpireSweep flips any OPEN row (status approved OR requested) whose expires_at has passed to expired and emits compliance.exception.expired per row; it is idempotent. A requested row is expired too because its expires_at is the requested waiver end: once it has passed there is nothing left to approve, so a lapsed request must not sit pending forever. Approve rejects a requested row whose expires_at has already passed (ErrExpired) so the sub-sweep-interval window cannot approve a lapsed request into an immediately-dead waiver'
       type: technical
       enforcement: error
 
@@ -115,7 +115,7 @@ spec:
       priority: critical
       references_constraints: [C-01, C-06]
     - id: AC-05
-      description: 'ExpireSweep flips every approved row whose expires_at has passed to expired, emits compliance.exception.expired per flipped row, returns the count, and is idempotent (a second run flips zero); approved rows with a future or null expires_at are untouched'
+      description: 'ExpireSweep flips every OPEN row (status approved OR requested) whose expires_at has passed to expired, emits compliance.exception.expired per flipped row, returns the count, and is idempotent (a second run flips zero); rows with a future or null expires_at, and already-terminal rows (rejected/revoked/expired), are untouched'
       priority: high
       references_constraints: [C-06]
     - id: AC-06
@@ -126,3 +126,7 @@ spec:
       description: 'v1.1.0 - the list responses (GET /hosts/{id}/exceptions and GET /compliance/exceptions) populate host_name via a join on hosts so the fleet approver queue is readable without resolving UUIDs; the fleet list excludes soft-deleted hosts (JOIN ... deleted_at IS NULL); single-row lifecycle results (request/approve/reject/revoke) leave host_name empty'
       priority: high
       references_constraints: [C-05]
+    - id: AC-08
+      description: 'v1.2.0 - a lapsed request cannot become a dead waiver: Approve of a requested exception whose expires_at has already passed returns ErrExpired and leaves the row unchanged (Reject and Revoke apply no such guard). ExpireSweep additionally flips a requested (not just approved) row whose expires_at has passed to expired, so a request that is never decided before its requested end is expired rather than left pending forever'
+      priority: high
+      references_constraints: [C-06]

--- a/specs/api/host-compliance.spec.yaml
+++ b/specs/api/host-compliance.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-host-compliance
   title: Per-host compliance lens + failed-rules API + fleet scan-queue KPI
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -121,6 +121,10 @@ spec:
       description: 'v1.3.0 - /compliance/frameworks MUST filter version-pinned frameworks by the host OS: a framework id embedding an OS-pinned segment (a known family name followed by digits, e.g. rhel8, ubuntu2404) lists only when the family equals hosts.os_family and the digits equal the major version (or major+minor concatenation); ids with no OS-pinned segment are OS-neutral and always list; an empty os_family disables filtering entirely. The overall aggregate and the ?framework= lens query are NOT filtered'
       type: technical
       enforcement: error
+    - id: C-07
+      description: 'v1.5.0 - the per-host lens bar (GET /hosts/{id}/compliance/frameworks) MUST also honor the enabled-frameworks allowlist (system-compliance-lens C-04): when ComplianceConfig.EnabledFrameworks is non-empty, a framework key lists only when its FAMILY (framework.FamilyOf) is in the allowlist; an empty allowlist lists every family (unchanged). It is a DISPLAY filter, not a security boundary - a config-load error degrades to listing all, and neither the overall aggregate nor the ?framework= deep link is filtered (a disabled family stays viewable by direct link). This filter composes with the OS-aware filter (C-06): both must pass for a key to list'
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -191,3 +195,7 @@ spec:
       description: 'v1.4.0 - scan_context.scan_state reflects the host''s in-flight run independent of the latest COMPLETED run: a host with a queued run returns scan_state="queued"; a running run returns "running"; a host with only completed/failed runs (or never scanned) returns scan_state null while last_scan_at/scan_id keep tracking the latest COMPLETED run. It is sourced from scanruns.ActiveForHost so a running scan does not disturb last_scan_at.'
       priority: high
       references_constraints: [C-02]
+    - id: AC-18
+      description: 'v1.5.0 - the lens bar honors the enabled-frameworks allowlist. With ComplianceConfig.EnabledFrameworks=[cis, nist_800_53, stig], GET /hosts/{id}/compliance/frameworks on a host (os_family rhel) whose rows carry refs for cis_rhel9, nist_800_53, pci_dss_4, srg and stig_rhel9 lists exactly cis_rhel9, nist_800_53, stig_rhel9 (pci_dss_4 and srg dropped by family); clearing the allowlist to empty lists all five; the overall aggregate still counts all rows and GET /compliance?framework=pci_dss_4 still projects normally (deep link unfiltered).'
+      priority: high
+      references_constraints: [C-07]

--- a/specs/frontend/dashboard.spec.yaml
+++ b/specs/frontend/dashboard.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-dashboard
   title: Dashboard (authenticated fleet overview)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -72,6 +72,17 @@ spec:
         (no api.POST / PUT / DELETE). UI copy carries no em-dashes
       type: technical
       enforcement: error
+    - id: C-04
+      description: >-
+        v1.1.0 - the compliance-trend widget MUST render the shared
+        interactive TrendChart (src/components/charts/TrendChart.tsx): a fixed
+        0..100 score domain with an 80% target line (no auto min/max scaling,
+        which would exaggerate small moves), a date-positioned x-axis with
+        visible gaps for missing days, and a hover tooltip. It MUST NOT label
+        endpoints with a point-count-as-days ("Nd ago") or a "today" that may
+        not be the latest snapshot's date; it colors the line by trend direction
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -90,3 +101,7 @@ spec:
       description: 'Source-inspection — the dashboard modules contain no api.POST / api.PUT / api.DELETE call (read-only), and dashboard UI copy contains no em-dash.'
       priority: high
       references_constraints: [C-03]
+    - id: AC-05
+      description: 'v1.1.0 source-inspection — WidgetComplianceTrend renders the shared TrendChart (not the auto-scaled Sparkline) with a fleet tooltip carrying avg score, hosts, failing rules, and hosts with critical findings, colored by trend direction; it no longer labels endpoints as "Nd ago" or "today".'
+      priority: high
+      references_constraints: [C-04]

--- a/specs/frontend/host-detail.spec.yaml
+++ b/specs/frontend/host-detail.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-detail
   title: Host Detail page layout, behavior, and empty-state contracts
-  version: "1.9.0"
+  version: "1.10.0"
   status: approved
   tier: 2
 
@@ -235,7 +235,11 @@ spec:
       priority: critical
       references_constraints: [C-10]
     - id: AC-38
-      description: 'v1.4.0 - the Compliance trend card is LIVE: it queries /api/v1/hosts/{id}/compliance/trend with queryKey ["host", hostId, "compliance_trend"] (the host prefix gives free scan.completed refresh), renders the score sparkline plus the latest score and the over-window delta when snapshots exist, and an honest empty state ("No snapshots yet", naming the hourly rollup) when none do; the loading guard is isPending'
+      description: 'v1.4.0 - the Compliance trend card is LIVE: it queries /api/v1/hosts/{id}/compliance/trend with queryKey ["host", hostId, "compliance_trend"] (the host prefix gives free scan.completed refresh), renders the shared TrendChart plus the latest score and the delta since the first snapshot when snapshots exist, and an honest empty state ("No snapshots yet", naming the hourly rollup) when none do; the loading guard is isPending'
+      priority: high
+      references_constraints: [C-04]
+    - id: AC-46
+      description: 'v1.10.0 - the Compliance trend renders the shared interactive TrendChart (src/components/charts/TrendChart.tsx): a fixed 0..100 score domain with an 80% target line (no auto min/max scaling), a date-positioned x-axis over the 30-day window ending today so a day without a snapshot shows as a real gap (the polyline breaks where two snapshots are more than one calendar day apart, dayIndex delta != 1), and hover reveals the nearest point via a guide line + a tooltip carrying its date, score, and passing/total. The card delta is labeled against the first snapshot date, not a point count.'
       priority: high
       references_constraints: [C-04]
 

--- a/specs/frontend/settings-exception-queue.spec.yaml
+++ b/specs/frontend/settings-exception-queue.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings-exception-queue
   title: Settings Compliance policies - exception approver queue
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -61,7 +61,11 @@ spec:
       type: security
       enforcement: error
     - id: C-03
-      description: 'A 409 (state already changed, or separation-of-duties at the server) surfaces inline as an actionable message, not a crash; the host cell links to the host detail page using host_name when present. UI copy carries no em-dashes'
+      description: 'A 409 (state already changed, separation-of-duties, or a lapsed-expiry request per api-compliance-exceptions AC-08) surfaces inline as an actionable message, not a crash. The message prefers the server envelope so the specific reason shows, falling back to a generic "already changed state" hint when the envelope is unparseable; the host cell links to the host detail page using host_name when present. UI copy carries no em-dashes'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'A requested (pending) row whose expires_at is already in the past is LAPSED: its expires_at is the requested waiver end, which has elapsed, so it cannot be approved (the server returns the lapsed-expiry 409) and the expiry sweep will expire it. The queue marks such a row with a "lapsed" indicator next to the expiry so an approver does not try to approve a dead request'
       type: technical
       enforcement: error
 
@@ -75,6 +79,10 @@ spec:
       priority: critical
       references_constraints: [C-02]
     - id: AC-03
-      description: 'Source inspection: a 409 maps to an inline "already changed state" message (not a throw to an error boundary); the host cell is a Link to /hosts/$hostId showing host_name. PoliciesPage mounts <ExceptionQueue /> in the Exception workflow section and no longer renders the BackendPendingBanner there'
+      description: 'Source inspection: a 409 is handled inline (not a throw to an error boundary) by surfacing the server message with a generic "already changed state" fallback; the host cell is a Link to /hosts/$hostId showing host_name. PoliciesPage mounts <ExceptionQueue /> in the Exception workflow section and no longer renders the BackendPendingBanner there'
       priority: high
       references_constraints: [C-03]
+    - id: AC-04
+      description: 'Source inspection: a requested row whose expires_at is in the past renders a "lapsed" indicator alongside the expiry (a status===requested + past-expires_at check), signaling the request cannot be approved and will be expired by the sweep'
+      priority: medium
+      references_constraints: [C-04]

--- a/specs/frontend/settings.spec.yaml
+++ b/specs/frontend/settings.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-settings
   title: Settings — two-pane shell with 11 sub-pages
-  version: "1.17.0"
+  version: "1.18.0"
   status: draft
   tier: 2
 
@@ -241,6 +241,21 @@ spec:
         BackendPendingBanner.
       type: security
       enforcement: error
+    - id: C-17
+      description: >-
+        v1.18.0 — Framework-lens allowlist integrity on Compliance policies.
+        The "Limit lens options" toggle (EnabledFrameworksCard) MUST NOT persist
+        an empty enabled_frameworks when turned on: an empty allowlist is
+        indistinguishable from off, so seeding it from a corpus family list that
+        has not loaded (or errored, or is empty) would make the toggle silently
+        revert. The toggle is therefore disabled until the all=true corpus
+        family list has loaded with at least one family, and turning it on
+        never saves an empty list; an empty corpus shows an explanatory note.
+        Separately, DefaultLensCard's PUT MUST preserve the current
+        enabled_frameworks (the endpoint is a full replace, so omitting it wipes
+        the allowlist whenever the default lens changes).
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -379,3 +394,13 @@ spec:
       description: "v1.13.0 source-inspection: the Audit log renders Export CSV and Export JSON buttons that call exportAudit('csv'|'json'), which GETs '/api/v1/audit/events/export' with parseAs 'blob', passing the format plus the currently-applied filters (action / actor_type / since / until), then triggers a browser download by creating an object URL from the returned blob and clicking a temporary anchor (download attribute). It surfaces an inline export error on a non-ok response and disables both buttons while an export is in flight. Reading remains a GET (no new write verb)."
       priority: high
       references_constraints: [C-13]
+
+    - id: AC-33
+      description: "v1.18.0 source-inspection (EnabledFrameworksCard): the \"Limit lens options\" toggle is disabled when the corpus family list is empty (disabled includes an allFrameworks.length === 0 condition), setRestrict returns early without saving when turned on with an empty allFrameworks (so an empty enabled_frameworks is never persisted), and the card renders an explanatory note when no framework families are present in the scanned corpus. This closes the silent-revert where a not-yet-loaded or errored all=true query made turning the toggle on save an empty (== off) allowlist."
+      priority: high
+      references_constraints: [C-17]
+
+    - id: AC-34
+      description: "v1.18.0 source-inspection (DefaultLensCard): the PUT to /api/v1/system/compliance/config includes enabled_frameworks sourced from the current config (configQuery.data?.enabled_frameworks) alongside default_framework, so changing the default lens preserves the enabled-frameworks allowlist instead of wiping it (the endpoint is a full replace)."
+      priority: high
+      references_constraints: [C-17]

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-compliance-lens
   title: Default compliance lens — org-wide framework projection
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -70,6 +70,9 @@ spec:
         host's default lens: a host's compliance summary defaults to its effective
         target instead of All rules when no explicit lens is requested. A target
         family with no matching corpus key for a host scores N/A, never 0% (D3).
+        The host override is set via host.SetTarget and the group target via
+        group.SetTarget; each surfaces its stored target_framework on the
+        respective read model (host detail and the groups rollup list).
       type: technical
       enforcement: error
 
@@ -109,5 +112,16 @@ spec:
         yields NULL, and empty when neither is set. A group target set on an
         os_category group is rejected (only a site group may carry one, D1); a
         target on a site group sets and clears via SetTarget.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-08
+      description: >-
+        host.SetTarget sets (a valid family), clears (empty), and validates
+        (rejects an over-long or invalid-character token with ErrInvalidTarget)
+        the host's OWN target_framework, and returns ErrHostNotFound for an
+        unknown or soft-deleted host. Unlike a group target there is no
+        site-only constraint — a host may always carry its own target, and it is
+        the per-host override that wins in host_effective_target. GetByID
+        surfaces the stored target_framework (nil when unset).
       priority: high
       references_constraints: [C-05]


### PR DESCRIPTION
## Summary

Bundles the compliance-lens 3a UI slice, several compliance/settings fixes, an interactive compliance trend chart, and the v0.5.0 release-readiness sweep. Builds on `#742` (allowlist) and `#743` (per-host/group target backend).

### Features
- **Per-host / per-group compliance target UI + host override.** Assign a target framework from the host Compliance tab and the Groups page. A host's own target wins over its site group's, which wins over the org default; the host's compliance summary and default lens follow that effective target. New `POST /api/v1/hosts/{id}:target` (`host:write`); `resolveLensForHost` prefers the host target.
- **Interactive compliance trend chart.** One shared chart for the host card and the dashboard widget: hover any point for its date/score (fleet also shows hosts, failing rules, hosts with critical), a fixed 0–100 scale with an 80% target line (no auto-scaling), and a date-positioned axis where a day without a snapshot renders as a real gap rather than an interpolated line.

### Fixes
- The enabled-frameworks allowlist now reaches the per-host "View as" lens bar, not just the org picker (display filter only; deep links unaffected).
- The "Limit lens options" toggle no longer silently reverts, and changing the default lens no longer wipes the allowlist.
- A lapsed pending compliance exception is now expired by the sweep instead of sitting forever, and approving a lapsed request is refused with a clear 409.
- Target pickers offer the full family list so a target outside the allowlist is not misrepresented (from the release quality review).

### Release-readiness (v0.5.0)
- `version.env` → 0.5.0; CHANGELOG `[0.5.0]` cut.
- **docs/guides audit** (public MDX): truthfulness fixes verified against code + the live API (maintenance is a boolean toggle; inactivity timeout 5 min–24 h; host maintenance is `PUT`; migration 0051; distro matrix; runbook table names; health has no `degraded` body), style-guide pass, version/date bumps, no internal links.
- Test-CI workflow doc corrections.

## Testing
- `gofmt` · `go vet` · `go build ./...` · `make build` (release SPA-embed) — clean.
- `specter check` / coverage(annotation) / check --test — 116/116, 0 errors.
- Frontend `tsc` + `vitest` — 358/358.
- Generated artifacts (`server.gen.go`, `schema.d.ts`) in sync with `api/openapi.yaml`.
- Go DB suite (host/group/framework/exception/posture/systemconfig/server) — 0 failures.
- docs-links + changelog-format + version-alignment gates — pass.

Package-build / FIPS / upgrade-container / supply-chain / package-smoke are CI-gated (need rpmbuild/dpkg) and run in `release.yml` / `package-smoke.yml` on tag.

## Notes
- Independent quality + security review found no critical/high/medium issues; RBAC, input validation, SQL parameterization, CSRF, and allowlist-as-display-filter verified against the code. The one low finding (target picker option source) is fixed here.
- Specs updated: `system-compliance-lens` v1.3.0, `api-host-compliance` v1.5.0, `api-compliance-exceptions` v1.2.0, `frontend-settings` v1.18.0, `frontend-settings-exception-queue` v1.1.0, `frontend-host-detail` v1.10.0, `frontend-dashboard` v1.1.0.
