### PR TITLE
fix(remediation): accept staged requests at the :rollback precondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ the host.
   failure.
 - A remediation that only staged a change no longer marks the rule as passing.
   A re-scan correctly continues to report it failing until the host reboots.
+- **Rolling back a staged remediation returned a conflict instead of running.**
+  The interface offered a Roll back action on a staged change and the request
+  was refused, leaving the change in place on the host with no way to undo it
+  from the application. Staged remediations can now be rolled back.
 
 ### Security
 

--- a/internal/server/api_remediation_test.go
+++ b/internal/server/api_remediation_test.go
@@ -5,6 +5,7 @@
 //
 //	AC-05  TestAPI_Remediation_LifecycleAndRBAC
 //	AC-06  TestAPI_Remediation_ExecuteFreeCore
+//	AC-09  TestAPI_Remediation_RollbackAcceptsStaged
 package server
 
 import (
@@ -162,8 +163,9 @@ func TestAPI_Remediation_LifecycleAndRBAC(t *testing.T) {
 // AC-06: execute/rollback are FREE core (no license). A holder of
 // remediation:execute executing an APPROVED request gets 202 and enqueues a
 // remediation job; a caller lacking remediation:execute is 403; executing a
-// non-approved (pending) request is 409; rolling back a non-executed request
-// is 409. No act endpoint returns 402.
+// non-approved (pending) request is 409; rolling back a request that is not
+// rollback-eligible is 409 (see AC-09 for the staged case). No act endpoint
+// returns 402.
 func TestAPI_Remediation_ExecuteFreeCore(t *testing.T) {
 	t.Run("api-remediation/AC-06", func(t *testing.T) {
 		url, pool := freshAPIServer(t)
@@ -223,6 +225,70 @@ func TestAPI_Remediation_ExecuteFreeCore(t *testing.T) {
 			t.Errorf("rollback-before-execute status = %d, want 409", rb.StatusCode)
 		}
 	})
+}
+
+// @ac AC-09
+// AC-09: the :rollback PRECONDITION accepts staged, not just executed.
+//
+// WHY THIS EXISTS, at the HTTP layer specifically. AC-09 was already annotated
+// on internal/remediation.TestOutcome_Staged, which asserts
+// Status("staged").RollbackEligible() == true. That is the enum in isolation.
+// The handler did not call RollbackEligible; it compared `rq.Status !=
+// StatusExecuted` literally, so every staged rollback 409'd while the type
+// test, the worker, and the UI all agreed it should be allowed. Coverage was
+// 100% and the AC was still unmet, because the annotation sat on a unit test of
+// a predicate rather than on the precondition the AC describes.
+//
+// Found by running the release verification against a real immutable-audit host
+// (auditctl `enabled 2`), where the Roll back button the UI offers on a staged
+// remediation failed and stranded the change on the host.
+func TestAPI_Remediation_RollbackAcceptsStaged(t *testing.T) {
+	t.Run("api-remediation/AC-09", func(t *testing.T) {
+		url, pool := freshAPIServer(t)
+		hostID := seedHostForIntel(t, pool)
+		base := url + "/api/v1/remediation/requests"
+
+		// A staged request: the persist layer is written and the host HAS
+		// changed, so the change is reversible and rollback must be reachable.
+		stagedID := seedRemediationInStatus(t, pool, hostID,
+			roleUserIDs[auth.RoleOpsLead], "rule-staged", "staged")
+		rb := doReq(t, asRole(t, "POST", base+"/"+stagedID.String()+":rollback",
+			auth.RoleSecurityAdmin, map[string]any{}))
+		rb.Body.Close()
+		if rb.StatusCode != http.StatusAccepted {
+			t.Errorf("rollback of a staged request = %d, want 202; the handler "+
+				"must use Status.RollbackEligible, not a literal StatusExecuted "+
+				"comparison", rb.StatusCode)
+		}
+
+		// The negative direction still holds: an outcome that mutated nothing
+		// has nothing to reverse.
+		for _, st := range []string{"not_applied", "reverted", "failed"} {
+			id := seedRemediationInStatus(t, pool, hostID,
+				roleUserIDs[auth.RoleOpsLead], "rule-"+st, st)
+			r := doReq(t, asRole(t, "POST", base+"/"+id.String()+":rollback",
+				auth.RoleSecurityAdmin, map[string]any{}))
+			r.Body.Close()
+			if r.StatusCode != http.StatusConflict {
+				t.Errorf("rollback of a %s request = %d, want 409", st, r.StatusCode)
+			}
+		}
+	})
+}
+
+// seedRemediationInStatus inserts a remediation request already in a terminal
+// status, so the HTTP preconditions can be exercised without driving a real
+// Kensa transaction.
+func seedRemediationInStatus(t *testing.T, pool *pgxpool.Pool, hostID, requestedBy uuid.UUID, ruleID, status string) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO remediation_requests (id, host_id, rule_id, status, requested_by)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		id, hostID, ruleID, status, requestedBy); err != nil {
+		t.Fatalf("seed %s remediation: %v", status, err)
+	}
+	return id
 }
 
 // seedPendingRemediation inserts a pending_approval remediation request

