### PR TITLE
fix(auth): close the login timing oracle and stop logout reporting a revoke it did not do

### DIFF
--- a/internal/identity/password.go
+++ b/internal/identity/password.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"golang.org/x/crypto/argon2"
 )
@@ -204,4 +205,43 @@ func parsePHC(s string) (argonParams, []byte, []byte, error) {
 func sha1Hex(pw string) string {
 	h := sha1.Sum([]byte(pw)) //nolint:gosec // see function doc
 	return strings.ToUpper(hex.EncodeToString(h[:]))
+}
+
+// decoyHash is a valid PHC-encoded Argon2id hash of a random password,
+// computed once. It exists only to be verified against and never matches.
+var decoyHash = sync.OnceValue(func() string {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		// A hash of a fixed string is still a valid decoy: the point is the
+		// Argon2id work, not the secrecy of the input.
+		buf = []byte("openwatch-decoy-password-fallback")
+	}
+	h, err := HashPassword(base64.RawStdEncoding.EncodeToString(buf))
+	if err != nil {
+		return ""
+	}
+	return h
+})
+
+// BurnPasswordVerify performs an Argon2id verification that is guaranteed to
+// fail, so a caller can spend the same work on a missing account as on a real
+// one.
+//
+// WHY: VerifyUserPassword returned immediately when the username did not
+// exist, skipping Argon2id entirely. A real account costs tens of milliseconds
+// of deliberate key-stretching; a missing one cost a single indexed query. The
+// difference is trivially measurable over a handful of requests, which turns
+// the login endpoint into a username-enumeration oracle. Enumeration is the
+// step before credential stuffing and before targeted phishing, so it matters
+// even though no password is disclosed.
+//
+// This does not make login constant-time in the strict sense. Argon2id
+// dominates the request either way, which closes the gap that is actually
+// observable across a network.
+func BurnPasswordVerify() {
+	h := decoyHash()
+	if h == "" {
+		return
+	}
+	_ = VerifyPassword("openwatch-decoy-attempt", h)
 }

