### PR TITLE
feat(intelligence): observation reason for OS-intelligence collector categories

### DIFF
--- a/internal/intelligence/collector/collector.go
+++ b/internal/intelligence/collector/collector.go
@@ -317,17 +317,23 @@ func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snap
 			af, _ := ParsePasswdShadow(out, nil)
 			snap.Users = af.Users
 		}
+	} else {
+		snap.recordFailure(SnapUsers, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "getent group"); err == nil && code == 0 {
 		snap.Groups = parseGroupOutput(out)
 		snap.Observed[SnapGroups] = true
+	} else {
+		snap.recordFailure(SnapGroups, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "ss -tln"); err == nil && code == 0 {
 		ports, _ := ParseListeningPorts(out)
 		snap.ListeningPorts = ports
 		snap.Observed[SnapPorts] = true
+	} else {
+		snap.recordFailure(SnapPorts, out, err)
 	}
 
 	// Network interfaces: `ip -j addr` gives addresses + state + MAC +
@@ -353,6 +359,8 @@ func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snap
 			snap.NetworkInterfaces = MergeNetworkInterfaces(ifaces, stats)
 			snap.Observed[SnapInterfaces] = true
 		}
+	} else {
+		snap.recordFailure(SnapInterfaces, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "ip -j route show 2>/dev/null"); err == nil && code == 0 {
@@ -360,6 +368,8 @@ func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snap
 			snap.Routes = routes
 			snap.Observed[SnapRoutes] = true
 		}
+	} else {
+		snap.recordFailure(SnapRoutes, out, err)
 	}
 
 	// Firewall rule count: try engines in priority order. First non-
@@ -404,22 +414,30 @@ func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snap
 			nn := n
 			snap.FirewallRuleCount = &nn
 		}
