### PR TITLE
feat(intelligence): explain stale discovery facts with an observation reason

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6546,12 +6546,15 @@ components:
         Per-category collection freshness. status=ok when the category was
         observed on the most recent run; status=stale when the run did not
         observe it and the last-known-good value was carried forward
-        (observed_at then points at the last successful observation).
-        Spec system-host-discovery / system-os-intelligence.
+        (observed_at then points at the last successful observation). On a
+        stale entry, reason records WHY it was not re-observed: denied (a
+        fixable sudo/permission refusal), failed (transport or command
+        failure), or timeout. Spec system-host-discovery / system-os-intelligence.
       properties:
         status:      {type: string, enum: [ok, stale]}
         observed_at: {type: string, format: date-time}
         attempt_at:  {type: string, format: date-time}
+        reason:      {type: string, enum: [denied, failed, timeout], description: 'Present only on stale entries: why the category was not re-observed this run'}
     CategoryFreshness:
       type: object
       additionalProperties: {$ref: '#/components/schemas/FreshnessEntry'}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4369,8 +4369,10 @@ export interface components {
          * @description Per-category collection freshness. status=ok when the category was
          *     observed on the most recent run; status=stale when the run did not
          *     observe it and the last-known-good value was carried forward
-         *     (observed_at then points at the last successful observation).
-         *     Spec system-host-discovery / system-os-intelligence.
+         *     (observed_at then points at the last successful observation). On a
+         *     stale entry, reason records WHY it was not re-observed: denied (a
+         *     fixable sudo/permission refusal), failed (transport or command
+         *     failure), or timeout. Spec system-host-discovery / system-os-intelligence.
          */
         FreshnessEntry: {
             /** @enum {string} */
@@ -4379,6 +4381,11 @@ export interface components {
             observed_at: string;
             /** Format: date-time */
             attempt_at: string;
+            /**
+             * @description Present only on stale entries: why the category was not re-observed this run
+             * @enum {string}
+             */
+            reason?: "denied" | "failed" | "timeout";
         };
         /**
          * @description Map of fact category -> freshness. Absent categories were never

--- a/frontend/src/pages/host-detail/CardSystem.tsx
+++ b/frontend/src/pages/host-detail/CardSystem.tsx
@@ -41,11 +41,21 @@ export interface CardSystemHost {
 // (system-host-discovery v1.6.0). status=stale means the value shown was
 // carried forward from an earlier successful run — the most recent Discovery
 // did not re-observe this category (SSH degraded, sudo denied, probe failed).
+// reason (v1.7.0) records WHY a stale value was not re-observed.
 export interface CategoryFreshness {
   status: 'ok' | 'stale';
   observed_at: string;
   attempt_at: string;
+  reason?: 'denied' | 'failed' | 'timeout';
 }
+
+// Human labels for the stale reason. "denied" is the actionable one (grant
+// sudo); the others signal a transient collection problem.
+const REASON_LABEL: Record<string, string> = {
+  denied: 'sudo denied',
+  failed: 'probe failed',
+  timeout: 'probe timed out',
+};
 
 // Subset of HostSystemInfo we render. Mirrors the API schema column
 // names; null fields tolerate partial-collection rows (sudo unavailable,
@@ -383,12 +393,14 @@ export function StaleNote({
 }) {
   const entry = freshness?.[category];
   if (!entry || entry.status !== 'stale') return null;
+  const reasonLabel = entry.reason ? REASON_LABEL[entry.reason] : undefined;
   return (
     <div
       style={{ ...subValueStyle, color: 'var(--ow-warn)' }}
       title={`Last verified ${entry.observed_at}`}
     >
       Last verified {formatTimeAgo(entry.observed_at)}
+      {reasonLabel ? ` (${reasonLabel})` : ''}
     </div>
   );
 }

--- a/frontend/tests/pages/host-detail-system-card.test.tsx
+++ b/frontend/tests/pages/host-detail-system-card.test.tsx
@@ -131,12 +131,12 @@ describe('frontend-host-detail-system-card — freshness', () => {
     const twoDaysAgo = new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString();
     const now = new Date().toISOString();
 
-    // Stale firewall → caveat present.
+    // Stale firewall with reason "denied" → caveat present + actionable label.
     const staleInfo: CardSystemInfo = {
       firewall_status: 'active',
       firewall_service: 'firewalld',
       category_freshness: {
-        firewall: { status: 'stale', observed_at: twoDaysAgo, attempt_at: now },
+        firewall: { status: 'stale', reason: 'denied', observed_at: twoDaysAgo, attempt_at: now },
       },
     };
     const { unmount } = renderWith(
@@ -146,8 +146,27 @@ describe('frontend-host-detail-system-card — freshness', () => {
         systemInfo={staleInfo}
       />,
     );
-    expect(screen.getByText(/Last verified/i)).toBeInTheDocument();
+    expect(screen.getByText(/Last verified 2d ago \(sudo denied\)/i)).toBeInTheDocument();
     unmount();
+
+    // Stale with NO reason → caveat present, no parenthetical.
+    const staleNoReason: CardSystemInfo = {
+      firewall_status: 'active',
+      firewall_service: 'firewalld',
+      category_freshness: {
+        firewall: { status: 'stale', observed_at: twoDaysAgo, attempt_at: now },
+      },
+    };
+    const noReason = renderWith(
+      <CardSystem
+        host={makeHost({ os_family: 'rhel', os_version: '9.2' })}
+        intelligenceSnapshot={null}
+        systemInfo={staleNoReason}
+      />,
+    );
+    expect(screen.getByText(/Last verified 2d ago$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/sudo denied/i)).toBeNull();
+    noReason.unmount();
 
     // ok firewall → no caveat.
     const freshInfo: CardSystemInfo = {

--- a/internal/intelligence/discovery/discovery.go
+++ b/internal/intelligence/discovery/discovery.go
@@ -123,6 +123,53 @@ type SystemFacts struct {
 	// category keeps the run's values even when genuinely empty/zero — that is
 	// a real observation, not a missing one.
 	Observed map[FactCategory]bool
+
+	// Attempts records WHY a non-observed category was not collected this run
+	// (denied | failed | timeout), so the persisted freshness can tell an
+	// operator whether a stale value is a fixable sudo denial or a transient
+	// connectivity failure. Only categories that were attempted-but-not-observed
+	// appear here; an observed category is absent from this map. Spec C-14,
+	// v1.7.0.
+	Attempts map[FactCategory]string
+}
+
+// Attempt outcomes for a non-observed fact category on one run. observed is
+// represented by absence from SystemFacts.Attempts (the category is in Observed
+// instead). These label the reason a probe did not yield a value so a stale
+// carried-forward value can be explained.
+const (
+	outcomeDenied  = "denied"  // positive evidence of a sudo/permission refusal
+	outcomeFailed  = "failed"  // transport error or non-permission command failure
+	outcomeTimeout = "timeout" // the probe exceeded the run deadline
+)
+
+// classifyOutcome maps a probe's (out, code, err) triple to a non-observed
+// outcome. Positive-evidence only for "denied": we label a category denied
+// ONLY when the combined output carries a recognizable sudo-refusal signature,
+// so a genuinely-absent tool or a transport error is never mislabeled as a
+// permission problem (under-reporting denied is safer than over-reporting an
+// actionable signal). A context deadline is a timeout; any other Go-level error
+// is a failure; a non-zero exit without a sudo signature is a failure.
+func classifyOutcome(out []byte, err error) string {
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return outcomeTimeout
+		}
+		return outcomeFailed
+	}
+	if sudoDenied(out) {
+		return outcomeDenied
+	}
+	return outcomeFailed
+}
+
+// recordFailure stamps the reason a category was not observed this run. Safe
+// to call with a nil Attempts map (lazily initialized).
+func (f *SystemFacts) recordFailure(cat FactCategory, out []byte, err error) {
+	if f.Attempts == nil {
+		f.Attempts = make(map[FactCategory]string, len(allFactCategories))
+	}
+	f.Attempts[cat] = classifyOutcome(out, err)
 }
 
 // FactCategory groups host_system_info columns by the probe that collects them,
@@ -154,15 +201,18 @@ var allFactCategories = []FactCategory{
 type freshnessEntry struct {
 	ObservedAt time.Time `json:"observed_at"`
 	AttemptAt  time.Time `json:"attempt_at"`
-	Status     string    `json:"status"` // ok | stale
+	Status     string    `json:"status"`           // ok | stale
+	Reason     string    `json:"reason,omitempty"` // denied | failed | timeout (stale only)
 }
 
 // computeFreshness builds the per-category freshness map from this run's
-// observed set and the prior stored freshness. An observed category is "ok"
-// (observed_at = now); an unobserved category with a prior observation is
-// "stale" (prior observed_at kept, attempt_at = now, so a consumer can show
-// "last good X ago"); a category never observed has no entry.
-func computeFreshness(observed map[FactCategory]bool, prior map[string]freshnessEntry, now time.Time) map[string]freshnessEntry {
+// observed set, its per-category failure reasons, and the prior stored
+// freshness. An observed category is "ok" (observed_at = now); an unobserved
+// category with a prior observation is "stale" (prior observed_at kept,
+// attempt_at = now, so a consumer can show "last good X ago") and carries the
+// reason it was not re-observed this run (denied | failed | timeout); a
+// category never observed has no entry. Spec C-13 (freshness) + C-14 (reason).
+func computeFreshness(observed map[FactCategory]bool, attempts map[FactCategory]string, prior map[string]freshnessEntry, now time.Time) map[string]freshnessEntry {
 	out := make(map[string]freshnessEntry, len(allFactCategories))
 	for _, cat := range allFactCategories {
 		key := string(cat)
@@ -171,7 +221,16 @@ func computeFreshness(observed map[FactCategory]bool, prior map[string]freshness
 			out[key] = freshnessEntry{ObservedAt: now, AttemptAt: now, Status: "ok"}
 		case prior != nil:
 			if p, ok := prior[key]; ok {
-				out[key] = freshnessEntry{ObservedAt: p.ObservedAt, AttemptAt: now, Status: "stale"}
+				reason := attempts[cat]
+				if reason == "" {
+					reason = outcomeFailed // not observed, cause unrecorded → failed
+				}
+				out[key] = freshnessEntry{
+					ObservedAt: p.ObservedAt,
+					AttemptAt:  now,
+					Status:     "stale",
+					Reason:     reason,
+				}
 			}
 		}
 	}
@@ -363,7 +422,10 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 
 	facts := SystemFacts{CollectedAt: time.Now().UTC(), Observed: map[FactCategory]bool{}}
 
-	// World-readable probes — sudo not required.
+	// World-readable probes — sudo not required. On a non-observation we record
+	// the reason (classifyOutcome) so a stale carried-forward value can be
+	// explained; these read-only probes never need sudo, so their failures
+	// classify as failed/timeout (never denied) absent a sudo signature.
 	if out, code, err := sess.Run(ctx, "cat /etc/os-release"); err == nil && code == 0 {
 		osf, _ := probe.ParseOSRelease(out)
 		facts.OSName = osf.OSName
@@ -375,6 +437,8 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 		facts.PlatformIdentifier = osf.PlatformIdentifier
 		facts.OSFamily = deriveOSFamily(osf.OSID, osf.OSIDLike)
 		facts.Observed[CatOSRelease] = true
+	} else {
+		facts.recordFailure(CatOSRelease, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "uname -srvm"); err == nil && code == 0 {
@@ -384,6 +448,8 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 		facts.KernelVersion = uf.KernelVersion
 		facts.Architecture = uf.Architecture
 		facts.Observed[CatUname] = true
+	} else {
+		facts.recordFailure(CatUname, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "cat /proc/meminfo"); err == nil && code == 0 {
@@ -392,6 +458,8 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 		facts.MemAvailableMB = mi.MemAvailableMB
 		facts.SwapTotalMB = mi.SwapTotalMB
 		facts.Observed[CatMemory] = true
+	} else {
+		facts.recordFailure(CatMemory, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "df -BG /"); err == nil && code == 0 {
@@ -400,26 +468,36 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 		facts.DiskUsedGB = used
 		facts.DiskFreeGB = free
 		facts.Observed[CatDisk] = true
+	} else {
+		facts.recordFailure(CatDisk, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "hostname"); err == nil && code == 0 {
 		facts.Hostname = strings.TrimSpace(string(out))
 		facts.Observed[CatHostname] = true
+	} else {
+		facts.recordFailure(CatHostname, out, err)
 	}
 	if out, code, err := sess.Run(ctx, "hostname -f"); err == nil && code == 0 {
 		facts.FQDN = strings.TrimSpace(string(out))
 		facts.Observed[CatFQDN] = true
+	} else {
+		facts.recordFailure(CatFQDN, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "getenforce"); err == nil && code == 0 {
 		facts.SELinuxStatus = strings.TrimSpace(string(out))
 		facts.Observed[CatSELinux] = true
+	} else {
+		facts.recordFailure(CatSELinux, out, err)
 	}
-	if _, code, err := sess.Run(ctx, "aa-status --enabled"); err == nil {
+	if out, code, err := sess.Run(ctx, "aa-status --enabled"); err == nil {
 		// aa-status --enabled exits 0 when enabled, 1 when not. Either exit is
 		// a genuine observation of the AppArmor state.
 		facts.AppArmorEnabled = code == 0
 		facts.Observed[CatAppArmor] = true
+	} else {
+		facts.recordFailure(CatAppArmor, out, err)
 	}
 
 	// Firewall introspection — needs sudo on most distros. Per spec C-03
@@ -444,11 +522,18 @@ func (s *Service) discoverWithTransport(ctx context.Context, hf hostFacts) (Syst
 			cfg.prefer = knownSudo
 		}
 	}
-	svc, status, learnedSudo, ok := probeFirewall(ctx, sess, cfg)
+	svc, status, learnedSudo, ok, fwReason := probeFirewall(ctx, sess, cfg)
 	if ok {
 		facts.FirewallService = svc
 		facts.FirewallStatus = status
 		facts.Observed[CatFirewall] = true
+	} else {
+		// probeFirewall already classified the non-observation: "denied" when a
+		// sudo-refusal signature was seen across its attempts, else "failed".
+		if facts.Attempts == nil {
+			facts.Attempts = make(map[FactCategory]string, len(allFactCategories))
+		}
+		facts.Attempts[CatFirewall] = fwReason
 	}
 	if s.profiles != nil && learnedSudo != connprofile.SudoUnknown && learnedSudo != knownSudo {
 		_ = s.profiles.RecordSudoMode(ctx, hf.HostID, learnedSudo)
@@ -486,8 +571,9 @@ func (s *Service) persist(ctx context.Context, hostID uuid.UUID, f SystemFacts) 
 	}
 	// Per-category freshness (spec v1.6.0): stamp when each category was last
 	// observed vs merely attempted, so a consumer can tell fresh from
-	// carried-forward data.
-	freshJSON, _ := json.Marshal(computeFreshness(f.Observed, priorFresh, f.CollectedAt))
+	// carried-forward data. v1.7.0 also stamps WHY a stale category was not
+	// re-observed (denied | failed | timeout) from f.Attempts.
+	freshJSON, _ := json.Marshal(computeFreshness(f.Observed, f.Attempts, priorFresh, f.CollectedAt))
 
 	const upsertSystemInfo = `
 		INSERT INTO host_system_info (

--- a/internal/intelligence/discovery/discovery_db_test.go
+++ b/internal/intelligence/discovery/discovery_db_test.go
@@ -5,6 +5,7 @@
 //	AC-08  TestDiscover_HappyPath_PersistsAndPublishes
 //	AC-24  TestDiscover_NoClobberOnPartialCollection
 //	AC-25  TestDiscover_CategoryFreshness
+//	AC-27  TestDiscover_FreshnessReason
 
 package discovery
 
@@ -257,6 +258,73 @@ func TestDiscover_CategoryFreshness(t *testing.T) {
 		}
 		if !fwEarlier {
 			t.Errorf("firewall observed_at should be earlier than os_release (kept run1 time)")
+		}
+	})
+}
+
+// @ac AC-27
+// AC-27: a stale category carries the reason it was not re-observed. A second
+// run whose Attempts records firewall="denied" and disk="failed" persists those
+// reasons on the stale freshness entries; an observed category has status "ok"
+// with no reason; a stale category whose reason was unrecorded defaults to
+// "failed", never a false "denied".
+func TestDiscover_FreshnessReason(t *testing.T) {
+	t.Run("system-host-discovery/AC-27", func(t *testing.T) {
+		pool, hostID, _ := freshDBHost(t)
+		ctx := context.Background()
+		svc := &Service{pool: pool}
+		allObserved := map[FactCategory]bool{
+			CatOSRelease: true, CatUname: true, CatMemory: true, CatDisk: true,
+			CatHostname: true, CatFQDN: true, CatSELinux: true, CatAppArmor: true, CatFirewall: true,
+		}
+
+		// Run 1: fully observed.
+		if err := svc.persist(ctx, hostID, SystemFacts{
+			OSVersion: "9.4", KernelRelease: "5.14.0-570", FirewallService: "firewalld",
+			DiskTotalGB: 100, DiskFreeGB: 40, SELinuxStatus: "Enforcing",
+			CollectedAt: time.Now().Add(-time.Hour).UTC(), Observed: allObserved,
+		}); err != nil {
+			t.Fatalf("run1 persist: %v", err)
+		}
+
+		// Run 2: os_release observed; firewall denied, disk failed, selinux
+		// unobserved with NO recorded reason (defaults to failed).
+		if err := svc.persist(ctx, hostID, SystemFacts{
+			OSVersion:   "9.5",
+			CollectedAt: time.Now().UTC(),
+			Observed:    map[FactCategory]bool{CatOSRelease: true},
+			Attempts: map[FactCategory]string{
+				CatFirewall: outcomeDenied,
+				CatDisk:     outcomeFailed,
+			},
+		}); err != nil {
+			t.Fatalf("run2 persist: %v", err)
+		}
+
+		var osStatus, osReason, fwStatus, fwReason, diskReason, selinuxReason string
+		if err := pool.QueryRow(ctx, `
+			SELECT category_freshness->'os_release'->>'status',
+			       COALESCE(category_freshness->'os_release'->>'reason', ''),
+			       category_freshness->'firewall'->>'status',
+			       COALESCE(category_freshness->'firewall'->>'reason', ''),
+			       COALESCE(category_freshness->'disk'->>'reason', ''),
+			       COALESCE(category_freshness->'selinux'->>'reason', '')
+			  FROM host_system_info WHERE host_id = $1`, hostID).
+			Scan(&osStatus, &osReason, &fwStatus, &fwReason, &diskReason, &selinuxReason); err != nil {
+			t.Fatalf("read freshness: %v", err)
+		}
+		if osStatus != "ok" || osReason != "" {
+			t.Errorf("os_release = {status:%q reason:%q}, want ok with no reason", osStatus, osReason)
+		}
+		if fwStatus != "stale" || fwReason != "denied" {
+			t.Errorf("firewall = {status:%q reason:%q}, want stale/denied", fwStatus, fwReason)
+		}
+		if diskReason != "failed" {
+			t.Errorf("disk reason = %q, want failed", diskReason)
+		}
+		// Unrecorded reason on a stale category defaults to failed — never denied.
+		if selinuxReason != "failed" {
+			t.Errorf("selinux reason = %q, want failed (unrecorded default)", selinuxReason)
 		}
 	})
 }

--- a/internal/intelligence/discovery/firewall_fallback_test.go
+++ b/internal/intelligence/discovery/firewall_fallback_test.go
@@ -57,7 +57,7 @@ func TestProbeFirewall_PasswordFallback_UFWSuccess(t *testing.T) {
 			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true},
 			cred:   validHostCred(),
 		}
-		svc, status, learned, ok := probeFirewall(testCtx(t), sess, cfg)
+		svc, status, learned, ok, _ := probeFirewall(testCtx(t), sess, cfg)
 		if !ok {
 			t.Fatalf("ok: want true (fallback succeeded), got false")
 		}
@@ -111,7 +111,7 @@ func TestProbeFirewall_PasswordFallback_PolicyOff(t *testing.T) {
 			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: false},
 			cred:   validHostCred(),
 		}
-		_, _, learned, ok := probeFirewall(testCtx(t), sess, cfg)
+		_, _, learned, ok, _ := probeFirewall(testCtx(t), sess, cfg)
 		if ok {
 			t.Errorf("ok: want false (policy off, no sudo path succeeded), got true")
 		}
@@ -142,7 +142,7 @@ func TestProbeFirewall_NoFallbackOnSudoNSuccess(t *testing.T) {
 			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true},
 			cred:   validHostCred(),
 		}
-		svc, status, learned, ok := probeFirewall(testCtx(t), sess, cfg)
+		svc, status, learned, ok, _ := probeFirewall(testCtx(t), sess, cfg)
 		if !ok || svc != "firewalld" || status != "active" {
 			t.Errorf("first-firewall hit: svc=%q status=%q ok=%v", svc, status, ok)
 		}
@@ -176,7 +176,7 @@ func TestProbeFirewall_SudoModeLearning(t *testing.T) {
 			policy: systemconfig.SecurityConfig{AllowCredentialSudoPassword: true},
 			cred:   validHostCred(),
 		}
-		svc, _, learned, ok := probeFirewall(testCtx(t), sess, cfg)
+		svc, _, learned, ok, _ := probeFirewall(testCtx(t), sess, cfg)
 		if !ok || svc != "ufw" {
 			t.Fatalf("probe: ok=%v svc=%q, want true/ufw", ok, svc)
 		}
@@ -201,7 +201,7 @@ func TestProbeFirewall_SudoModeLearning(t *testing.T) {
 			cred:   validHostCred(),
 			prefer: connprofile.SudoPassword,
 		}
-		svc, _, learned, ok := probeFirewall(testCtx(t), sess, cfg)
+		svc, _, learned, ok, _ := probeFirewall(testCtx(t), sess, cfg)
 		if !ok || svc != "ufw" {
 			t.Fatalf("probe: ok=%v svc=%q, want true/ufw", ok, svc)
 		}

--- a/internal/intelligence/discovery/helpers.go
+++ b/internal/intelligence/discovery/helpers.go
@@ -170,6 +170,35 @@ func runSudoWithFallback(ctx context.Context, sess SSHSession, sudoCmd string, c
 	return fOut, fCode, connprofile.SudoUnknown, fErr
 }
 
+// sudoDenialSignatures are lowercase substrings sudo (or PAM) emits on the
+// combined stdout+stderr when a command is refused for permission / tty /
+// password reasons. Detection is positive-evidence only: a category is labeled
+// "denied" ONLY when one of these appears, so a genuinely-absent tool or a
+// transport error is never mislabeled as a permission problem. Spec C-14.
+var sudoDenialSignatures = []string{
+	"a password is required",
+	"a terminal is required",
+	"no tty present",
+	"is not allowed to run sudo",
+	"is not in the sudoers file",
+	"not allowed to execute",
+	"incorrect password",
+	"sorry, try again",
+}
+
+// sudoDenied reports whether the combined command output carries a recognizable
+// sudo-refusal signature. Case-insensitive substring match on the signatures
+// above.
+func sudoDenied(out []byte) bool {
+	s := strings.ToLower(string(out))
+	for _, sig := range sudoDenialSignatures {
+		if strings.Contains(s, sig) {
+			return true
+		}
+	}
+	return false
+}
+
 // probeFirewall tries each known firewall service in order. The first
 // one to answer (exit 0) wins. Returns ("", "", false) when none answer
 // — typically because the credential lacks sudo. Per spec C-03 + AC-05
@@ -185,42 +214,58 @@ func runSudoWithFallback(ctx context.Context, sess SSHSession, sudoCmd string, c
 // sudo firewall command (SudoUnknown when none answered via sudo — e.g.
 // a sudoless firewalld host, or one with no firewall tool). Spec
 // system-connection-profile v1.2.0 C-07 / AC-11.
-func probeFirewall(ctx context.Context, sess SSHSession, cfg sudoFallbackConfig) (service, status string, learned connprofile.SudoMode, ok bool) {
+func probeFirewall(ctx context.Context, sess SSHSession, cfg sudoFallbackConfig) (service, status string, learned connprofile.SudoMode, ok bool, reason string) {
 	// note records the strongest confirmation a sudo attempt produced.
 	note := func(observed connprofile.SudoMode) {
 		if observed != connprofile.SudoUnknown {
 			learned = observed
 		}
 	}
+	// sawDenial latches when any sudo attempt's output shows a permission
+	// refusal, so a non-answering firewall probe reports "denied" (actionable:
+	// grant sudo) rather than the generic "failed". Positive-evidence only.
+	sawDenial := false
+	seen := func(out []byte) {
+		if sudoDenied(out) {
+			sawDenial = true
+		}
+	}
 	// firewalld via systemctl is sudoless on many distros.
 	if out, code, err := sess.Run(ctx, "systemctl is-active firewalld"); err == nil && code == 0 {
-		return "firewalld", strings.TrimSpace(string(out)), learned, true
+		return "firewalld", strings.TrimSpace(string(out)), learned, true, ""
 	}
 	// ufw — Debian / Ubuntu. Needs sudo on most distros for `status`.
 	out, code, observed, err := runSudoWithFallback(ctx, sess, "ufw status", cfg)
 	note(observed)
+	seen(out)
 	if err == nil && code == 0 {
-		return "ufw", firstWord(string(out)), learned, true
+		return "ufw", firstWord(string(out)), learned, true, ""
 	}
 	// nftables.
-	_, code, observed, err = runSudoWithFallback(ctx, sess, "nft list ruleset", cfg)
+	out, code, observed, err = runSudoWithFallback(ctx, sess, "nft list ruleset", cfg)
 	note(observed)
+	seen(out)
 	if err == nil && code == 0 {
-		return "nftables", "active", learned, true
+		return "nftables", "active", learned, true, ""
 	}
 	// iptables fallback.
-	_, code, observed, err = runSudoWithFallback(ctx, sess, "iptables -L", cfg)
+	out, code, observed, err = runSudoWithFallback(ctx, sess, "iptables -L", cfg)
 	note(observed)
+	seen(out)
 	if err == nil && code == 0 {
-		return "iptables", "active", learned, true
+		return "iptables", "active", learned, true, ""
 	}
 	// firewall-cmd as last resort (RHEL).
 	out, code, observed, err = runSudoWithFallback(ctx, sess, "firewall-cmd --state", cfg)
 	note(observed)
+	seen(out)
 	if err == nil && code == 0 {
-		return "firewalld", strings.TrimSpace(string(out)), learned, true
+		return "firewalld", strings.TrimSpace(string(out)), learned, true, ""
 	}
-	return "", "", learned, false
+	if sawDenial {
+		return "", "", learned, false, outcomeDenied
+	}
+	return "", "", learned, false, outcomeFailed
 }
 
 func firstWord(s string) string {

--- a/internal/intelligence/discovery/outcome_test.go
+++ b/internal/intelligence/discovery/outcome_test.go
@@ -1,0 +1,111 @@
+// @spec system-host-discovery
+//
+// AC traceability (this file):
+//
+//	AC-26  TestClassifyOutcome_AndSudoDenied
+//	AC-28  TestProbeFirewall_ReasonOnNonObservation
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// @ac AC-26
+// AC-26: classifyOutcome maps a probe's (out, err) to a non-observed reason —
+// deadline→timeout, other error→failed, sudo signature→denied, non-zero exit
+// without a signature→failed; sudoDenied is a case-insensitive substring match.
+func TestClassifyOutcome_AndSudoDenied(t *testing.T) {
+	t.Run("system-host-discovery/AC-26", func(t *testing.T) {
+		cases := []struct {
+			name string
+			out  string
+			err  error
+			want string
+		}{
+			{"deadline is timeout", "partial", context.DeadlineExceeded, outcomeTimeout},
+			{"wrapped deadline is timeout", "x", errWrap(context.DeadlineExceeded), outcomeTimeout},
+			{"transport error is failed", "x", errors.New("ssh: connection lost"), outcomeFailed},
+			{"sudo password signature is denied", "sudo: a password is required", nil, outcomeDenied},
+			{"sudoers signature is denied", "owadmin is not in the sudoers file", nil, outcomeDenied},
+			{"not-allowed signature is denied", "user is not allowed to execute", nil, outcomeDenied},
+			{"command-not-found is failed", "bash: getenforce: command not found", nil, outcomeFailed},
+			{"empty non-zero is failed", "", nil, outcomeFailed},
+		}
+		for _, c := range cases {
+			if got := classifyOutcome([]byte(c.out), c.err); got != c.want {
+				t.Errorf("%s: classifyOutcome(%q, %v) = %q, want %q", c.name, c.out, c.err, got, c.want)
+			}
+		}
+
+		// sudoDenied is case-insensitive and does not false-positive on benign
+		// output.
+		if !sudoDenied([]byte("SUDO: A PASSWORD IS REQUIRED")) {
+			t.Error("sudoDenied should match case-insensitively")
+		}
+		if sudoDenied([]byte("Status: active")) {
+			t.Error("sudoDenied should not match benign firewall output")
+		}
+	})
+}
+
+// errWrap wraps err so errors.Is still finds it — proves classifyOutcome uses
+// errors.Is, not ==.
+func errWrap(err error) error { return errWrapped{err} }
+
+type errWrapped struct{ err error }
+
+func (e errWrapped) Error() string { return "wrapped: " + e.err.Error() }
+func (e errWrapped) Unwrap() error { return e.err }
+
+// @ac AC-28
+// AC-28: probeFirewall reports WHY it found no firewall — "denied" when any
+// attempt shows a sudo-refusal signature, "failed" when the attempts fail
+// without one, and an empty reason on success.
+func TestProbeFirewall_ReasonOnNonObservation(t *testing.T) {
+	t.Run("system-host-discovery/AC-28", func(t *testing.T) {
+		cred := validHostCred()
+
+		// Denied: systemctl absent (127), sudo -n ufw status refused with a
+		// password-required signature. Policy off → no sudo -S fallback.
+		denyStub := newStubSSHTransport()
+		denyStub.SeedAll()
+		denyStub.FailCommand("sudo -n ufw status", "sudo: a password is required", 1)
+		denySess, _ := denyStub.Dial(testCtx(t), "host", 22, cred)
+		_, _, _, ok, reason := probeFirewall(testCtx(t), denySess, sudoFallbackConfig{cred: cred})
+		if ok {
+			t.Fatalf("denied case: ok=true, want false")
+		}
+		if reason != outcomeDenied {
+			t.Errorf("denied case: reason=%q, want %q", reason, outcomeDenied)
+		}
+
+		// Failed: no firewall tool present, every attempt returns 127 with no
+		// sudo signature → reason "failed", not a false "denied".
+		failStub := newStubSSHTransport()
+		failStub.SeedAll() // firewall left unseeded → 127, nil output
+		failSess, _ := failStub.Dial(testCtx(t), "host", 22, cred)
+		_, _, _, ok, reason = probeFirewall(testCtx(t), failSess, sudoFallbackConfig{cred: cred})
+		if ok {
+			t.Fatalf("failed case: ok=true, want false")
+		}
+		if reason != outcomeFailed {
+			t.Errorf("failed case: reason=%q, want %q", reason, outcomeFailed)
+		}
+
+		// Success: firewalld active via sudoless systemctl → empty reason.
+		okStub := newStubSSHTransport()
+		okStub.SeedAll()
+		okStub.outputs["systemctl is-active firewalld"] = stubResult{out: []byte("active\n"), exitCode: 0}
+		okSess, _ := okStub.Dial(testCtx(t), "host", 22, cred)
+		_, _, _, ok, reason = probeFirewall(testCtx(t), okSess, sudoFallbackConfig{cred: cred})
+		if !ok {
+			t.Fatalf("success case: ok=false, want true")
+		}
+		if reason != "" {
+			t.Errorf("success case: reason=%q, want empty", reason)
+		}
+	})
+}

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -431,6 +431,27 @@ func (e FleetTransactionStatus) Valid() bool {
 	}
 }
 
+// Defines values for FreshnessEntryReason.
+const (
+	FreshnessEntryReasonDenied  FreshnessEntryReason = "denied"
+	FreshnessEntryReasonFailed  FreshnessEntryReason = "failed"
+	FreshnessEntryReasonTimeout FreshnessEntryReason = "timeout"
+)
+
+// Valid indicates whether the value is a known member of the FreshnessEntryReason enum.
+func (e FreshnessEntryReason) Valid() bool {
+	switch e {
+	case FreshnessEntryReasonDenied:
+		return true
+	case FreshnessEntryReasonFailed:
+		return true
+	case FreshnessEntryReasonTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FreshnessEntryStatus.
 const (
 	FreshnessEntryStatusOk    FreshnessEntryStatus = "ok"
@@ -1384,25 +1405,25 @@ func (e GetAuditEventsExportParamsFormat) Valid() bool {
 
 // Defines values for GetComplianceExceptionsParamsStatus.
 const (
-	GetComplianceExceptionsParamsStatusApproved  GetComplianceExceptionsParamsStatus = "approved"
-	GetComplianceExceptionsParamsStatusExpired   GetComplianceExceptionsParamsStatus = "expired"
-	GetComplianceExceptionsParamsStatusRejected  GetComplianceExceptionsParamsStatus = "rejected"
-	GetComplianceExceptionsParamsStatusRequested GetComplianceExceptionsParamsStatus = "requested"
-	GetComplianceExceptionsParamsStatusRevoked   GetComplianceExceptionsParamsStatus = "revoked"
+	Approved  GetComplianceExceptionsParamsStatus = "approved"
+	Expired   GetComplianceExceptionsParamsStatus = "expired"
+	Rejected  GetComplianceExceptionsParamsStatus = "rejected"
+	Requested GetComplianceExceptionsParamsStatus = "requested"
+	Revoked   GetComplianceExceptionsParamsStatus = "revoked"
 )
 
 // Valid indicates whether the value is a known member of the GetComplianceExceptionsParamsStatus enum.
 func (e GetComplianceExceptionsParamsStatus) Valid() bool {
 	switch e {
-	case GetComplianceExceptionsParamsStatusApproved:
+	case Approved:
 		return true
-	case GetComplianceExceptionsParamsStatusExpired:
+	case Expired:
 		return true
-	case GetComplianceExceptionsParamsStatusRejected:
+	case Rejected:
 		return true
-	case GetComplianceExceptionsParamsStatusRequested:
+	case Requested:
 		return true
-	case GetComplianceExceptionsParamsStatusRevoked:
+	case Revoked:
 		return true
 	default:
 		return false
@@ -2190,13 +2211,21 @@ type FleetTransactionStatus string
 // FreshnessEntry Per-category collection freshness. status=ok when the category was
 // observed on the most recent run; status=stale when the run did not
 // observe it and the last-known-good value was carried forward
-// (observed_at then points at the last successful observation).
-// Spec system-host-discovery / system-os-intelligence.
+// (observed_at then points at the last successful observation). On a
+// stale entry, reason records WHY it was not re-observed: denied (a
+// fixable sudo/permission refusal), failed (transport or command
+// failure), or timeout. Spec system-host-discovery / system-os-intelligence.
 type FreshnessEntry struct {
-	AttemptAt  time.Time            `json:"attempt_at"`
-	ObservedAt time.Time            `json:"observed_at"`
-	Status     FreshnessEntryStatus `json:"status"`
+	AttemptAt  time.Time `json:"attempt_at"`
+	ObservedAt time.Time `json:"observed_at"`
+
+	// Reason Present only on stale entries: why the category was not re-observed this run
+	Reason *FreshnessEntryReason `json:"reason,omitempty"`
+	Status FreshnessEntryStatus  `json:"status"`
 }
+
+// FreshnessEntryReason Present only on stale entries: why the category was not re-observed this run
+type FreshnessEntryReason string
 
 // FreshnessEntryStatus defines model for FreshnessEntry.Status.
 type FreshnessEntryStatus string

--- a/internal/server/api_host_system_info_test.go
+++ b/internal/server/api_host_system_info_test.go
@@ -230,6 +230,7 @@ func TestAPI_HostSystemInfo_GET_ExposesCategoryFreshness(t *testing.T) {
 			   jsonb_build_object(
 			     'firewall', jsonb_build_object(
 			       'status', 'stale',
+			       'reason', 'denied',
 			       'observed_at', to_char((now() - interval '2 days') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
 			       'attempt_at', to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')),
 			     'os_release', jsonb_build_object(
@@ -253,6 +254,7 @@ func TestAPI_HostSystemInfo_GET_ExposesCategoryFreshness(t *testing.T) {
 		var body struct {
 			CategoryFreshness map[string]struct {
 				Status     string `json:"status"`
+				Reason     string `json:"reason"`
 				ObservedAt string `json:"observed_at"`
 				AttemptAt  string `json:"attempt_at"`
 			} `json:"category_freshness"`
@@ -266,6 +268,9 @@ func TestAPI_HostSystemInfo_GET_ExposesCategoryFreshness(t *testing.T) {
 		}
 		if fw.Status != "stale" {
 			t.Errorf("firewall status = %q, want stale", fw.Status)
+		}
+		if fw.Reason != "denied" {
+			t.Errorf("firewall reason = %q, want denied", fw.Reason)
 		}
 		if !(fw.ObservedAt < fw.AttemptAt) {
 			t.Errorf("stale observed_at %q not earlier than attempt_at %q", fw.ObservedAt, fw.AttemptAt)

--- a/specs/api/host-system-info.spec.yaml
+++ b/specs/api/host-system-info.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-host-system-info
   title: GET /hosts/{id}/system-info — last Discovery result for one host
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -96,6 +96,6 @@ spec:
       priority: critical
       references_constraints: [C-02]
     - id: AC-06
-      description: 'GET /api/v1/hosts/{id}/system-info with host:read on a row whose category_freshness JSONB records a stale category returns 200 with a category_freshness object; the stale category entry carries status="stale" and an observed_at earlier than attempt_at. A row with NULL category_freshness returns 200 with the field omitted'
+      description: 'GET /api/v1/hosts/{id}/system-info with host:read on a row whose category_freshness JSONB records a stale category returns 200 with a category_freshness object; the stale category entry carries status="stale", an observed_at earlier than attempt_at, and a reason ∈ {denied, failed, timeout} (system-host-discovery v1.7.0). A row with NULL category_freshness returns 200 with the field omitted'
       priority: high
       references_constraints: [C-05]

--- a/specs/frontend/host-detail-system-card.spec.yaml
+++ b/specs/frontend/host-detail-system-card.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-detail-system-card
   title: Host detail System card — Distribution / Kernel / Uptime from real data
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 2
 
@@ -99,7 +99,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-07
-      description: 'When systemInfo.category_freshness marks a rendered category status="stale" (the value was carried forward from an earlier run because the latest Discovery did not re-observe it; api-host-system-info C-05), the card MUST render an inline "Last verified <relative>" caveat beneath that value so the operator knows the reading is last-known-good, not fresh. A category with status="ok" or an absent freshness map MUST render NO caveat. The relative helper MUST be pure of locale/timezone effects that would change the coarse bucket (m/h/d ago)'
+      description: 'When systemInfo.category_freshness marks a rendered category status="stale" (the value was carried forward from an earlier run because the latest Discovery did not re-observe it; api-host-system-info C-05), the card MUST render an inline "Last verified <relative>" caveat beneath that value so the operator knows the reading is last-known-good, not fresh. When the stale entry carries a reason (denied | failed | timeout; system-host-discovery v1.7.0), the caveat MUST append a human label for it — "sudo denied" / "probe failed" / "probe timed out" — so the actionable denied case is distinguishable from a transient failure. A category with status="ok" or an absent freshness map MUST render NO caveat. The relative helper MUST be pure of locale/timezone effects that would change the coarse bucket (m/h/d ago)'
       type: technical
       enforcement: error
 
@@ -133,6 +133,6 @@ spec:
       priority: high
       references_constraints: [C-06]
     - id: AC-08
-      description: 'CardSystem rendered with a discovered host whose systemInfo.category_freshness marks "firewall" status="stale" (observed_at ~2 days earlier) shows a "Last verified" caveat on the Firewall row; the same card with category_freshness null (or the firewall entry status="ok") renders NO "Last verified" text. formatTimeAgo(now-2d) buckets to "2d ago"; formatTimeAgo of a value < 1 minute old is "just now"'
+      description: 'CardSystem rendered with a discovered host whose systemInfo.category_freshness marks "firewall" status="stale" (observed_at ~2 days earlier) with reason="denied" shows a "Last verified 2d ago (sudo denied)" caveat on the Firewall row; a stale entry with no reason shows "Last verified <relative>" and no parenthetical; the same card with category_freshness null (or the firewall entry status="ok") renders NO "Last verified" text. formatTimeAgo(now-2d) buckets to "2d ago"; formatTimeAgo of a value < 1 minute old is "just now"'
       priority: high
       references_constraints: [C-07]

--- a/specs/system/host-discovery.spec.yaml
+++ b/specs/system/host-discovery.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-host-discovery
   title: Host OS fingerprint discovery via SSH
-  version: "1.6.0"
+  version: "1.7.0"
   status: approved
   tier: 1
 
@@ -138,6 +138,10 @@ spec:
       description: 'v1.6.0 — persist stamps host_system_info.category_freshness (JSONB, migration 0052): one key per fact category mapping to {observed_at, attempt_at, status}. An OBSERVED category this run is status "ok" with observed_at = attempt_at = collected_at. An UNOBSERVED category that has a prior observation is status "stale" with the prior observed_at kept and attempt_at = this run (so a consumer can render "last good X ago"). A category never observed has no key. This is the read-side companion to the C-08 no-clobber merge: it records WHEN each carried-forward value was actually last seen.'
       type: technical
       enforcement: error
+    - id: C-14
+      description: 'v1.7.0 — a "stale" freshness entry MUST also carry a reason ∈ {denied, failed, timeout} recording WHY the category was not re-observed this run, so an operator can tell a fixable sudo denial from a transient connectivity failure. Classification is positive-evidence only for "denied": a category is labeled denied ONLY when the probe''s combined stdout+stderr carries a recognizable sudo-refusal signature (e.g. "a password is required", "is not in the sudoers file", "not allowed to execute"); a context-deadline error is "timeout"; any other Go-level error or a non-zero exit without a sudo signature is "failed". World-readable probes (os_release, uname, memory, disk, hostname, fqdn, selinux, apparmor) require no sudo, so their non-observations classify as failed/timeout and never denied. An "ok" entry carries no reason. When a stale category''s cause was not recorded, reason defaults to "failed" (never a false "denied").'
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -216,3 +220,15 @@ spec:
       description: 'v1.6.0 freshness: after a Discover run, host_system_info.category_freshness has status "ok" for every observed category with observed_at = the row''s collected_at; after a SECOND run that observes only some categories, the observed ones stay "ok" with a bumped observed_at while the unobserved ones flip to "stale" keeping their earlier observed_at (attempt_at advances). A first run stamps only observed categories (no key for never-observed ones).'
       priority: high
       references_constraints: [C-13]
+    - id: AC-26
+      description: 'v1.7.0 classifyOutcome (pure): a context.DeadlineExceeded error maps to "timeout"; any other non-nil error maps to "failed"; a nil error whose combined output carries a sudo-refusal signature ("a password is required", "is not in the sudoers file", "not allowed to execute", "a terminal is required", "incorrect password") maps to "denied"; a nil error with a non-zero-exit output that has NO sudo signature maps to "failed". sudoDenied is a case-insensitive substring match over that signature set.'
+      priority: high
+      references_constraints: [C-14]
+    - id: AC-27
+      description: 'v1.7.0 reason persistence: after a full first run, a second Discover run whose Attempts records firewall="denied" and disk="failed" (both unobserved, carried forward) persists category_freshness.firewall = {status:"stale", reason:"denied"} and category_freshness.disk = {status:"stale", reason:"failed"}; an observed category (os_release) is {status:"ok"} with no reason key. A stale category whose reason was not recorded defaults to reason "failed", never "denied".'
+      priority: high
+      references_constraints: [C-14]
+    - id: AC-28
+      description: 'v1.7.0 probeFirewall reason: when every firewall attempt is refused with a sudo-denial signature (systemctl absent, sudo -n / sudo -S all show "a password is required" / "not in the sudoers file"), probeFirewall returns ok=false with reason="denied"; when the attempts fail WITHOUT any sudo signature (no firewall tool present, plain non-zero exits), it returns ok=false with reason="failed". A successful probe returns ok=true with an empty reason.'
+      priority: high
+      references_constraints: [C-14]


### PR DESCRIPTION
## Summary

Follow-on to #745. Per-category freshness told an operator *that* a discovery fact was stale (carried forward because the latest run didn't re-observe it). This PR records *why* — so a **fixable sudo denial** is distinguishable from a **transient connectivity failure** rather than both reading as "stale."

## Backend (discovery)
- Each probe classifies its non-observation into `denied` | `failed` | `timeout`:
  - **denied** is **positive-evidence only** — labeled only when the probe's combined stdout+stderr carries a recognizable sudo-refusal signature ("a password is required", "is not in the sudoers file", "not allowed to execute", ...). A genuinely-absent tool or a transport error is **never** mislabeled as a permission problem (under-reporting denied is safer than over-reporting an actionable signal).
  - **timeout** = context deadline; **failed** = any other Go error or a non-zero exit without a sudo signature.
  - World-readable probes (os_release, uname, memory, disk, hostname, fqdn, selinux, apparmor) need no sudo, so they classify as failed/timeout, never denied.
  - `probeFirewall` now returns the reason it found no firewall (denied vs failed) instead of a bare `ok bool`.
- `freshnessEntry` gains `reason`; `computeFreshness` stamps it on stale entries, defaulting an unrecorded cause to `failed` (never a false `denied`).

## API + UI
- `FreshnessEntry.reason` (enum `denied|failed|timeout`) added to the OpenAPI schema; flows through both host read endpoints automatically (the handler unmarshals JSONB into the typed map). `server.gen.go` + `schema.d.ts` regenerated with pinned oapi-codegen v2.7.0 (deterministic).
- The host detail **System card** appends a human label to the stale caveat: `Last verified 2d ago (sudo denied)` / `(probe failed)` / `(probe timed out)`.

## Testing
- gofmt · `go build ./...` · vet clean · frontend `tsc` + prettier clean.
- `specter check` 116/116; `check --test` 0 errors; `coverage --strictness annotation` 100% — `system-host-discovery` 22/22, `api-host-system-info` 6/6, `frontend-host-detail-system-card` 8/8.
- New tests (pass against a real Postgres where DB-backed): `TestClassifyOutcome_AndSudoDenied` (AC-26, pure — incl. wrapped-deadline via errors.Is and no false-positive on benign output), `TestProbeFirewall_ReasonOnNonObservation` (AC-28, stub — denied/failed/success), `TestDiscover_FreshnessReason` (AC-27, DB — denied+failed persisted, unrecorded defaults to failed), extended API `AC-06` (reason exposed on the read endpoint) and frontend `AC-08` (reason label rendered, no parenthetical when absent).
- Full `internal/intelligence/...` + `internal/server` suites green (no regression; existing firewall/sudo-mode tests unaffected by the `probeFirewall` signature change).

## Not in this PR
- The **intelligence-collector** categories (packages/services/users/…) get the same observation-reason treatment in a follow-up. They have no UI consumer yet, so their reason would be API-only — cleanly separable.
- The `absent` state (observed-genuinely-not-present, distinct from `ok`) from the design doc remains residual (thin value for these columns, higher classification ambiguity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)