### PR TITLE
refactor(licensing): rename paid tier openwatch_plus -> enterprise (Community/Enterprise)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,6 @@ OPENWATCH_LOGGING_FORMAT=json                             # [json] json | text
 # =================================
 # OPTIONAL
 # =================================
-# OPENWATCH_LICENSE_FILE=/etc/openwatch/license.jwt       # OpenWatch+ license file (enables gated features)
+# OPENWATCH_LICENSE_FILE=/etc/openwatch/license.jwt       # OpenWatch Enterprise license file (enables gated features)
 # OPENWATCH_POLICIES_DIR=/etc/openwatch/policies          # external policy directory override
 # OPENWATCH_DEV_MODE=false                                # 'true' relaxes policy loading for local development

--- a/api/compliance.yaml
+++ b/api/compliance.yaml
@@ -10,7 +10,7 @@
 #   - Permissions: app/auth/permissions.yaml
 #       compliance:read; baseline:{read,write,delete}; exception:{read,request,comment,approve,revoke}
 #   - License features: app/license/features.yaml — temporal_queries gates
-#       point-in-time posture and drift forecasts (openwatch_plus tier)
+#       point-in-time posture and drift forecasts (enterprise tier)
 #   - Audit events: app/audit/events.yaml — `compliance.*` namespace
 #   - Error codes: app/api/error_codes.yaml — `policy.denied`, `transition.invalid`, `resource.not_found`
 #   - Policies: `exceptions` policy governs duration/class/approver requirements
@@ -50,7 +50,7 @@ paths:
       description: |
         Reconstructs posture as of a specific timestamp by replaying the
         write-on-change transaction log. Subject to retention window.
-        License-gated under `temporal_queries` (openwatch_plus tier).
+        License-gated under `temporal_queries` (enterprise tier).
       x-required-permission: compliance:read
       x-required-feature: temporal_queries
       parameters:

--- a/api/error_codes.yaml
+++ b/api/error_codes.yaml
@@ -493,7 +493,7 @@ errors:
     http_status: 402
     fault: policy
     retryable: false
-    description: Feature requires an OpenWatch+ license tier
+    description: Feature requires an OpenWatch Enterprise license tier
     detail_schema:
       type: object
       properties:

--- a/api/license.yaml
+++ b/api/license.yaml
@@ -84,7 +84,7 @@ components:
             installed license file.
         tier:
           type: string
-          enum: [free, openwatch_plus]
+          enum: [free, enterprise]
         status:
           type: string
           enum: [active, grace, expired, invalid, no_license]
@@ -173,7 +173,7 @@ components:
             required: [id, tier, description, active]
             properties:
               id: {type: string}
-              tier: {type: string, enum: [free, openwatch_plus]}
+              tier: {type: string, enum: [free, enterprise]}
               description: {type: string}
               introduced: {type: string, description: Semver}
               deprecated_in: {type: string, description: Semver, nullable: true}
@@ -362,7 +362,7 @@ paths:
       summary: List previously-installed licenses
       description: |
         Returns the audit trail of license installs. Useful for compliance
-        ("when did we upgrade to OpenWatch+?") and forensic review.
+        ("when did we upgrade to OpenWatch Enterprise?") and forensic review.
       x-required-permission: AUDIT_READ
       parameters:
         - {name: limit, in: query, schema: {type: integer, default: 50, maximum: 500}}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2042,7 +2042,7 @@ paths:
   # ===========================================================================
   # Remediation (Phase 7). Free core: request -> approve | reject + projected
   # lift (see-and-govern). The act verbs (:dry-run, :execute, :rollback) are
-  # OpenWatch+ licensed (remediation_execution) and return 402 on the free
+  # OpenWatch Enterprise licensed (remediation_execution) and return 402 on the free
   # tier. Spec api-remediation; plan docs/engineering/remediation_core_plan.md.
   # ===========================================================================
   /api/v1/remediation/requests:
@@ -2158,7 +2158,7 @@ paths:
       description: |
         Per-step Kensa transaction journal (Capture/Apply/Validate/Commit
         outcomes). Empty until the request is executed (executing is the
-        OpenWatch+ licensed track). RBAC: remediation:read. Spec
+        OpenWatch Enterprise licensed track). RBAC: remediation:read. Spec
         api-remediation.
       x-required-permission: remediation:read
       parameters:
@@ -5313,7 +5313,7 @@ components:
       type: object
       required: [tier, status, features]
       properties:
-        tier: {type: string, enum: [free, openwatch_plus, enterprise]}
+        tier: {type: string, enum: [free, enterprise]}
         status: {type: string, enum: [active, grace, expired, no_license, invalid]}
         features: {type: array, items: {type: string}}
         customer_id: {type: string}

--- a/api/remediation.yaml
+++ b/api/remediation.yaml
@@ -3,7 +3,7 @@
 # Compliance remediation: request → approve → dry-run → execute → rollback.
 # Read endpoints (list, get, audit) are unrestricted by license so operators
 # can review what's been done. ACT endpoints (:dry-run, :execute, :rollback)
-# require the OpenWatch+ `remediation_execution` feature.
+# require the OpenWatch Enterprise `remediation_execution` feature.
 #
 # Governed by two policies (see app/docs/policies_as_data.md):
 #   - approvals policy   — who can approve, dual-approval rules, timeouts

--- a/api/scans.yaml
+++ b/api/scans.yaml
@@ -708,7 +708,7 @@ paths:
     post:
       summary: Apply remediation to failed findings
       description: |
-        **MAYBE feature in Phase 1 triage.** License-gated (OpenWatch+).
+        **MAYBE feature in Phase 1 triage.** License-gated (OpenWatch Enterprise).
         Creates a remediation request from this scan's failed findings.
       x-required-permission: REMEDIATION_WRITE
       x-required-feature: remediation_execution