+	} else {
+		snap.recordFailure(SnapFirewall, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "rpm -qa --queryformat='%{NAME} %{VERSION}-%{RELEASE}\\n' 2>/dev/null || dpkg -l 2>/dev/null"); err == nil && code == 0 {
 		pkgs, _ := ParseInstalledPackages(out)
 		snap.Packages = pkgs
 		snap.Observed[SnapPackages] = true
+	} else {
+		snap.recordFailure(SnapPackages, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "systemctl list-units --type=service --all --no-legend --plain"); err == nil && code == 0 {
 		snap.Services = parseSystemctlUnits(out)
 		snap.Observed[SnapServices] = true
+	} else {
+		snap.recordFailure(SnapServices, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "uname -r"); err == nil && code == 0 {
 		snap.KernelRelease = strings.TrimSpace(string(out))
 		snap.Observed[SnapKernel] = true
+	} else {
+		snap.recordFailure(SnapKernel, out, err)
 	}
 
 	// Reboot marker — present on Debian-family; some RHEL setups expose
@@ -431,11 +449,15 @@ func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snap
 	if out, code, err := sess.Run(ctx, "cat /proc/uptime"); err == nil && code == 0 {
 		snap.UptimeSeconds = parseUptime(out)
 		snap.Observed[SnapUptime] = true
+	} else {
+		snap.recordFailure(SnapUptime, out, err)
 	}
 
 	if out, code, err := sess.Run(ctx, "cat /proc/mounts"); err == nil && code == 0 {
 		snap.Mountpoints = parseProcMounts(out)
 		snap.Observed[SnapMounts] = true
+	} else {
+		snap.recordFailure(SnapMounts, out, err)
 	}
 
 	// Config hashes — small fixed set. sha256 keeps the JSONB short.
@@ -467,8 +489,13 @@ func (s *Service) runCycleWithTransport(ctx context.Context, hf hostFacts) (Snap
 	// Config hashes are partial by nature (sudo-gated /etc/shadow may drop);
 	// treat the category as observed only when at least one file hashed, so a
 	// fully-denied run carries forward the prior hashes rather than blanking.
+	// A fully-empty result means even the world-readable sha256sums failed —
+	// a broad collection failure, classified "failed" (no single probe output
+	// to attribute a specific sudo denial to).
 	if len(snap.ConfigHashes) > 0 {
 		snap.Observed[SnapConfig] = true
+	} else {
+		snap.recordFailure(SnapConfig, nil, nil)
 	}
 
 	// TODO(v1.2): the firewall-rule probe embeds three `sudo -n` calls
@@ -589,7 +616,7 @@ func (s *Service) persist(ctx context.Context, hostID uuid.UUID, snap Snapshot, 
 	if len(priorFreshRaw) > 0 {
 		_ = json.Unmarshal(priorFreshRaw, &priorFresh)
 	}
-	freshJSON, _ := json.Marshal(computeSnapFreshness(snap.Observed, priorFresh, snap.CollectedAt))
+	freshJSON, _ := json.Marshal(computeSnapFreshness(snap.Observed, snap.Attempts, priorFresh, snap.CollectedAt))
 
 	// Spec C-03: UPSERT keyed by host_id.
 	if _, err := tx.Exec(ctx, `

--- a/internal/intelligence/collector/collector_db_test.go
+++ b/internal/intelligence/collector/collector_db_test.go
@@ -123,22 +123,28 @@ func TestRunCycle_EmitsAuditPerTaxonomyCode(t *testing.T) {
 			t.Skip("first-ever cycle suppressed all changes — taxonomy-emit path not exercised this run")
 		}
 
-		// Allow the async audit writer to flush.
-		time.Sleep(100 * time.Millisecond)
-
-		// Count audit rows whose action matches one of the events we
-		// emitted. Every change MUST yield exactly one row.
+		// The audit writer is async + batched (FlushInterval 20ms). Poll for
+		// each emitted event's row up to a deadline rather than sleeping a
+		// fixed interval — a fixed wait is flaky under -race + -p 4 CI load
+		// when the writer goroutine is starved past the sleep. Every change
+		// MUST eventually yield exactly one row.
+		deadline := time.Now().Add(5 * time.Second)
 		for _, ev := range events {
 			var count int
-			err := pool.QueryRow(context.Background(),
-				`SELECT COUNT(*) FROM audit_events
-				   WHERE action = $1 AND resource_id = $2`,
-				string(ev.Code), hostID.String()).Scan(&count)
-			if err != nil {
-				t.Fatalf("count audit rows for %s: %v", ev.Code, err)
+			for {
+				if err := pool.QueryRow(context.Background(),
+					`SELECT COUNT(*) FROM audit_events
+					   WHERE action = $1 AND resource_id = $2`,
+					string(ev.Code), hostID.String()).Scan(&count); err != nil {
+					t.Fatalf("count audit rows for %s: %v", ev.Code, err)
+				}
+				if count > 0 || time.Now().After(deadline) {
+					break
+				}
+				time.Sleep(20 * time.Millisecond)
 			}
 			if count == 0 {
-				t.Errorf("audit row missing for taxonomy code %q (host %s)",
+				t.Errorf("audit row missing for taxonomy code %q (host %s) after 5s",
 					ev.Code, hostID)
 			}
 		}

--- a/internal/intelligence/collector/merge_test.go
+++ b/internal/intelligence/collector/merge_test.go
@@ -4,12 +4,15 @@
 //
 //	AC-18  TestMergeUnobserved_NoClobberAndNoFalseEvents
 //	AC-19  TestComputeSnapFreshness
+//	AC-20  TestComputeSnapFreshness_Reason
 
 package collector
 
 import (
 	"testing"
 	"time"
+
+	"github.com/Hanalyx/openwatch/internal/intelligence/probe"
 )
 
 // @ac AC-18
@@ -84,7 +87,7 @@ func TestComputeSnapFreshness(t *testing.T) {
 			"services": {ObservedAt: earlier, AttemptAt: earlier, Status: "ok"},
 		}
 
-		out := computeSnapFreshness(map[SnapCategory]bool{SnapPackages: true}, prior, now)
+		out := computeSnapFreshness(map[SnapCategory]bool{SnapPackages: true}, nil, prior, now)
 
 		if e := out["packages"]; e.Status != "ok" || !e.ObservedAt.Equal(now) {
 			t.Errorf("packages = %+v, want ok observed_at=now", e)
@@ -96,8 +99,46 @@ func TestComputeSnapFreshness(t *testing.T) {
 			t.Errorf("users should be absent (never observed, no prior)")
 		}
 
-		if out2 := computeSnapFreshness(map[SnapCategory]bool{}, nil, now); len(out2) != 0 {
+		if out2 := computeSnapFreshness(map[SnapCategory]bool{}, nil, nil, now); len(out2) != 0 {
 			t.Errorf("nil prior + nothing observed should be empty, got %+v", out2)
+		}
+	})
+}
+
+// @ac AC-20
+// AC-20: a stale category carries the reason it was not re-observed, from the
+// cycle's Attempts map; an unrecorded cause defaults to "failed", never a false
+// "denied".
+func TestComputeSnapFreshness_Reason(t *testing.T) {
+	t.Run("system-os-intelligence/AC-20", func(t *testing.T) {
+		now := time.Now().UTC()
+		earlier := now.Add(-time.Hour)
+		prior := map[string]snapFreshnessEntry{
+			"services":        {ObservedAt: earlier, AttemptAt: earlier, Status: "ok"},
+			"packages":        {ObservedAt: earlier, AttemptAt: earlier, Status: "ok"},
+			"listening_ports": {ObservedAt: earlier, AttemptAt: earlier, Status: "ok"},
+		}
+		attempts := map[SnapCategory]string{
+			SnapServices: probe.OutcomeDenied,
+			SnapPackages: probe.OutcomeTimeout,
+			// listening_ports unobserved with NO recorded reason → defaults to failed.
+		}
+
+		out := computeSnapFreshness(map[SnapCategory]bool{}, attempts, prior, now)
+
+		if e := out["services"]; e.Status != "stale" || e.Reason != "denied" {
+			t.Errorf("services = %+v, want stale/denied", e)
+		}
+		if e := out["packages"]; e.Status != "stale" || e.Reason != "timeout" {
+			t.Errorf("packages = %+v, want stale/timeout", e)
+		}
+		if e := out["listening_ports"]; e.Status != "stale" || e.Reason != "failed" {
+			t.Errorf("listening_ports = %+v, want stale/failed (unrecorded default)", e)
+		}
+		// An observed category carries no reason.
+		out2 := computeSnapFreshness(map[SnapCategory]bool{SnapServices: true}, attempts, prior, now)
+		if e := out2["services"]; e.Status != "ok" || e.Reason != "" {
+			t.Errorf("observed services = %+v, want ok with no reason", e)
 		}
 	})
 }

--- a/internal/intelligence/collector/types.go
+++ b/internal/intelligence/collector/types.go
@@ -1,6 +1,10 @@
 package collector
 
-import "time"
+import (
+	"time"
+
+	"github.com/Hanalyx/openwatch/internal/intelligence/probe"
+)
 
 // Snapshot is the full structured state one RunCycle collects from a
 // host. Persisted as JSONB in host_intelligence_state.snapshot; the
@@ -82,6 +86,24 @@ type Snapshot struct {
 	// v1.2.0). An observed category keeps this cycle's value even when
 	// genuinely empty — that is a real observation.
 	Observed map[SnapCategory]bool `json:"-"`
+
+	// Attempts records WHY a non-observed category was not collected this cycle
+	// (denied | failed | timeout), so the persisted freshness can explain a
+	// stale carried-forward value. Transient (`json:"-"`, never stored); only
+	// categories attempted-but-not-observed appear. Spec C-10, v1.4.0.
+	Attempts map[SnapCategory]string `json:"-"`
+}
+
+// recordFailure stamps the reason a category was not observed this cycle, via
+// the shared probe.ClassifyOutcome classifier. Safe with a nil Attempts map.
+// Note: several collector probes suppress stderr (2>/dev/null) or fall back to
+// a non-sudo path, so a sudo-refusal signature is often not visible — such
+// categories honestly classify as "failed" rather than a guessed "denied".
+func (s *Snapshot) recordFailure(cat SnapCategory, out []byte, err error) {
+	if s.Attempts == nil {
+		s.Attempts = make(map[SnapCategory]string, len(allSnapCategories))
+	}
+	s.Attempts[cat] = probe.ClassifyOutcome(out, err)
 }
 
 // SnapCategory groups Snapshot fields by the probe that collects them, so the
@@ -114,14 +136,17 @@ var allSnapCategories = []SnapCategory{
 type snapFreshnessEntry struct {
 	ObservedAt time.Time `json:"observed_at"`
 	AttemptAt  time.Time `json:"attempt_at"`
-	Status     string    `json:"status"` // ok | stale
+	Status     string    `json:"status"`           // ok | stale
+	Reason     string    `json:"reason,omitempty"` // denied | failed | timeout (stale only)
 }
 
 // computeSnapFreshness stamps per-category freshness: an observed category is
 // "ok" (observed_at = now); an unobserved category with a prior observation is
 // "stale" (prior observed_at kept, attempt_at = now, so a consumer can show
-// "last good X ago"); a category never observed has no entry.
-func computeSnapFreshness(observed map[SnapCategory]bool, prior map[string]snapFreshnessEntry, now time.Time) map[string]snapFreshnessEntry {
+// "last good X ago") and carries the reason it was not re-observed this cycle
+// (denied | failed | timeout, defaulting an unrecorded cause to failed — never
+// a false denied); a category never observed has no entry. Spec C-09 + C-10.
+func computeSnapFreshness(observed map[SnapCategory]bool, attempts map[SnapCategory]string, prior map[string]snapFreshnessEntry, now time.Time) map[string]snapFreshnessEntry {
 	out := make(map[string]snapFreshnessEntry, len(allSnapCategories))
 	for _, cat := range allSnapCategories {
 		key := string(cat)
@@ -130,7 +155,16 @@ func computeSnapFreshness(observed map[SnapCategory]bool, prior map[string]snapF
 			out[key] = snapFreshnessEntry{ObservedAt: now, AttemptAt: now, Status: "ok"}
 		case prior != nil:
 			if p, ok := prior[key]; ok {
-				out[key] = snapFreshnessEntry{ObservedAt: p.ObservedAt, AttemptAt: now, Status: "stale"}
+				reason := attempts[cat]
+				if reason == "" {
+					reason = probe.OutcomeFailed
+				}
+				out[key] = snapFreshnessEntry{
+					ObservedAt: p.ObservedAt,
+					AttemptAt:  now,
+					Status:     "stale",
+					Reason:     reason,
+				}
 			}
 		}
 	}

--- a/internal/intelligence/discovery/discovery.go
+++ b/internal/intelligence/discovery/discovery.go
@@ -133,43 +133,14 @@ type SystemFacts struct {
 	Attempts map[FactCategory]string
 }
 
-// Attempt outcomes for a non-observed fact category on one run. observed is
-// represented by absence from SystemFacts.Attempts (the category is in Observed
-// instead). These label the reason a probe did not yield a value so a stale
-// carried-forward value can be explained.
-const (
-	outcomeDenied  = "denied"  // positive evidence of a sudo/permission refusal
-	outcomeFailed  = "failed"  // transport error or non-permission command failure
-	outcomeTimeout = "timeout" // the probe exceeded the run deadline
-)
-
-// classifyOutcome maps a probe's (out, code, err) triple to a non-observed
-// outcome. Positive-evidence only for "denied": we label a category denied
-// ONLY when the combined output carries a recognizable sudo-refusal signature,
-// so a genuinely-absent tool or a transport error is never mislabeled as a
-// permission problem (under-reporting denied is safer than over-reporting an
-// actionable signal). A context deadline is a timeout; any other Go-level error
-// is a failure; a non-zero exit without a sudo signature is a failure.
-func classifyOutcome(out []byte, err error) string {
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return outcomeTimeout
-		}
-		return outcomeFailed
-	}
-	if sudoDenied(out) {
-		return outcomeDenied
-	}
-	return outcomeFailed
-}
-
-// recordFailure stamps the reason a category was not observed this run. Safe
-// to call with a nil Attempts map (lazily initialized).
+// recordFailure stamps the reason a category was not observed this run, via the
+// shared probe.ClassifyOutcome classifier (denied | failed | timeout). Safe to
+// call with a nil Attempts map (lazily initialized). Spec C-14.
 func (f *SystemFacts) recordFailure(cat FactCategory, out []byte, err error) {
 	if f.Attempts == nil {
 		f.Attempts = make(map[FactCategory]string, len(allFactCategories))
 	}
-	f.Attempts[cat] = classifyOutcome(out, err)
+	f.Attempts[cat] = probe.ClassifyOutcome(out, err)
 }
 
 // FactCategory groups host_system_info columns by the probe that collects them,
@@ -223,7 +194,7 @@ func computeFreshness(observed map[FactCategory]bool, attempts map[FactCategory]
 			if p, ok := prior[key]; ok {
 				reason := attempts[cat]
 				if reason == "" {
-					reason = outcomeFailed // not observed, cause unrecorded → failed
+					reason = probe.OutcomeFailed // not observed, cause unrecorded → failed
 				}
 				out[key] = freshnessEntry{
 					ObservedAt: p.ObservedAt,

--- a/internal/intelligence/discovery/discovery_db_test.go
+++ b/internal/intelligence/discovery/discovery_db_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/credential"
 	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
+	"github.com/Hanalyx/openwatch/internal/intelligence/probe"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -294,8 +295,8 @@ func TestDiscover_FreshnessReason(t *testing.T) {
 			CollectedAt: time.Now().UTC(),
 			Observed:    map[FactCategory]bool{CatOSRelease: true},
 			Attempts: map[FactCategory]string{
-				CatFirewall: outcomeDenied,
-				CatDisk:     outcomeFailed,
+				CatFirewall: probe.OutcomeDenied,
+				CatDisk:     probe.OutcomeFailed,
 			},
 		}); err != nil {
 			t.Fatalf("run2 persist: %v", err)

--- a/internal/intelligence/discovery/helpers.go
+++ b/internal/intelligence/discovery/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Hanalyx/openwatch/internal/connprofile"
 	"github.com/Hanalyx/openwatch/internal/credential"
+	"github.com/Hanalyx/openwatch/internal/intelligence/probe"
 	"github.com/Hanalyx/openwatch/internal/systemconfig"
 )
 
@@ -170,35 +171,6 @@ func runSudoWithFallback(ctx context.Context, sess SSHSession, sudoCmd string, c
 	return fOut, fCode, connprofile.SudoUnknown, fErr
 }
 
-// sudoDenialSignatures are lowercase substrings sudo (or PAM) emits on the
-// combined stdout+stderr when a command is refused for permission / tty /
-// password reasons. Detection is positive-evidence only: a category is labeled
-// "denied" ONLY when one of these appears, so a genuinely-absent tool or a
-// transport error is never mislabeled as a permission problem. Spec C-14.
-var sudoDenialSignatures = []string{
-	"a password is required",
-	"a terminal is required",
-	"no tty present",
-	"is not allowed to run sudo",
-	"is not in the sudoers file",
-	"not allowed to execute",
-	"incorrect password",
-	"sorry, try again",
-}
-
-// sudoDenied reports whether the combined command output carries a recognizable
-// sudo-refusal signature. Case-insensitive substring match on the signatures
-// above.
-func sudoDenied(out []byte) bool {
-	s := strings.ToLower(string(out))
-	for _, sig := range sudoDenialSignatures {
-		if strings.Contains(s, sig) {
-			return true
-		}
-	}
-	return false
-}
-
 // probeFirewall tries each known firewall service in order. The first
 // one to answer (exit 0) wins. Returns ("", "", false) when none answer
 // — typically because the credential lacks sudo. Per spec C-03 + AC-05
@@ -226,7 +198,7 @@ func probeFirewall(ctx context.Context, sess SSHSession, cfg sudoFallbackConfig)
 	// grant sudo) rather than the generic "failed". Positive-evidence only.
 	sawDenial := false
 	seen := func(out []byte) {
-		if sudoDenied(out) {
+		if probe.SudoDenied(out) {
 			sawDenial = true
 		}
 	}
@@ -263,9 +235,9 @@ func probeFirewall(ctx context.Context, sess SSHSession, cfg sudoFallbackConfig)
 		return "firewalld", strings.TrimSpace(string(out)), learned, true, ""
 	}
 	if sawDenial {
-		return "", "", learned, false, outcomeDenied
+		return "", "", learned, false, probe.OutcomeDenied
 	}
-	return "", "", learned, false, outcomeFailed
+	return "", "", learned, false, probe.OutcomeFailed
 }
 
 func firstWord(s string) string {

--- a/internal/intelligence/discovery/outcome_test.go
+++ b/internal/intelligence/discovery/outcome_test.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/intelligence/probe"
 )
 
 // @ac AC-26
@@ -25,27 +27,27 @@ func TestClassifyOutcome_AndSudoDenied(t *testing.T) {
 			err  error
 			want string
 		}{
-			{"deadline is timeout", "partial", context.DeadlineExceeded, outcomeTimeout},
-			{"wrapped deadline is timeout", "x", errWrap(context.DeadlineExceeded), outcomeTimeout},
-			{"transport error is failed", "x", errors.New("ssh: connection lost"), outcomeFailed},
-			{"sudo password signature is denied", "sudo: a password is required", nil, outcomeDenied},
-			{"sudoers signature is denied", "owadmin is not in the sudoers file", nil, outcomeDenied},
-			{"not-allowed signature is denied", "user is not allowed to execute", nil, outcomeDenied},
-			{"command-not-found is failed", "bash: getenforce: command not found", nil, outcomeFailed},
-			{"empty non-zero is failed", "", nil, outcomeFailed},
+			{"deadline is timeout", "partial", context.DeadlineExceeded, probe.OutcomeTimeout},
+			{"wrapped deadline is timeout", "x", errWrap(context.DeadlineExceeded), probe.OutcomeTimeout},
+			{"transport error is failed", "x", errors.New("ssh: connection lost"), probe.OutcomeFailed},
+			{"sudo password signature is denied", "sudo: a password is required", nil, probe.OutcomeDenied},
+			{"sudoers signature is denied", "owadmin is not in the sudoers file", nil, probe.OutcomeDenied},
+			{"not-allowed signature is denied", "user is not allowed to execute", nil, probe.OutcomeDenied},
+			{"command-not-found is failed", "bash: getenforce: command not found", nil, probe.OutcomeFailed},
+			{"empty non-zero is failed", "", nil, probe.OutcomeFailed},
 		}
 		for _, c := range cases {
-			if got := classifyOutcome([]byte(c.out), c.err); got != c.want {
-				t.Errorf("%s: classifyOutcome(%q, %v) = %q, want %q", c.name, c.out, c.err, got, c.want)
+			if got := probe.ClassifyOutcome([]byte(c.out), c.err); got != c.want {
+				t.Errorf("%s: probe.ClassifyOutcome(%q, %v) = %q, want %q", c.name, c.out, c.err, got, c.want)
 			}
 		}
 
 		// sudoDenied is case-insensitive and does not false-positive on benign
 		// output.
-		if !sudoDenied([]byte("SUDO: A PASSWORD IS REQUIRED")) {
+		if !probe.SudoDenied([]byte("SUDO: A PASSWORD IS REQUIRED")) {
 			t.Error("sudoDenied should match case-insensitively")
 		}
-		if sudoDenied([]byte("Status: active")) {
+		if probe.SudoDenied([]byte("Status: active")) {
 			t.Error("sudoDenied should not match benign firewall output")
 		}
 	})
@@ -78,8 +80,8 @@ func TestProbeFirewall_ReasonOnNonObservation(t *testing.T) {
 		if ok {
 			t.Fatalf("denied case: ok=true, want false")
 		}
-		if reason != outcomeDenied {
-			t.Errorf("denied case: reason=%q, want %q", reason, outcomeDenied)
+		if reason != probe.OutcomeDenied {
+			t.Errorf("denied case: reason=%q, want %q", reason, probe.OutcomeDenied)
 		}
 
 		// Failed: no firewall tool present, every attempt returns 127 with no
@@ -91,8 +93,8 @@ func TestProbeFirewall_ReasonOnNonObservation(t *testing.T) {
 		if ok {
 			t.Fatalf("failed case: ok=true, want false")
 		}
-		if reason != outcomeFailed {
-			t.Errorf("failed case: reason=%q, want %q", reason, outcomeFailed)
+		if reason != probe.OutcomeFailed {
+			t.Errorf("failed case: reason=%q, want %q", reason, probe.OutcomeFailed)
 		}
 
 		// Success: firewalld active via sudoless systemctl → empty reason.

--- a/internal/intelligence/probe/probe.go
+++ b/internal/intelligence/probe/probe.go
@@ -10,10 +10,69 @@ package probe
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strconv"
 	"strings"
 )
+
+// Observation outcomes for a probe that did NOT yield a value on a run. Shared
+// by Discovery (system-host-discovery) and the intelligence collector
+// (system-os-intelligence) so the sudo-refusal signature list — a
+// security-relevant classifier — lives in exactly one place and cannot drift
+// between the two callers.
+const (
+	OutcomeDenied  = "denied"  // positive evidence of a sudo/permission refusal
+	OutcomeFailed  = "failed"  // transport error or non-permission command failure
+	OutcomeTimeout = "timeout" // the probe exceeded the run deadline
+)
+
+// sudoDenialSignatures are lowercase substrings sudo (or PAM) emits on the
+// combined stdout+stderr when a command is refused for permission / tty /
+// password reasons. Detection is positive-evidence only: a category is labeled
+// "denied" ONLY when one of these appears, so a genuinely-absent tool or a
+// transport error is never mislabeled as a permission problem.
+var sudoDenialSignatures = []string{
+	"a password is required",
+	"a terminal is required",
+	"no tty present",
+	"is not allowed to run sudo",
+	"is not in the sudoers file",
+	"not allowed to execute",
+	"incorrect password",
+	"sorry, try again",
+}
+
+// SudoDenied reports whether the combined command output carries a recognizable
+// sudo-refusal signature. Case-insensitive substring match.
+func SudoDenied(out []byte) bool {
+	s := strings.ToLower(string(out))
+	for _, sig := range sudoDenialSignatures {
+		if strings.Contains(s, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// ClassifyOutcome maps a probe's (out, err) to a non-observed outcome. A
+// context-deadline error is OutcomeTimeout; any other error is OutcomeFailed; a
+// nil error whose output carries a sudo-refusal signature is OutcomeDenied; a
+// nil error with a non-zero-exit output and no signature is OutcomeFailed.
+// Positive-evidence only for denied — under-reporting a denial is safer than
+// mislabeling an absent tool or a dropped connection as a permission problem.
+func ClassifyOutcome(out []byte, err error) string {
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return OutcomeTimeout
+		}
+		return OutcomeFailed
+	}
+	if SudoDenied(out) {
+		return OutcomeDenied
+	}
+	return OutcomeFailed
+}
 
 // OSFacts is the structured form of /etc/os-release. Field semantics
 // follow the FHS/os-release standard; both RHEL-family (quoted values)

--- a/specs/system/os-intelligence.spec.yaml
+++ b/specs/system/os-intelligence.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-os-intelligence
   title: Host OS Intelligence — recurring snapshot + diff-driven event log
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -116,6 +116,10 @@ spec:
       description: 'v1.3.0 — persist stamps host_intelligence_state.category_freshness (JSONB, migration 0052): one key per snapshot category mapping to {observed_at, attempt_at, status}. computeSnapFreshness sets an OBSERVED category to status "ok" (observed_at = attempt_at = collected_at); an UNOBSERVED category with a prior observation to status "stale" (prior observed_at kept, attempt_at = this run); a never-observed category has no key. This is the read-side companion to the C-03 no-clobber merge — it records WHEN each carried-forward category was actually last seen.'
       type: technical
       enforcement: error
+    - id: C-10
+      description: 'v1.4.0 — a "stale" freshness entry MUST also carry a reason ∈ {denied, failed, timeout} recording WHY the category was not re-observed this cycle, from the cycle Snapshot.Attempts map. Each probe records its non-observation via the shared probe.ClassifyOutcome classifier (positive-evidence-only "denied": only when the combined output shows a sudo-refusal signature). Note: several collector probes suppress stderr (2>/dev/null) or fall back to a non-sudo path, so a sudo signature is often not visible — those categories honestly classify as "failed" rather than a guessed "denied". A stale category whose cause was not recorded defaults to reason "failed", never "denied". An "ok" entry carries no reason. Attempts is transient (json:"-"), never stored in the snapshot.'
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -194,3 +198,7 @@ spec:
       description: 'v1.3.0 freshness (computeSnapFreshness): an observed category maps to status "ok" with observed_at = attempt_at = the passed now; an unobserved category present in the prior freshness maps to status "stale" with the prior observed_at kept and attempt_at = now; an unobserved category with no prior entry is absent from the output; a nil prior with an unobserved category yields no entry.'
       priority: high
       references_constraints: [C-09]
+    - id: AC-20
+      description: 'v1.4.0 reason (computeSnapFreshness): a stale category whose SnapCategory appears in the attempts map with "denied" / "timeout" carries that reason; a stale category absent from attempts defaults to reason "failed" (never a false "denied"); an observed category carries no reason. The attempts map is threaded from the cycle Snapshot.Attempts.'
+      priority: high
+      references_constraints: [C-10]


### PR DESCRIPTION
## Summary

Follow-on to #746, which added the observation *reason* (denied | failed | timeout) to **discovery** facts. This PR extends the same treatment to the recurring **OS-intelligence collector** and unifies the shared classifier so the security-relevant sudo-refusal logic lives in exactly one place.

## Changes
- **Extracted the classifier to `internal/intelligence/probe`** (exported `ClassifyOutcome`, `SudoDenied`, `OutcomeDenied/Failed/Timeout` + the sudo-denial signature list). Discovery now uses it (its local copy removed); the collector uses it too — **no drift** between the two callers of a security-relevant list.
- **Collector reason plumbing**: each probe records its non-observation reason in a transient `Snapshot.Attempts` map (`json:"-"`, never stored); `computeSnapFreshness` stamps it on stale entries, defaulting an unrecorded cause to `failed` (never a false `denied`).
- **No API/schema change**: the reason flows through the existing `host_intelligence_state.category_freshness` JSONB and the already-shared `FreshnessEntry.reason` field (added in #746). `GET /intelligence/state/{host_id}` exposes it automatically.

## Honest limitation (documented in spec C-10)
Several collector probes suppress stderr (`2>/dev/null`) or fall back to a non-sudo path, so a sudo-refusal signature is often not visible. Those categories honestly classify as `failed` rather than a guessed `denied` — the same positive-evidence-only discipline as discovery. Under-reporting denied is the safe direction.

## Testing
- gofmt · `go build ./...` · vet clean.
- `specter check` 116/116; `check --test` 0 errors; `coverage --strictness annotation` 100% — `system-os-intelligence` 20/20, `system-host-discovery` 22/22 (held through the classifier refactor).
- New/updated tests (pass, incl. real Postgres where DB-backed): `TestComputeSnapFreshness_Reason` (AC-20 — denied/timeout from attempts, unrecorded→failed, observed→no reason); `TestComputeSnapFreshness` (AC-19) updated for the new signature; discovery `AC-26`/`AC-28` re-pointed at the shared `probe.*` classifier and still green; full `internal/intelligence/...` suites pass (collector, discovery, both schedulers, probe).

## Arc status
This completes the observation-reason work across **both** collectors (discovery via #746, intelligence here). The intelligence categories have no dedicated UI consumer yet, so their reason is API-only until an Intelligence/Inventory tab renders it. The design doc's `absent` state and Phase 2 (temporal fact-history substrate) / Phase 3 remain the open follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)