### PR TITLE
test(rbac): fail the build when a route does not enforce its declared permission

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1475,7 +1475,7 @@ paths:
               schema: {$ref: '#/components/schemas/IntelligenceConfig'}
         '400': {$ref: '#/components/responses/BadRequest'}
         '403':
-          description: Caller lacks system:config:write permission
+          description: Caller lacks system:config_write permission
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -1524,7 +1524,7 @@ paths:
               schema: {$ref: '#/components/schemas/DiscoveryConfig'}
         '400': {$ref: '#/components/responses/BadRequest'}
         '403':
-          description: Caller lacks system:config:write permission
+          description: Caller lacks system:config_write permission
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -1548,7 +1548,7 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/DiscoverySweepResponse'}
         '403':
-          description: Caller lacks system:config:write permission
+          description: Caller lacks system:config_write permission
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -1603,7 +1603,7 @@ paths:
     put:
       operationId: putSystemComplianceConfig
       summary: Set the default compliance lens (framework family, or empty for All rules)
-      x-required-permission: system:config:write
+      x-required-permission: system:config_write
       requestBody:
         required: true
         content:
@@ -1621,7 +1621,7 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
         '403':
-          description: Caller lacks system:config:write
+          description: Caller lacks system:config_write
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -1671,7 +1671,7 @@ paths:
               schema: {$ref: '#/components/schemas/ScanConfig'}
         '400': {$ref: '#/components/responses/BadRequest'}
         '403':
-          description: Caller lacks system:config:write permission
+          description: Caller lacks system:config_write permission
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
@@ -1769,7 +1769,7 @@ paths:
               schema: {$ref: '#/components/schemas/ScanVariableOverrides'}
         '400': {$ref: '#/components/responses/BadRequest'}
         '403':
-          description: Caller lacks system:config:write permission
+          description: Caller lacks system:config_write permission
           content:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6694,7 +6694,7 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
-            /** @description Caller lacks system:config:write permission */
+            /** @description Caller lacks system:config_write permission */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6757,7 +6757,7 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
-            /** @description Caller lacks system:config:write permission */
+            /** @description Caller lacks system:config_write permission */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6786,7 +6786,7 @@ export interface operations {
                     "application/json": components["schemas"]["DiscoverySweepResponse"];
                 };
             };