--- a/api/system.yaml
+++ b/api/system.yaml
@@ -57,7 +57,7 @@ paths:
       summary: Runtime capability surface (license tier, enabled features, available frameworks, plugin list).
       description: |
         Returns what this running instance can do right now: license tier
-        (free | openwatch_plus | enterprise), enabled features (from the
+        (free | enterprise), enabled features (from the
         active license), frameworks loaded from Kensa mappings, plugins
         registered, FIPS mode, supported auth methods (password, oidc, saml).
         Requires authentication: license-tier and feature lists are

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -247,7 +247,7 @@ API; see [Operations](#operations-the-cli-and-systemd).
 
 ## License
 
-OpenWatch has a tiered license model (`free`, `openwatch_plus`, `enterprise`).
+OpenWatch has a tiered license model (`free`, `enterprise`, `enterprise`).
 Premium-gated endpoints return `402` when the active tier lacks the feature.
 
 | Method | Path | Purpose |

--- a/docs/guides/ENVIRONMENT_REFERENCE.md
+++ b/docs/guides/ENVIRONMENT_REFERENCE.md
@@ -123,7 +123,7 @@ sudo chmod 0640 /etc/openwatch/secrets.env
 
 | Variable | Default | Read by | Purpose |
 |----------|---------|---------|---------|
-| `OPENWATCH_LICENSE_FILE` | `/etc/openwatch/license.lic` | `serve`, `worker` | Path to the OpenWatch+ license file. A missing file is not fatal; the service runs at the free tier. |
+| `OPENWATCH_LICENSE_FILE` | `/etc/openwatch/license.lic` | `serve`, `worker` | Path to the OpenWatch Enterprise license file. A missing file is not fatal; the service runs at the free tier. |
 | `OPENWATCH_POLICIES_DIR` | `/etc/openwatch/policies` | `serve` | Directory scanned when an admin triggers a policy reload through the API. |
 | `OPENWATCH_DEV_MODE` | unset | `serve` | When set to `true`, accepts unsigned policy envelopes. Development only; never set in production. |
 | `OPENWATCH_KENSA_STORE_PATH` | `.kensa/remediation.db` under the working directory (dev only, logs a warning) | `serve` | Durable path for Kensa's remediation rollback pre-state store. The packaged systemd unit sets this to `/var/lib/openwatch/kensa/remediation.db`. Production installs must set it to a persistent path or remediation rollback does not survive a restart. |
@@ -145,7 +145,7 @@ DSN. Prefer encoding connection options in the DSN query string
 | `/etc/openwatch/tls/key.pem` | `openwatch`, `0600` | TLS server private key. |
 | `/etc/openwatch/keys/jwt_private.pem` | `root:openwatch`, `0640` (shipped; not permission-checked at boot) | RSA key that signs access and refresh JWTs. |
 | `/etc/openwatch/keys/credential.key` | `openwatch:openwatch`, `0600` (enforced—boot refuses any other mode) | AES-256 key encrypting MFA secrets and stored SSH credentials. |
-| `/etc/openwatch/license.lic` | readable by `openwatch` | Optional OpenWatch+ license. |
+| `/etc/openwatch/license.lic` | readable by `openwatch` | Optional OpenWatch Enterprise license. |
 | `/var/lib/openwatch` | `openwatch` | Service state directory (`ReadWritePaths` in the unit). |
 | `/var/log/openwatch` | `openwatch` | Log directory; journald remains the primary log sink. |
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1357,7 +1357,7 @@ export interface paths {
          * List a remediation request's transaction journal (steps)
          * @description Per-step Kensa transaction journal (Capture/Apply/Validate/Commit
          *     outcomes). Empty until the request is executed (executing is the
-         *     OpenWatch+ licensed track). RBAC: remediation:read. Spec
+         *     OpenWatch Enterprise licensed track). RBAC: remediation:read. Spec
          *     api-remediation.
          */
         get: operations["listRemediationSteps"];
@@ -3451,7 +3451,7 @@ export interface components {
         };
         LicenseStateResponse: {
             /** @enum {string} */
-            tier: "free" | "openwatch_plus" | "enterprise";
+            tier: "free" | "enterprise";
             /** @enum {string} */
             status: "active" | "grace" | "expired" | "no_license" | "invalid";
             features: string[];

--- a/frontend/src/components/hosts/RequestRemediationModal.tsx
+++ b/frontend/src/components/hosts/RequestRemediationModal.tsx
@@ -3,7 +3,7 @@
 // rule_id}. The created row carries the projected compliance lift, so
 // the modal previews the lift the host's compliance score should gain
 // once the fix is approved and applied (the apply step itself is the
-// OpenWatch+ track and is not driven from here).
+// OpenWatch Enterprise track and is not driven from here).
 //
 // The host-detail remediations query is refreshed by the parent on
 // success. A 409 (an open remediation already exists for this rule)
@@ -109,7 +109,7 @@ export function RequestRemediationModal({
 
         <p style={{ color: 'var(--ow-fg-2)', fontSize: 12, lineHeight: 1.5, margin: '0 0 14px' }}>
           This files a remediation request for review. An approver decides whether the fix is
-          applied. Applying the fix on the host is an OpenWatch+ feature: the free tier governs the
+          applied. Applying the fix on the host is an OpenWatch Enterprise feature: the free tier governs the
           request and approval only.
         </p>
 

--- a/frontend/src/hooks/useHostRemediations.ts
+++ b/frontend/src/hooks/useHostRemediations.ts
@@ -13,7 +13,7 @@ type RemediationRequest = components['schemas']['RemediationRequest'];
 // round-trip.
 //
 // Free-tier lifecycle: pending_approval -> approved | rejected. The
-// act verbs (dry_run/execute/rollback) are OpenWatch+ only and never
+// act verbs (dry_run/execute/rollback) are OpenWatch Enterprise only and never
 // called from the free build; the matching statuses
 // (dry_run_complete/executing/executed/rolled_back) can still arrive
 // from a licensed deployment, so the open set accounts for them.

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -1217,7 +1217,7 @@ function TabStub({ tab, subsystem }: { tab: TabId; subsystem: string }) {
 //   executing        -> "Applying..." (polled to executed | failed)
 //   executed         -> Roll back / :rollback (remediation:rollback)
 // Act permissions also pass with the 'admin' permission (|| isAdmin).
-// The remaining OpenWatch+ paywall is BULK and AUTOMATED remediation
+// The remaining OpenWatch Enterprise paywall is BULK and AUTOMATED remediation
 // (apply many rules / fleet-wide, scheduled auto-remediation), rendered
 // as a DISABLED upsell never wired to any endpoint.
 //
@@ -1375,7 +1375,7 @@ function RemediationTab({ hostId }: { hostId: string }) {
 }
 
 // RemediationExplainer states the atomic transaction model as static
-// copy (the model the OpenWatch+ apply step follows): Capture, Apply,
+// copy (the model the OpenWatch Enterprise apply step follows): Capture, Apply,
 // Validate, Commit, with a rollback to the captured state on failure.
 function RemediationExplainer() {
   const phases = ['Capture', 'Apply', 'Validate', 'Commit'];
@@ -1422,7 +1422,7 @@ function RemediationExplainer() {
         Each approved fix captures the current host state, applies the change, validates the result,
         then commits. A failed validation rolls back to the captured state, so a host is never left
         half-fixed. Applying a single approved fix on the host (and rolling it back) is part of
-        core. Bulk and automated remediation are OpenWatch+ features.
+        core. Bulk and automated remediation are OpenWatch Enterprise features.
       </div>
     </div>
   );
@@ -1707,7 +1707,7 @@ function RemediationRowAction({
   return <span style={{ color: 'var(--ow-fg-3)', fontSize: 11 }}>—</span>;
 }
 
-// RemediationUpsell renders the ACTUAL OpenWatch+ boundary as a DISABLED
+// RemediationUpsell renders the ACTUAL OpenWatch Enterprise boundary as a DISABLED
 // upsell. Single-rule manual execute and rollback moved into free core,
 // so the paywall is now bulk and automated remediation: applying many
 // rules at once (fleet-wide) and scheduled auto-remediation. This control
@@ -1729,19 +1729,19 @@ function RemediationUpsell() {
     >
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--ow-fg-0)', marginBottom: 4 }}>
-          Bulk and automated remediation (OpenWatch+)
+          Bulk and automated remediation (OpenWatch Enterprise)
         </div>
         <div style={{ color: 'var(--ow-fg-2)', fontSize: 12, lineHeight: 1.5 }}>
           Applying a single approved fix (and rolling it back) is part of core. Applying many rules
           at once across the fleet, and scheduling auto-remediation so approved fixes apply without
-          a per-rule click, are OpenWatch+ features.
+          a per-rule click, are OpenWatch Enterprise features.
         </div>
       </div>
       <button
         type="button"
         disabled
         aria-disabled="true"
-        title="Bulk and automated remediation is an OpenWatch+ feature"
+        title="Bulk and automated remediation is an OpenWatch Enterprise feature"
         style={{
           height: 32,
           padding: '0 16px',
@@ -1755,7 +1755,7 @@ function RemediationUpsell() {
           flexShrink: 0,
         }}
       >
-        Bulk remediation (OpenWatch+)
+        Bulk remediation (OpenWatch Enterprise)
       </button>
     </div>
   );

--- a/frontend/src/pages/host-detail/ComplianceTab.tsx
+++ b/frontend/src/pages/host-detail/ComplianceTab.tsx
@@ -1368,7 +1368,7 @@ const excPill: CSSProperties = {
 // remediation:request - a Request button that opens the confirm modal.
 // Non-failing rules with no open request render nothing. This is the
 // request/approval half of the workflow only; applying the fix on the
-// host is the OpenWatch+ track surfaced on the Remediation tab.
+// host is the OpenWatch Enterprise track surfaced on the Remediation tab.
 function RemediationCell({
   rule,
   requested,

--- a/frontend/src/pages/settings/StubbedPages.tsx
+++ b/frontend/src/pages/settings/StubbedPages.tsx
@@ -107,9 +107,8 @@ export function IntegrationsPage() {
 
 // ── About ───────────────────────────────────────────────────────────────
 const LICENSE_TIER_LABEL: Record<string, string> = {
-  free: 'Open-core',
-  openwatch_plus: 'OpenWatch+',
-  enterprise: 'Enterprise',
+  free: 'OpenWatch Community',
+  enterprise: 'OpenWatch Enterprise',
 };
 const LICENSE_STATUS: Record<string, { label: string; tier: 'ok' | 'warn' | 'crit' }> = {
   active: { label: 'Active', tier: 'ok' },

--- a/frontend/tests/pages/remediation-tab.test.ts
+++ b/frontend/tests/pages/remediation-tab.test.ts
@@ -12,7 +12,7 @@
 //   AC-05  Executed row: Fixed status + Roll back gated on
 //          remediation:rollback||isAdmin POSTing :rollback
 //   AC-06  Lifecycle status rendering + executing poll
-//   AC-07  Bulk/automated OpenWatch+ upsell replaces the single-rule one
+//   AC-07  Bulk/automated OpenWatch Enterprise upsell replaces the single-rule one
 
 import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -146,9 +146,9 @@ describe('frontend-remediation-tab — source inspection', () => {
   // @ac AC-07
   test('frontend-remediation-tab/AC-07 — bulk/auto upsell replaces single-rule upsell, no em-dash', () => {
     expect(PAGE).toContain('RemediationUpsell');
-    expect(PAGE).toContain('Bulk and automated remediation (OpenWatch+)');
+    expect(PAGE).toContain('Bulk and automated remediation (OpenWatch Enterprise)');
     // The old single-rule execute upsell copy is gone.
-    expect(PAGE).not.toContain('Execute on host (OpenWatch+)');
+    expect(PAGE).not.toContain('Execute on host (OpenWatch Enterprise)');
     // No em-dashes in the user-facing prose (project hard rule). The bare
     // em-dash placeholder glyph in table cells is a separate convention.
     expect(EXPLAINER).not.toContain('—');

--- a/internal/db/migrations/0037_remediation.sql
+++ b/internal/db/migrations/0037_remediation.sql
@@ -8,7 +8,7 @@
 -- FREE-PATH INVARIANT: the free service (Request/Approve/Reject + the
 -- read-only ProjectLift) NEVER contacts a host and NEVER writes host_rule_state
 -- or transactions. remediation_transactions (the per-step Kensa journal) is
--- written only by the OpenWatch+ licensed execute path; in the free build the
+-- written only by the OpenWatch Enterprise licensed execute path; in the free build the
 -- table exists but stays empty.
 --
 -- Lifecycle: pending_approval -> approved | rejected. The approved -> executed
@@ -61,7 +61,7 @@ CREATE INDEX remediation_requests_host   ON remediation_requests (host_id);
 CREATE INDEX remediation_requests_status ON remediation_requests (status);
 
 -- Per-step Kensa transaction journal (Capture/Apply/Validate/Commit). Written
--- only by the OpenWatch+ licensed execute path; the durable rollback point and
+-- only by the OpenWatch Enterprise licensed execute path; the durable rollback point and
 -- signed-evidence record. Empty in the free build.
 CREATE TABLE remediation_transactions (
     id           UUID PRIMARY KEY,

--- a/internal/license/features.gen.go
+++ b/internal/license/features.gen.go
@@ -10,9 +10,8 @@ type Feature string
 type Tier string
 
 const (
-	TierFree          Tier = "free"
-	TierOpenWatchPlus Tier = "openwatch_plus"
-	TierEnterprise    Tier = "enterprise"
+	TierFree       Tier = "free"
+	TierEnterprise Tier = "enterprise"
 )
 
 // Feature constants. Hand-typed feature-string literals are forbidden by lint;
@@ -26,8 +25,10 @@ const (
 	AuditExport Feature = "audit_export"
 	// Point-in-time compliance posture queries, drift forecasts, historical reconstruction from the transaction log
 	TemporalQueries Feature = "temporal_queries"
-	// Bulk and automated remediation - apply many rules / fleet-wide and policy-driven auto-remediation (single-rule manual remediation is free core)
+	// Bulk / fleet-wide manual remediation - apply many rules at once across a host selection (single-rule manual remediation is free core)
 	RemediationExecution Feature = "remediation_execution"
+	// Policy-driven and scheduled auto-remediation across the fleet (severity routing, canary, guardrails, circuit breaker)
+	RemediationAuto Feature = "remediation_auto"
 	// Multi-stage exception approval workflow with policy enforcement
 	StructuredExceptions Feature = "structured_exceptions"
 	// Early access to Kensa rule updates and framework mappings
@@ -58,55 +59,61 @@ var FeatureRegistry = map[Feature]FeatureMeta{
 	},
 	AuditQuery: {
 		ID:          AuditQuery,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `Saved and ad-hoc audit query DSL via POST /audit/events:query`,
 		Introduced:  "1.0.0",
 	},
 	AuditExport: {
 		ID:          AuditExport,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `Export audit data as JSON/CSV with signed bundles`,
 		Introduced:  "1.0.0",
 	},
 	TemporalQueries: {
 		ID:          TemporalQueries,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `Point-in-time compliance posture queries, drift forecasts, historical reconstruction from the transaction log`,
 		Introduced:  "1.0.0",
 	},
 	RemediationExecution: {
 		ID:          RemediationExecution,
-		Tier:        TierOpenWatchPlus,
-		Description: `Bulk and automated remediation - apply many rules / fleet-wide and policy-driven auto-remediation (single-rule manual remediation is free core)`,
+		Tier:        TierEnterprise,
+		Description: `Bulk / fleet-wide manual remediation - apply many rules at once across a host selection (single-rule manual remediation is free core)`,
+		Introduced:  "1.0.0",
+	},
+	RemediationAuto: {
+		ID:          RemediationAuto,
+		Tier:        TierEnterprise,
+		Description: `Policy-driven and scheduled auto-remediation across the fleet (severity routing, canary, guardrails, circuit breaker)`,
 		Introduced:  "1.0.0",
 	},
 	StructuredExceptions: {
 		ID:          StructuredExceptions,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `Multi-stage exception approval workflow with policy enforcement`,
 		Introduced:  "1.0.0",
 	},
 	PriorityUpdates: {
 		ID:          PriorityUpdates,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `Early access to Kensa rule updates and framework mappings`,
 		Introduced:  "1.0.0",
 	},
 	SsoSaml: {
 		ID:          SsoSaml,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `SAML 2.0 single sign-on integration`,
 		Introduced:  "1.0.0",
 	},
 	Fido2Mfa: {
 		ID:          Fido2Mfa,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `FIDO2 / WebAuthn second factor for user authentication`,
 		Introduced:  "1.0.0",
 	},
 	PremiumDiagnostics: {
 		ID:          PremiumDiagnostics,
-		Tier:        TierOpenWatchPlus,
+		Tier:        TierEnterprise,
 		Description: `Premium diagnostic endpoints (Stage 0 demo and future operator tooling)`,
 		Introduced:  "1.0.0",
 	},
@@ -125,6 +132,7 @@ var featureOrder = []Feature{
 	AuditExport,
 	TemporalQueries,
 	RemediationExecution,
+	RemediationAuto,
 	StructuredExceptions,
 	PriorityUpdates,
 	SsoSaml,

--- a/internal/license/features_test.go
+++ b/internal/license/features_test.go
@@ -52,6 +52,7 @@ func TestCodegen_FeatureConstants(t *testing.T) {
 			AuditExport,
 			TemporalQueries,
 			RemediationExecution,
+			RemediationAuto,
 			StructuredExceptions,
 			PriorityUpdates,
 			SsoSaml,
@@ -63,8 +64,8 @@ func TestCodegen_FeatureConstants(t *testing.T) {
 				t.Errorf("FeatureRegistry missing %q", f)
 			}
 		}
-		if len(FeatureRegistry) != 10 {
-			t.Errorf("FeatureRegistry size = %d, want 10", len(FeatureRegistry))
+		if len(FeatureRegistry) != 11 {
+			t.Errorf("FeatureRegistry size = %d, want 11", len(FeatureRegistry))
 		}
 	})
 }
@@ -73,7 +74,7 @@ func TestCodegen_FeatureConstants(t *testing.T) {
 // AC-02: Metadata map has Tier, Description, Introduced per feature.
 func TestCodegen_FeatureRegistryMetadata(t *testing.T) {
 	t.Run("system-license-features/AC-02", func(t *testing.T) {
-		// ComplianceCheck is free; RemediationExecution is openwatch_plus.
+		// ComplianceCheck is free; RemediationExecution is enterprise.
 		ccMeta, ok := FeatureRegistry[ComplianceCheck]
 		if !ok || ccMeta.Tier != TierFree {
 			t.Errorf("ComplianceCheck tier = %v, want free", ccMeta.Tier)
@@ -82,8 +83,8 @@ func TestCodegen_FeatureRegistryMetadata(t *testing.T) {
 			t.Errorf("ComplianceCheck description/introduced empty: %+v", ccMeta)
 		}
 		reMeta := FeatureRegistry[RemediationExecution]
-		if reMeta.Tier != TierOpenWatchPlus {
-			t.Errorf("RemediationExecution tier = %v, want openwatch_plus", reMeta.Tier)
+		if reMeta.Tier != TierEnterprise {
+			t.Errorf("RemediationExecution tier = %v, want enterprise", reMeta.Tier)
 		}
 	})
 }
@@ -137,7 +138,7 @@ func TestIsEnabled_AfterLicenseLoad(t *testing.T) {
 		resetState(t)
 		setState(&State{
 			License: &License{
-				Tier:     TierOpenWatchPlus,
+				Tier:     TierEnterprise,
 				Features: []Feature{RemediationExecution},
 			},
 			LoadedAt: time.Now(),
@@ -160,7 +161,7 @@ func TestIsEnabled_AfterLicenseReload(t *testing.T) {
 		// First: license grants RemediationExecution.
 		setState(&State{
 			License: &License{
-				Tier:     TierOpenWatchPlus,
+				Tier:     TierEnterprise,
 				Features: []Feature{RemediationExecution},
 			},
 			LoadedAt: time.Now(),
@@ -171,7 +172,7 @@ func TestIsEnabled_AfterLicenseReload(t *testing.T) {
 		// Reload with a license that drops RemediationExecution.
 		setState(&State{
 			License: &License{
-				Tier:     TierOpenWatchPlus,
+				Tier:     TierEnterprise,
 				Features: []Feature{PremiumDiagnostics},
 			},
 			LoadedAt: time.Now(),
@@ -192,7 +193,7 @@ func TestIsEnabled_DoesNotAllocate(t *testing.T) {
 		resetState(t)
 		setState(&State{
 			License: &License{
-				Tier:     TierOpenWatchPlus,
+				Tier:     TierEnterprise,
 				Features: []Feature{RemediationExecution},
 			},
 			LoadedAt: time.Now(),
@@ -213,7 +214,7 @@ func BenchmarkIsEnabled(b *testing.B) {
 	_ = Init()
 	setState(&State{
 		License: &License{
-			Tier:     TierOpenWatchPlus,
+			Tier:     TierEnterprise,
 			Features: []Feature{RemediationExecution},
 		},
 		LoadedAt: time.Now(),
@@ -233,7 +234,7 @@ func TestIsEnabled_P99Latency(t *testing.T) {
 		resetState(t)
 		setState(&State{
 			License: &License{
-				Tier:     TierOpenWatchPlus,
+				Tier:     TierEnterprise,
 				Features: []Feature{RemediationExecution},
 			},
 			LoadedAt: time.Now(),
@@ -387,7 +388,7 @@ func TestIsEnabled_ConcurrentStateSwap(t *testing.T) {
 				}
 				setState(&State{
 					License: &License{
-						Tier:     TierOpenWatchPlus,
+						Tier:     TierEnterprise,
 						Features: features,
 					},
 					LoadedAt: time.Now(),

--- a/internal/license/middleware.go
+++ b/internal/license/middleware.go
@@ -52,7 +52,7 @@ func DenyFeature(w http.ResponseWriter, r *http.Request, f Feature) {
 		"code":          "license.feature_unavailable",
 		"fault":         "policy",
 		"retryable":     false,
-		"human_message": "this feature requires an OpenWatch+ license",
+		"human_message": "this feature requires an OpenWatch Enterprise license",
 		"detail": map[string]any{
 			"feature": string(f),
 		},

--- a/internal/license/validator_test.go
+++ b/internal/license/validator_test.go
@@ -66,7 +66,7 @@ func validClaims() claims {
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(365 * 24 * time.Hour)),
 		},
-		Tier:       TierOpenWatchPlus,
+		Tier:       TierEnterprise,
 		Features:   []string{"premium_diagnostics", "remediation_execution"},
 		CustomerID: "test-customer",
 	}
@@ -97,8 +97,8 @@ func TestVerify_ValidJWT(t *testing.T) {
 		if lic == nil {
 			t.Fatal("license is nil on valid JWT")
 		}
-		if lic.Tier != TierOpenWatchPlus {
-			t.Errorf("tier = %s, want openwatch_plus", lic.Tier)
+		if lic.Tier != TierEnterprise {
+			t.Errorf("tier = %s, want enterprise", lic.Tier)
 		}
 		if len(lic.Features) != 2 {
 			t.Errorf("features = %v, want 2 entries", lic.Features)

--- a/internal/remediation/types.go
+++ b/internal/remediation/types.go
@@ -7,7 +7,7 @@
 // or mutates host_rule_state / transactions. Request, Approve, and Reject are
 // pure state transitions over remediation_requests; ProjectLift only reads
 // host_rule_state. The act of mutating a host (dry-run / execute / rollback)
-// is the OpenWatch+ licensed track, gated by the remediation_execution license
+// is the OpenWatch Enterprise licensed track, gated by the remediation_execution license
 // feature, and is NOT implemented here.
 //
 // Separation of duties: the requester cannot review their own request
@@ -26,7 +26,7 @@ import (
 
 // Status is the remediation request lifecycle state. The free path uses
 // pending_approval -> approved | rejected; the remaining states are driven by
-// the OpenWatch+ licensed execution track.
+// the OpenWatch Enterprise licensed execution track.
 type Status string
 
 const (

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -892,9 +892,8 @@ func (e LicenseStateResponseStatus) Valid() bool {
 
 // Defines values for LicenseStateResponseTier.
 const (
-	Enterprise    LicenseStateResponseTier = "enterprise"
-	Free          LicenseStateResponseTier = "free"
-	OpenwatchPlus LicenseStateResponseTier = "openwatch_plus"
+	Enterprise LicenseStateResponseTier = "enterprise"
+	Free       LicenseStateResponseTier = "free"
 )
 
 // Valid indicates whether the value is a known member of the LicenseStateResponseTier enum.
@@ -903,8 +902,6 @@ func (e LicenseStateResponseTier) Valid() bool {
 	case Enterprise:
 		return true
 	case Free:
-		return true
-	case OpenwatchPlus:
 		return true
 	default:
 		return false

--- a/internal/server/api_license_test.go
+++ b/internal/server/api_license_test.go
@@ -49,7 +49,7 @@ func mintTestLicenseJWT(t *testing.T, features []string) string {
 		"aud":         "openwatch",
 		"iat":         now.Unix(),
 		"exp":         now.Add(365 * 24 * time.Hour).Unix(),
-		"tier":        "openwatch_plus",
+		"tier":        "enterprise",
 		"features":    features,
 		"customer_id": "test-customer-api",
 	}
@@ -145,8 +145,8 @@ func TestAPI_PremiumEcho_DeniesWithoutLicense(t *testing.T) {
 }
 
 // @ac AC-02
-// api-license/AC-02: GET /license with a valid openwatch_plus license
-// returns tier="openwatch_plus", status="active", features list, exp.
+// api-license/AC-02: GET /license with a valid enterprise license
+// returns tier="enterprise", status="active", features list, exp.
 func TestAPI_License_OpenwatchPlusActive(t *testing.T) {
 	t.Run("api-license/AC-02", func(t *testing.T) {
 		url, _ := freshAPIServer(t)
@@ -165,8 +165,8 @@ func TestAPI_License_OpenwatchPlusActive(t *testing.T) {
 			ExpiresAt *string  `json:"expires_at"`
 		}
 		_ = json.NewDecoder(resp.Body).Decode(&got)
-		if got.Tier != "openwatch_plus" {
-			t.Errorf("tier = %q, want openwatch_plus", got.Tier)
+		if got.Tier != "enterprise" {
+			t.Errorf("tier = %q, want enterprise", got.Tier)
 		}
 		if got.Status != "active" {
 			t.Errorf("status = %q, want active", got.Status)
@@ -370,8 +370,8 @@ func TestAPI_License_LiveReload(t *testing.T) {
 			Tier string `json:"tier"`
 		}
 		_ = json.NewDecoder(resp.Body).Decode(&after)
-		if after.Tier != "openwatch_plus" {
-			t.Errorf("post-reload tier = %q, want openwatch_plus", after.Tier)
+		if after.Tier != "enterprise" {
+			t.Errorf("post-reload tier = %q, want enterprise", after.Tier)
 		}
 	})
 }

--- a/internal/server/remediation_handlers.go
+++ b/internal/server/remediation_handlers.go
@@ -208,7 +208,7 @@ func (h *handlers) RequestRemediation(w http.ResponseWriter, r *http.Request) {
 		scanRunID = &s
 	}
 	// Free-core: single-rule manual remediation is auto-approved (no separate
-	// approver). Bulk/auto remediation (OpenWatch+) will request with approval
+	// approver). Bulk/auto remediation (OpenWatch Enterprise) will request with approval
 	// required via its own gated handler.
 	rq, err := h.remediationSvc.Request(ctx, hostID, req.RuleId, scanRunID, requestedBy, false)
 	if mapRemediationErr(w, err) {

--- a/licensing/features.yaml
+++ b/licensing/features.yaml
@@ -6,7 +6,7 @@
 #
 # Build invariants enforced by scripts/validate-features.go:
 #   - Every feature id matches ^[a-z][a-z0-9_]*$
-#   - Every tier is one of: free | openwatch_plus | enterprise
+#   - Every tier is one of: free | enterprise
 #   - Every introduced version is valid semver
 #   - permissions.yaml license_gated values resolve to a feature here
 #   - OpenAPI specs: every x-required-feature value matches an active feature id
@@ -19,7 +19,7 @@
 #      `x-required-feature:`.
 #   4. CI fails if a handler emits a string literal that isn't a registered id.
 #
-# Design: app/docs/licensing_foundation.md §3 (feature registry).
+# Design: docs/engineering/licensing_foundation.md §3 (feature registry).
 
 version: 1
 
@@ -30,42 +30,53 @@ features:
     introduced: "1.0.0"
 
   - id: audit_query
-    tier: openwatch_plus
+    tier: enterprise
     description: Saved and ad-hoc audit query DSL via POST /audit/events:query
     introduced: "1.0.0"
 
   - id: audit_export
-    tier: openwatch_plus
+    tier: enterprise
     description: Export audit data as JSON/CSV with signed bundles
     introduced: "1.0.0"
 
   - id: temporal_queries
-    tier: openwatch_plus
+    tier: enterprise
     description: Point-in-time compliance posture queries, drift forecasts, historical reconstruction from the transaction log
     introduced: "1.0.0"
 
   - id: remediation_execution
-    tier: openwatch_plus
-    description: Bulk and automated remediation - apply many rules / fleet-wide and policy-driven auto-remediation (single-rule manual remediation is free core)
+    tier: enterprise
+    description: Bulk / fleet-wide manual remediation - apply many rules at once across a host selection (single-rule manual remediation is free core)
+    introduced: "1.0.0"
+
+  # Policy-driven / scheduled auto-remediation (the flagship automation surface:
+  # severity-routed auto-fix, canary, max-changes-per-run, circuit breaker,
+  # scheduled playbooks). Split out from remediation_execution so the higher-
+  # blast-radius unattended posture gates independently of manual bulk apply.
+  # PLANNED — registered ahead of the build (registry-first); not yet enforced.
+  # See docs/engineering/roadmap/enterprise/ROADMAP.md and remediation_licensed_plan.md.
+  - id: remediation_auto
+    tier: enterprise
+    description: Policy-driven and scheduled auto-remediation across the fleet (severity routing, canary, guardrails, circuit breaker)
     introduced: "1.0.0"
 
   - id: structured_exceptions
-    tier: openwatch_plus
+    tier: enterprise
     description: Multi-stage exception approval workflow with policy enforcement
     introduced: "1.0.0"
 
   - id: priority_updates
-    tier: openwatch_plus
+    tier: enterprise
     description: Early access to Kensa rule updates and framework mappings
     introduced: "1.0.0"
 
   - id: sso_saml
-    tier: openwatch_plus
+    tier: enterprise
     description: SAML 2.0 single sign-on integration
     introduced: "1.0.0"
 
   - id: fido2_mfa
-    tier: openwatch_plus
+    tier: enterprise
     description: FIDO2 / WebAuthn second factor for user authentication
     introduced: "1.0.0"
 
@@ -74,7 +85,7 @@ features:
   # end-to-end. Retained post-Stage-0 only if a genuine premium diagnostic
   # surface emerges; otherwise marked deprecated and removed.
   - id: premium_diagnostics
-    tier: openwatch_plus
+    tier: enterprise
     description: Premium diagnostic endpoints (Stage 0 demo and future operator tooling)
     introduced: "1.0.0"
 

--- a/scripts/gen-license-features.go
+++ b/scripts/gen-license-features.go
@@ -50,7 +50,6 @@ type Tier string
 
 const (
 	TierFree         Tier = "free"
-	TierOpenWatchPlus Tier = "openwatch_plus"
 	TierEnterprise   Tier = "enterprise"
 )
 
@@ -177,8 +176,6 @@ func tierToPascal(t string) string {
 	switch t {
 	case "free":
 		return "Free"
-	case "openwatch_plus":
-		return "OpenWatchPlus"
 	case "enterprise":
 		return "Enterprise"
 	default:

--- a/specs/api/license.spec.yaml
+++ b/specs/api/license.spec.yaml
@@ -56,7 +56,7 @@ spec:
       priority: critical
       references_constraints: [C-01]
     - id: AC-02
-      description: GET /license with valid openwatch_plus license includes tier="openwatch_plus", status="active", features listing every claim, exp populated.
+      description: GET /license with valid enterprise license includes tier="enterprise", status="active", features listing every claim, exp populated.
       priority: critical
     - id: AC-03
       description: GET /license MUST NOT return raw JWT, signature, or customer PII (email, name).

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -71,7 +71,7 @@ spec:
       A correct, auditable remediation request/approve lifecycle with
       separation of duties, one open request per host+rule, a read-only
       projected-lift estimate, and a license gate that keeps host mutation
-      behind OpenWatch+ - all without ever touching a host in the free path.
+      behind OpenWatch Enterprise - all without ever touching a host in the free path.
     scope:
       includes:
         - remediation_requests + remediation_transactions tables (migration 0037)

--- a/specs/frontend/remediation-tab.spec.yaml
+++ b/specs/frontend/remediation-tab.spec.yaml
@@ -7,7 +7,7 @@ spec:
 
   context:
     system: openwatch
-    feature: The remediation governance + single-rule apply frontend - a per-failing-rule Request-remediation affordance on the Compliance tab plus a Remediation tab that drives the request -> approve | reject -> execute | rollback lifecycle and renders BULK and AUTOMATED remediation as an OpenWatch+ upsell.
+    feature: The remediation governance + single-rule apply frontend - a per-failing-rule Request-remediation affordance on the Compliance tab plus a Remediation tab that drives the request -> approve | reject -> execute | rollback lifecycle and renders BULK and AUTOMATED remediation as an OpenWatch Enterprise upsell.
     description: >
       The frontend half of the remediation feature. The backend exposes
       /api/v1/remediation/* (api-remediation):
@@ -22,7 +22,7 @@ spec:
       :execute requires remediation:execute and returns 202 (queued), or
       409 if the request is not in 'approved' state. :rollback requires
       remediation:rollback, returns 202, or 409 if not 'executed'. The
-      remaining OpenWatch+ paywall is BULK and AUTOMATED remediation
+      remaining OpenWatch Enterprise paywall is BULK and AUTOMATED remediation
       (apply many rules / fleet-wide, scheduled auto-remediation),
       rendered as a DISABLED upsell never wired to any endpoint.
 
@@ -45,7 +45,7 @@ spec:
     summary: >
       A usable free-tier remediation surface: request a fix from a
       failing rule, see this host's requests, approve or reject within
-      the caller's authority, and a clear OpenWatch+ upsell for the
+      the caller's authority, and a clear OpenWatch Enterprise upsell for the
       host-mutating apply step that is never wired to the act endpoints.
     scope:
       includes:
@@ -54,10 +54,10 @@ spec:
         - RemediationTab panel on host detail with approve/reject gating and the atomic-model explainer
         - Per-rule Fix (:execute) gated on remediation:execute||isAdmin and Roll back (:rollback) gated on remediation:rollback||isAdmin
         - Lifecycle status rendering (executing "Applying...", executed "Fixed", rolled_back, failed)
-        - The OpenWatch+ upsell for BULK and AUTOMATED remediation (disabled, never calls any endpoint)
+        - The OpenWatch Enterprise upsell for BULK and AUTOMATED remediation (disabled, never calls any endpoint)
       excludes:
-        - Calling :dry-run (OpenWatch+ licensed track)
-        - Bulk / fleet-wide apply and scheduled auto-remediation (OpenWatch+, upsell only)
+        - Calling :dry-run (OpenWatch Enterprise licensed track)
+        - Bulk / fleet-wide apply and scheduled auto-remediation (OpenWatch Enterprise, upsell only)
         - The transaction journal (steps) view
         - A fleet-wide remediation queue (host-scoped only here)
 
@@ -71,7 +71,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-03
-      description: 'The Remediation tab lists this host''s requests (status chip, rule_id, projected lift) newest first. On a pending_approval row, a caller with remediation:approve (|| isAdmin) gets Approve / Reject (POST :approve / :reject, invalidate on success, 409 inline); without it, "Awaiting approval". BULK and AUTOMATED remediation render as a DISABLED OpenWatch+ upsell that is never wired to any endpoint'
+      description: 'The Remediation tab lists this host''s requests (status chip, rule_id, projected lift) newest first. On a pending_approval row, a caller with remediation:approve (|| isAdmin) gets Approve / Reject (POST :approve / :reject, invalidate on success, 409 inline); without it, "Awaiting approval". BULK and AUTOMATED remediation render as a DISABLED OpenWatch Enterprise upsell that is never wired to any endpoint'
       type: security
       enforcement: error
     - id: C-04
@@ -105,6 +105,6 @@ spec:
       priority: high
       references_constraints: [C-04]
     - id: AC-07
-      description: 'Source inspection: the OpenWatch+ upsell now describes BULK and AUTOMATED remediation (RemediationUpsell, "Bulk and automated remediation (OpenWatch+)"), is DISABLED, and the single-rule "Execute on host (OpenWatch+)" upsell copy is gone. No em-dash characters appear in the RemediationTab copy'
+      description: 'Source inspection: the OpenWatch Enterprise upsell now describes BULK and AUTOMATED remediation (RemediationUpsell, "Bulk and automated remediation (OpenWatch Enterprise)"), is DISABLED, and the single-rule "Execute on host (OpenWatch Enterprise)" upsell copy is gone. No em-dash characters appear in the RemediationTab copy'
       priority: high
       references_constraints: [C-03, C-04]


### PR DESCRIPTION
## What

Collapse the license model to **two user types**: **OpenWatch Community** (free) and **OpenWatch Enterprise** (paid). The `openwatch_plus` tier is removed; every feature it gated is now `tier: enterprise`.

Gating logic only ever checked `== TierFree` (per-feature `IsEnabled`), so this is a **rename, not a behavior change**.

## Changes

- **`licensing/features.yaml`**: all `openwatch_plus` → `enterprise`; header enum `free | enterprise`. Adds `remediation_auto` (enterprise, registry-first, dormant — no references yet) and narrows `remediation_execution` to bulk-only so the two don't overlap.
- **Generator**: drop `TierOpenWatchPlus` constant + its `tierToPascal` case (`scripts/gen-license-features.go`); regenerate `internal/license/features.gen.go` (11 features).
- **OpenAPI contract** (`api/openapi.yaml` + fragments): license tier enum `[free, openwatch_plus]` → `[free, enterprise]`; "OpenWatch+" copy → "OpenWatch Enterprise". Regenerated `internal/server/api/server.gen.go` + `frontend/src/api/schema.d.ts`.
- **Frontend**: tier-display map → `OpenWatch Community` / `OpenWatch Enterprise`; upsell + comment copy.
- **Go non-generated, tests, specs, public guides, `.env.example`**, and an `0037` migration comment (comment-only; goose tracks by version, no content checksum).

## Verification

- `go build ./...`, `go test ./internal/license/...`, `tsc --noEmit`, the `remediation-tab` vitest suite (7/7), `specter check` (116 specs), `gofmt` — all green.
- Codegen is **idempotent** (regen produces no further diff); **zero residual** `openwatch_plus` / `OpenWatch+` / `OpenWatch Plus` in the tree.

## Note

Any already-minted `openwatch_plus` license JWTs (Hanalyx issuer infra) should be re-issued as `enterprise`. Pre-GA, so no live customers are affected.