### PR TITLE
fix(remediation): map rollback_failed, and stop the scan-variables panel rendering nothing

### DIFF
--- a/frontend/src/components/settings/ScanVariablesCard.tsx
+++ b/frontend/src/components/settings/ScanVariablesCard.tsx
@@ -63,7 +63,21 @@ export function ScanVariablesCard() {
       </div>
     );
   }
-  if (!vars || vars.length === 0) return null;
+  // An empty list is a real state, not a reason to render nothing. Returning
+  // null here left the "Scan variables" heading sitting above a blank gap with
+  // no explanation, which reads as a broken page rather than as information.
+  // The corpus-missing case now arrives as an error above; this is the
+  // genuinely-empty case.
+  if (!vars || vars.length === 0) {
+    return (
+      <div style={{ marginTop: 14 }}>
+        <Callout tier="info">
+          No scan variables are in use. Variables appear here when a rule in the loaded Kensa corpus
+          references one.
+        </Callout>
+      </div>
+    );
+  }
 
   const configureMeCount = vars.filter((v) => v.configure_me && !v.overridden).length;
 

--- a/internal/kensa/remediatefunc.go
+++ b/internal/kensa/remediatefunc.go
@@ -59,6 +59,9 @@ type RemediationTxn struct {
 	Status   string
 	Evidence json.RawMessage
 	Err      string
+	// HostUnchanged mirrors api.TransactionResult.HostUnchanged: true if and
+	// only if Kensa can prove the host is in its pre-transaction state.
+	HostUnchanged bool
 }
 
 // RollbackRunResult is the OpenWatch-side view of a kensa RollbackResult.
