### PR TITLE
docs(changelog): cut internal rationale from the Unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,34 +12,17 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **The paid tier is now "OpenWatch Enterprise" and the free tier is "OpenWatch
-  Community"; the `openwatch_plus` identifier is gone.** Wherever the API
-  reports a license tier, the enum is now `free | enterprise` rather than
-  `free | openwatch_plus` — `GET /api/v1/license` and every schema that embeds
-  a tier. This is a breaking change for any client that matches on the literal
-  string `openwatch_plus`, and it rides in a minor release under the pre-1.0
-  allowance. **Action required if you hold a license key:** keys minted with
-  the `openwatch_plus` tier must be re-issued as `enterprise` before they will
-  validate. Feature gating itself is unchanged — entitlement still turns on
-  whether the tier is free — so no deployment gains or loses access by
-  upgrading.
-- **Narrowed the `remediation_execution` entitlement to bulk remediation only,
-  and registered a new `remediation_auto` flag.** Single-rule remediation stays
-  free, as it is today. `remediation_auto` is registered but dormant: nothing
-  consumes it yet, so no behavior changes in this release.
-- **SAML 2.0 SSO and FIDO2 / WebAuthn MFA are now free core.** `sso_saml` and
-  `fido2_mfa` move from the enterprise tier to free, so the paid tier is eight
-  entitlements rather than ten. OIDC single sign-on and TOTP multi-factor
-  already shipped free; gating their SAML and FIDO2 counterparts behind a paid
-  tier would have placed an authentication-strength ceiling on the free tier.
-  No deployment gains or loses access, because neither entitlement gated a
-  route: nothing declares them as a required feature and no handler enforces
-  them. **One response does change:** `GET /api/v1/license` builds its
-  `features` array from the free tier of the entitlement registry, so a
-  deployment running without a license key now reports `compliance_check`,
-  `fido2_mfa`, and `sso_saml` where it previously reported `compliance_check`
-  alone. A client that asserts on the exact length or contents of that array
-  needs updating. The `tier` enum is unchanged.
+- **The paid tier is now OpenWatch Enterprise and the free tier is OpenWatch
+  Community.** Wherever the API reports a license tier, the enum is now
+  `free | enterprise` rather than `free | openwatch_plus`. Update any client
+  that matches on the literal string `openwatch_plus`. **Action required if you
+  hold a license key:** keys minted with the `openwatch_plus` tier must be
+  re-issued as `enterprise` before they validate. No deployment gains or loses
+  access.
+- **SAML 2.0 SSO and FIDO2 / WebAuthn MFA are now available in the free tier.**
+  No deployment gains or loses access. `GET /api/v1/license` now lists
+  `sso_saml` and `fido2_mfa` in its `features` array; update any client that
+  asserts on the array's exact contents or length.
 
 ## [0.6.0] Eyrie — 2026-07-17
 


### PR DESCRIPTION
The style guide gained a **Release notes and changelogs** section (CP `dev/DEVELOPER_DOCUMENTATION_STYLE_GUIDE`, updated 2026-07-28). A changelog answers *what changed for me* and *what must I do*, and nothing else. It names five things to keep out; the Unreleased block violated four.

**The SSO/MFA entry is the guide's published counter-example**, so this is a correction, not an interpretation. It carried the packaging rationale, the paid-tier entitlement count, the admission that neither flag ever gated a route, and the internal mechanics of how the `features` array is assembled. Rewritten to the guide's recommended form.

The tier-rename entry keeps its break and action, and loses the pre-1.0 meta-commentary.

The `remediation_auto` entry is **dropped**: the guide is explicit that a dormant registered flag is not a changelog entry. Nothing consumes it, single-rule remediation was free before and after. The scoping decision already lives in the roadmap and the licensing plan.

No behaviour change. `CHANGELOG.md` only.