### PR TITLE
docs(guides): restamp to v0.7.0, correct the migration number, document /capabilities

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,7 +158,7 @@
         "filename": "docs/guides/API_GUIDE.md",
         "hashed_secret": "b48cf0140bea12734db05ebcdb012f1d265bed84",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 71
       }
     ],
     "docs/guides/DATABASE_MIGRATIONS.md": [
@@ -674,5 +674,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T11:03:29Z"
+  "generated_at": "2026-07-30T12:14:46Z"
 }

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -1,6 +1,6 @@
 # API guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 Most operators use the web UI for daily work: managing hosts, viewing fleet
 health, reading compliance state, and triaging alerts. This guide is for
@@ -53,8 +53,14 @@ permission set:
   rotation and the on-401 refresh flow are UI concerns and are not covered here.
 
 Anonymous endpoints (`GET /api/v1/health`, `GET /api/v1/version`,
-`POST /api/v1/auth/login`, `POST /api/v1/auth/refresh`) require no credential.
-Everything else requires a valid identity.
+`GET /api/v1/capabilities`, `POST /api/v1/auth/login`,
+`POST /api/v1/auth/refresh`) require no credential. Everything else requires a
+valid identity.
+
+`GET /api/v1/capabilities` reports every capability this deployment has, with
+whether it is available here, so a client can present a locked control rather
+than discovering the limit from a `402`. It exposes no customer identity or
+licence detail; `GET /api/v1/license` is the authenticated surface for that.
 
 ### Log in
 

--- a/docs/guides/BACKUP_RECOVERY.md
+++ b/docs/guides/BACKUP_RECOVERY.md
@@ -1,6 +1,6 @@
 # Backup and recovery
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers backup, restore, and disaster recovery for an OpenWatch
 deployment. OpenWatch is a single Go binary (`/usr/bin/openwatch`) that serves

--- a/docs/guides/COMPLIANCE_CONTROLS.md
+++ b/docs/guides/COMPLIANCE_CONTROLS.md
@@ -1,6 +1,6 @@
 # Compliance control mapping
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This document maps OpenWatch's security controls to industry frameworks, providing evidence for compliance audits.
 

--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Database migration guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers how OpenWatch's PostgreSQL schema is versioned, how migrations
 are applied in production, and how to add a new migration. OpenWatch is a single
@@ -105,8 +105,8 @@ That number corresponds to the `NNNN` prefix of the last applied migration file.
 ## Adding a new migration
 
 1. Create a new migration file named with the next ascending
-   integer, for example `0052_add_scan_findings.sql` (the current highest
-   applied migration is `0051`; use the next free number, not this example
+   integer, for example `0055_add_scan_findings.sql` (the current highest
+   applied migration is `0054`; use the next free number, not this example
    literally). Migration order is driven by the filename prefix, not by
    dates.
 

--- a/docs/guides/ENVIRONMENT_REFERENCE.md
+++ b/docs/guides/ENVIRONMENT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Configuration and environment reference
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This document is the field reference for how you configure the OpenWatch
 binary: the TOML file, the environment-variable overrides, and the on-disk paths

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -1,6 +1,6 @@
 # Host management and remediation
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers adding and managing hosts, organizing them into groups,
 understanding server intelligence data, and using automated remediation to fix

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,6 +1,6 @@
 # OpenWatch install guide (native packages)
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide takes an administrator from a fresh Linux host to a running,
 logged-in OpenWatch: install the package, point it at PostgreSQL, create the

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -7,7 +7,7 @@
 > evidence, which distributions work for (1) running the OpenWatch server and
 > (2) being added as a managed/scanned host.
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 **Last verified:** 2026-07-28 against Kensa rule corpus **v0.8.0** (769 rules in the corpus).
 Per-OS counts below are read from each rule's `platforms:` declarations in the

--- a/docs/guides/MONITORING_SETUP.md
+++ b/docs/guides/MONITORING_SETUP.md
@@ -1,6 +1,6 @@
 # OpenWatch monitoring and operations guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide describes how you monitor a running OpenWatch deployment and how you
 respond to common operational incidents. OpenWatch ships as a single Go binary

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Production deployment guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers running OpenWatch in production: a single Go binary that serves
 the REST API and the embedded React UI over HTTPS, backed by PostgreSQL, managed

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 Go from a freshly installed package to your first host under automatic
 compliance monitoring. This guide assumes OpenWatch is already installed and

--- a/docs/guides/SCALING_GUIDE.md
+++ b/docs/guides/SCALING_GUIDE.md
@@ -1,6 +1,6 @@
 # Scaling guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers how OpenWatch behaves as you add hosts, run more scans, and
 push more concurrent API traffic, and what you can tune today. It describes the

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Scanning and compliance
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers how OpenWatch performs compliance scanning, how to read
 results and posture scores, and how to use drift detection, alerts, and

--- a/docs/guides/SECRET_ROTATION.md
+++ b/docs/guides/SECRET_ROTATION.md
@@ -1,6 +1,6 @@
 # Secret rotation procedures
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide describes how to rotate each secret used by OpenWatch on the current
 single-binary stack: one `/usr/bin/openwatch` process that serves the REST API

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -1,6 +1,6 @@
 # OpenWatch security hardening guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 **Audience:** System administrators, security engineers, compliance officers
 
 This guide covers the security controls you operate when you deploy OpenWatch

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -1,6 +1,6 @@
 # Upgrade procedure
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide covers upgrading an OpenWatch deployment to a newer version. OpenWatch
 ships as a single Go binary (`/usr/bin/openwatch`) that serves both the REST API

--- a/docs/guides/USER_ROLES.md
+++ b/docs/guides/USER_ROLES.md
@@ -1,6 +1,6 @@
 # User roles and permissions
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.6.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide describes the role-based access control (RBAC) system in the Go-era
 OpenWatch. It covers the five built-in roles, the permissions they grant, and how


### PR DESCRIPTION
The user-facing doc refresh required before tagging, per `docs/runbooks/RELEASING.md`. `version.env` and `CHANGELOG.md` landed in #773.

## Three gaps closed

**Guide banners restamped v0.6.0 to v0.7.0** across all 17. They were corrected to v0.6.0 two days ago after sitting on v0.5.0 for two releases, so this is the first cycle where the stamp is maintained rather than repaired.

**`DATABASE_MIGRATIONS.md` told a contributor the highest applied migration is `0051`** and to use `0052` for a new one. It is **0054**, so following the guide literally would have collided with an existing file. Now derived from the migrations directory: highest `0054`, next free `0055`.

**`API_GUIDE.md` did not mention `GET /api/v1/capabilities`**, which is new this cycle and anonymous. Added with what it does and what it does *not* expose, so nobody reaches for it expecting licence detail.

## Verification

`specter` clean, 117 specs. Doc-style gate clean on all 17 changed files.