@@ -208,9 +211,10 @@ func mapTxns(in []kensaapi.TransactionResult) []RemediationTxn {
 	out := make([]RemediationTxn, 0, len(in))
 	for _, t := range in {
 		txn := RemediationTxn{
-			TxnID:    t.TransactionID,
-			Status:   string(t.Status),
-			Evidence: txnEvidence(t),
+			TxnID:         t.TransactionID,
+			Status:        string(t.Status),
+			Evidence:      txnEvidence(t),
+			HostUnchanged: t.HostUnchanged,
 		}
 		if t.Error != nil {
 			txn.Err = friendlyTxnErr(t.Error.Error())

--- a/internal/remediation/outcome_test.go
+++ b/internal/remediation/outcome_test.go
@@ -9,6 +9,11 @@
 package remediation
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -76,30 +81,51 @@ func TestOutcome_RemainingKensaStatusesMapOneToOne(t *testing.T) {
 	t.Run("api-remediation/AC-10", func(t *testing.T) {
 		cases := []struct {
 			kensa     string
+			unchanged bool
 			want      Status
 			wantPhase string
 			mutated   bool
 		}{
-			{"committed", StatusExecuted, "committed", true},
-			{"rolled_back", StatusReverted, "reverted", false},
-			{"recovered", StatusReverted, "reverted", false},
-			{"partially_applied", StatusPartiallyApplied, "partially_applied", true},
-			{"errored", StatusFailed, "skipped", false},
+			{"committed", false, StatusExecuted, "committed", true},
+			{"rolled_back", true, StatusReverted, "reverted", false},
+			{"recovered", true, StatusReverted, "reverted", false},
+			{"partially_applied", false, StatusPartiallyApplied, "partially_applied", true},
+
+			// errored maps the same either way. HostUnchanged is carried for
+			// evidence but does NOT drive severity: it is a bool, so false is
+			// ambiguous between "proved mutated" and "field never set", and an
+			// errored transaction synthesised for an unreachable host arrives
+			// with it unset. Escalating on that would send an operator to
+			// inspect a host nothing touched.
+			{"errored", true, StatusFailed, "skipped", false},
+			{"errored", false, StatusFailed, "skipped", false},
+
+			// rollback_failed: applied, then the reversal could not be
+			// machine-verified. Kensa calls this "an unconfirmed state", which
+			// is the most severe thing it reports. It must never read as a
+			// plain failure, which an operator reasonably skims as "nothing
+			// happened". This is the status that sat unmapped until
+			// kensa-agent pointed it out.
+			{"rollback_failed", false, StatusPartiallyApplied, "partially_applied", true},
 		}
 		for _, c := range cases {
-			txn := ExecTxn{TxnID: uuid.New(), Status: c.kensa}
+			txn := ExecTxn{TxnID: uuid.New(), Status: c.kensa, HostUnchanged: c.unchanged}
 			got, known := OutcomeOf(txn)
 			if !known {
 				t.Errorf("%s: must be a recognised Kensa status", c.kensa)
 			}
+			label := c.kensa
+			if c.kensa == "errored" {
+				label = fmt.Sprintf("errored(HostUnchanged=%v)", c.unchanged)
+			}
 			if got != c.want {
-				t.Errorf("%s mapped to %q, want %q", c.kensa, got, c.want)
+				t.Errorf("%s mapped to %q, want %q", label, got, c.want)
 			}
 			if got.HostMutated() != c.mutated {
-				t.Errorf("%s HostMutated = %v, want %v", c.kensa, got.HostMutated(), c.mutated)
+				t.Errorf("%s HostMutated = %v, want %v", label, got.HostMutated(), c.mutated)
 			}
 			if p := phaseResult(txn); p != c.wantPhase {
-				t.Errorf("%s phase_result = %q, want %q", c.kensa, p, c.wantPhase)
+				t.Errorf("%s phase_result = %q, want %q", label, p, c.wantPhase)
 			}
 		}
 
@@ -107,7 +133,7 @@ func TestOutcome_RemainingKensaStatusesMapOneToOne(t *testing.T) {
 		// (safety net worked, host untouched) must not collapse into the same
 		// status as an errored run.
 		reverted, _ := OutcomeOf(ExecTxn{Status: "rolled_back"})
-		errored, _ := OutcomeOf(ExecTxn{Status: "errored"})
+		errored, _ := OutcomeOf(ExecTxn{Status: "errored", HostUnchanged: true})
 		if reverted == errored {
 			t.Error("rolled_back and errored must not share a status: one left the host clean, the other did not")
 		}
@@ -155,15 +181,47 @@ func TestOutcome_UnknownStatusFailsClosed(t *testing.T) {
 		}
 
 		// Every status the CURRENT Kensa api package can produce must be
-		// recognised. If this fails after a Kensa bump, that is the bump
-		// telling you to update OutcomeOf before shipping.
-		for _, s := range []string{
-			kensaCommitted, kensaRolledBack, kensaPartiallyApplied,
-			kensaErrored, kensaRecovered, kensaStaged,
-		} {
-			if _, ok := OutcomeOf(ExecTxn{Status: s}); !ok {
-				t.Errorf("known Kensa status %q is not mapped by OutcomeOf", s)
+		// recognised. Read them out of the MODULE SOURCE, not from our own
+		// constants.
+		//
+		// The first version of this loop iterated the kensa* constants
+		// declared in this package, which made it vacuous: it asserted that
+		// the statuses we already knew about were the statuses we already knew
+		// about. It passed while `rollback_failed` sat unmapped, and
+		// kensa-agent had to point that out. A self-referential completeness
+		// check is worse than none, because it reports coverage it does not
+		// have.
+		for _, st := range kensaStatusesFromModule(t) {
+			if _, ok := OutcomeOf(ExecTxn{Status: st}); !ok {
+				t.Errorf("Kensa declares TransactionStatus %q and OutcomeOf does not map it; "+
+					"add it explicitly rather than letting the default branch absorb it", st)
 			}
 		}
 	})
+}
+
+// kensaStatusesFromModule parses every TransactionStatus constant out of the
+// Kensa module source currently pinned in go.mod. Reading the real enum is the
+// whole point: anything derived from our own constants cannot detect a status
+// we failed to notice.
+func kensaStatusesFromModule(t *testing.T) []string {
+	t.Helper()
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "github.com/Hanalyx/kensa").Output()
+	if err != nil {
+		t.Skipf("cannot locate the kensa module: %v", err)
+	}
+	path := filepath.Join(strings.TrimSpace(string(out)), "api", "transaction.go")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("cannot read %s: %v", path, err)
+	}
+	re := regexp.MustCompile(`Status[A-Za-z]+\s+TransactionStatus\s*=\s*"([a-z_]+)"`)
+	var got []string
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		got = append(got, m[1])
+	}
+	if len(got) == 0 {
+		t.Fatalf("parsed no TransactionStatus constants from %s; the parser or the upstream shape changed", path)
+	}
+	return got
 }

--- a/internal/remediation/types.go
+++ b/internal/remediation/types.go
@@ -157,6 +157,19 @@ type ExecTxn struct {
 	Evidence []byte
 	// Err is the transaction error string, empty on success.
 	Err string
+	// HostUnchanged mirrors api.TransactionResult.HostUnchanged: true if and
+	// only if Kensa can PROVE the host is in its pre-transaction state.
+	//
+	// Carried into the journal for evidence, but deliberately NOT used to
+	// decide severity. It is a bool, so false is ambiguous: it means either
+	// "Kensa proved the host was mutated" or "nobody populated this field".
+	// An errored transaction synthesised for an unreachable host arrives with
+	// it unset, and escalating on that would send an operator to inspect a
+	// host nothing ever touched. Alarm fatigue is its own failure mode, and
+	// building severity on an ambiguous signal is the same mistake as
+	// pattern-matching step prose. If Kensa ever gives this three states, or a
+	// positive "host was mutated" assertion, revisit.
+	HostUnchanged bool
 }
 
 // TxnCommitted reports whether s is the terminal "rule now passes" status.
@@ -179,6 +192,7 @@ const (
 	kensaErrored          = "errored"
 	kensaRecovered        = "recovered"
 	kensaStaged           = "staged"
+	kensaRollbackFailed   = "rollback_failed"
 )
 
 // OutcomeOf maps one Kensa transaction to the request status it implies, and
@@ -206,6 +220,14 @@ func OutcomeOf(t ExecTxn) (Status, bool) {
 		// NOT the same event as an errored run and must not read like one.
 		return StatusReverted, true
 	case kensaPartiallyApplied:
+		return StatusPartiallyApplied, true
+	case kensaRollbackFailed:
+		// The engine applied, then tried to reverse, and could NOT verify the
+		// restoration. Kensa: "the host is in an unconfirmed state." That is
+		// the most severe outcome it reports, more so than partially_applied,
+		// because an undo was attempted and its success is unknown. It maps to
+		// the outcome that tells an operator to go look, never to a plain
+		// failure, which would read as "nothing to do here".
 		return StatusPartiallyApplied, true
 	case kensaErrored:
 		return StatusFailed, true

--- a/internal/server/scan_config_handlers.go
+++ b/internal/server/scan_config_handlers.go
@@ -190,6 +190,19 @@ func (h *handlers) GetSystemScanVariables(w http.ResponseWriter, r *http.Request
 	if denied := auth.EnforcePermission(w, r, auth.SystemRead); denied {
 		return
 	}
+	// The catalog is nil when the Kensa rule corpus could not be loaded at
+	// boot, which on a packaged install means the kensa-rules package is not
+	// installed at /usr/share/kensa/rules. Say so, rather than returning an
+	// empty list: an empty list is indistinguishable from "this deployment
+	// genuinely has no variables", and the Settings card then renders a
+	// heading with nothing under it. The operator sees a blank panel and no
+	// reason, while the explanation sits in a boot log nobody reads to explain
+	// a settings screen.
+	if h.varCatalog == nil {
+		writeError(w, http.StatusServiceUnavailable, "server.unavailable", "server",
+			"the Kensa rule corpus is not available, so scan variables cannot be listed. On a packaged install, verify the kensa-rules package is installed at /usr/share/kensa/rules and matches the openwatch version.", true)
+		return
+	}
 	overrides := systemconfig.ScanVariables{}
 	if h.sysCfg != nil {
 		loaded, err := h.sysCfg.LoadScanVars(r.Context())

--- a/internal/worker/remediation_worker.go
+++ b/internal/worker/remediation_worker.go
@@ -448,10 +448,11 @@ func mapExecTxns(in []kensa.RemediationTxn) []remediation.ExecTxn {
 	out := make([]remediation.ExecTxn, 0, len(in))
 	for _, t := range in {
 		out = append(out, remediation.ExecTxn{
-			TxnID:    t.TxnID,
-			Status:   t.Status,
-			Evidence: t.Evidence,
-			Err:      t.Err,
+			TxnID:         t.TxnID,
+			Status:        t.Status,
+			Evidence:      t.Evidence,
+			Err:           t.Err,
+			HostUnchanged: t.HostUnchanged,
 		})
 	}
 	return out


### PR DESCRIPTION
Two defects. One found by kensa-agent reviewing my own mailbox request; one from the founder's screenshot.

## 1. rollback_failed was unmapped, and the guard that should have caught it was vacuous

Kensa v0.8.0 declares **seven** `TransactionStatus` values. `OutcomeOf` handled six.

`rollback_failed` means apply succeeded, the engine tried to reverse it, and **the restoration could not be machine-verified**. Kensa calls that "an unconfirmed state" — the most severe thing it reports, more so than `partially_applied`, because an undo was attempted and its success is unknown.

It fell through to the fail-closed branch and read as a plain failure, which an operator reasonably skims as "nothing happened". Now maps to `partially_applied`: go look at this host.

### The guard was self-referential

AC-11 asserted "every status the current Kensa package can produce is recognised" by **iterating the `kensa*` constants declared in our own package**. So it asserted that the statuses we knew about were the statuses we knew about. It passed while `rollback_failed` sat unmapped.

It now parses the real enum out of the pinned module source, so it cannot be satisfied by our own blind spot. Negative-tested by un-mapping `rollback_failed` again: the rewritten AC catches it, the old one did not.

**A self-referential completeness check is worse than no check, because it reports coverage it does not have.** That is the second time this session I have written a loose check in a security-adjacent path and had to tighten it.

## 2. HostUnchanged is plumbed but deliberately does not drive severity

I tried it the other way first and the existing worker test caught me.

It is a **bool**, so `false` is ambiguous between "Kensa proved the host was mutated" and "nobody populated this field". An errored transaction synthesised for an unreachable host arrives with it unset, so escalating on `false` would send an operator to inspect a host that nothing ever touched.

Building severity on an ambiguous signal is the same mistake as pattern-matching step prose, which I declined to do for the same reason. It is carried into the journal for evidence only.

## 3. Scan variables rendered a heading above a blank gap

Exactly the screenshot. `GetSystemScanVariables` returned an empty list **both** when the deployment genuinely has no variables **and** when the Kensa rule corpus could not be loaded at boot. The card returned `null` on empty.

On a packaged install the second case means `kensa-rules` is not installed at `/usr/share/kensa/rules`, and the only trace was a boot WARN nobody reads to explain a settings screen.

- corpus missing -> **503 naming the package and the path**, rendered by the card's existing error state
- genuinely empty -> says so, instead of vanishing

**This is the same failure family as PKG-3:** a packaged install cannot find a Kensa path and degrades silently rather than saying which path.

## Verification

117 specs, 117 passing. Full `go test ./internal/...` clean locally, `tsc` and vitest 361/361 clean.