-            /** @description Caller lacks system:config:write permission */
+            /** @description Caller lacks system:config_write permission */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6889,7 +6889,7 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
-            /** @description Caller lacks system:config:write */
+            /** @description Caller lacks system:config_write */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6952,7 +6952,7 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
-            /** @description Caller lacks system:config:write permission */
+            /** @description Caller lacks system:config_write permission */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -7073,7 +7073,7 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
-            /** @description Caller lacks system:config:write permission */
+            /** @description Caller lacks system:config_write permission */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/internal/server/rbac_coverage_test.go
+++ b/internal/server/rbac_coverage_test.go
@@ -1,0 +1,209 @@
+// @spec system-rbac
+//
+// Per-route RBAC enforcement coverage (v0.7 exit criterion 1).
+//
+//	AC-18  TestRBACCoverage_EveryDeclaredPermissionIsEnforced
+//
+// WHY THIS EXISTS: authorization was enforced only by a hand-written
+// auth.EnforcePermission call inside each handler. Every privileged mutation
+// did call it, verified by hand in the 2026-06-29 review, but nothing failed
+// the build if a future handler forgot, and the OpenAPI x-required-permission
+// declarations were decorative: no CI step linked the contract to the code.
+//
+// This test makes the link structural. A route that declares a permission in
+// api/openapi.yaml and whose handler does not enforce that exact permission
+// constant fails the build.
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// permConstByValue reads the generated permission registry and returns a map
+// from the permission string ("host:read") to its Go constant name
+// ("HostRead"). Derived from the generated source rather than re-implementing
+// the generator's naming convention, so the two cannot drift.
+func permConstByValue(t *testing.T) map[string]string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("..", "auth", "permissions.gen.go"))
+	if err != nil {
+		t.Fatalf("read permissions.gen.go: %v", err)
+	}
+	re := regexp.MustCompile(`(?m)^\s*([A-Z][A-Za-z0-9]*)\s+Permission\s*=\s*"([^"]+)"`)
+	out := map[string]string{}
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		out[m[2]] = m[1]
+	}
+	if len(out) == 0 {
+		t.Fatal("no permission constants parsed from permissions.gen.go")
+	}
+	return out
+}
+
+// serverSource concatenates the non-test Go sources in this package, and also
+// records which file each handler came from for readable failures.
+func serverSource(t *testing.T) string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	var b strings.Builder
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(n)
+		if err != nil {
+			t.Fatalf("read %s: %v", n, err)
+		}
+		b.Write(src)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// declaredPermissions parses the OpenAPI contract for every operation that
+// declares x-required-permission, returning operationId -> permission.
+func declaredPermissions(t *testing.T) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "api", "openapi.yaml"))
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var doc struct {
+		Paths map[string]map[string]struct {
+			OperationID string `yaml:"operationId"`
+			Permission  string `yaml:"x-required-permission"`
+		} `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+	out := map[string]string{}
+	for _, item := range doc.Paths {
+		for method, op := range item {
+			switch method {
+			case "get", "post", "put", "patch", "delete":
+			default:
+				continue
+			}
+			if op.Permission != "" && op.OperationID != "" {
+				out[op.OperationID] = op.Permission
+			}
+		}
+	}
+	return out
+}
+
+// handlerBody returns the source of the handler method implementing
+// operationId, or "" when no such method exists. oapi-codegen names the method
+// after the operationId with the first letter upper-cased.
+func handlerBody(src, operationID string) string {
+	name := strings.ToUpper(operationID[:1]) + operationID[1:]
+	marker := "func (h *handlers) " + name + "("
+	i := strings.Index(src, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := src[i+len(marker):]
+	// Body ends at the next top-level func declaration.
+	if j := strings.Index(rest, "\nfunc "); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}
+
+// enforces reports whether body enforces constName, following delegation to a
+// same-receiver helper up to maxDelegationDepth levels.
+//
+// Several handlers are thin wrappers: ApproveRemediation and RejectRemediation
+// both delegate to h.reviewRemediation, which is where EnforcePermission
+// actually lives. A checker that only looked at the handler body would report
+// those as unenforced, and the natural "fix" for a false positive like that is
+// to weaken the check, which is how a real gap gets let through later.
+const maxDelegationDepth = 2
+
+func enforces(src, body, constName string, depth int) bool {
+	if strings.Contains(body, "auth."+constName) {
+		return true
+	}
+	if depth >= maxDelegationDepth {
+		return false
+	}
+	// Follow calls to same-receiver helpers, e.g. "h.reviewRemediation(".
+	re := regexp.MustCompile(`h\.([a-z][A-Za-z0-9]*)\(`)
+	for _, m := range re.FindAllStringSubmatch(body, -1) {
+		marker := "func (h *handlers) " + m[1] + "("
+		i := strings.Index(src, marker)
+		if i < 0 {
+			continue
+		}
+		rest := src[i+len(marker):]
+		if j := strings.Index(rest, "\nfunc "); j >= 0 {
+			rest = rest[:j]
+		}
+		if enforces(src, rest, constName, depth+1) {
+			return true
+		}
+	}
+	return false
+}
+
+// @ac AC-18
+// AC-18: every route declaring x-required-permission has a handler that
+// enforces that exact permission constant. A route that forgets fails the
+// build.
+func TestRBACCoverage_EveryDeclaredPermissionIsEnforced(t *testing.T) {
+	t.Run("system-rbac/AC-18", func(t *testing.T) {
+		declared := declaredPermissions(t)
+		if len(declared) == 0 {
+			t.Fatal("no x-required-permission declarations found; the contract or this parser is broken")
+		}
+		constOf := permConstByValue(t)
+		src := serverSource(t)
+
+		var missingHandler, unknownPerm, notEnforced []string
+
+		for opID, perm := range declared {
+			constName, ok := constOf[perm]
+			if !ok {
+				// The contract names a permission the registry does not have.
+				unknownPerm = append(unknownPerm, opID+" declares "+perm)
+				continue
+			}
+			body := handlerBody(src, opID)
+			if body == "" {
+				missingHandler = append(missingHandler, opID)
+				continue
+			}
+			// The handler must reference the generated constant, not a raw
+			// string. forbidigo separately bans raw permission literals.
+			if enforces(src, body, constName, 0) {
+				continue
+			}
+			notEnforced = append(notEnforced, opID+" must enforce auth."+constName+" ("+perm+")")
+		}
+
+		for _, m := range unknownPerm {
+			t.Errorf("openapi declares a permission missing from the registry: %s", m)
+		}
+		for _, m := range missingHandler {
+			t.Errorf("no handler found for operationId %q; if it was renamed, the contract is stale", m)
+		}
+		for _, m := range notEnforced {
+			t.Errorf("route does not enforce its declared permission: %s", m)
+		}
+
+		if len(notEnforced) == 0 && len(unknownPerm) == 0 && len(missingHandler) == 0 {
+			t.Logf("%d routes declare a permission; all enforce it", len(declared))
+		}
+	})
+}

--- a/specs/system/rbac.spec.yaml
+++ b/specs/system/rbac.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-rbac
   title: RBAC permission registry and middleware
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 1
 
@@ -132,3 +132,17 @@ spec:
       description: "Built-in role grants match the remediation/exception governance matrix, locking separation of duties against drift. Remediation: ops_lead grants request/execute/rollback but NOT approve; remediation:approve is held only by security_admin and admin; viewer/auditor cannot request remediation. Exceptions: auditor grants request/approve, ops_lead grants request but NOT approve, revoke is security_admin/admin only. viewer holds only remediation:read/exception:read of the governed categories; admin holds all. Verified against BuiltInRoles so a permissions.yaml edit that breaks the matrix fails the build."
       priority: critical
       references_constraints: [C-08]
+    - id: AC-18
+      description: >
+        Per-route enforcement is structurally guaranteed, not remembered. Every
+        operation in api/openapi.yaml that declares x-required-permission MUST
+        have a handler that enforces the matching codegen-typed constant from
+        internal/auth/permissions.gen.go, and the declared permission MUST exist
+        in the registry. A handler that omits the check, or a contract that
+        names a permission the registry does not have, fails the build. The
+        check follows delegation to a same-receiver helper (several handlers are
+        thin wrappers whose enforcement lives one call down), so a false
+        positive cannot be "fixed" by weakening it. Before this AC the
+        x-required-permission declarations were decorative: nothing linked the
+        contract to the code, and the link was maintained by review alone.
+      priority: critical


### PR DESCRIPTION
## What

**v0.7 exit criterion 1.** Authorization was enforced only by a hand-written `auth.EnforcePermission` call inside each handler. Every privileged mutation *did* call it (verified by hand in the 2026-06-29 review), but **nothing failed the build if a future handler forgot**, and the OpenAPI `x-required-permission` declarations were decorative: no CI step linked contract to code.

This makes the link structural. **65 routes declare a permission; all 65 now provably enforce it.**

## What it found

The reason this test earns its keep, on its very first run:

> `api/openapi.yaml` declared **`system:config:write`** (three colons) on `putSystemComplianceConfig`. The registry has **`system:config_write`**.

The contract referenced a permission that **does not exist**, across one `x-required-permission` and six description strings. Harmless today *precisely because nothing linked the two* — which is the gap being closed. The handler enforces `auth.SystemConfigWrite` correctly, so the registry name is authoritative and the contract was wrong. Fixed, with `server.gen.go` and `schema.d.ts` regenerated.

## How it avoids being weakened later

Two design choices worth reviewing:

**It reads the generator's output, not its rules.** The permission-string to constant-name mapping is parsed out of `internal/auth/permissions.gen.go` rather than reimplementing the snake-to-Pascal convention. The two cannot drift.

**It follows delegation, bounded at 2 levels.** `ApproveRemediation` and `RejectRemediation` are thin wrappers over `h.reviewRemediation`, which is where `EnforcePermission` actually lives. A body-only check reports those as unenforced — and the tempting fix for a false positive like that is to *weaken the assertion*, which is exactly how a real gap gets through later. So the checker handles the pattern instead.

## Negative-tested

Removing the `EnforcePermission` call from `GetHosts`:

```
route does not enforce its declared permission: getHosts must enforce auth.HostRead (host:read)
```

## SDD

`system-rbac` 1.0.0 -> **1.1.0**, AC-18. **116 specs, 116 passing.**

Worth flagging for the SDD tooling: I first appended this as AC-13, which **collided with an existing AC-13**, and `specter`'s gate did not catch the duplicate id. The YAML parsed to 18 ACs and reported 18/18 passing. Caught by inspection, not by the gate. That is a gap in the gate itself.

## Not in scope

This covers `x-required-permission`. The sibling `x-required-feature` validator (A2, license enforcement) is **blocked on the subscription-matrix decision** and ships separately. They were planned to share a harness; this is the half that is unblocked.

## Verification

`gofmt`, `go vet`, `go build ./...`, `go test ./internal/server/`, spec gate.
