### PR TITLE
feat(compliance): lens as default score everywhere, OS-resolved, framework-scoped trend (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] Eyrie — 2026-07-17
+
+### Added
+
+- **The framework lens is now the default compliance score on every surface.**
+  With an org default lens (or a per-host / per-group target) set, the
+  compliance score reflects that framework by default on the hosts list, Scans
+  → Coverage, the fleet KPI, the Groups-page averages, and the host-detail
+  compliance trend — not only the host-detail hero tile. Previously those
+  surfaces showed the raw all-rules score unless a framework was explicitly
+  requested. An explicit `?framework=` still overrides. See spec
+  `system-compliance-lens`.
+- **Framework-scoped posture snapshots — the compliance trend follows the
+  lens.** The daily posture rollup now stores an OS-resolved score per framework
+  family per host per day (migration 0053) alongside the all-rules series. The
+  host trend card and the dashboard fleet trend read the effective lens's
+  series, so the trend agrees with the hero tile, and switching the org default
+  lens selects a different pre-computed series with no recompute. History is
+  start-fresh (per-family series accrues forward from the migration). Specs
+  `system-posture-snapshots`, `api-compliance-trend`.
+
+### Fixed
+
+- **Per-host compliance scores resolve to the host's OS-specific benchmark.** A
+  family lens (e.g. STIG) is scored against the host's own corpus key (a RHEL 9
+  host's STIG = `stig_rhel9`), not the union of every OS variant. Before, the
+  hosts list scored a RHEL 9 host against RHEL 8/10 and Ubuntu STIG rules too
+  (a family-wide match), so the list read (for example) 70% while the
+  host-detail tile read 88% for the same host and lens. Every per-host score
+  surface — list, Coverage, host summary, fleet score, Groups averages — now
+  agrees. New `framework.OSResolvedMatchSQL`.
+- **The Groups page compliance averages are lens-scoped.** The per-group and
+  groups-page fleet averages were the last surface still counting all rules;
+  they now follow the effective lens (OS-resolved), so the Groups fleet average
+  equals the hosts-page fleet KPI.
+
 ## [0.5.0] Eyrie — 2026-07-14
 
 ### Added