--- a/internal/server/remediation_handlers.go
+++ b/internal/server/remediation_handlers.go
@@ -372,9 +372,15 @@ func (h *handlers) RollbackRemediation(w http.ResponseWriter, r *http.Request, r
 	if mapRemediationErr(w, err) {
 		return
 	}
-	if rq.Status != remediation.StatusExecuted {
+	// Eligibility is Status.RollbackEligible, never a literal comparison: a
+	// staged change is written to the host and IS reversible, so the HTTP
+	// layer must accept it exactly as the worker and the UI already do. This
+	// guard read `!= StatusExecuted` when 'staged' was introduced, which made
+	// the Roll back button the UI offers on a staged remediation fail with a
+	// 409 and stranded the change on the host.
+	if !rq.Status.RollbackEligible() {
 		writeError(w, http.StatusConflict, "remediation.wrong_state", "client",
-			"only an executed request can be rolled back", false)
+			"only an executed or staged request can be rolled back", false)
 		return
 	}
 

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -159,7 +159,7 @@ spec:
       priority: critical
       references_constraints: [C-05, C-03]
     - id: AC-06
-      description: 'Execute/rollback are FREE core: a caller WITH remediation:execute executing an approved request gets 202 and a remediation job is enqueued. A free-core request is auto-approved, so it executes directly with no separate approval step. A caller LACKING remediation:execute is 403; executing a non-approved (pending_approval) request is 409; rolling back (remediation:rollback) a non-executed request is 409. No remediation act endpoint returns 402. :dry-run returns 501. request/approve/reject and the GET reads return their normal status codes.'
+      description: 'Execute/rollback are FREE core: a caller WITH remediation:execute executing an approved request gets 202 and a remediation job is enqueued. A free-core request is auto-approved, so it executes directly with no separate approval step. A caller LACKING remediation:execute is 403; executing a non-approved (pending_approval) request is 409; rolling back (remediation:rollback) a request that is not rollback-eligible is 409 (eligibility is Status.RollbackEligible - executed OR staged - never a literal equality with executed; see AC-09). No remediation act endpoint returns 402. :dry-run returns 501. request/approve/reject and the GET reads return their normal status codes.'
       priority: critical
       references_constraints: [C-06]
     - id: AC-07


### PR DESCRIPTION
## What

`POST /api/v1/remediation/requests/{rid}:rollback` refused a `staged` request
with `409 remediation.wrong_state`. The handler compared the status to
`executed` literally instead of using `Status.RollbackEligible`, which is the
single point of truth and already covers both `executed` and `staged`.

## Why it matters

A staged remediation has written the persist layer, so the host **is** changed.
The UI offers a Roll back action on it (`ROLLBACK_ELIGIBLE = {executed, staged}`)
and the worker accepts one (`rq.Status.RollbackEligible()`). Only the HTTP layer
disagreed, so the button failed and the change stayed on the host with no way to
undo it from the application.

## How it was found

Release verification for v0.7.0-rc.1 against `owas-tst02`, a RHEL 9.6 host with
an immutable audit configuration (`auditctl -s` reports `enabled 2`).
Remediating `audit-network-change` correctly produced:

- Kensa outcome `staged`, detail *"audit config immutable (enabled 2); staged
  into /etc/audit/rules.d/50-system_locale.rules, PENDING reboot to load"*
- request status `staged`, persist file written, runtime rule **not** loaded
- `host_rule_state` correctly left at `fail`

and the rollback then returned 409, stranding the file. After the fix the same
rollback returns 202 and restores the host byte-perfect.

## Why coverage did not catch it

`api-remediation` AC-09 was annotated on a unit test asserting
`Status("staged").RollbackEligible() == true`. That is the predicate in
isolation, not the precondition the AC describes ("the rollback precondition
accepts staged as well as executed"). Structural coverage was 100% and the AC
was still unmet.

AC-06 also still read "rolling back a non-executed request is 409", which
contradicted AC-09 and is what the handler implemented. Both AC texts are
corrected.

## Tests

New endpoint test `TestAPI_Remediation_RollbackAcceptsStaged` (AC-09) asserts
202 for `staged` and 409 for `not_applied` / `reverted` / `failed`. Verified it
**fails** against the unfixed handler rather than assuming:

```
rollback of a staged request = 409, want 202; the handler must use
Status.RollbackEligible, not a literal StatusExecuted comparison
```

`internal/server`, `internal/remediation`, `internal/worker` all green.
`specter coverage --strictness annotation`: 117/117.