--- a/internal/identity/timing_test.go
+++ b/internal/identity/timing_test.go
@@ -1,0 +1,51 @@
+// @spec system-auth-identity
+//
+//	AC-32  TestBurnPasswordVerify_DoesRealKeyStretching
+package identity
+
+import (
+	"testing"
+	"time"
+)
+
+// @ac AC-32
+// AC-32: the decoy verification does REAL Argon2id work.
+//
+// The point of BurnPasswordVerify is that a username miss costs what a hit
+// costs. A sleep, a constant, or a no-op would satisfy a naive reading and
+// close nothing: a sleep is trivially distinguishable under load, and a no-op
+// leaves the original oracle intact. So assert the work actually happens, by
+// comparing it against a genuine verification of a real hash.
+func TestBurnPasswordVerify_DoesRealKeyStretching(t *testing.T) {
+	t.Run("system-auth-identity/AC-32", func(t *testing.T) {
+		hash, err := HashPassword("a-real-password-for-comparison")
+		if err != nil {
+			t.Fatalf("HashPassword: %v", err)
+		}
+
+		// Cost of a real failed verification: the work an attacker observes
+		// when the username EXISTS and the password is wrong.
+		start := time.Now()
+		_ = VerifyPassword("wrong-password", hash)
+		real := time.Since(start)
+
+		// Warm the decoy so its one-time hash computation is not counted.
+		BurnPasswordVerify()
+
+		start = time.Now()
+		BurnPasswordVerify()
+		decoy := time.Since(start)
+
+		if decoy <= 0 {
+			t.Fatal("decoy did no measurable work")
+		}
+		// Generous bound: this asserts the same ORDER of work, not a constant
+		// time guarantee, and it must not flake on a loaded CI runner. A
+		// sleep-based or no-op implementation fails this by orders of
+		// magnitude; normal scheduler jitter does not.
+		if decoy < real/8 {
+			t.Errorf("decoy work %v is far below a real verification %v; "+
+				"the enumeration oracle is not closed", decoy, real)
+		}
+	})
+}

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/Hanalyx/openwatch/internal/audit"
@@ -174,14 +175,30 @@ func (h *handlers) PostAuthLogin(w http.ResponseWriter, r *http.Request) {
 // Spec api-auth + system-auth-identity AC-24.
 func (h *handlers) PostAuthLogout(w http.ResponseWriter, r *http.Request) {
 	id := auth.FromContext(r.Context())
+	// revokeFailed tracks whether we could NOT guarantee the credential is
+	// dead server-side. Logout previously discarded both revoke errors and
+	// answered 204 unconditionally. That is a lie with consequences: the
+	// cookies are cleared either way, so the user sees a successful logout and
+	// stops worrying, while a stolen session or refresh token stays valid.
+	// Someone logging out on a shared or compromised machine is exactly the
+	// person who cannot afford that.
+	revokeFailed := false
+
 	// If anonymous, this is a no-op — still 204 (logout is idempotent).
 	if !id.IsAnonymous {
 		// Find the session by cookie token and revoke it.
 		if cookie, err := r.Cookie(identity.SessionCookieName); err == nil && cookie.Value != "" {
 			if sess, err := identity.VerifySession(r.Context(), h.pool, cookie.Value); err == nil {
-				_ = identity.RevokeSession(r.Context(), h.pool, sess.ID)
+				if rerr := identity.RevokeSession(r.Context(), h.pool, sess.ID); rerr != nil {
+					revokeFailed = true
+					slog.ErrorContext(r.Context(), "logout: session revoke failed; session may still be valid",
+						slog.String("session_id", sess.ID.String()),
+						slog.String("error", rerr.Error()))
+				}
 				emitAudit(r, audit.AuthLogout, id.ID, nil)
 			}
+			// A session that does not verify needs no revoking: it is already
+			// expired or unknown. That is not a failure.
 		}
 	}
 	// Revoke the refresh token if the cookie carries one, regardless of
@@ -189,7 +206,14 @@ func (h *handlers) PostAuthLogout(w http.ResponseWriter, r *http.Request) {
 	// was holding. Best-effort: an unparseable / unknown refresh cookie
 	// is silently ignored (no oracle).
 	if rc, err := r.Cookie(identity.RefreshCookieName); err == nil && rc.Value != "" {
-		_ = identity.RevokeRefreshToken(r.Context(), h.pool, rc.Value)
+		if rerr := identity.RevokeRefreshToken(r.Context(), h.pool, rc.Value); rerr != nil {
+			// An unknown or unparseable refresh cookie is not an error and
+			// RevokeRefreshToken does not report one, so reaching here means a
+			// real failure to revoke a token that exists.
+			revokeFailed = true
+			slog.ErrorContext(r.Context(), "logout: refresh-token revoke failed; token may still be valid",
+				slog.String("error", rerr.Error()))
+		}
 	}
 	// Clear both cookies in the same response.
 	http.SetCookie(w, &http.Cookie{
@@ -210,6 +234,16 @@ func (h *handlers) PostAuthLogout(w http.ResponseWriter, r *http.Request) {
 		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
+	// Cookies are cleared above regardless, so the browser stops presenting
+	// the credential either way. But if the server could not revoke, say so
+	// rather than reporting a clean logout: the client needs to know the
+	// credential may still be live so a human can revoke the session
+	// explicitly or rotate.
+	if revokeFailed {
+		writeError(w, http.StatusInternalServerError, "auth.logout_incomplete", "server",
+			"signed out on this device, but the server could not revoke the session. It may remain valid until it expires. Revoke it from Settings or contact an administrator.", true)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/server/auth_logout_truth_test.go
+++ b/internal/server/auth_logout_truth_test.go
@@ -1,0 +1,69 @@
+// @spec system-auth-identity
+//
+//	AC-33  TestLogout_ReportsIncompleteRevoke
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// @ac AC-33
+// AC-33: logout does not report success it did not achieve.
+//
+// Source inspection rather than a live failure injection: making the revoke
+// fail for real needs a seam through the pool that does not exist, and adding
+// one only for this would be a larger change than the fix. What must not
+// regress is structural and is checkable directly: the two revoke errors must
+// not be discarded, and the handler must be able to answer with something
+// other than 204.
+//
+// The bug: both revokes were `_ = ...` and the handler returned 204
+// unconditionally. Cookies are cleared either way, so the user saw a clean
+// logout while a stolen session or refresh token stayed live. Someone logging
+// out on a shared or compromised machine is precisely the person who cannot
+// afford that.
+func TestLogout_ReportsIncompleteRevoke(t *testing.T) {
+	t.Run("system-auth-identity/AC-33", func(t *testing.T) {
+		raw, err := os.ReadFile("auth_handlers.go")
+		if err != nil {
+			t.Fatalf("read auth_handlers.go: %v", err)
+		}
+		src := string(raw)
+		i := strings.Index(src, "func (h *handlers) PostAuthLogout(")
+		if i < 0 {
+			t.Fatal("PostAuthLogout not found")
+		}
+		body := src[i:]
+		if j := strings.Index(body[1:], "\nfunc "); j >= 0 {
+			body = body[:j]
+		}
+
+		// Neither revoke may be discarded.
+		for _, discarded := range []string{
+			"_ = identity.RevokeSession(",
+			"_ = identity.RevokeRefreshToken(",
+		} {
+			if strings.Contains(body, discarded) {
+				t.Errorf("logout still discards a revoke error: %s", discarded)
+			}
+		}
+
+		// A failed revoke must be observable to the operator and to the caller.
+		if !strings.Contains(body, "slog.ErrorContext") {
+			t.Error("a failed revoke must be logged at error level")
+		}
+		if !strings.Contains(body, "auth.logout_incomplete") {
+			t.Error("logout must be able to tell the caller the revoke did not complete")
+		}
+
+		// Cookies must still be cleared even on the failure path, so the
+		// browser stops presenting a credential the server could not kill.
+		clearIdx := strings.Index(body, "MaxAge:   -1")
+		failIdx := strings.Index(body, "auth.logout_incomplete")
+		if clearIdx < 0 || failIdx < 0 || clearIdx > failIdx {
+			t.Error("cookies must be cleared BEFORE the incomplete-revoke response, not skipped by it")
+		}
+	})
+}

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -334,6 +334,12 @@ func (s *Service) VerifyUserPassword(ctx context.Context, username, password str
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			// Spend the same Argon2id work as a real account before answering.
+			// Returning here directly made login a username-enumeration
+			// oracle: a real user costs tens of milliseconds of key
+			// stretching, a missing one cost a single indexed query, and the
+			// difference is measurable over a few requests.
+			identity.BurnPasswordVerify()
 			return User{}, ErrUserNotFound
 		}
 		return User{}, fmt.Errorf("users: lookup: %w", err)

--- a/specs/system/auth-identity.spec.yaml
+++ b/specs/system/auth-identity.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-auth-identity
   title: Auth identity primitives (password, session, JWT, MFA)
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 1
 
@@ -144,6 +144,20 @@ spec:
         unattended session alive forever. Fail-safe: an UNMARKED non-SSE request
         slides as before, so a client that does not send the header is unaffected
         (no premature logout).
+      type: security
+      enforcement: error
+
+    - id: C-30
+      description: >
+        Login MUST NOT leak whether a username exists via response time. The
+        password path deliberately costs Argon2id work; a lookup miss that
+        skips it is measurably faster over a handful of requests, which turns
+        login into a username-enumeration oracle. A miss MUST spend equivalent
+        key-stretching work before answering. Logout MUST NOT report success it
+        did not achieve: if the server cannot revoke the session or refresh
+        token, it MUST say so rather than answer 204, because the client clears
+        its cookies either way and the user would otherwise believe a
+        credential is dead when it is still live.
       type: security
       enforcement: error
 
@@ -310,3 +324,22 @@ spec:
         (source-inspection of frontend/src/api/client.ts).
       priority: high
       references_constraints: [C-29]
+    - id: AC-32
+      description: >
+        Username enumeration via login timing is closed. VerifyUserPassword
+        spends Argon2id work on a username that does not exist, using a decoy
+        verification that always fails, so a miss and a wrong password cost
+        comparable time. The decoy performs real key stretching rather than a
+        sleep or a constant.
+      priority: critical
+      references_constraints: [C-30]
+    - id: AC-33
+      description: >
+        Logout reports the truth. A failure to revoke the session or the
+        refresh token is logged at error level and returns a 5xx naming the
+        incomplete revoke, rather than the unconditional 204 the handler
+        previously returned while discarding both errors. Cookies are still
+        cleared in that case, so the browser stops presenting the credential
+        even though the server could not kill it.
+      priority: critical
+      references_constraints: [C-30]


### PR DESCRIPTION
Two SEC-M items. Both are cases where the code **answered as if a security property held when it did not**.

## M2: username enumeration via login timing

`VerifyUserPassword` returned immediately on `pgx.ErrNoRows`, **skipping Argon2id entirely**. A real account costs tens of milliseconds of deliberate key stretching; a missing one cost a single indexed query.

That gap is measurable over a handful of requests, so the login endpoint told an unauthenticated caller which usernames exist. Enumeration is the step before credential stuffing and before targeted phishing, so it matters even though no password is disclosed.

`identity.BurnPasswordVerify` spends equivalent work against a decoy hash computed once from a random password. It does **real Argon2id work rather than sleeping** — a sleep is distinguishable under load, and would satisfy a naive reading of the fix while closing nothing.

**AC-32** asserts the decoy costs the same order as a genuine failed verification, with a deliberately generous bound so it cannot flake on a loaded runner. **Negative-tested:** replacing the decoy with a no-op fails the AC.

This does not make login constant-time in the strict sense, and the code says so. Argon2id dominates the request either way, which closes the gap that is observable across a network.

## M3: logout reporting success it did not achieve

Both revokes were discarded with `_ =` and the handler answered **204 unconditionally**. The cookies are cleared either way, so the user saw a clean logout while a stolen session or refresh token stayed valid server-side.

Someone logging out on a shared or compromised machine is exactly the person who cannot afford that.

A revoke failure is now logged at error level and answered with a 5xx naming the incomplete revoke. **Cookies are still cleared first**, so the browser stops presenting the credential regardless.

## Not done, and not quick wins despite being filed as such

**M4, MFA backup codes.** A real feature: generation, hashed single-use storage, substitution at verify time, burn-on-use, regeneration, and UI. Security-sensitive storage. Needs its own change.

**M6, CSP `style-src 'unsafe-inline'`.** Removing it needs a per-request nonce, and `index.html` is served from a **static `embed.FS` with no templating** — so this is backend serving plus emotion cache wiring in the frontend, with total styling breakage as the failure mode.

Worth noting the app CSP already has `script-src 'self'` with no unsafe-inline; the remaining exposure is style-level, which is far narrower. The **docs** CSP does allow inline *script* for Swagger UI, which is the sharper of the two and is scoped to `/docs`.

## Verification

`system-auth-identity` 1.4.0 -> **1.5.0**, C-30 with AC-32 and AC-33. **116 specs, 116 passing.** Full `go test ./internal/...` clean locally against the test database **before** pushing.