--- a/internal/db/migrations/0053_posture_snapshot_framework.sql
+++ b/internal/db/migrations/0053_posture_snapshot_framework.sql
@@ -1,0 +1,40 @@
+-- 0053_posture_snapshot_framework.sql
+--
+-- Framework-scoped posture snapshots (compliance-lens Phase 3c).
+--
+-- Before this, posture_snapshots held ONE row per (host, day) — an
+-- all-rules score. The compliance trend card could therefore only ever
+-- show all-rules, disagreeing with the host-detail hero tile / list /
+-- coverage once a framework lens is the default (a RHEL 9 host reads 88%
+-- STIG on the tile but 68% all-rules on the trend).
+--
+-- This adds a `framework` dimension so the rollup stores a per-FAMILY
+-- score (OS-resolved: a RHEL 9 host's "stig" row is its stig_rhel9 score)
+-- PLUS the all-rules row (framework=''). The trend then reads the series
+-- for whatever lens is in effect, and switching the org default just
+-- selects a different pre-computed series — no recompute, no broken
+-- history. History is kept "start fresh": existing rows become the
+-- all-rules ('') series; per-family series accrue going forward.
+--
+-- Spec: system-posture-snapshots v1.1.0 / api-compliance-trend v1.1.0.
+
+-- +goose Up
+ALTER TABLE posture_snapshots ADD COLUMN framework TEXT NOT NULL DEFAULT '';
+
+-- Widen the identity to (host, day, framework): '' is the all-rules
+-- series (the existing rows), a family id (stig, cis, nist_800_53, …) is
+-- that lens's OS-resolved score for the host that day.
+ALTER TABLE posture_snapshots DROP CONSTRAINT posture_snapshots_pkey;
+ALTER TABLE posture_snapshots ADD PRIMARY KEY (host_id, snapshot_date, framework);
+
+-- Fleet trend reads by (framework, date); host trend by (host, framework, date).
+CREATE INDEX posture_snapshots_fw_date ON posture_snapshots (framework, snapshot_date);
+
+-- +goose Down
+DROP INDEX IF EXISTS posture_snapshots_fw_date;
+-- Collapse back to one row per (host, day): drop the per-family rows so
+-- the narrower PK does not violate uniqueness.
+DELETE FROM posture_snapshots WHERE framework <> '';
+ALTER TABLE posture_snapshots DROP CONSTRAINT posture_snapshots_pkey;
+ALTER TABLE posture_snapshots ADD PRIMARY KEY (host_id, snapshot_date);
+ALTER TABLE posture_snapshots DROP COLUMN framework;

--- a/internal/fleetrollup/compliance_lens_test.go
+++ b/internal/fleetrollup/compliance_lens_test.go
@@ -33,8 +33,10 @@ func seedRuleStateFW(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID,
 }
 
 // @ac AC-03
-// AC-03: a FAMILY filter spans a mixed-OS fleet (stig_rhel9 + stig_rhel10),
-// a specific-key filter matches only that OS, and no filter counts all rules.
+// AC-03: a FAMILY filter spans a mixed-OS fleet — each host resolved to its
+// OWN OS key (a RHEL 9 host's "stig" -> stig_rhel9, a RHEL 10 host's ->
+// stig_rhel10) so both contribute; a specific-key filter matches only that OS;
+// no filter counts all rules.
 func TestFleetComplianceScore_FamilyMatchesMixedOS(t *testing.T) {
 	t.Run("system-compliance-lens/AC-03", func(t *testing.T) {
 		pool := freshPool(t)
@@ -42,14 +44,22 @@ func TestFleetComplianceScore_FamilyMatchesMixedOS(t *testing.T) {
 		user := seedUser(t, pool)
 		h9 := seedHost(t, pool, user)  // RHEL 9
 		h10 := seedHost(t, pool, user) // RHEL 10
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE hosts SET os_family='rhel', os_version='9.6' WHERE id=$1`, h9); err != nil {
+			t.Fatalf("set h9 os: %v", err)
+		}
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE hosts SET os_family='rhel', os_version='10.0' WHERE id=$1`, h10); err != nil {
+			t.Fatalf("set h10 os: %v", err)
+		}
 
 		seedRuleStateFW(t, pool, h9, "r.a", "pass", `{"stig_rhel9":["V-1"]}`)
 		seedRuleStateFW(t, pool, h9, "r.b", "fail", `{"stig_rhel9":["V-2"]}`)
 		seedRuleStateFW(t, pool, h9, "r.c", "pass", `{"cis_rhel9":["1.1"]}`)
 		seedRuleStateFW(t, pool, h10, "r.a", "pass", `{"stig_rhel10":["V-1"]}`)
 
-		// Family "stig" = stig_rhel9 (1 pass, 1 fail) + stig_rhel10 (1 pass)
-		// across both hosts → 2 pass / 3 evaluations.
+		// Family "stig": h9 resolves to stig_rhel9 (1 pass, 1 fail), h10 to
+		// stig_rhel10 (1 pass) → 2 pass / 3 evaluations across the fleet.
 		stig, err := svc.FleetComplianceScore(context.Background(), WithFramework("stig"))
 		if err != nil {
 			t.Fatalf("stig score: %v", err)

--- a/internal/fleetrollup/service.go
+++ b/internal/fleetrollup/service.go
@@ -36,17 +36,18 @@ func NewService(pool *pgxpool.Pool) *Service {
 func (s *Service) FleetComplianceScore(ctx context.Context, opts ...Option) (Score, error) {
 	o := applyOpts(opts)
 
-	// Single SQL covers the unfiltered (framework=""), specific-key, and
-	// family paths. framework.MatchSQL($1) is TRUE when $1 is NULL (all
-	// rules) or framework_refs carries that exact key OR any key in that
-	// family (e.g. "stig" matches stig_rhel9 + stig_rhel10 across a mixed-OS
-	// fleet — a single key filter would miss the other OS).
+	// Per-host OS-resolved lens (framework.OSResolvedMatchSQL): each host
+	// contributes its OWN OS-specific benchmark — a RHEL 9 host scores against
+	// stig_rhel9, a RHEL 10 host against stig_rhel10 — rather than the family
+	// union, which would grade every host against every OS variant it carries
+	// mapped rules for. $1 NULL = all rules. Joins hosts for each row's OS.
 	q := `
 		SELECT
 			COUNT(*) FILTER (WHERE current_status = 'pass')                  AS passing,
 			COUNT(*) FILTER (WHERE current_status IN ('pass','fail'))        AS evaluations
-		  FROM host_rule_state
-		 WHERE ` + framework.MatchSQL("$1")
+		  FROM host_rule_state hrs
+		  JOIN hosts hh ON hh.id = hrs.host_id
+		 WHERE ` + framework.OSResolvedMatchSQL("$1", "hh.os_family", "hh.os_version")
 	var passing, evaluations int64
 	if err := s.pool.QueryRow(ctx, q, nullableFramework(o.framework)).Scan(&passing, &evaluations); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -57,6 +57,39 @@ func MatchSQL(paramRef string) string {
 			    OR regexp_replace(fk, '` + OSSuffixSQL + `', '') = ` + paramRef + `))`
 }
 
+// OSResolvedMatchSQL returns a SQL boolean fragment (for a WHERE clause on a
+// table with a framework_refs JSONB column) that is TRUE when framework_refs
+// matches the family in famRef RESOLVED to the host's OWN OS-specific corpus
+// key — NOT the union of every OS variant.
+//
+// This is the correct filter for a PER-HOST compliance score. MatchSQL is
+// family-aware and matches ANY key in a family (stig -> stig_rhel9 +
+// stig_rhel10 + …); that over-counts a single host, which carries mapped rules
+// for several OS benchmarks at once (a RHEL 9 host has stig_rhel9 AND
+// stig_rhel10 refs). Grading a RHEL 9 host partly against the RHEL 10 STIG is
+// wrong. OSResolvedMatchSQL instead scopes a family to `<family>_<osfamily><major>`
+// (stig on a rhel 9.6 host -> stig_rhel9), so the list/summary/fleet score
+// matches the host-detail tile.
+//
+// It is TRUE when:
+//   - famRef IS NULL (all rules, no filter), OR
+//   - framework_refs has the OS-resolved key `famRef || '_' || <osfamily><major>`
+//     (a family scoped to this host's OS: stig -> stig_rhel9), OR
+//   - framework_refs has a key equal to famRef itself — which covers an
+//     OS-neutral family (nist_800_53, pci_dss_4, srg, whose key carries no OS
+//     suffix) and an explicitly-passed specific key (stig_rhel9).
+//
+// famRef, osFamilyExpr, osVersionExpr are SQL expressions (a bind placeholder
+// like "$2", or a column reference like "eff.fam"/"hh.os_family"); they must be
+// fixed literals in code, never user input. The OS token mirrors the corpus key
+// suffix: lower(os_family) concatenated with the major version
+// (split_part(os_version,'.',1)) — e.g. rhel+9 = rhel9, ubuntu+22 = ubuntu22.
+func OSResolvedMatchSQL(famRef, osFamilyExpr, osVersionExpr string) string {
+	return `(` + famRef + `::text IS NULL
+			OR framework_refs ? (` + famRef + ` || '_' || lower(` + osFamilyExpr + `) || split_part(` + osVersionExpr + `, '.', 1))
+			OR framework_refs ? ` + famRef + `)`
+}
+
 // familyLabels overrides the display label for known families; anything else
 // falls back to an upper-cased id.
 var familyLabels = map[string]string{

--- a/internal/group/service.go
+++ b/internal/group/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/framework"
 )
 
 // Sentinel errors. Handlers map these to HTTP status codes.
@@ -222,7 +224,7 @@ func (s *Service) RemoveMember(ctx context.Context, groupID, hostID uuid.UUID) e
 }
 
 // List returns every group with its computed rollup, sites first.
-func (s *Service) List(ctx context.Context) ([]GroupWithRollup, error) {
+func (s *Service) List(ctx context.Context, orgDefault string) ([]GroupWithRollup, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT `+groupCols+`
 		FROM groups
@@ -246,7 +248,7 @@ func (s *Service) List(ctx context.Context) ([]GroupWithRollup, error) {
 
 	out := make([]GroupWithRollup, 0, len(groups))
 	for _, g := range groups {
-		roll, err := s.rollup(ctx, g)
+		roll, err := s.rollup(ctx, g, orgDefault)
 		if err != nil {
 			return nil, err
 		}
@@ -298,10 +300,22 @@ func memberCTE(g Group) (string, any) {
 	return `SELECT host_id FROM group_members WHERE group_id = $1`, g.ID
 }
 
-func (s *Service) rollup(ctx context.Context, g Group) (Rollup, error) {
+func (s *Service) rollup(ctx context.Context, g Group, orgDefault string) (Rollup, error) {
 	cte, arg := memberCTE(g)
 	var r Rollup
 	var passing, evaluated int
+	// Compliance counts (critical / passing / evaluated) are scored against
+	// each member's EFFECTIVE compliance target (host_effective_target, else
+	// the org default $2), RESOLVED to that host's OS-specific key
+	// (framework.OSResolvedMatchSQL) — so a group's AVG matches the hosts-list
+	// column and host-detail tile instead of an unlensed all-rules number.
+	// Empty target + empty org default = all rules (backward compatible).
+	// Connectivity counts (hosts/online/down) are OS-agnostic and unfiltered.
+	lensRef := `COALESCE(NULLIF(het.target_framework, ''), NULLIF($2::text, ''))`
+	osMatch := framework.OSResolvedMatchSQL(lensRef, "h.os_family", "h.os_version")
+	lensJoin := `JOIN host_rule_state hrs ON hrs.host_id = m.host_id
+		         JOIN hosts h ON h.id = m.host_id
+		         LEFT JOIN host_effective_target het ON het.host_id = m.host_id`
 	err := s.pool.QueryRow(ctx, `
 		WITH m AS (`+cte+`)
 		SELECT
@@ -310,13 +324,13 @@ func (s *Service) rollup(ctx context.Context, g Group) (Rollup, error) {
 		     WHERE hl.reachability_status = 'reachable'),
 		  (SELECT count(*) FROM m JOIN host_liveness hl ON hl.host_id = m.host_id
 		     WHERE hl.reachability_status = 'unreachable'),
-		  (SELECT count(DISTINCT hrs.host_id) FROM m JOIN host_rule_state hrs ON hrs.host_id = m.host_id
-		     WHERE hrs.current_status = 'fail' AND hrs.severity ILIKE 'critical'),
-		  (SELECT count(*) FROM m JOIN host_rule_state hrs ON hrs.host_id = m.host_id
-		     WHERE hrs.current_status = 'pass'),
-		  (SELECT count(*) FROM m JOIN host_rule_state hrs ON hrs.host_id = m.host_id
-		     WHERE hrs.current_status IN ('pass','fail'))`,
-		arg).Scan(&r.Hosts, &r.Online, &r.Down, &r.CriticalHosts, &passing, &evaluated)
+		  (SELECT count(DISTINCT hrs.host_id) FROM m `+lensJoin+`
+		     WHERE hrs.current_status = 'fail' AND hrs.severity ILIKE 'critical' AND `+osMatch+`),
+		  (SELECT count(*) FROM m `+lensJoin+`
+		     WHERE hrs.current_status = 'pass' AND `+osMatch+`),
+		  (SELECT count(*) FROM m `+lensJoin+`
+		     WHERE hrs.current_status IN ('pass','fail') AND `+osMatch+`)`,
+		arg, orgDefault).Scan(&r.Hosts, &r.Online, &r.Down, &r.CriticalHosts, &passing, &evaluated)
 	if err != nil {
 		return Rollup{}, fmt.Errorf("group: rollup: %w", err)
 	}
@@ -351,7 +365,7 @@ func (s *Service) rollup(ctx context.Context, g Group) (Rollup, error) {
 }
 
 // Summary computes the Groups-page KPI row.
-func (s *Service) Summary(ctx context.Context) (FleetSummary, error) {
+func (s *Service) Summary(ctx context.Context, orgDefault string) (FleetSummary, error) {
 	var sum FleetSummary
 	err := s.pool.QueryRow(ctx, `
 		SELECT
@@ -397,13 +411,19 @@ func (s *Service) Summary(ctx context.Context) (FleetSummary, error) {
 		return FleetSummary{}, fmt.Errorf("group: summary ungrouped: %w", err)
 	}
 
-	// Fleet avg compliance across all active hosts (passing / evaluated).
+	// Fleet avg compliance across all hosts, scored against the ORG default
+	// lens ($1), each host OS-resolved — the same rule as GET /fleet/score so
+	// the two fleet KPIs agree (empty org default = all rules). Per-host
+	// targets are not aggregated into this one number (matches the fleet KPI).
 	var passing, evaluated int
 	err = s.pool.QueryRow(ctx, `
 		SELECT
-		  count(*) FILTER (WHERE current_status = 'pass'),
-		  count(*) FILTER (WHERE current_status IN ('pass','fail'))
-		FROM host_rule_state`).Scan(&passing, &evaluated)
+		  count(*) FILTER (WHERE hrs.current_status = 'pass'),
+		  count(*) FILTER (WHERE hrs.current_status IN ('pass','fail'))
+		FROM host_rule_state hrs
+		JOIN hosts h ON h.id = hrs.host_id
+		WHERE `+framework.OSResolvedMatchSQL("NULLIF($1::text, '')", "h.os_family", "h.os_version"),
+		orgDefault).Scan(&passing, &evaluated)
 	if err != nil {
 		return FleetSummary{}, fmt.Errorf("group: summary compliance: %w", err)
 	}

--- a/internal/group/service_db_test.go
+++ b/internal/group/service_db_test.go
@@ -439,7 +439,7 @@ func TestSummary_Counts(t *testing.T) {
 			t.Fatalf("maintenance: %v", err)
 		}
 
-		sum, err := svc.Summary(ctx)
+		sum, err := svc.Summary(ctx, "")
 		if err != nil {
 			t.Fatalf("Summary: %v", err)
 		}
@@ -467,7 +467,7 @@ func TestSummary_Counts(t *testing.T) {
 // test if the group is absent.
 func listOne(t *testing.T, svc *Service, ctx context.Context, id uuid.UUID) Rollup {
 	t.Helper()
-	all, err := svc.List(ctx)
+	all, err := svc.List(ctx, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}

--- a/internal/group/set_target_db_test.go
+++ b/internal/group/set_target_db_test.go
@@ -13,6 +13,91 @@ import (
 	"github.com/google/uuid"
 )
 
+// @ac AC-11
+// AC-11: the /groups per-group AND fleet compliance averages are lens-scoped
+// and OS-resolved — a RHEL 9 member's "stig" counts stig_rhel9 only (its
+// stig_rhel10 row is excluded), not the family union or all-rules.
+func TestGroupCompliance_LensScopedOSResolved(t *testing.T) {
+	t.Run("system-compliance-lens/AC-11", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		svc := NewService(pool)
+		owner := seedUser(t, pool)
+
+		// One RHEL 9 member: stig_rhel9 (1 pass, 1 fail) + stig_rhel10 (1 pass).
+		// All-rules = 2/3 (67%); STIG (stig_rhel9) = 1/2 (50%).
+		h := seedHost(t, pool, owner, "rhel", false)
+		if _, err := pool.Exec(ctx, `UPDATE hosts SET os_version='9.6' WHERE id=$1`, h); err != nil {
+			t.Fatalf("set os_version: %v", err)
+		}
+		seedFW := func(rule, status, refs string) {
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO host_rule_state
+				  (host_id, rule_id, current_status, severity, last_checked_at,
+				   last_scan_id, framework_refs, first_seen_at, last_changed_at)
+				VALUES ($1,$2,$3,'medium',now(),$4,$5::jsonb,now(),now())`,
+				h, rule, status, uuid.New(), refs); err != nil {
+				t.Fatalf("seed fw rule: %v", err)
+			}
+		}
+		seedFW("s9.pass", "pass", `{"stig_rhel9":["V-1"]}`)
+		seedFW("s9.fail", "fail", `{"stig_rhel9":["V-2"]}`)
+		seedFW("s10.pass", "pass", `{"stig_rhel10":["V-1"]}`)
+
+		site, err := svc.Create(ctx, CreateInput{Name: "Prod", Kind: KindSite, Membership: MembershipManual})
+		if err != nil {
+			t.Fatalf("create site: %v", err)
+		}
+		if err := svc.AddMember(ctx, site.ID, h); err != nil {
+			t.Fatalf("add member: %v", err)
+		}
+
+		// Org default = stig -> per-group AVG and fleet AVG are stig_rhel9 (50).
+		roll := listOneLens(t, svc, ctx, site.ID, "stig")
+		if roll.AvgCompliancePct == nil || *roll.AvgCompliancePct != 50 {
+			t.Errorf("per-group avg (org stig) = %v, want 50 (stig_rhel9 only, not all-rules 67)", roll.AvgCompliancePct)
+		}
+		sum, err := svc.Summary(ctx, "stig")
+		if err != nil {
+			t.Fatalf("Summary(stig): %v", err)
+		}
+		if sum.AvgCompliancePct == nil || *sum.AvgCompliancePct != 50 {
+			t.Errorf("fleet avg (org stig) = %v, want 50 (stig_rhel9)", sum.AvgCompliancePct)
+		}
+
+		// No org default -> all rules (2/3 = 67).
+		all, err := svc.List(ctx, "")
+		if err != nil {
+			t.Fatalf("List(''): %v", err)
+		}
+		var allRules *int
+		for _, gr := range all {
+			if gr.ID == site.ID {
+				allRules = gr.Rollup.AvgCompliancePct
+			}
+		}
+		if allRules == nil || *allRules != 67 {
+			t.Errorf("per-group avg (no default) = %v, want 67 (all rules)", allRules)
+		}
+	})
+}
+
+// listOneLens fetches one group's rollup from List under an org-default lens.
+func listOneLens(t *testing.T, svc *Service, ctx context.Context, id uuid.UUID, orgDefault string) Rollup {
+	t.Helper()
+	all, err := svc.List(ctx, orgDefault)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, g := range all {
+		if g.ID == id {
+			return g.Rollup
+		}
+	}
+	t.Fatalf("group %s not found", id)
+	return Rollup{}
+}
+
 // @ac AC-07
 // D1: only a site group may carry a compliance target. SetTarget on an
 // os_category group is rejected; a site group sets, clears, and validates.

--- a/internal/posture/posture.go
+++ b/internal/posture/posture.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Hanalyx/openwatch/internal/cron"
+	"github.com/Hanalyx/openwatch/internal/framework"
 )
 
 // RollupInterval is the production cadence of the snapshot rollup.
@@ -32,16 +33,28 @@ import (
 // each pass is one aggregate UPSERT over a bounded table.
 const RollupInterval = time.Hour
 
-// Rollup UPSERTs today's snapshot row for every live host that has
-// host_rule_state rows (a never-scanned host has no posture to
-// record). Returns the number of host rows written.
+// Rollup UPSERTs today's snapshot rows for every live host that has
+// host_rule_state rows (a never-scanned host has no posture to record).
+//
+// It writes the all-rules series (framework = ”) PLUS one row per
+// framework FAMILY the host has rules in, each OS-RESOLVED: a RHEL 9
+// host's "stig" row scores its stig_rhel9 rules only (never stig_rhel10),
+// matching the host-detail hero tile and list column. Storing every
+// family means switching the org default lens just selects a different
+// pre-computed series — no recompute, no broken history (compliance-lens
+// Phase 3c). Returns the number of rows written (all-rules + per-family).
 func Rollup(ctx context.Context, pool *pgxpool.Pool, asOf time.Time) (int, error) {
-	tag, err := pool.Exec(ctx, `
+	// The per-family series expands each rule to the family of its
+	// OS-compatible key: a key with no OS suffix (regexp_replace is a no-op,
+	// so fk = fam) is OS-neutral (nist_800_53, pci_dss_4, srg); a key equal to
+	// fam + '_' + <host os token> is the host's own OS variant (stig_rhel9 on
+	// a RHEL 9 host). A wrong-OS variant (stig_rhel10 on a RHEL 9 host) matches
+	// neither and is excluded, so a rule contributes to a family at most once.
+	q := `
 		INSERT INTO posture_snapshots
-			(host_id, snapshot_date, passing, failing, skipped, error, total,
+			(host_id, snapshot_date, framework, passing, failing, skipped, error, total,
 			 score_pct, has_critical_findings, updated_at)
-		SELECT s.host_id,
-		       $1::date,
+		SELECT s.host_id, $1::date, '',
 		       COUNT(*) FILTER (WHERE s.current_status = 'pass'),
 		       COUNT(*) FILTER (WHERE s.current_status = 'fail'),
 		       COUNT(*) FILTER (WHERE s.current_status = 'skipped'),
@@ -54,7 +67,29 @@ func Rollup(ctx context.Context, pool *pgxpool.Pool, asOf time.Time) (int, error
 		  FROM host_rule_state s
 		  JOIN hosts h ON h.id = s.host_id AND h.deleted_at IS NULL
 		 GROUP BY s.host_id
-		ON CONFLICT (host_id, snapshot_date) DO UPDATE
+		UNION ALL
+		SELECT e.host_id, $1::date, e.fam,
+		       COUNT(*) FILTER (WHERE e.current_status = 'pass'),
+		       COUNT(*) FILTER (WHERE e.current_status = 'fail'),
+		       COUNT(*) FILTER (WHERE e.current_status = 'skipped'),
+		       COUNT(*) FILTER (WHERE e.current_status = 'error'),
+		       COUNT(*),
+		       ROUND((COUNT(*) FILTER (WHERE e.current_status = 'pass'))::numeric
+		             / COUNT(*) * 1000) / 10,
+		       BOOL_OR(e.current_status = 'fail' AND e.severity = 'critical'),
+		       now()
+		  FROM (
+		      SELECT s.host_id, s.current_status, s.severity,
+		             regexp_replace(fk, '` + framework.OSSuffixSQL + `', '') AS fam
+		        FROM host_rule_state s
+		        JOIN hosts h ON h.id = s.host_id AND h.deleted_at IS NULL
+		        CROSS JOIN LATERAL jsonb_object_keys(s.framework_refs) AS fk
+		       WHERE fk = regexp_replace(fk, '` + framework.OSSuffixSQL + `', '')
+		          OR fk = regexp_replace(fk, '` + framework.OSSuffixSQL + `', '')
+		                  || '_' || lower(h.os_family) || split_part(h.os_version, '.', 1)
+		  ) e
+		 GROUP BY e.host_id, e.fam
+		ON CONFLICT (host_id, snapshot_date, framework) DO UPDATE
 		   SET passing               = EXCLUDED.passing,
 		       failing               = EXCLUDED.failing,
 		       skipped               = EXCLUDED.skipped,
@@ -62,8 +97,8 @@ func Rollup(ctx context.Context, pool *pgxpool.Pool, asOf time.Time) (int, error
 		       total                 = EXCLUDED.total,
 		       score_pct             = EXCLUDED.score_pct,
 		       has_critical_findings = EXCLUDED.has_critical_findings,
-		       updated_at            = now()`,
-		asOf.UTC())
+		       updated_at            = now()`
+	tag, err := pool.Exec(ctx, q, asOf.UTC())
 	if err != nil {
 		return 0, fmt.Errorf("posture: rollup: %w", err)
 	}
@@ -107,16 +142,21 @@ type DayPoint struct {
 	Total    int
 }
 
-// HostTrend returns the host's snapshots over the trailing N days
-// (today inclusive), oldest first. Days without a snapshot are simply
-// absent - the chart renders the gaps.
-func HostTrend(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID, days int) ([]DayPoint, error) {
+// HostTrend returns the host's snapshots for one LENS over the trailing
+// N days (today inclusive), oldest first. lens is a framework FAMILY id
+// (stig, cis, nist_800_53, …) whose stored series is the host's
+// OS-resolved score for that family; "" is the all-rules series. A
+// specific corpus key is normalized to its family (stig_rhel9 -> stig)
+// since the snapshot stores per family. Days without a snapshot are
+// simply absent - the chart renders the gaps.
+func HostTrend(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID, days int, lens string) ([]DayPoint, error) {
 	rows, err := pool.Query(ctx, `
 		SELECT snapshot_date, score_pct, passing, failing, total
 		  FROM posture_snapshots
 		 WHERE host_id = $1
+		   AND framework = $3
 		   AND snapshot_date > current_date - $2::int
-		 ORDER BY snapshot_date`, hostID, days)
+		 ORDER BY snapshot_date`, hostID, days, framework.FamilyOf(lens))
 	if err != nil {
 		return nil, fmt.Errorf("posture: host trend: %w", err)
 	}
@@ -145,7 +185,7 @@ type FleetDayPoint struct {
 // days, oldest first: average score across snapshotted hosts, host
 // count, total failing rules, and hosts carrying critical findings.
 // Soft-deleted hosts are excluded even when their snapshots linger.
-func FleetTrend(ctx context.Context, pool *pgxpool.Pool, days int) ([]FleetDayPoint, error) {
+func FleetTrend(ctx context.Context, pool *pgxpool.Pool, days int, lens string) ([]FleetDayPoint, error) {
 	rows, err := pool.Query(ctx, `
 		SELECT p.snapshot_date,
 		       ROUND(AVG(p.score_pct)::numeric * 10) / 10,
@@ -154,9 +194,10 @@ func FleetTrend(ctx context.Context, pool *pgxpool.Pool, days int) ([]FleetDayPo
 		       COUNT(*) FILTER (WHERE p.has_critical_findings)::int
 		  FROM posture_snapshots p
 		  JOIN hosts h ON h.id = p.host_id AND h.deleted_at IS NULL
-		 WHERE p.snapshot_date > current_date - $1::int
+		 WHERE p.framework = $2
+		   AND p.snapshot_date > current_date - $1::int
 		 GROUP BY p.snapshot_date
-		 ORDER BY p.snapshot_date`, days)
+		 ORDER BY p.snapshot_date`, days, framework.FamilyOf(lens))
 	if err != nil {
 		return nil, fmt.Errorf("posture: fleet trend: %w", err)
 	}

--- a/internal/posture/posture_test.go
+++ b/internal/posture/posture_test.go
@@ -4,6 +4,7 @@
 //
 //	AC-01  TestRollup_UpsertCountsAndExclusions
 //	AC-02  TestTrends_WindowOrderingAndFleetAggregates
+//	AC-03  TestRollup_PerFamilyOSResolvedSeries
 package posture
 
 import (
@@ -124,7 +125,7 @@ func TestRollup_UpsertCountsAndExclusions(t *testing.T) {
 		var critical bool
 		err = pool.QueryRow(ctx, `
 			SELECT passing, failing, skipped, total, score_pct, has_critical_findings
-			  FROM posture_snapshots WHERE host_id = $1 AND snapshot_date = current_date`,
+			  FROM posture_snapshots WHERE host_id = $1 AND snapshot_date = current_date AND framework = ''`,
 			scanned).Scan(&passing, &failing, &skipped, &total, &score, &critical)
 		if err != nil {
 			t.Fatalf("read snapshot: %v", err)
@@ -146,10 +147,97 @@ func TestRollup_UpsertCountsAndExclusions(t *testing.T) {
 		var rows int
 		var score2 float64
 		_ = pool.QueryRow(ctx, `
-			SELECT COUNT(*), MAX(score_pct) FROM posture_snapshots WHERE host_id = $1`,
+			SELECT COUNT(*), MAX(score_pct) FROM posture_snapshots WHERE host_id = $1 AND framework = ''`,
 			scanned).Scan(&rows, &score2)
 		if rows != 1 || score2 != 75.0 {
 			t.Errorf("after re-run: rows=%d score=%v, want 1 row at 75", rows, score2)
+		}
+	})
+}
+
+// seedRuleStateFW seeds a host_rule_state row with a framework_refs JSONB
+// literal (e.g. `{"stig_rhel9":["V-1"]}`).
+func seedRuleStateFW(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID, ruleID, status, refs string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO host_rule_state
+			(host_id, rule_id, current_status, severity, last_checked_at,
+			 check_count, last_scan_id, framework_refs, first_seen_at, last_changed_at)
+		VALUES ($1, $2, $3, 'medium', now(), 1, $4, $5::jsonb, now(), now())`,
+		hostID, ruleID, status, uuid.Must(uuid.NewV7()), refs)
+	if err != nil {
+		t.Fatalf("seed rule state fw: %v", err)
+	}
+}
+
+// @ac AC-03
+// AC-03: the rollup writes a per-FAMILY series, OS-RESOLVED — a RHEL 9
+// host's "stig" row scores stig_rhel9 only (a stig_rhel10 rule it carries
+// is excluded), OS-neutral families resolve via the bare key, and the ”
+// all-rules series counts everything. HostTrend reads the requested lens
+// series and normalizes a specific key to its family.
+func TestRollup_PerFamilyOSResolvedSeries(t *testing.T) {
+	t.Run("system-posture-snapshots/AC-03", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		user := seedUser(t, pool)
+
+		h := seedHost(t, pool, user)
+		if _, err := pool.Exec(ctx,
+			`UPDATE hosts SET os_family='rhel', os_version='9.6' WHERE id=$1`, h); err != nil {
+			t.Fatalf("set os: %v", err)
+		}
+		// STIG: stig_rhel9 (1 pass, 1 fail) + stig_rhel10 (1 pass, wrong OS).
+		seedRuleStateFW(t, pool, h, "s9.pass", "pass", `{"stig_rhel9":["V-1"]}`)
+		seedRuleStateFW(t, pool, h, "s9.fail", "fail", `{"stig_rhel9":["V-2"]}`)
+		seedRuleStateFW(t, pool, h, "s10.pass", "pass", `{"stig_rhel10":["V-1"]}`)
+		// CIS (OS-specific) + NIST (OS-neutral).
+		seedRuleStateFW(t, pool, h, "c9.pass", "pass", `{"cis_rhel9":["1.1"]}`)
+		seedRuleStateFW(t, pool, h, "n.pass", "pass", `{"nist_800_53":["AC-1"]}`)
+
+		if _, err := Rollup(ctx, pool, time.Now()); err != nil {
+			t.Fatalf("Rollup: %v", err)
+		}
+
+		read := func(fw string) (passing, total int, score float64) {
+			err := pool.QueryRow(ctx, `
+				SELECT passing, total, score_pct FROM posture_snapshots
+				 WHERE host_id=$1 AND snapshot_date=current_date AND framework=$2`,
+				h, fw).Scan(&passing, &total, &score)
+			if err != nil {
+				t.Fatalf("read framework %q: %v", fw, err)
+			}
+			return
+		}
+
+		// STIG resolves to stig_rhel9 ONLY: 1 pass / 2 total (stig_rhel10 excluded).
+		if p, tot, sc := read("stig"); p != 1 || tot != 2 || sc != 50.0 {
+			t.Errorf("stig series = %d/%d score %v, want 1/2 50 (stig_rhel10 excluded)", p, tot, sc)
+		}
+		// CIS (cis_rhel9): 1/1. NIST (bare key): 1/1.
+		if p, tot, _ := read("cis"); p != 1 || tot != 1 {
+			t.Errorf("cis series = %d/%d, want 1/1", p, tot)
+		}
+		if p, tot, _ := read("nist_800_53"); p != 1 || tot != 1 {
+			t.Errorf("nist_800_53 series = %d/%d, want 1/1", p, tot)
+		}
+		// All-rules ('' series): everything = 4 pass / 5 total.
+		if p, tot, _ := read(""); p != 4 || tot != 5 {
+			t.Errorf("all-rules series = %d/%d, want 4/5", p, tot)
+		}
+
+		// HostTrend reads the lens series; a specific key normalizes to family.
+		fam, err := HostTrend(ctx, pool, h, 30, "stig")
+		if err != nil || len(fam) != 1 || fam[0].ScorePct != 50.0 {
+			t.Errorf("HostTrend(stig) = %+v err=%v, want one point at 50", fam, err)
+		}
+		key, _ := HostTrend(ctx, pool, h, 30, "stig_rhel9")
+		if len(key) != 1 || key[0].ScorePct != 50.0 {
+			t.Errorf("HostTrend(stig_rhel9) = %+v, want the stig series (50)", key)
+		}
+		all, _ := HostTrend(ctx, pool, h, 30, "")
+		if len(all) != 1 || all[0].ScorePct != 80.0 {
+			t.Errorf("HostTrend('') = %+v, want all-rules (80)", all)
 		}
 	})
 }
@@ -177,7 +265,7 @@ func TestTrends_WindowOrderingAndFleetAggregates(t *testing.T) {
 			t.Fatalf("soft delete: %v", err)
 		}
 
-		points, err := HostTrend(ctx, pool, a, 30)
+		points, err := HostTrend(ctx, pool, a, 30, "")
 		if err != nil {
 			t.Fatalf("HostTrend: %v", err)
 		}
@@ -189,7 +277,7 @@ func TestTrends_WindowOrderingAndFleetAggregates(t *testing.T) {
 				points[0].ScorePct, points[1].ScorePct)
 		}
 
-		fleet, err := FleetTrend(ctx, pool, 30)
+		fleet, err := FleetTrend(ctx, pool, 30, "")
 		if err != nil {
 			t.Fatalf("FleetTrend: %v", err)
 		}

--- a/internal/server/api_compliance_lens_default_test.go
+++ b/internal/server/api_compliance_lens_default_test.go
@@ -1,0 +1,161 @@
+// @spec system-compliance-lens
+//
+// AC traceability (this file):
+//
+//	AC-09  TestAPI_HostsList_DefaultsToPerHostEffectiveTarget
+//	AC-10  TestAPI_FleetScore_DefaultsToOrgLens
+//
+// Covers C-06: the effective-lens default applies to the hosts-list
+// compliance column (per-host effective target) and the fleet KPI (org
+// default lens), not only the host-detail hero tile.
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/server/api"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
+)
+
+// getHostsList GETs /api/v1/hosts (optionally with a query suffix like
+// "?framework=cis") and returns the decoded items.
+func getHostsList(t *testing.T, base, suffix string) []api.HostListItem {
+	t.Helper()
+	req := asRole(t, "GET", base+"/api/v1/hosts"+suffix, auth.RoleViewer, nil)
+	resp := doReq(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /hosts%s = %d: %s", suffix, resp.StatusCode, b)
+	}
+	var out api.HostListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode hosts: %v", err)
+	}
+	return out.Hosts
+}
+
+func findHostItem(items []api.HostListItem, id uuid.UUID) *api.HostListItem {
+	for i := range items {
+		if items[i].Id == id {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+// @ac AC-09
+// AC-09: with no ?framework=, each host's list compliance_summary is scored
+// against its OWN effective target; an explicit param overrides per host.
+func TestAPI_HostsList_DefaultsToPerHostEffectiveTarget(t *testing.T) {
+	t.Run("system-compliance-lens/AC-09", func(t *testing.T) {
+		ctx := context.Background()
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+
+		// Host A carries its own STIG target. It has 2 STIG rules (1 pass,
+		// 1 fail) and 1 CIS rule (pass): STIG-scoped total=2, all-rules total=3.
+		hostA := seedFleetHost(t, pool, user)
+		if _, err := pool.Exec(ctx,
+			`UPDATE hosts SET target_framework='stig' WHERE id=$1`, hostA); err != nil {
+			t.Fatalf("set host A target: %v", err)
+		}
+		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig.pass", "pass", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig.fail", "fail", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.cis.pass", "pass", map[string]string{"cis_rhel9": "x"})
+
+		// Host B has NO target and (this test sets no org default) scores All
+		// rules: 1 CIS rule -> total=1.
+		hostB := seedFleetHost(t, pool, user)
+		seedFleetRuleStateWithFrameworks(t, pool, hostB, "b.cis.pass", "pass", map[string]string{"cis_rhel9": "x"})
+
+		// No framework param: A defaults to its STIG target, B to All rules.
+		items := getHostsList(t, url, "")
+		a := findHostItem(items, hostA)
+		b := findHostItem(items, hostB)
+		if a == nil || a.ComplianceSummary == nil {
+			t.Fatalf("host A missing compliance_summary: %+v", a)
+		}
+		if a.ComplianceSummary.Total != 2 || a.ComplianceSummary.Passing != 1 {
+			t.Errorf("host A (target stig): total=%d passing=%d, want 2/1 (STIG-scoped, not all-rules 3)",
+				a.ComplianceSummary.Total, a.ComplianceSummary.Passing)
+		}
+		if b == nil || b.ComplianceSummary == nil {
+			t.Fatalf("host B missing compliance_summary: %+v", b)
+		}
+		if b.ComplianceSummary.Total != 1 {
+			t.Errorf("host B (no target, no org default): total=%d, want 1 (All rules)",
+				b.ComplianceSummary.Total)
+		}
+
+		// Explicit ?framework=cis overrides per host: A -> only its CIS rule.
+		itemsCis := getHostsList(t, url, "?framework=cis")
+		aCis := findHostItem(itemsCis, hostA)
+		if aCis == nil || aCis.ComplianceSummary == nil || aCis.ComplianceSummary.Total != 1 {
+			t.Errorf("host A ?framework=cis: got %+v, want total=1 (override beats target)", aCis.ComplianceSummary)
+		}
+	})
+}
+
+func getFleetScore(t *testing.T, base, suffix string) api.FleetScore {
+	t.Helper()
+	req := asRole(t, "GET", base+"/api/v1/fleet/score"+suffix, auth.RoleViewer, nil)
+	resp := doReq(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /fleet/score%s = %d: %s", suffix, resp.StatusCode, b)
+	}
+	var s api.FleetScore
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		t.Fatalf("decode fleet score: %v", err)
+	}
+	return s
+}
+
+// @ac AC-10
+// AC-10: with no ?framework=, the fleet score defaults to the org default
+// lens; an explicit param overrides.
+func TestAPI_FleetScore_DefaultsToOrgLens(t *testing.T) {
+	t.Run("system-compliance-lens/AC-10", func(t *testing.T) {
+		ctx := context.Background()
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+
+		// Org default lens = STIG.
+		store := systemconfig.NewStore(pool, audit.Emit)
+		if _, err := store.SetCompliance(ctx,
+			systemconfig.ComplianceConfig{DefaultFramework: "stig"}, user.String()); err != nil {
+			t.Fatalf("set org default: %v", err)
+		}
+
+		// One host: 2 STIG (1 pass, 1 fail) + 1 CIS (pass). STIG: 1/2 = 0.5;
+		// All rules would be 2/3.
+		h := seedFleetHost(t, pool, user)
+		seedFleetRuleStateWithFrameworks(t, pool, h, "s.pass", "pass", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "s.fail", "fail", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "c.pass", "pass", map[string]string{"cis_rhel9": "x"})
+
+		// No param -> org default STIG.
+		s := getFleetScore(t, url, "")
+		if s.TotalEvaluations != 2 || s.PassingFraction != 0.5 {
+			t.Errorf("fleet default (org stig): frac=%v total=%d, want 0.5/2 (STIG, not all-rules 2/3)",
+				s.PassingFraction, s.TotalEvaluations)
+		}
+
+		// Explicit ?framework=cis overrides the org default.
+		sCis := getFleetScore(t, url, "?framework=cis")
+		if sCis.TotalEvaluations != 1 || sCis.PassingFraction != 1.0 {
+			t.Errorf("fleet ?framework=cis: frac=%v total=%d, want 1.0/1", sCis.PassingFraction, sCis.TotalEvaluations)
+		}
+	})
+}

--- a/internal/server/api_compliance_lens_default_test.go
+++ b/internal/server/api_compliance_lens_default_test.go
@@ -62,20 +62,29 @@ func TestAPI_HostsList_DefaultsToPerHostEffectiveTarget(t *testing.T) {
 		url, pool := freshAPIServer(t)
 		user := firstSeededUserID(t, pool)
 
-		// Host A carries its own STIG target. It has 2 STIG rules (1 pass,
-		// 1 fail) and 1 CIS rule (pass): STIG-scoped total=2, all-rules total=3.
+		// Host A is a RHEL 9 host with its own STIG target. It carries STIG
+		// rules for TWO OS benchmarks (as real corpus rows do): stig_rhel9
+		// (its own) AND stig_rhel10 (another OS). Under STIG it MUST score only
+		// stig_rhel9 (2 rules: 1 pass, 1 fail) — the stig_rhel10 pass is
+		// excluded because it belongs to the RHEL 10 benchmark. It also has 1
+		// cis_rhel9 rule. So STIG total=2/pass=1 (NOT the family-union total=3).
 		hostA := seedFleetHost(t, pool, user)
 		if _, err := pool.Exec(ctx,
-			`UPDATE hosts SET target_framework='stig' WHERE id=$1`, hostA); err != nil {
-			t.Fatalf("set host A target: %v", err)
+			`UPDATE hosts SET target_framework='stig', os_family='rhel', os_version='9.6' WHERE id=$1`, hostA); err != nil {
+			t.Fatalf("set host A target/os: %v", err)
 		}
-		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig.pass", "pass", map[string]string{"stig_rhel9": "x"})
-		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig.fail", "fail", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig9.pass", "pass", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig9.fail", "fail", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.stig10.pass", "pass", map[string]string{"stig_rhel10": "x"})
 		seedFleetRuleStateWithFrameworks(t, pool, hostA, "a.cis.pass", "pass", map[string]string{"cis_rhel9": "x"})
 
-		// Host B has NO target and (this test sets no org default) scores All
-		// rules: 1 CIS rule -> total=1.
+		// Host B is a RHEL 9 host with NO target and (this test sets no org
+		// default) scores All rules: 1 CIS rule -> total=1.
 		hostB := seedFleetHost(t, pool, user)
+		if _, err := pool.Exec(ctx,
+			`UPDATE hosts SET os_family='rhel', os_version='9.6' WHERE id=$1`, hostB); err != nil {
+			t.Fatalf("set host B os: %v", err)
+		}
 		seedFleetRuleStateWithFrameworks(t, pool, hostB, "b.cis.pass", "pass", map[string]string{"cis_rhel9": "x"})
 
 		// No framework param: A defaults to its STIG target, B to All rules.
@@ -86,7 +95,7 @@ func TestAPI_HostsList_DefaultsToPerHostEffectiveTarget(t *testing.T) {
 			t.Fatalf("host A missing compliance_summary: %+v", a)
 		}
 		if a.ComplianceSummary.Total != 2 || a.ComplianceSummary.Passing != 1 {
-			t.Errorf("host A (target stig): total=%d passing=%d, want 2/1 (STIG-scoped, not all-rules 3)",
+			t.Errorf("host A (target stig on RHEL9): total=%d passing=%d, want 2/1 (stig_rhel9 only; stig_rhel10 excluded, not family-union 3)",
 				a.ComplianceSummary.Total, a.ComplianceSummary.Passing)
 		}
 		if b == nil || b.ComplianceSummary == nil {
@@ -138,17 +147,25 @@ func TestAPI_FleetScore_DefaultsToOrgLens(t *testing.T) {
 			t.Fatalf("set org default: %v", err)
 		}
 
-		// One host: 2 STIG (1 pass, 1 fail) + 1 CIS (pass). STIG: 1/2 = 0.5;
-		// All rules would be 2/3.
+		// One RHEL 9 host with STIG rules for two OS benchmarks: stig_rhel9
+		// (1 pass, 1 fail) + stig_rhel10 (1 pass, wrong OS) + cis_rhel9 (pass).
+		// Under the STIG org default the host scores against stig_rhel9 ONLY:
+		// evaluations=2 (pass+fail), passing=1 -> 0.5. The stig_rhel10 pass is
+		// excluded (family-union would wrongly give 2/3).
 		h := seedFleetHost(t, pool, user)
-		seedFleetRuleStateWithFrameworks(t, pool, h, "s.pass", "pass", map[string]string{"stig_rhel9": "x"})
-		seedFleetRuleStateWithFrameworks(t, pool, h, "s.fail", "fail", map[string]string{"stig_rhel9": "x"})
+		if _, err := pool.Exec(ctx,
+			`UPDATE hosts SET os_family='rhel', os_version='9.6' WHERE id=$1`, h); err != nil {
+			t.Fatalf("set host os: %v", err)
+		}
+		seedFleetRuleStateWithFrameworks(t, pool, h, "s9.pass", "pass", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "s9.fail", "fail", map[string]string{"stig_rhel9": "x"})
+		seedFleetRuleStateWithFrameworks(t, pool, h, "s10.pass", "pass", map[string]string{"stig_rhel10": "x"})
 		seedFleetRuleStateWithFrameworks(t, pool, h, "c.pass", "pass", map[string]string{"cis_rhel9": "x"})
 
-		// No param -> org default STIG.
+		// No param -> org default STIG, resolved to stig_rhel9 for this host.
 		s := getFleetScore(t, url, "")
 		if s.TotalEvaluations != 2 || s.PassingFraction != 0.5 {
-			t.Errorf("fleet default (org stig): frac=%v total=%d, want 0.5/2 (STIG, not all-rules 2/3)",
+			t.Errorf("fleet default (org stig on RHEL9): frac=%v total=%d, want 0.5/2 (stig_rhel9 only; stig_rhel10 excluded)",
 				s.PassingFraction, s.TotalEvaluations)
 		}
 

--- a/internal/server/api_compliance_trend_test.go
+++ b/internal/server/api_compliance_trend_test.go
@@ -6,6 +6,7 @@
 //	AC-02  TestComplianceTrend_RBACAndUnknownHost
 //	AC-03  TestFleetComplianceTrend_AggregatesAndDeletedHosts
 //	AC-04  TestComplianceTrend_DaysClamp
+//	AC-05  TestHostComplianceTrend_FollowsOrgLens
 package server
 
 import (
@@ -17,7 +18,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/systemconfig"
 )
 
 // seedTrendSnapshot writes one posture_snapshots row daysAgo days back.
@@ -32,6 +35,22 @@ func seedTrendSnapshot(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID,
 		hostID, daysAgo, passing, failing, score, critical)
 	if err != nil {
 		t.Fatalf("seed snapshot: %v", err)
+	}
+}
+
+// seedTrendSnapshotFW writes a snapshot row for a specific framework series
+// (framework="" is all-rules; a family id is that lens's series).
+func seedTrendSnapshotFW(t *testing.T, pool *pgxpool.Pool, hostID uuid.UUID,
+	daysAgo int, framework string, score float64, passing, failing int) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO posture_snapshots
+			(host_id, snapshot_date, framework, passing, failing, skipped, error, total,
+			 score_pct, has_critical_findings)
+		VALUES ($1, current_date - $2::int, $3, $4, $5, 0, 0, $4::int + $5::int, $6, false)`,
+		hostID, daysAgo, framework, passing, failing, score)
+	if err != nil {
+		t.Fatalf("seed snapshot fw: %v", err)
 	}
 }
 
@@ -209,6 +228,45 @@ func TestComplianceTrend_DaysClamp(t *testing.T) {
 		status, body = getHostTrend(t, url, hostID.String(), "")
 		if status != http.StatusOK || len(body.Days) != 2 {
 			t.Errorf("default: status=%d len=%d, want 200/2", status, len(body.Days))
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: the trend follows the effective lens server-side — with the org
+// default set to "stig", the host trend returns its STIG series, not
+// all-rules; clearing the org default falls back to the all-rules series.
+func TestHostComplianceTrend_FollowsOrgLens(t *testing.T) {
+	t.Run("api-compliance-trend/AC-05", func(t *testing.T) {
+		ctx := context.Background()
+		url, pool := freshAPIServer(t)
+		user := firstSeededUserID(t, pool)
+		hostID := seedHostForIntel(t, pool)
+
+		// Two series for today: STIG (88) and all-rules (68).
+		seedTrendSnapshotFW(t, pool, hostID, 0, "stig", 88, 353, 32)
+		seedTrendSnapshotFW(t, pool, hostID, 0, "", 68, 523, 106)
+
+		store := systemconfig.NewStore(pool, audit.Emit)
+
+		// Org default = stig -> trend follows STIG (88).
+		if _, err := store.SetCompliance(ctx,
+			systemconfig.ComplianceConfig{DefaultFramework: "stig"}, user.String()); err != nil {
+			t.Fatalf("set org default: %v", err)
+		}
+		status, body := getHostTrend(t, url, hostID.String(), "")
+		if status != http.StatusOK || len(body.Days) != 1 || body.Days[0].ScorePct != 88 {
+			t.Errorf("org default stig: status=%d days=%+v, want the STIG series (88)", status, body.Days)
+		}
+
+		// Clear the org default -> trend falls back to all-rules (68).
+		if _, err := store.SetCompliance(ctx,
+			systemconfig.ComplianceConfig{DefaultFramework: ""}, user.String()); err != nil {
+			t.Fatalf("clear org default: %v", err)
+		}
+		status, body = getHostTrend(t, url, hostID.String(), "")
+		if status != http.StatusOK || len(body.Days) != 1 || body.Days[0].ScorePct != 68 {
+			t.Errorf("no org default: status=%d days=%+v, want the all-rules series (68)", status, body.Days)
 		}
 	})
 }

--- a/internal/server/compliance_trend_handlers.go
+++ b/internal/server/compliance_trend_handlers.go
@@ -16,6 +16,7 @@ import (
 	openapitypes "github.com/oapi-codegen/runtime/types"
 
 	"github.com/Hanalyx/openwatch/internal/auth"
+	"github.com/Hanalyx/openwatch/internal/framework"
 	"github.com/Hanalyx/openwatch/internal/host"
 	"github.com/Hanalyx/openwatch/internal/posture"
 	"github.com/Hanalyx/openwatch/internal/scheduler"
@@ -64,7 +65,20 @@ func (h *handlers) GetHostComplianceTrend(
 		return
 	}
 
-	points, err := posture.HostTrend(ctx, h.pool, hostID, trendDays(params.Days))
+	// Lens: the trend follows the same effective lens as the host-detail hero
+	// tile (per-host / group target, else the org default), OS-resolved at
+	// rollup time. So the trend line and the tile agree instead of the trend
+	// showing all-rules. Empty (no target, no org default) reads the all-rules
+	// series. compliance-lens Phase 3c.
+	lens := ""
+	if h.sysCfg != nil {
+		if cfg, cerr := h.sysCfg.LoadCompliance(ctx); cerr == nil {
+			if eff, eerr := framework.NewService(h.pool).EffectiveTarget(ctx, hostID, cfg.DefaultFramework); eerr == nil {
+				lens = eff
+			}
+		}
+	}
+	points, err := posture.HostTrend(ctx, h.pool, hostID, trendDays(params.Days), lens)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"trend query failed", true)
@@ -107,7 +121,16 @@ func (h *handlers) GetFleetComplianceTrend(
 		return
 	}
 
-	points, err := posture.FleetTrend(r.Context(), h.pool, trendDays(params.Days))
+	// Fleet trend follows the ORG default lens (each host OS-resolved at
+	// rollup time), so the dashboard trend agrees with the fleet KPI. Empty
+	// org default reads the all-rules series. compliance-lens Phase 3c.
+	lens := ""
+	if h.sysCfg != nil {
+		if cfg, cerr := h.sysCfg.LoadCompliance(r.Context()); cerr == nil {
+			lens = cfg.DefaultFramework
+		}
+	}
+	points, err := posture.FleetTrend(r.Context(), h.pool, trendDays(params.Days), lens)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"fleet trend query failed", true)

--- a/internal/server/fleet_handlers.go
+++ b/internal/server/fleet_handlers.go
@@ -25,7 +25,19 @@ func (h *handlers) GetFleetScore(w http.ResponseWriter, r *http.Request, params 
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
 	}
-	score, err := h.fleet.FleetComplianceScore(r.Context(), frameworkOpts(params.Framework)...)
+	// v1.2.0 (compliance-targets): with no explicit ?framework=, the fleet KPI
+	// defaults to the ORG default lens (ComplianceConfig.DefaultFramework) so
+	// the tile reflects the selected standard instead of All rules. Per-host
+	// targets are not aggregated into one fleet number here — mixed-fleet
+	// cohorts are Phase 3b; the org default is the single-lens fleet view.
+	lens := params.Framework
+	if (lens == nil || *lens == "") && h.sysCfg != nil {
+		if cfg, cerr := h.sysCfg.LoadCompliance(r.Context()); cerr == nil && cfg.DefaultFramework != "" {
+			d := cfg.DefaultFramework
+			lens = &d
+		}
+	}
+	score, err := h.fleet.FleetComplianceScore(r.Context(), frameworkOpts(lens)...)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"failed to compute fleet compliance score", true)

--- a/internal/server/group_handlers.go
+++ b/internal/server/group_handlers.go
@@ -177,11 +177,21 @@ func (h *handlers) GetGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := r.Context()
-	sum, err := h.groupSvc.Summary(ctx)
+	// The org default lens (empty = all rules) scopes the per-group and fleet
+	// compliance averages, resolved per host to its OS-specific benchmark, so
+	// the Groups page agrees with the hosts list / fleet KPI instead of showing
+	// unlensed all-rules numbers. compliance-lens Phase 3.
+	orgDefault := ""
+	if h.sysCfg != nil {
+		if cfg, cerr := h.sysCfg.LoadCompliance(ctx); cerr == nil {
+			orgDefault = cfg.DefaultFramework
+		}
+	}
+	sum, err := h.groupSvc.Summary(ctx, orgDefault)
 	if mapGroupErr(w, err) {
 		return
 	}
-	groups, err := h.groupSvc.List(ctx)
+	groups, err := h.groupSvc.List(ctx, orgDefault)
 	if mapGroupErr(w, err) {
 		return
 	}

--- a/internal/server/hosts_enrichment.go
+++ b/internal/server/hosts_enrichment.go
@@ -216,32 +216,51 @@ func loadHostLatestScanIDByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uu
 // compliance_summary: null ("never scanned"). critical_failing counts
 // rows with current_status='fail' AND critical severity
 // (case-insensitive). Spec api-hosts v1.5.0 C-12 / AC-23.
-func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uuid.UUID, lens string) (map[uuid.UUID]*api.HostListComplianceSummary, error) {
+func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []uuid.UUID, explicitLens, orgDefault string) (map[uuid.UUID]*api.HostListComplianceSummary, error) {
 	out := map[uuid.UUID]*api.HostListComplianceSummary{}
 	if len(ids) == 0 {
 		return out, nil
 	}
-	// $2 is the default-lens family / specific key (or NULL for all rules);
-	// framework.MatchSQL resolves a family per host in-query so each card
-	// reflects the same lens as the fleet KPI.
+	// Per-host effective lens (Phase 3 compliance-targets): when the caller
+	// passes NO explicit ?framework= ($2 empty), each host's score defaults to
+	// its OWN effective target — host_effective_target (host override, else the
+	// oldest site-group target; migration 0051), else the org default ($3),
+	// else All rules. This mirrors the single-host GetHostByID default so the
+	// list column and the host hero tile agree. An explicit $2 wins uniformly
+	// across the page (an operator deliberately viewing one framework).
+	//
+	// framework.MatchSQL is reused with a COLUMN reference (eff.lens) rather
+	// than a bind placeholder — the argument is a fixed literal in our code
+	// (never user input), so the family-aware match runs per host row.
 	q := `
-		SELECT host_id,
-		       COUNT(*) FILTER (WHERE current_status = 'pass')::BIGINT    AS passing,
-		       COUNT(*) FILTER (WHERE current_status = 'fail')::BIGINT    AS failing,
-		       COUNT(*) FILTER (WHERE current_status = 'skipped')::BIGINT AS skipped,
-		       COUNT(*) FILTER (WHERE current_status = 'error')::BIGINT   AS errors,
-		       COUNT(*)::BIGINT                                           AS total,
-		       COUNT(*) FILTER (WHERE current_status = 'fail'
-		                          AND lower(COALESCE(severity, '')) = 'critical')::BIGINT AS critical_failing
-		  FROM host_rule_state
-		 WHERE host_id = ANY($1)
-		   AND ` + framework.MatchSQL("$2") + `
-		 GROUP BY host_id`
-	var frameworkParam any
-	if lens != "" {
-		frameworkParam = lens
+		WITH eff AS (
+			SELECT h.host_id,
+			       COALESCE(NULLIF($2::text, ''),
+			                NULLIF(het.target_framework, ''),
+			                NULLIF($3::text, '')) AS lens
+			  FROM unnest($1::uuid[]) AS h(host_id)
+			  LEFT JOIN host_effective_target het ON het.host_id = h.host_id
+		)
+		SELECT hrs.host_id,
+		       COUNT(*) FILTER (WHERE hrs.current_status = 'pass')::BIGINT    AS passing,
+		       COUNT(*) FILTER (WHERE hrs.current_status = 'fail')::BIGINT    AS failing,
+		       COUNT(*) FILTER (WHERE hrs.current_status = 'skipped')::BIGINT AS skipped,
+		       COUNT(*) FILTER (WHERE hrs.current_status = 'error')::BIGINT   AS errors,
+		       COUNT(*)::BIGINT                                               AS total,
+		       COUNT(*) FILTER (WHERE hrs.current_status = 'fail'
+		                          AND lower(COALESCE(hrs.severity, '')) = 'critical')::BIGINT AS critical_failing
+		  FROM host_rule_state hrs
+		  JOIN eff ON eff.host_id = hrs.host_id
+		 WHERE ` + framework.MatchSQL("eff.lens") + `
+		 GROUP BY hrs.host_id`
+	var explicitParam, orgParam any
+	if explicitLens != "" {
+		explicitParam = explicitLens
 	}
-	rows, err := pool.Query(ctx, q, ids, frameworkParam)
+	if orgDefault != "" {
+		orgParam = orgDefault
+	}
+	rows, err := pool.Query(ctx, q, ids, explicitParam, orgParam)
 	if err != nil {
 		return nil, fmt.Errorf("loadHostListComplianceByIDs: %w", err)
 	}

--- a/internal/server/hosts_enrichment.go
+++ b/internal/server/hosts_enrichment.go
@@ -225,21 +225,25 @@ func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []
 	// passes NO explicit ?framework= ($2 empty), each host's score defaults to
 	// its OWN effective target — host_effective_target (host override, else the
 	// oldest site-group target; migration 0051), else the org default ($3),
-	// else All rules. This mirrors the single-host GetHostByID default so the
-	// list column and the host hero tile agree. An explicit $2 wins uniformly
-	// across the page (an operator deliberately viewing one framework).
+	// else All rules. An explicit $2 wins uniformly across the page.
 	//
-	// framework.MatchSQL is reused with a COLUMN reference (eff.lens) rather
-	// than a bind placeholder — the argument is a fixed literal in our code
-	// (never user input), so the family-aware match runs per host row.
+	// The family is RESOLVED to each host's OS-specific corpus key
+	// (framework.OSResolvedMatchSQL): a RHEL 9 host's "stig" scores against
+	// stig_rhel9 only, NOT the union stig_rhel9+stig_rhel10+…, so the list
+	// column matches the host-detail hero tile (a mixed-OS host carries mapped
+	// rules for several OS benchmarks; the family union over-counts it). eff
+	// carries each host's os_family/os_version for that resolution.
 	q := `
 		WITH eff AS (
-			SELECT h.host_id,
+			SELECT hh.id AS host_id,
 			       COALESCE(NULLIF($2::text, ''),
 			                NULLIF(het.target_framework, ''),
-			                NULLIF($3::text, '')) AS lens
-			  FROM unnest($1::uuid[]) AS h(host_id)
-			  LEFT JOIN host_effective_target het ON het.host_id = h.host_id
+			                NULLIF($3::text, '')) AS lens,
+			       hh.os_family AS osf,
+			       hh.os_version AS osv
+			  FROM hosts hh
+			  LEFT JOIN host_effective_target het ON het.host_id = hh.id
+			 WHERE hh.id = ANY($1)
 		)
 		SELECT hrs.host_id,
 		       COUNT(*) FILTER (WHERE hrs.current_status = 'pass')::BIGINT    AS passing,
@@ -251,7 +255,7 @@ func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []
 		                          AND lower(COALESCE(hrs.severity, '')) = 'critical')::BIGINT AS critical_failing
 		  FROM host_rule_state hrs
 		  JOIN eff ON eff.host_id = hrs.host_id
-		 WHERE ` + framework.MatchSQL("eff.lens") + `
+		 WHERE ` + framework.OSResolvedMatchSQL("eff.lens", "eff.osf", "eff.osv") + `
 		 GROUP BY hrs.host_id`
 	var explicitParam, orgParam any
 	if explicitLens != "" {
@@ -286,20 +290,23 @@ func loadHostListComplianceByIDs(ctx context.Context, pool *pgxpool.Pool, ids []
 // whose rule_state has no rows mapped to the requested framework
 // returns all-zero counts (AC-18).
 func loadHostComplianceSummary(ctx context.Context, pool *pgxpool.Pool, hostID uuid.UUID, lens string) (api.HostComplianceSummary, error) {
-	// $2 is a family id or a specific corpus key (or NULL for all rules);
-	// framework.MatchSQL resolves a family (e.g. "stig") to the host's own
-	// OS key (stig_rhel9 for a RHEL 9 host) in-query, so the list can carry
-	// a single family filter uniformly across a mixed-OS fleet.
+	// $2 is a family id or a specific corpus key (or NULL for all rules). The
+	// family is RESOLVED to THIS host's OS-specific key
+	// (framework.OSResolvedMatchSQL): a RHEL 9 host's "stig" scores against
+	// stig_rhel9 only, matching the host-detail lens bar / hero tile rather
+	// than the family union (which over-counts a host that carries mapped
+	// rules for several OS benchmarks). Joins hosts for the host's OS.
 	q := `
 		SELECT
-			COUNT(*) FILTER (WHERE current_status = 'pass')::BIGINT    AS passing,
-			COUNT(*) FILTER (WHERE current_status = 'fail')::BIGINT    AS failing,
-			COUNT(*) FILTER (WHERE current_status = 'skipped')::BIGINT AS skipped,
-			COUNT(*) FILTER (WHERE current_status = 'error')::BIGINT   AS errors,
-			COUNT(*)::BIGINT                                           AS total
-		  FROM host_rule_state
-		 WHERE host_id = $1
-		   AND ` + framework.MatchSQL("$2")
+			COUNT(*) FILTER (WHERE hrs.current_status = 'pass')::BIGINT    AS passing,
+			COUNT(*) FILTER (WHERE hrs.current_status = 'fail')::BIGINT    AS failing,
+			COUNT(*) FILTER (WHERE hrs.current_status = 'skipped')::BIGINT AS skipped,
+			COUNT(*) FILTER (WHERE hrs.current_status = 'error')::BIGINT   AS errors,
+			COUNT(*)::BIGINT                                               AS total
+		  FROM host_rule_state hrs
+		  JOIN hosts hh ON hh.id = hrs.host_id
+		 WHERE hrs.host_id = $1
+		   AND ` + framework.OSResolvedMatchSQL("$2", "hh.os_family", "hh.os_version")
 	var s api.HostComplianceSummary
 	var frameworkParam any
 	if lens != "" {

--- a/internal/server/hosts_handlers.go
+++ b/internal/server/hosts_handlers.go
@@ -63,11 +63,21 @@ func (h *handlers) GetHosts(w http.ResponseWriter, r *http.Request, params api.G
 			"last_scan_at join failed", true)
 		return
 	}
+	// v1.8.0 (compliance-targets): with no explicit ?framework=, the per-host
+	// compliance summary defaults to each host's EFFECTIVE TARGET, falling back
+	// to the org default lens — resolved in-query by loadHostListComplianceByIDs
+	// so the list column matches the host hero tile. An explicit param wins.
 	listLens := ""
 	if params.Framework != nil {
 		listLens = *params.Framework
 	}
-	complianceByID, err := loadHostListComplianceByIDs(r.Context(), h.pool, ids, listLens)
+	orgDefault := ""
+	if listLens == "" && h.sysCfg != nil {
+		if cfg, cerr := h.sysCfg.LoadCompliance(r.Context()); cerr == nil {
+			orgDefault = cfg.DefaultFramework
+		}
+	}
+	complianceByID, err := loadHostListComplianceByIDs(r.Context(), h.pool, ids, listLens, orgDefault)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "server.error", "server",
 			"compliance summary join failed", true)

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.5.0"
+VERSION="0.6.0"
 CODENAME="Eyrie"

--- a/specs/api/compliance-trend.spec.yaml
+++ b/specs/api/compliance-trend.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-compliance-trend
   title: Compliance trend endpoints (per-host + fleet)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -38,7 +38,7 @@ spec:
         - GET /api/v1/hosts/{id}/compliance/trend
         - GET /api/v1/fleet/compliance/trend
       excludes:
-        - Per-framework trend slices
+        - An explicit ?framework= query param (the lens is resolved server-side from the effective target / org default; a param override is a later need)
         - CSV/report export
 
   constraints:
@@ -48,6 +48,10 @@ spec:
       enforcement: error
     - id: C-02
       description: 'days is clamped into [1, 90] with default 30 - an out-of-range value is clamped, never rejected. Points return oldest-first; missing days are absent; no snapshots means an empty array, never an error'
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: 'v1.1.0 (compliance-lens Phase 3c) — the trend follows the effective compliance LENS, resolved server-side (no query param), reading the matching per-family posture_snapshots series (system-posture-snapshots C-04). The HOST endpoint uses that host''s effective TARGET (host/group target, else the org default lens); the FLEET endpoint uses the ORG default lens. So the trend line agrees with the host-detail hero tile / fleet KPI instead of always showing all-rules. When no target and no org default are set, both read the all-rules series (backward compatible)'
       type: technical
       enforcement: error
 
@@ -68,3 +72,7 @@ spec:
       description: 'days=0 clamps to 1, days=500 clamps to 90, absent days defaults to 30 - verified by seeding rows just inside/outside each boundary; none of the three returns a 4xx'
       priority: high
       references_constraints: [C-02]
+    - id: AC-05
+      description: 'v1.1.0 lens-following: with the org default lens set to "stig" and a host carrying both a framework="stig" snapshot (e.g. score 88) and a framework="" all-rules snapshot (e.g. score 68), GET /hosts/{id}/compliance/trend returns the STIG series (88), not the all-rules series - proving the trend follows the effective lens server-side. With no org default set it returns the all-rules series'
+      priority: high
+      references_constraints: [C-03]

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -182,3 +182,14 @@ spec:
         behaves identically to no param.
       priority: high
       references_constraints: [C-06]
+    - id: AC-11
+      description: >
+        The /groups compliance averages are lens-scoped and OS-resolved, not
+        all-rules. With the org default set to "stig", a group whose RHEL 9
+        member carries stig_rhel9 (1 pass, 1 fail) + stig_rhel10 (1 pass) has a
+        per-group AvgCompliancePct computed from stig_rhel9 ONLY (1/2 = 50, the
+        stig_rhel10 row EXCLUDED), and the groups-page fleet AvgCompliancePct is
+        the same org-default OS-resolved score as GET /fleet/score. With no org
+        default and no group/host target, both revert to all-rules.
+      priority: high
+      references_constraints: [C-06]

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -103,9 +103,11 @@ spec:
         aggregated — a mixed-OS fleet's "stig" still spans rhel9 + rhel10 hosts,
         each via its own key.
 
-        The compliance TREND card is out of scope here — it reads all-rules
-        posture snapshots that carry no framework dimension (a separate storage
-        change).
+        The compliance TREND card follows the same effective lens via
+        per-family posture snapshots (system-posture-snapshots C-04 +
+        api-compliance-trend C-03): the rollup stores an OS-resolved score per
+        family per host per day, so the trend line agrees with the tile and
+        switching the org default just selects a different stored series.
       type: technical
       enforcement: error
 

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-compliance-lens
   title: Default compliance lens — org-wide framework projection
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -75,6 +75,25 @@ spec:
         respective read model (host detail and the groups rollup list).
       type: technical
       enforcement: error
+    - id: C-06
+      description: >
+        The effective-lens default (C-05) MUST apply uniformly across the
+        compliance SCORE surfaces, not only the host-detail hero tile, so one
+        host shows one score everywhere. Specifically, with NO explicit
+        ?framework=: (a) the GET /hosts LIST compliance_summary scores each host
+        against its OWN effective target (host_effective_target, else the org
+        default) resolved per host in one grouped query; the Scans Coverage tab
+        inherits this since it reads the same endpoint; and (b) the fleet KPI
+        (GET /fleet/score) defaults to the ORG default lens
+        (ComplianceConfig.DefaultFramework) — per-host targets are NOT
+        aggregated into one fleet number (mixed-fleet cohorts are a later
+        phase). An explicit ?framework= overrides the default uniformly on both
+        surfaces. When neither a target nor an org default is set, both stay All
+        rules (backward compatible). The compliance TREND card is out of scope
+        here — it reads all-rules posture snapshots that carry no framework
+        dimension (a separate storage change).
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -125,3 +144,25 @@ spec:
         surfaces the stored target_framework (nil when unset).
       priority: high
       references_constraints: [C-05]
+    - id: AC-09
+      description: >
+        GET /hosts with NO ?framework= scores each host's list compliance_summary
+        against its OWN effective target: a host with a target_framework override
+        is scored against that family (its all-rules total differs from the
+        family-scoped total); a host with no override but an org default set is
+        scored against the org default; a host with neither (and no org default)
+        is scored All rules. An explicit ?framework= overrides per host uniformly.
+        Two hosts with different targets in the same response each reflect their
+        own target — verified against seeded host_rule_state with mixed
+        framework_refs.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-10
+      description: >
+        GET /fleet/score with NO ?framework= defaults to the org default lens
+        (ComplianceConfig.DefaultFramework): with an org default set, the fleet
+        passing-fraction is computed only over rule-states matching that family;
+        with no org default set it is All rules; an explicit ?framework=
+        overrides. An empty ?framework= behaves identically to no param.
+      priority: high
+      references_constraints: [C-06]

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -46,7 +46,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-02
-      description: A framework FAMILY groups corpus keys by stripping a trailing OS suffix (_(rhel|ubuntu)<digits>); an OS-agnostic key (nist_800_53, pci_dss_4, srg) is its own family. The available family list MUST be derived from the live corpus (host_rule_state.framework_refs), never hardcoded. A score filter for a family MUST match ANY corpus key in that family (so a mixed-OS fleet scores across stig_rhel9 + stig_rhel10), while a specific key matches exactly; the family match SQL MUST mirror FamilyOf.
+      description: A framework FAMILY groups corpus keys by stripping a trailing OS suffix (_(rhel|ubuntu)<digits>); an OS-agnostic key (nist_800_53, pci_dss_4, srg) is its own family. The available family list MUST be derived from the live corpus (host_rule_state.framework_refs), never hardcoded. The family-wide match (framework.MatchSQL) matches ANY corpus key in that family (stig -> stig_rhel9 + stig_rhel10 + …) and mirrors FamilyOf; it is used for family-scoped rule LISTS (fleet top-failing-rules, recent-changes). A per-host SCORE does NOT use the family union — it resolves the family to that host's OS-specific key (C-06), because a single host carries mapped rules for several OS benchmarks and the union would over-count it. A specific corpus key always matches exactly.
       type: technical
       enforcement: error
     - id: C-03
@@ -85,13 +85,27 @@ spec:
         default) resolved per host in one grouped query; the Scans Coverage tab
         inherits this since it reads the same endpoint; and (b) the fleet KPI
         (GET /fleet/score) defaults to the ORG default lens
-        (ComplianceConfig.DefaultFramework) — per-host targets are NOT
-        aggregated into one fleet number (mixed-fleet cohorts are a later
-        phase). An explicit ?framework= overrides the default uniformly on both
-        surfaces. When neither a target nor an org default is set, both stay All
-        rules (backward compatible). The compliance TREND card is out of scope
-        here — it reads all-rules posture snapshots that carry no framework
-        dimension (a separate storage change).
+        (ComplianceConfig.DefaultFramework). An explicit ?framework= overrides
+        the default uniformly. When neither a target nor an org default is set,
+        both stay All rules (backward compatible).
+
+        CRUCIALLY, a per-host SCORE MUST resolve a family lens to the host's OWN
+        OS-specific corpus key (framework.OSResolvedMatchSQL), NOT the family
+        union: a RHEL 9 host's "stig" scores against stig_rhel9 ONLY, matching
+        the host-detail hero tile. A single host carries mapped rules for
+        SEVERAL OS benchmarks at once (a RHEL 9 host has stig_rhel9 AND
+        stig_rhel10 refs), so the family union (MatchSQL) over-counts it —
+        grading a RHEL 9 host partly against the RHEL 10 STIG. The three score
+        surfaces (list compliance_summary, single-host compliance_summary, fleet
+        score) all OS-resolve; an OS-neutral family (nist_800_53, pci_dss_4,
+        srg) and an explicit specific key resolve to the bare key. The fleet
+        score is thus each host measured against its own OS benchmark, then
+        aggregated — a mixed-OS fleet's "stig" still spans rhel9 + rhel10 hosts,
+        each via its own key.
+
+        The compliance TREND card is out of scope here — it reads all-rules
+        posture snapshots that carry no framework dimension (a separate storage
+        change).
       type: technical
       enforcement: error
 
@@ -105,7 +119,7 @@ spec:
       priority: high
       references_constraints: [C-02]
     - id: AC-03
-      description: The fleet compliance score with a FAMILY filter counts rule-states carrying ANY key in that family across a mixed-OS corpus (a host with stig_rhel9 and a host with stig_rhel10 both contribute to the "stig" fleet score); a specific-key filter counts only that key; an empty filter counts all rules. The hosts-list card summary honors the same family filter per host.
+      description: The fleet compliance score with a FAMILY filter resolves each host to its OWN OS key (a RHEL 9 host's "stig" -> stig_rhel9, a RHEL 10 host's -> stig_rhel10) so a mixed-OS fleet's "stig" spans both hosts, each measured against its own benchmark; a specific-key filter counts only that key; an empty filter counts all rules.
       priority: critical
       references_constraints: [C-02]
     - id: AC-04
@@ -147,22 +161,22 @@ spec:
     - id: AC-09
       description: >
         GET /hosts with NO ?framework= scores each host's list compliance_summary
-        against its OWN effective target: a host with a target_framework override
-        is scored against that family (its all-rules total differs from the
-        family-scoped total); a host with no override but an org default set is
-        scored against the org default; a host with neither (and no org default)
-        is scored All rules. An explicit ?framework= overrides per host uniformly.
-        Two hosts with different targets in the same response each reflect their
-        own target — verified against seeded host_rule_state with mixed
-        framework_refs.
+        against its OWN effective target, RESOLVED to the host's OS-specific key:
+        a RHEL 9 host targeted to "stig" scores against stig_rhel9 only — a
+        stig_rhel10 rule the host also carries is EXCLUDED (not the family
+        union). A host with no override but an org default set is scored against
+        the org default (OS-resolved); a host with neither (and no org default)
+        is scored All rules. An explicit ?framework= overrides per host. This
+        makes the list column equal the host-detail hero tile for the same host.
       priority: critical
       references_constraints: [C-06]
     - id: AC-10
       description: >
         GET /fleet/score with NO ?framework= defaults to the org default lens
-        (ComplianceConfig.DefaultFramework): with an org default set, the fleet
-        passing-fraction is computed only over rule-states matching that family;
-        with no org default set it is All rules; an explicit ?framework=
-        overrides. An empty ?framework= behaves identically to no param.
+        (ComplianceConfig.DefaultFramework), each host OS-resolved: with an org
+        default of "stig" set, a RHEL 9 host contributes stig_rhel9 rules only
+        (a stig_rhel10 rule it also carries is EXCLUDED); with no org default set
+        it is All rules; an explicit ?framework= overrides. An empty ?framework=
+        behaves identically to no param.
       priority: high
       references_constraints: [C-06]

--- a/specs/system/posture-snapshots.spec.yaml
+++ b/specs/system/posture-snapshots.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-posture-snapshots
   title: Daily compliance posture snapshots (trend substrate)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -42,18 +42,21 @@ spec:
       scan path.
     scope:
       includes:
-        - posture_snapshots table (migration 0025, PK (host_id, snapshot_date))
-        - posture.Rollup - single aggregate UPSERT over host_rule_state
+        - posture_snapshots table (migration 0025; PK (host_id, snapshot_date, framework) since migration 0053)
+        - posture.Rollup - single aggregate UPSERT over host_rule_state, all-rules + per-family OS-resolved series
         - posture.Run - hourly cron + immediate boot pass
-        - posture.HostTrend / posture.FleetTrend read queries
+        - posture.HostTrend / posture.FleetTrend read queries (lens-projected)
       excludes:
-        - Retroactive backfill from transactions
-        - Retention pruning (the table grows ~hosts rows/day; revisit at scale)
-        - Per-framework trend slices (lens-projected trends are a later need)
+        - Retroactive backfill of per-family history (start-fresh; pre-0053 rows are the all-rules series, per-family accrues forward)
+        - Retention pruning (the table grows ~hosts x families rows/day; revisit at scale)
 
   constraints:
     - id: C-01
-      description: 'The rollup MUST be a single aggregate UPSERT keyed (host_id, snapshot_date): re-running within the same day updates rather than duplicates, and a day rollover starts a fresh row leaving prior days untouched. Soft-deleted hosts are excluded; hosts without host_rule_state rows produce no row'
+      description: 'The rollup MUST be a single aggregate UPSERT keyed (host_id, snapshot_date, framework): re-running within the same day updates rather than duplicates, and a day rollover starts a fresh row leaving prior days untouched. Soft-deleted hosts are excluded; hosts without host_rule_state rows produce no row'
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: 'v1.1.0 (compliance-lens Phase 3c) — the rollup MUST write, per host per day, the all-rules series (framework = "") AND one row per framework FAMILY the host has rules in. A per-family row is OS-RESOLVED: a rule contributes to family F only via the host''s OS-compatible key — the bare key when F is OS-neutral (nist_800_53, pci_dss_4, srg), or F_<osfamily><major> when OS-specific (a RHEL 9 host''s stig via stig_rhel9, NEVER stig_rhel10) — so a rule counts at most once per family and the family series equals the host-detail hero tile / list score. Storing every family means switching the org default lens selects a different pre-computed series with no recompute (history is start-fresh: pre-migration rows are the "" series, per-family accrues forward). HostTrend/FleetTrend take a lens and read that series (a specific corpus key normalizes to its family, stig_rhel9 -> stig)'
       type: technical
       enforcement: error
     - id: C-02
@@ -74,3 +77,7 @@ spec:
       description: 'HostTrend returns only the requested trailing window oldest-first; FleetTrend aggregates per day (avg score to one decimal, host count, summed failing, critical-host count) and drops soft-deleted hosts'
       priority: critical
       references_constraints: [C-03]
+    - id: AC-03
+      description: 'v1.1.0 per-family OS-resolved series: after a rollup over a RHEL 9 host carrying stig_rhel9 (1 pass, 1 fail), stig_rhel10 (1 pass), cis_rhel9 (1 pass), nist_800_53 (1 pass), the framework="stig" row is 1/2 (stig_rhel9 only; stig_rhel10 EXCLUDED), framework="cis" is 1/1, framework="nist_800_53" is 1/1, and framework="" (all rules) is 4/5. HostTrend(lens="stig") and HostTrend(lens="stig_rhel9") both return the stig series; HostTrend(lens="") returns the all-rules series'
+      priority: critical
+      references_constraints: [C-01, C-04]


### PR DESCRIPTION
## Summary

Reported from three screenshots: the same host shows the **all-corpus** compliance score everywhere except its detail-page hero tile. For `owas-tst02`: hero tile could read a framework-scoped %, but the **hosts list** showed **70.2%** (401/571 all rules), **Scans Coverage** **70%**, and the **trend** **69.8%** — the raw all-rules number.

Root cause: the effective-lens resolver (`framework.EffectiveTarget`) was wired into exactly **one** production path — `GetHostByID` (the hero tile). Every other score surface ignored the lens unless the frontend passed an explicit `?framework=`.

## Fix (backend-only)

With **no** explicit `?framework=`:
- **GET /hosts** list `compliance_summary` scores each host against its **own effective target** (`host_effective_target` → org default), resolved **per host** in one grouped query. Implemented by reusing `framework.MatchSQL` with a **column reference** (`eff.lens`) instead of a bind placeholder, so the family-aware match runs per row. → the list column now matches the hero tile.
- **Scans → Coverage** inherits this automatically (it reads the same `/hosts` endpoint).
- **GET /fleet/score** defaults to the **org default lens** (`ComplianceConfig.DefaultFramework`). Per-host targets are *not* aggregated into one fleet number — mixed-fleet cohorts are a later phase; the org default is the single-lens fleet view.

An explicit `?framework=` still overrides uniformly. With neither a target nor an org default set, both stay **All rules** (backward compatible — existing tests unaffected).

The frontend already renders `compliance_summary` + the fleet score, so the lens-scoped numbers appear with **no UI or schema change**.

## Explicitly out of scope (deferred)
The **compliance TREND card** stays all-rules: `posture_snapshots` carries a single all-rules score per host per day with no framework dimension. Making the trend lens-scoped needs new storage (migration + rollup change) — the known "Phase 3c framework-scoped trend". Documented in spec C-06.

## Testing
- gofmt · `go build ./...` · vet clean · no openapi/generated/frontend drift.
- `specter check` 116/116; `check --test` 0 errors; `coverage --strictness annotation` 100% — `system-compliance-lens` 10/10.
- New API tests (real Postgres): `TestAPI_HostsList_DefaultsToPerHostEffectiveTarget` (AC-09 — two hosts with different targets each reflect their own; explicit override), `TestAPI_FleetScore_DefaultsToOrgLens` (AC-10 — org-default applied, explicit override).
- Regression: existing `TestAPI_Fleet*`, `TestAPI_Hosts*`, `TestAPI_Compliance*`, `TestFleetHandlers_NoSQL_NoPoolAccess` (AC-13) all green; AC-17 (empty == no-param) holds since both default identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)