### PR TITLE
feat(setup): add `openwatch setup`, a guided one-command install

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -156,9 +156,16 @@
       {
         "type": "Secret Keyword",
         "filename": "cmd/openwatch/setup.go",
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_verified": false,
+        "line_number": 248
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "cf674860f87e78d70243bbe8b4514305398899e4",
         "is_verified": false,
-        "line_number": 226
+        "line_number": 276
       }
     ],
     "docs/guides/API_GUIDE.md": [
@@ -558,14 +565,14 @@
         "filename": "internal/setup/plan_test.go",
         "hashed_secret": "eaf89be3612f295df6e3eefb4a11101579128739",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 118
       },
       {
         "type": "Secret Keyword",
         "filename": "internal/setup/plan_test.go",
         "hashed_secret": "4120946bea1fda449543e32325948a9eed320257",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 121
       }
     ],
     "internal/setup/steps.go": [
@@ -574,7 +581,7 @@
         "filename": "internal/setup/steps.go",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 226
+        "line_number": 254
       }
     ],
     "internal/ssh/sudo.go": [
@@ -738,5 +745,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T01:46:18Z"
+  "generated_at": "2026-07-31T02:54:04Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -595,7 +595,7 @@
         "filename": "internal/setup/steps.go",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 264
+        "line_number": 276
       }
     ],
     "internal/ssh/sudo.go": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T12:20:21Z"
+  "generated_at": "2026-07-31T13:16:29Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -581,7 +581,7 @@
         "filename": "internal/setup/steps.go",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 264
       }
     ],
     "internal/ssh/sudo.go": [
@@ -745,5 +745,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T02:54:04Z"
+  "generated_at": "2026-07-31T11:02:38Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -201,35 +201,35 @@
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 340
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 377
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 197
+        "line_number": 425
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c761ff698fa44c8d7f1a8e30816441866cbf7f76",
         "is_verified": false,
-        "line_number": 218
+        "line_number": 446
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 465
+        "line_number": 798
       }
     ],
     "docs/guides/PRODUCTION_DEPLOYMENT.md": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T12:16:10Z"
+  "generated_at": "2026-07-31T12:20:21Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,12 +183,12 @@
       {
         "type": "Secret Keyword",
         "filename": "docs/guides/INSTALLATION.md",
-        "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
+        "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 84
+        "line_number": 112
       },
       {
-        "type": "Basic Auth Credentials",
+        "type": "Secret Keyword",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
@@ -197,9 +197,23 @@
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
+        "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
+        "is_verified": false,
+        "line_number": 197
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/guides/INSTALLATION.md",
+        "hashed_secret": "c761ff698fa44c8d7f1a8e30816441866cbf7f76",
+        "is_verified": false,
+        "line_number": 218
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 382
+        "line_number": 465
       }
     ],
     "docs/guides/PRODUCTION_DEPLOYMENT.md": [
@@ -674,5 +688,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T12:14:46Z"
+  "generated_at": "2026-07-30T23:29:32Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -152,6 +152,15 @@
         "line_number": 127
       }
     ],
+    "cmd/openwatch/setup.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "cmd/openwatch/setup.go",
+        "hashed_secret": "cf674860f87e78d70243bbe8b4514305398899e4",
+        "is_verified": false,
+        "line_number": 226
+      }
+    ],
     "docs/guides/API_GUIDE.md": [
       {
         "type": "Secret Keyword",
@@ -513,6 +522,61 @@
         "line_number": 292
       }
     ],
+    "internal/setup/plan.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/plan.go",
+        "hashed_secret": "9e59d42533de13285d6ef99427563967a25bfcf7",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/plan.go",
+        "hashed_secret": "9c7e05e5868afcf303ae4d1b7982921411378f96",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/plan.go",
+        "hashed_secret": "920f8f5815b381ea692e9e7c2f7119f2b1aa620a",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/plan.go",
+        "hashed_secret": "971c419dd609331343dee105fffd0f4608dc0bf2",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "internal/setup/plan_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/plan_test.go",
+        "hashed_secret": "eaf89be3612f295df6e3eefb4a11101579128739",
+        "is_verified": false,
+        "line_number": 108
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/plan_test.go",
+        "hashed_secret": "4120946bea1fda449543e32325948a9eed320257",
+        "is_verified": false,
+        "line_number": 111
+      }
+    ],
+    "internal/setup/steps.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "internal/setup/steps.go",
+        "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
+        "is_verified": false,
+        "line_number": 226
+      }
+    ],
     "internal/ssh/sudo.go": [
       {
         "type": "Secret Keyword",
@@ -674,5 +738,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-30T12:14:46Z"
+  "generated_at": "2026-07-31T01:46:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,14 +158,14 @@
         "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_verified": false,
-        "line_number": 248
+        "line_number": 250
       },
       {
         "type": "Secret Keyword",
         "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "cf674860f87e78d70243bbe8b4514305398899e4",
         "is_verified": false,
-        "line_number": 276
+        "line_number": 281
       }
     ],
     "docs/guides/API_GUIDE.md": [
@@ -745,5 +745,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T11:02:38Z"
+  "generated_at": "2026-07-31T11:09:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,14 +158,14 @@
         "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_verified": false,
-        "line_number": 250
+        "line_number": 254
       },
       {
         "type": "Secret Keyword",
         "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "cf674860f87e78d70243bbe8b4514305398899e4",
         "is_verified": false,
-        "line_number": 281
+        "line_number": 285
       }
     ],
     "docs/guides/API_GUIDE.md": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T13:16:29Z"
+  "generated_at": "2026-07-31T13:22:59Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ the host.
 
 ### Added
 
+- **`openwatch setup` installs and configures a deployment in one command.**
+  After installing the packages, run `openwatch setup` as root: it detects the
+  distribution, PostgreSQL, SELinux, FIPS and fapolicyd, shows a plan marking
+  what is already done, asks before it changes anything, then provisions
+  PostgreSQL, creates the role and database, writes the DSN, migrates, creates
+  the first administrator, opens the listen port, starts the service, and
+  confirms the API answers with `db_connected`. Every change lands in a receipt
+  at `/var/lib/openwatch/setup-receipt.json`. It is safe to re-run after a
+  part-way failure: each step reports whether it is already satisfied before it
+  acts. `--yes` runs unattended, `--save-plan` and `--plan` capture and replay a
+  configuration across a fleet, and no credential value is written to either the
+  plan or the receipt. `pg_hba.conf` is only edited with `--manage-pg-hba`, and
+  `--no-firewall` declines the port. The manual database and configuration steps
+  remain documented in the installation guide for anyone who prefers them.
 - **`GET /api/v1/capabilities`** lists every capability with whether this
   deployment can use it, so a client can show a locked or upgradable control
   instead of discovering an entitlement by receiving a `402`. Unauthenticated,

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -144,6 +144,8 @@ func run(args []string, stdout, stderr *os.File) int {
 		return cmdCheckConfig(cfg, rest, stdout, stderr)
 	case "create-admin":
 		return cmdCreateAdmin(cfg, rest, stdout, stderr)
+	case "setup":
+		return cmdSetup(rest, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "openwatch: unknown subcommand %q\n\n", subcommand)
 		printUsage(stderr)
@@ -1006,6 +1008,12 @@ subcommands:
                   --backup-dir <dir>  pg_dump a restore point before applying
   create-admin  create the first admin user (requires --username --email --password)
   check-config  validate and print resolved config
+  setup         provision the database, configure, and start the service
+                  --dry-run          show the plan, change nothing
+                  --yes              accept defaults without prompting
+                  --plan <file>      apply a saved plan
+                  --save-plan <file> capture answers without applying
+                  --manage-pg-hba    let setup edit pg_hba.conf
 
 global flags:
   --config <path>       TOML config file (default %s)

--- a/cmd/openwatch/setup.go
+++ b/cmd/openwatch/setup.go
@@ -1,0 +1,307 @@
+// `openwatch setup`: detect, plan, confirm, apply, prove, record.
+//
+// One plan object, three ways to fill it. Guided prompts with the detected
+// values pre-filled, --yes takes them as-is, and --plan reads a saved file.
+// All three then run identical validation and identical steps, so the
+// unattended path is exercised by the same code a human just reviewed rather
+// than being a separate, rarely-tested implementation.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Hanalyx/openwatch/internal/setup"
+	"github.com/Hanalyx/openwatch/internal/version"
+)
+
+func cmdSetup(args []string, stdout, stderr *os.File) int {
+	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		yes           = fs.Bool("yes", false, "accept every default without prompting")
+		dryRun        = fs.Bool("dry-run", false, "show the plan and change nothing")
+		planPath      = fs.String("plan", "", "apply a saved plan file (implies non-interactive)")
+		savePlan      = fs.String("save-plan", "", "write the resolved plan to this path and exit")
+		allowUntested = fs.Bool("allow-untested", false, "proceed on a platform CI does not cover")
+		managePgHba   = fs.Bool("manage-pg-hba", false, "let setup edit pg_hba.conf (backed up, validated, rolled back on failure)")
+		dbMode        = fs.String("db-mode", "", "provision | existing (default provision)")
+		dbHost        = fs.String("db-host", "", "database host (default 127.0.0.1)")
+		dbPort        = fs.Int("db-port", 0, "database port (default 5432)")
+		dbName        = fs.String("db-name", "", "database name (default openwatch)")
+		dbRole        = fs.String("db-role", "", "database role (default openwatch)")
+		listenPort    = fs.Int("listen-port", 0, "HTTPS port (default 8443)")
+		adminUser     = fs.String("admin-username", "", "first admin username (default admin)")
+		adminEmail    = fs.String("admin-email", "", "first admin email")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	out := func(format string, a ...any) { fmt.Fprintf(stdout, format+"\n", a...) }
+	ctx := context.Background()
+
+	platform := setup.DetectPlatform()
+
+	// Fill the plan: from a file, or from defaults plus flags.
+	var plan setup.Plan
+	if *planPath != "" {
+		b, err := os.ReadFile(*planPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "openwatch setup: read plan: %v\n", err)
+			return 1
+		}
+		if err := yaml.Unmarshal(b, &plan); err != nil {
+			fmt.Fprintf(stderr, "openwatch setup: parse plan: %v\n", err)
+			return 1
+		}
+		// The platform is re-detected, never taken from the file: a plan saved
+		// on one distro must not be applied to another on the strength of its
+		// own say-so.
+		if plan.Platform.ID != "" && plan.Platform.ID != platform.ID {
+			fmt.Fprintf(stderr, "openwatch setup: plan was captured on %q but this host is %q; "+
+				"re-run guided setup here, or edit the plan deliberately\n", plan.Platform.ID, platform.ID)
+			return 1
+		}
+		plan.Platform = platform
+	} else {
+		plan = setup.DefaultPlan(platform)
+	}
+
+	applyFlagOverrides(&plan, flagOverrides{
+		managePgHba: *managePgHba, dbMode: *dbMode, dbHost: *dbHost, dbPort: *dbPort,
+		dbName: *dbName, dbRole: *dbRole, listenPort: *listenPort,
+		adminUser: *adminUser, adminEmail: *adminEmail,
+	}, fs)
+
+	interactive := !*yes && *planPath == "" && isTerminal(os.Stdin)
+	if interactive {
+		if err := promptPlan(&plan, stdout, os.Stdin); err != nil {
+			fmt.Fprintf(stderr, "openwatch setup: %v\n", err)
+			return 1
+		}
+	}
+	plan.Derive()
+
+	if errs := plan.Validate(); len(errs) > 0 {
+		fmt.Fprintln(stderr, "openwatch setup: the plan is not valid:")
+		for _, e := range errs {
+			fmt.Fprintf(stderr, "  - %v\n", e)
+		}
+		return 1
+	}
+
+	if *savePlan != "" {
+		b, err := yaml.Marshal(plan)
+		if err != nil {
+			fmt.Fprintf(stderr, "openwatch setup: marshal plan: %v\n", err)
+			return 1
+		}
+		header := "# OpenWatch setup plan. Contains no secrets: each credential records\n" +
+			"# only where it comes from. Apply with: openwatch setup --plan <file>\n"
+		if err := os.WriteFile(*savePlan, append([]byte(header), b...), 0o644); err != nil {
+			fmt.Fprintf(stderr, "openwatch setup: write plan: %v\n", err)
+			return 1
+		}
+		out("plan written to %s", *savePlan)
+		return 0
+	}
+
+	checks := setup.Preflight(ctx, plan, *allowUntested)
+	planned := setup.Resolve(ctx, plan)
+	setup.RenderPlan(out, plan, checks, planned)
+
+	if bad := setup.FatalFailures(checks); len(bad) > 0 {
+		fmt.Fprintln(stderr, "openwatch setup: preflight failed:")
+		for _, c := range bad {
+			fmt.Fprintf(stderr, "  - %s: %s\n", c.Name, c.Detail)
+		}
+		return 1
+	}
+
+	if *dryRun {
+		out("Dry run: nothing was changed.")
+		return 0
+	}
+
+	if interactive && !confirm(stdout, os.Stdin, "Proceed?") {
+		out("Aborted; nothing was changed.")
+		return 1
+	}
+
+	r := &setup.Run{Plan: plan, Out: out}
+	var prompt func(string) (string, error)
+	if interactive {
+		prompt = func(label string) (string, error) { return readSecret(stdout, os.Stdin, label) }
+	}
+	if err := setup.ResolveSecrets(r, prompt); err != nil {
+		fmt.Fprintf(stderr, "openwatch setup: %v\n", err)
+		return 1
+	}
+
+	out("")
+	if err := setup.Execute(ctx, r, planned); err != nil {
+		fmt.Fprintf(stderr, "\nopenwatch setup: %v\n", err)
+		if receipt, werr := setup.WriteReceipt(r, version.Version); werr == nil && receipt != "" {
+			fmt.Fprintf(stderr, "Partial run recorded at %s; setup is idempotent, so fix the "+
+				"cause and run it again.\n", receipt)
+		}
+		return 1
+	}
+
+	receipt, err := setup.WriteReceipt(r, version.Version)
+	if err != nil {
+		out("warning: could not write the receipt: %v", err)
+	}
+	setup.RenderSummary(out, r, receipt)
+	return 0
+}
+
+type flagOverrides struct {
+	managePgHba            bool
+	dbMode, dbHost, dbName string
+	dbRole                 string
+	dbPort, listenPort     int
+	adminUser, adminEmail  string
+}
+
+// applyFlagOverrides applies only the flags actually passed, so a flag left
+// alone never clobbers a value that came from a plan file.
+func applyFlagOverrides(p *setup.Plan, o flagOverrides, fs *flag.FlagSet) {
+	set := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+	if set["manage-pg-hba"] {
+		p.Database.ManagePgHba = o.managePgHba
+	}
+	if set["db-mode"] {
+		p.Database.Mode = setup.DatabaseMode(o.dbMode)
+	}
+	if set["db-host"] {
+		p.Database.Host = o.dbHost
+	}
+	if set["db-port"] {
+		p.Database.Port = o.dbPort
+	}
+	if set["db-name"] {
+		p.Database.Name = o.dbName
+	}
+	if set["db-role"] {
+		p.Database.RoleName = o.dbRole
+	}
+	if set["listen-port"] {
+		p.Service.ListenPort = o.listenPort
+	}
+	if set["admin-username"] {
+		p.Admin.Username = o.adminUser
+	}
+	if set["admin-email"] {
+		p.Admin.Email = o.adminEmail
+	}
+}
+
+// promptPlan walks the plan by section rather than field, so the default path
+// is a few keystrokes while every value stays reachable. Each section shows
+// what it will do; Enter accepts, "e" opens it.
+func promptPlan(p *setup.Plan, out *os.File, in *os.File) error {
+	r := bufio.NewReader(in)
+
+	fmt.Fprintf(out, "\nDatabase\n")
+	fmt.Fprintf(out, "  mode      %s\n", p.Database.Mode)
+	fmt.Fprintf(out, "  host:port %s:%d\n", p.Database.Host, p.Database.Port)
+	fmt.Fprintf(out, "  database  %s\n", p.Database.Name)
+	fmt.Fprintf(out, "  role      %s (password: %s)\n", p.Database.RoleName, p.Database.Password.Source)
+	if ask(out, r, "  [Enter] accept, [e] edit: ") == "e" {
+		p.Database.Mode = setup.DatabaseMode(askDefault(out, r, "  mode (provision|existing)", string(p.Database.Mode)))
+		p.Database.Host = askDefault(out, r, "  host", p.Database.Host)
+		p.Database.Port = askInt(out, r, "  port", p.Database.Port)
+		p.Database.Name = askDefault(out, r, "  database name", p.Database.Name)
+		p.Database.RoleName = askDefault(out, r, "  role name", p.Database.RoleName)
+		if ask(out, r, "  supply the role password yourself instead of generating one? [y/N] ") == "y" {
+			p.Database.Password = setup.Secret{Source: setup.SecretPrompt}
+		}
+	}
+
+	fmt.Fprintf(out, "\nService\n")
+	fmt.Fprintf(out, "  listen    %s:%d\n", p.Service.ListenHost, p.Service.ListenPort)
+	if ask(out, r, "  [Enter] accept, [e] edit: ") == "e" {
+		p.Service.ListenHost = askDefault(out, r, "  listen host", p.Service.ListenHost)
+		p.Service.ListenPort = askInt(out, r, "  listen port", p.Service.ListenPort)
+		p.Derive()
+		if p.Service.BindCapability {
+			fmt.Fprintf(out, "  note: port %d is privileged, so setup will add\n", p.Service.ListenPort)
+			fmt.Fprintf(out, "        AmbientCapabilities=CAP_NET_BIND_SERVICE to the unit.\n")
+		}
+	}
+
+	fmt.Fprintf(out, "\nAdministrator\n")
+	fmt.Fprintf(out, "  username  %s\n", p.Admin.Username)
+	fmt.Fprintf(out, "  email     %s\n", p.Admin.Email)
+	if ask(out, r, "  [Enter] accept, [e] edit: ") == "e" {
+		p.Admin.Username = askDefault(out, r, "  username", p.Admin.Username)
+		p.Admin.Email = askDefault(out, r, "  email", p.Admin.Email)
+	}
+	fmt.Fprintln(out)
+	return nil
+}
+
+func ask(out *os.File, r *bufio.Reader, prompt string) string {
+	fmt.Fprint(out, prompt)
+	line, _ := r.ReadString('\n')
+	return strings.ToLower(strings.TrimSpace(line))
+}
+
+func askDefault(out *os.File, r *bufio.Reader, label, def string) string {
+	fmt.Fprintf(out, "%s [%s]: ", label, def)
+	line, _ := r.ReadString('\n')
+	if v := strings.TrimSpace(line); v != "" {
+		return v
+	}
+	return def
+}
+
+func askInt(out *os.File, r *bufio.Reader, label string, def int) int {
+	for {
+		v := askDefault(out, r, label, strconv.Itoa(def))
+		n, err := strconv.Atoi(v)
+		if err == nil {
+			return n
+		}
+		fmt.Fprintf(out, "  %q is not a number\n", v)
+	}
+}
+
+func confirm(out *os.File, in *os.File, prompt string) bool {
+	r := bufio.NewReader(in)
+	answer := ask(out, r, prompt+" [y/N] ")
+	return answer == "y" || answer == "yes"
+}
+
+// readSecret reads a credential. It does not disable terminal echo, and says
+// so: silently pretending input is hidden when it is not would be worse than
+// stating it plainly.
+func readSecret(out *os.File, in *os.File, label string) (string, error) {
+	fmt.Fprintf(out, "%s (input is visible): ", label)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", label, err)
+	}
+	v := strings.TrimSpace(line)
+	if v == "" {
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	return v, nil
+}
+
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/cmd/openwatch/setup.go
+++ b/cmd/openwatch/setup.go
@@ -110,7 +110,11 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		}
 		header := "# OpenWatch setup plan. Contains no secrets: each credential records\n" +
 			"# only where it comes from. Apply with: openwatch setup --plan <file>\n"
-		if err := os.WriteFile(*savePlan, append([]byte(header), b...), 0o644); err != nil {
+		// Written 0600 even though the plan holds no credential: setup runs as
+		// root, and a root-written world-readable file in an operator-chosen
+		// path (often /tmp) is not something to create by default. Sharing it
+		// is a deliberate chmod away.
+		if err := os.WriteFile(*savePlan, append([]byte(header), b...), 0o600); err != nil {
 			fmt.Fprintf(stderr, "openwatch setup: write plan: %v\n", err)
 			return 1
 		}

--- a/cmd/openwatch/setup.go
+++ b/cmd/openwatch/setup.go
@@ -10,6 +10,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -40,6 +41,8 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		listenPort    = fs.Int("listen-port", 0, "HTTPS port (default 8443)")
 		adminUser     = fs.String("admin-username", "", "first admin username (default admin)")
 		adminEmail    = fs.String("admin-email", "", "first admin email")
+		adminPwFrom   = fs.String("admin-password-from", "", "where the admin password comes from: prompt | generate | env:NAME | file:PATH")
+		dbPwFrom      = fs.String("db-password-from", "", "where the database password comes from: generate | prompt | env:NAME | file:PATH")
 	)
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -78,6 +81,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		managePgHba: *managePgHba, dbMode: *dbMode, dbHost: *dbHost, dbPort: *dbPort,
 		dbName: *dbName, dbRole: *dbRole, listenPort: *listenPort,
 		adminUser: *adminUser, adminEmail: *adminEmail,
+		adminPwFrom: *adminPwFrom, dbPwFrom: *dbPwFrom,
 	}, fs)
 
 	interactive := !*yes && *planPath == "" && isTerminal(os.Stdin)
@@ -140,15 +144,29 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 	if interactive {
 		prompt = func(label string) (string, error) { return readSecret(stdout, os.Stdin, label) }
 	}
-	if err := setup.ResolveSecrets(r, prompt); err != nil {
+	if err := setup.ResolveSecrets(ctx, r, prompt); err != nil {
 		fmt.Fprintf(stderr, "openwatch setup: %v\n", err)
 		return 1
 	}
 
 	out("")
 	if err := setup.Execute(ctx, r, planned); err != nil {
+		receipt, _ := setup.WriteReceipt(r, version.Version)
+		// A pause is the operator's own choice coming due, not a fault, and
+		// saying "failed" for it would send them looking for a bug.
+		var pause *setup.PauseError
+		if errors.As(err, &pause) {
+			out("")
+			out("Setup paused: %s", pause.Reason)
+			out("Everything before this step is done. Complete the manual step above,")
+			out("then run `openwatch setup` again to continue from here.")
+			if receipt != "" {
+				out("Progress recorded at %s", receipt)
+			}
+			return 3
+		}
 		fmt.Fprintf(stderr, "\nopenwatch setup: %v\n", err)
-		if receipt, werr := setup.WriteReceipt(r, version.Version); werr == nil && receipt != "" {
+		if receipt != "" {
 			fmt.Fprintf(stderr, "Partial run recorded at %s; setup is idempotent, so fix the "+
 				"cause and run it again.\n", receipt)
 		}
@@ -169,6 +187,28 @@ type flagOverrides struct {
 	dbRole                 string
 	dbPort, listenPort     int
 	adminUser, adminEmail  string
+	adminPwFrom, dbPwFrom  string
+}
+
+// parseSecretSpec turns a --*-password-from value into a Secret.
+//
+// Unattended installs need a way to supply credentials that is not a prompt,
+// and the alternatives are worse: a --password flag lands the value in the
+// process table and shell history, where any user on the box can read it.
+// env: and file: keep it out of both.
+func parseSecretSpec(spec string) (setup.Secret, error) {
+	switch {
+	case spec == "generate":
+		return setup.Secret{Source: setup.SecretGenerate, Length: 32}, nil
+	case spec == "prompt":
+		return setup.Secret{Source: setup.SecretPrompt}, nil
+	case strings.HasPrefix(spec, "env:"):
+		return setup.Secret{Source: setup.SecretEnv, Ref: strings.TrimPrefix(spec, "env:")}, nil
+	case strings.HasPrefix(spec, "file:"):
+		return setup.Secret{Source: setup.SecretFile, Ref: strings.TrimPrefix(spec, "file:")}, nil
+	default:
+		return setup.Secret{}, fmt.Errorf("password source %q must be generate, prompt, env:NAME, or file:PATH", spec)
+	}
 }
 
 // applyFlagOverrides applies only the flags actually passed, so a flag left
@@ -202,6 +242,16 @@ func applyFlagOverrides(p *setup.Plan, o flagOverrides, fs *flag.FlagSet) {
 	}
 	if set["admin-email"] {
 		p.Admin.Email = o.adminEmail
+	}
+	if set["admin-password-from"] {
+		if sec, err := parseSecretSpec(o.adminPwFrom); err == nil {
+			p.Admin.Password = sec
+		}
+	}
+	if set["db-password-from"] {
+		if sec, err := parseSecretSpec(o.dbPwFrom); err == nil {
+			p.Database.Password = sec
+		}
 	}
 }
 

--- a/cmd/openwatch/setup.go
+++ b/cmd/openwatch/setup.go
@@ -32,6 +32,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		planPath      = fs.String("plan", "", "apply a saved plan file (implies non-interactive)")
 		savePlan      = fs.String("save-plan", "", "write the resolved plan to this path and exit")
 		allowUntested = fs.Bool("allow-untested", false, "proceed on a platform CI does not cover")
+		noFirewall    = fs.Bool("no-firewall", false, "do not open the listen port in the host firewall (the service will only be reachable from this host)")
 		managePgHba   = fs.Bool("manage-pg-hba", false, "let setup edit pg_hba.conf (backed up, validated, rolled back on failure)")
 		dbMode        = fs.String("db-mode", "", "provision | existing (default provision)")
 		dbHost        = fs.String("db-host", "", "database host (default 127.0.0.1)")
@@ -81,7 +82,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		managePgHba: *managePgHba, dbMode: *dbMode, dbHost: *dbHost, dbPort: *dbPort,
 		dbName: *dbName, dbRole: *dbRole, listenPort: *listenPort,
 		adminUser: *adminUser, adminEmail: *adminEmail,
-		adminPwFrom: *adminPwFrom, dbPwFrom: *dbPwFrom,
+		adminPwFrom: *adminPwFrom, dbPwFrom: *dbPwFrom, noFirewall: *noFirewall,
 	}, fs)
 
 	interactive := !*yes && *planPath == "" && isTerminal(os.Stdin)
@@ -188,6 +189,7 @@ type flagOverrides struct {
 	dbPort, listenPort     int
 	adminUser, adminEmail  string
 	adminPwFrom, dbPwFrom  string
+	noFirewall             bool
 }
 
 // parseSecretSpec turns a --*-password-from value into a Secret.
@@ -247,6 +249,9 @@ func applyFlagOverrides(p *setup.Plan, o flagOverrides, fs *flag.FlagSet) {
 		if sec, err := parseSecretSpec(o.adminPwFrom); err == nil {
 			p.Admin.Password = sec
 		}
+	}
+	if set["no-firewall"] {
+		p.Service.OpenFirewall = !o.noFirewall
 	}
 	if set["db-password-from"] {
 		if sec, err := parseSecretSpec(o.dbPwFrom); err == nil {

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,10 +1,11 @@
 # OpenWatch install guide (native packages)
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-31 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
 
 This guide takes an administrator from a fresh Linux host to a running,
-logged-in OpenWatch: install the package, point it at PostgreSQL, create the
-first admin user, start the service, and sign in to the web UI.
+logged-in OpenWatch. Install the packages and run `openwatch setup`, which does
+the rest. The manual procedure that follows documents every step `setup`
+performs, for operators who need to stage the work themselves.
 
 ## What you get
 
@@ -24,18 +25,25 @@ After the steps below you have:
 
 ## At a glance
 
-| Step | What | Command |
-|------|------|---------|
-| 1 | Install PostgreSQL | `dnf install postgresql-server` / `apt install postgresql` |
-| 2 | Provision the database | `createdb` + role (see below) |
-| 3 | Install the packages | `dnf install ./openwatch-*.rpm ./kensa-rules-*.rpm` / `apt install ./openwatch_*.deb ./kensa-rules_*.deb` |
-| 4 | Configure the database secret | edit `/etc/openwatch/secrets.env` |
-| 5 | Run migrations | `openwatch migrate` |
-| 6 | Create the first admin | `openwatch create-admin --username admin --email …` |
-| 7 | Start the service | `systemctl enable --now openwatch` |
-| 8 | Sign in | open `https://<host>:8443/` |
+Install the packages, then run `openwatch setup`:
 
-On a host that already runs PostgreSQL, this takes about five minutes.
+```bash
+sudo dnf install -y ./openwatch-*.rpm ./kensa-rules-*.noarch.rpm
+sudo openwatch setup
+```
+
+`setup` provisions PostgreSQL, creates the role and database, writes the
+connection string, applies migrations, creates your first administrator, opens
+the firewall port, starts the service, and confirms the API answers. It shows
+you the whole plan and waits for confirmation before changing anything.
+
+**This is the supported way to install OpenWatch.** The
+[manual procedure](#manual-installation-rhel-family-rpm) documents every step
+`setup` performs, for operators who need to stage the work differently, satisfy
+a change-control process, or integrate with existing configuration management.
+Both paths reach the same result.
+
+On a host that already runs PostgreSQL, either takes about five minutes.
 
 ---
 
@@ -68,7 +76,227 @@ On a host that already runs PostgreSQL, this takes about five minutes.
 
 ---
 
-## Install on RHEL family (RPM)
+## Install with `openwatch setup`
+
+### Step 1: Install the packages
+
+```bash
+sudo dnf install -y ./openwatch-*.x86_64.rpm ./kensa-rules-*.noarch.rpm
+```
+
+On Debian and Ubuntu:
+
+```bash
+sudo apt install -y ./openwatch_*_amd64.deb ./kensa-rules_*_all.deb
+```
+
+Install **both** files in one transaction. `openwatch` depends on `kensa-rules`,
+the rule corpus the scan engine loads. The packages do not start the service:
+`setup` does that once the database exists.
+
+`setup` ships inside the `openwatch` package, so this step comes first. It
+configures OpenWatch; it does not install it.
+
+### Step 2: Run setup
+
+```bash
+sudo openwatch setup
+```
+
+It detects the host, prints a plan, and waits:
+
+```
+OpenWatch setup: rhel 9.8 (amd64)
+
+Preflight
+  [ok  ] running as root
+  [ok  ] platform rhel 9.8 (amd64)
+           tested
+  [ok  ] openwatch binary installed
+  [ok  ] port 8443 available
+  [ok  ] fapolicyd is active
+  [ok  ] SELinux enforcing
+
+Plan
+   1. install PostgreSQL (dnf install postgresql-server postgresql-contrib)
+   2. initialise the data directory and enable postgresql
+   3. verify PostgreSQL >= 13 (supported >= 15)
+   4. create role "openwatch" with a generated password, hashed scram-sha-256
+   5. create database "openwatch" owned by "openwatch"
+   6. check pg_hba.conf for the required host rules
+   7. write /etc/openwatch/secrets.env with the database DSN
+   8. apply database migrations
+   9. create the first admin user "admin"
+  10. allow inbound 8443/tcp through the host firewall
+  11. enable and start openwatch.service
+  12. confirm the API answers on https://0.0.0.0:8443/api/v1/health
+```
+
+Guided mode asks about the database, the service and the administrator in turn,
+with the detected values filled in. Press Enter to accept a section, or `e` to
+edit it. Nothing is written until you confirm the plan.
+
+It finishes by proving the install rather than declaring it done:
+
+```
+Done.
+
+  URL       https://192.168.1.251:8443/
+  Admin     admin <admin@example.com>
+  Database  openwatch@127.0.0.1:5432/openwatch
+
+  Changed:
+    postgres-install install postgresql
+    postgres-cluster initdb /var/lib/pgsql/data
+    database-role  create role openwatch
+    database       create database openwatch
+    secrets-env    write /etc/openwatch/secrets.env
+    firewall       allow 8443/tcp
+    service        enable --now openwatch.service
+
+  Receipt: /var/lib/openwatch/setup-receipt.json
+```
+
+### Step 3: Sign in
+
+Open **`https://<host>:8443/`** and sign in with the administrator you created.
+The browser warns about the bundled self-signed certificate; accept it, or
+[replace the certificate](#replace-the-demo-tls-cert) first.
+
+---
+
+## How `openwatch setup` behaves
+
+### Running it again is safe
+
+Every step checks whether it is already satisfied before acting, and reports
+what it skipped. The usual moment to run an installer is after a previous
+attempt stopped part-way, so re-running is the intended recovery: fix whatever
+blocked it and run the same command again.
+
+Re-running does **not** rotate the database password. It is recovered from
+`/etc/openwatch/secrets.env` so the role and the connection string stay in
+agreement.
+
+### It will not edit `pg_hba.conf` unless you ask
+
+PostgreSQL decides who may connect using `pg_hba.conf`, and editing it wrongly
+is the most effective way to lock yourself out of your own database. By default
+`setup` reports what is missing, prints the exact lines, and stops with exit
+code 3:
+
+```
+Setup paused: pg_hba.conf needs the rules above before the database role can
+authenticate
+Everything before this step is done. Complete the manual step above,
+then run `openwatch setup` again to continue from here.
+```
+
+Add the lines, reload PostgreSQL, and run `setup` again. It resumes from where
+it stopped.
+
+To have `setup` do it, pass `--manage-pg-hba`. It then backs the file up,
+inserts its rules **above** the existing ones, reloads PostgreSQL, and restores
+the original file if the reload fails. The ordering matters: `pg_hba.conf` is
+first-match-wins, and the stock RHEL file matches `127.0.0.1/32` with `ident`
+before anything appended to the end would be reached.
+
+### It opens the listen port
+
+An active `firewalld` is reconfigured to allow the listen port, because the
+health check runs over loopback where the firewall does not apply. Without this
+step an install can report itself healthy while being unreachable from every
+other machine. Pass `--no-firewall` to decline; `setup` then prints the commands
+to open it later and says the service will only be reachable from the host
+itself.
+
+`ufw` on Debian and Ubuntu is **not** configured. Open the port yourself.
+
+### Platforms it will run on
+
+| Platform | Behaviour |
+|---|---|
+| RHEL 9 | Runs. Covered by testing. |
+| Rocky, AlmaLinux, Oracle Linux 8-10 | Requires `--allow-untested` |
+| Debian 12, Ubuntu 22.04 and 24.04 | Requires `--allow-untested` |
+| Anything else | Refused |
+
+`untested` means the code recognises the layout and is expected to work, but it
+is not covered by automated testing. It runs with `--allow-untested`; please
+report the result.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Finished; the API answered and reported a database connection |
+| 1 | Failed. Nothing after the failing step ran |
+| 3 | Paused for a manual step. Complete it and re-run |
+
+### The receipt
+
+Every applied run writes `/var/lib/openwatch/setup-receipt.json`: the platform,
+the resolved plan, every change with the path of any backup taken, and the URL.
+It records **where** each credential came from, never the credential, so it is
+safe to attach to a ticket.
+
+### Options
+
+| Option | Effect |
+|---|---|
+| `--dry-run` | Print the plan and change nothing |
+| `--yes` | Accept every default without prompting |
+| `--plan <file>` | Apply a saved plan; implies non-interactive |
+| `--save-plan <file>` | Write the resolved plan and exit without applying |
+| `--allow-untested` | Proceed on a platform not covered by testing |
+| `--manage-pg-hba` | Let `setup` edit `pg_hba.conf` |
+| `--no-firewall` | Do not open the listen port |
+| `--db-mode provision\|existing` | Provision PostgreSQL, or use one that already runs |
+| `--db-host`, `--db-port`, `--db-name`, `--db-role` | Database connection and names |
+| `--listen-port` | HTTPS port (default 8443) |
+| `--admin-username`, `--admin-email` | First administrator |
+| `--admin-password-from`, `--db-password-from` | `generate`, `prompt`, `env:NAME`, or `file:PATH` |
+
+There is deliberately no `--password` option: a password on the command line is
+visible in the process table and lands in shell history. Use `env:NAME` or
+`file:PATH`.
+
+### Using a database you already run
+
+```bash
+sudo openwatch setup --db-mode existing --db-host db.internal --db-port 5432
+```
+
+`setup` then validates rather than provisions: it checks the server is
+reachable and supported, and creates the role and database only if they are
+missing. It never installs or initialises a remote PostgreSQL.
+
+A non-loopback host requires TLS. `sslmode` is raised off `disable`
+automatically, and a plan that sets it back is rejected.
+
+### Unattended and repeated installs
+
+Capture the answers once, apply them anywhere:
+
+```bash
+sudo openwatch setup --save-plan /root/openwatch-plan.yaml
+sudo openwatch setup --plan /root/openwatch-plan.yaml --admin-password-from env:OW_ADMIN_PW
+```
+
+The plan file holds no secrets, so it is safe to commit to configuration
+management. The platform is re-detected on every apply and a plan captured on
+one distribution is refused on another.
+
+---
+
+## Manual installation: RHEL family (RPM)
+
+Everything below is what `openwatch setup` performs. Use it when you need to
+stage the steps separately, when a change-control process requires each action
+to be recorded individually, or when integrating with existing configuration
+management.
+
+The result is identical. If you are not sure which to use, use `setup`.
 
 ### Step 1: Install PostgreSQL
 
@@ -266,21 +494,49 @@ printf '%s' "$ADMIN_PASSWORD" | sudo -u openwatch env $(cat /etc/openwatch/secre
 On success it prints `created admin user admin (admin@example.com) with id=…` and
 assigns the built-in `admin` role.
 
-### Step 7: Start the service
+### Step 7: Allow the port through the firewall
+
+RHEL enables `firewalld` by default with no ports open, so the service would be
+reachable only from the host itself. Skipping this step is easy to miss: the
+health check in Step 9 runs over loopback, where the firewall does not apply, so
+a fully blocked host looks identical to a working one until someone tries the
+URL from another machine.
+
+```bash
+sudo firewall-cmd --permanent --add-port=8443/tcp
+sudo firewall-cmd --reload
+sudo firewall-cmd --list-ports
+```
+
+Skip this only if the host has no firewall, or if OpenWatch is reached through a
+reverse proxy on the same machine.
+
+### Step 8: Start the service
 
 ```bash
 sudo systemctl enable --now openwatch
 sudo systemctl status openwatch
 ```
 
-### Step 8: Sign in
+### Step 9: Sign in
 
-Confirm the API is healthy, then open the UI:
+Confirm the API is healthy:
 
 ```bash
 curl -k https://localhost:8443/api/v1/health
 # {"status":"healthy","db_connected":true,"version":"<your installed version>"}
 ```
+
+That proves the service is serving and reached its database. It does **not**
+prove anyone else can reach it, because loopback traffic bypasses the firewall.
+Confirm that separately, from a different machine:
+
+```bash
+curl -k https://<host>:8443/api/v1/health
+```
+
+If this hangs or reports `No route to host`, the firewall is still closed;
+revisit Step 7.
 
 In a browser, go to **`https://<host>:8443/`**. The browser warns about the
 self-signed cert: accept it (or install a CA cert first; see
@@ -292,7 +548,7 @@ cert. Replace it before any non-loopback use.
 
 ---
 
-## Install on Ubuntu and Debian (DEB)
+## Manual installation: Ubuntu and Debian (DEB)
 
 The flow is identical to the RPM path; only Steps 1–3 differ.
 
@@ -354,12 +610,29 @@ dpkg -l openwatch
 openwatch --version
 ```
 
-### Steps 4–8
+### Steps 4-9
 
-Follow Steps 4 through 8 from the RPM section above: configure
+Follow Steps 4 through 9 from the RPM section above: configure
 `/etc/openwatch/secrets.env`, run `openwatch migrate`, run
-`openwatch create-admin`, `systemctl enable --now openwatch`, and sign in at
-`https://<host>:8443/`. The commands are the same.
+`openwatch create-admin`, open the firewall port, `systemctl enable --now
+openwatch`, and sign in at `https://<host>:8443/`. The commands are the same
+with one exception.
+
+**The firewall step differs.** Debian and Ubuntu use `ufw`, which is inactive
+on a default install and needs no action. Check before assuming:
+
+```bash
+sudo ufw status
+```
+
+If it reports `Status: active`, allow the port:
+
+```bash
+sudo ufw allow 8443/tcp
+```
+
+As on RHEL, confirm from another machine rather than from the host, since
+loopback traffic bypasses the firewall entirely.
 
 ---
 
@@ -453,6 +726,66 @@ Recognized environment variables:
 
 ## Troubleshooting
 
+### `setup` stopped and said "Setup paused"
+
+Not a failure. `setup` reached a step it will not perform without you: by
+default that is `pg_hba.conf`. Everything before it is done. Complete the
+printed step and run `openwatch setup` again; it resumes from there. Exit code
+is 3.
+
+### `setup` says the platform is not covered by testing
+
+The distribution is recognised and expected to work, but is not covered by
+automated testing. Re-run with `--allow-untested`. If it reports the platform
+as unsupported instead, `setup` does not know that distribution's PostgreSQL
+layout and will not guess; use the manual procedure.
+
+### `setup` reports PostgreSQL is too old
+
+The server is below the minimum of 13. On RHEL, the default stream is older
+than the supported version; enable a newer one and reinstall PostgreSQL:
+
+```bash
+dnf module list postgresql
+sudo dnf module enable -y postgresql:16
+```
+
+### `setup` says PostgreSQL refuses local superuser connections
+
+`pg_hba.conf` has no rule for local connections by the `postgres` user, so
+`setup` cannot inspect the server at all. This usually follows a hand-edit that
+replaced the file's default rules instead of adding to them. Add
+
+```
+local   all   all   peer
+```
+
+above the other rules, run `sudo systemctl reload postgresql`, and run `setup`
+again.
+
+### The install finished but nobody can reach it
+
+The health check runs over loopback, where the firewall does not apply, so a
+blocked host still reports healthy. Check from another machine:
+
+```bash
+curl -k https://<host>:8443/api/v1/health
+```
+
+`No route to host` or a hang means the firewall is closed:
+
+```bash
+sudo firewall-cmd --list-ports          # RHEL family
+sudo firewall-cmd --permanent --add-port=8443/tcp && sudo firewall-cmd --reload
+sudo ufw status                         # Debian family
+```
+
+Also confirm the service is not bound to loopback only:
+
+```bash
+sudo ss -tlnp | grep 8443               # want *:8443, not 127.0.0.1:8443
+```
+
 ### Service won't start
 
 ```bash
@@ -463,7 +796,8 @@ sudo journalctl -u openwatch --since '1 min ago' -p err
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `database.dsn: scheme "" must be postgres:// or postgresql://` | Malformed DSN in `secrets.env` | Use `postgres://user:pass@host:port/db?sslmode=…` |
-| `db: ping: … password authentication failed` | Wrong DSN password, or `pg_hba.conf` rejects scram | Recheck Step 2; reload PostgreSQL after edits |
+| `db: ping: … password authentication failed` | Wrong DSN password, or `pg_hba.conf` rejects scram | Recheck Step 2; reload PostgreSQL after edits. If the password contains a reserved character, confirm it is percent-encoded in the DSN |
+| `db: ping: … Ident authentication failed` | A catch-all `pg_hba.conf` rule matches before yours | `pg_hba.conf` is first-match-wins: move the OpenWatch rules **above** any `host all all` line, then reload |
 | `db: ping: … connection refused` | PostgreSQL not running | `sudo systemctl status postgresql` |
 | `server: … no such file: cert.pem` | TLS cert path or perms wrong | Ensure `/etc/openwatch/tls/cert.pem` is readable by `openwatch` |
 
@@ -606,8 +940,13 @@ Service unit   /etc/systemd/system/openwatch.service
 Binary         /usr/bin/openwatch
 Data / logs    /var/lib/openwatch  /var/log/openwatch  (journald is primary)
 User/group     openwatch:openwatch
+Install        sudo openwatch setup                (--dry-run to preview)
+Re-run         sudo openwatch setup                (idempotent; resumes)
+Receipt        /var/lib/openwatch/setup-receipt.json
 Migrate        sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch migrate
 Create admin   sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch create-admin --username admin --email you@example.com
 Logs           journalctl -u openwatch -f
 Restart        sudo systemctl restart openwatch
+Open port      sudo firewall-cmd --permanent --add-port=8443/tcp && sudo firewall-cmd --reload
+Check remotely curl -k https://<host>:8443/api/v1/health   (from ANOTHER machine)
 ```

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -49,8 +49,11 @@ On a host that already runs PostgreSQL, this takes about five minutes.
 - **Architecture:** `x86_64`/`amd64` or `aarch64`/`arm64` (packages ship for both).
 - **CPU/RAM:** 1 vCPU / 512 MB for the service itself; size up for large fleets.
 - **Disk:** 500 MB for the binary plus database growth sized to your retention.
-- **PostgreSQL:** 14 or newer. The package depends on the PostgreSQL client/server
-  but does **not** create a database. You do that in Step 2.
+- **PostgreSQL:** 15 or newer. The package depends on the PostgreSQL
+  client/server but does **not** create a database. You do that in Step 2.
+  PostgreSQL 14 reaches end of life in November 2026, within this release's
+  service life, so it is not a supported target for a new install. RHEL 9
+  defaults to PostgreSQL 13 and needs a newer module stream enabled: see Step 1.
 - **Network:**
   - TCP/8443 inbound for the API and UI.
   - TCP/22 outbound from this host to every managed host (Kensa scans over SSH).
@@ -69,22 +72,69 @@ On a host that already runs PostgreSQL, this takes about five minutes.
 
 ### Step 1: Install PostgreSQL
 
+**Check which version your distribution offers before installing.** RHEL 9
+defaults to PostgreSQL 13, which is below the supported minimum:
+
+```bash
+dnf module list postgresql
+```
+
+If the default stream is 14 or lower, enable a stream of 15 or newer first.
+Substitute the highest stream your release offers:
+
+```bash
+sudo dnf module enable -y postgresql:16
+```
+
+Then install, initialise, and start:
+
 ```bash
 sudo dnf install -y postgresql-server postgresql-contrib
 sudo postgresql-setup --initdb
 sudo systemctl enable --now postgresql
 ```
 
+Confirm you got what you expected before continuing:
+
+```bash
+psql --version
+```
+
+If this reports 14 or lower, go back and enable a newer stream. Continuing puts
+you on a version this release does not support, and the symptom appears several
+steps later as an authentication failure rather than a version error.
+
 ### Step 2: Provision the database
 
 Create the role and database:
 
 ```bash
-sudo -u postgres psql <<'SQL'
-CREATE ROLE openwatch WITH LOGIN PASSWORD 'replace-with-a-strong-password';
-CREATE DATABASE openwatch OWNER openwatch;
-SQL
+sudo -u postgres psql -c "SET password_encryption = 'scram-sha-256'; CREATE ROLE openwatch WITH LOGIN PASSWORD 'replace-with-a-strong-password'"
+sudo -u postgres psql -c "CREATE DATABASE openwatch OWNER openwatch"
 ```
+
+Setting `password_encryption` explicitly is deliberate. `CREATE ROLE` otherwise
+hashes the password using whatever the server default happens to be, and that
+default changed from `md5` to `scram-sha-256` in PostgreSQL 14. On an older
+server the password is stored as an md5 hash while the `pg_hba.conf` rules below
+require `scram-sha-256`, and the two can never match. Setting it in the same
+session makes this step behave identically on every supported version.
+
+Each statement reports its own `CREATE ROLE` or `CREATE DATABASE`, so you can
+see which one succeeded. `could not change directory to "/root"` is harmless:
+the `postgres` user cannot read root's working directory, and the command still
+runs. Run these from a directory `postgres` can read, such as `/tmp`, to silence
+it.
+
+Confirm the password was stored in the expected format:
+
+```bash
+sudo -u postgres psql -c "SELECT rolname, substring(rolpassword,1,13) AS stored_as FROM pg_authid WHERE rolname='openwatch'"
+```
+
+This must report `SCRAM-SHA-256`. If it reports `md5`, the `SET` did not take
+effect; re-run it as `ALTER ROLE openwatch PASSWORD '...'` in the same session
+as the `SET`.
 
 Allow password auth from localhost. Edit `/var/lib/pgsql/data/pg_hba.conf` and
 ensure these lines exist near the top of the host rules, then reload:
@@ -96,8 +146,7 @@ host    openwatch    openwatch    ::1/128         scram-sha-256
 
 ```bash
 sudo systemctl reload postgresql
-PGPASSWORD='replace-with-a-strong-password' \
-  psql -h 127.0.0.1 -U openwatch -d openwatch -c '\conninfo'
+PGPASSWORD='replace-with-a-strong-password' psql -h 127.0.0.1 -U openwatch -d openwatch -c '\conninfo'
 ```
 
 ### Step 3: Install the packages
@@ -145,12 +194,38 @@ The service reads its database connection string from
 config. The `systemd` unit loads this file automatically.
 
 ```bash
-sudo tee /etc/openwatch/secrets.env >/dev/null <<'EOF'
-OPENWATCH_DATABASE_DSN=postgres://openwatch:replace-with-a-strong-password@127.0.0.1:5432/openwatch?sslmode=disable
-EOF
+echo 'OPENWATCH_DATABASE_DSN=postgres://openwatch:replace-with-a-strong-password@127.0.0.1:5432/openwatch?sslmode=disable' | sudo tee /etc/openwatch/secrets.env >/dev/null
 sudo chown root:openwatch /etc/openwatch/secrets.env
 sudo chmod 0640 /etc/openwatch/secrets.env
 ```
+
+> **Percent-encode any reserved character in the password.** The DSN is a URI,
+> so a password containing one of these characters must be encoded, or the
+> connection string parses into something other than what you typed:
+>
+> | Character | Encode as |
+> |---|---|
+> | `@` | `%40` |
+> | `:` | `%3A` |
+> | `/` | `%2F` |
+> | `?` | `%3F` |
+> | `#` | `%23` |
+> | `[` | `%5B` |
+> | `]` | `%5D` |
+> | `%` | `%25` |
+>
+> A password of `p@ss@word` becomes
+> `postgres://openwatch:p%40ss%40word@127.0.0.1:5432/openwatch?sslmode=disable`.
+> Encode only the password. The `@` that separates the credentials from the host
+> stays literal, and encoding a character that did not need it is harmless.
+>
+> This is worth care because it rarely fails as a parse error. An unencoded `@`
+> splits the URI at the wrong place and the result still looks like a valid DSN,
+> so the error you get points somewhere else. Depending on where the character
+> falls you will see either `password authentication failed for user
+> "openwatch"`, which points at the role, or a host resolution failure naming a
+> host built from part of your password. Step 5 below is the first command to
+> use this DSN, so that is where a bad encoding surfaces.
 
 > Use `sslmode=require` (or stronger) for any PostgreSQL that is not on the
 > loopback interface.
@@ -162,8 +237,7 @@ queue, and more). Run it as the `openwatch` user with the same DSN the service
 uses:
 
 ```bash
-sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
-    openwatch migrate
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch migrate
 ```
 
 The command applies every pending migration and reports the version it reached.
@@ -175,8 +249,7 @@ This is the account you sign in with. The admin password policy requires **at
 least 15 characters**; pick a single line with no spaces.
 
 ```bash
-sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
-    openwatch create-admin --username admin --email admin@example.com
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch create-admin --username admin --email admin@example.com
 # Type the admin password at the prompt and press Enter.
 ```
 
@@ -187,8 +260,7 @@ screen is not observed or recorded, or pipe the password in. For automation,
 pipe it instead:
 
 ```bash
-printf '%s' "$ADMIN_PASSWORD" | sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
-    openwatch create-admin --username admin --email admin@example.com
+printf '%s' "$ADMIN_PASSWORD" | sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch create-admin --username admin --email admin@example.com
 ```
 
 On success it prints `created admin user admin (admin@example.com) with id=…` and
@@ -232,22 +304,34 @@ sudo apt install -y postgresql postgresql-contrib
 sudo systemctl enable --now postgresql
 ```
 
+Ubuntu 24.04 ships PostgreSQL 16 and Debian 12 ships 15, so the default package
+is already at or above the supported minimum and no pinning is needed. Confirm
+anyway, since this is the check that catches an older or customised base image:
+
+```bash
+psql --version
+```
+
+If it reports 14 or lower, install a newer version from the PostgreSQL APT
+repository before continuing.
+
 ### Step 2: Provision the database
 
 ```bash
-sudo -u postgres psql <<'SQL'
-CREATE ROLE openwatch WITH LOGIN PASSWORD 'replace-with-a-strong-password';
-CREATE DATABASE openwatch OWNER openwatch;
-SQL
+sudo -u postgres psql -c "SET password_encryption = 'scram-sha-256'; CREATE ROLE openwatch WITH LOGIN PASSWORD 'replace-with-a-strong-password'"
+sudo -u postgres psql -c "CREATE DATABASE openwatch OWNER openwatch"
 ```
+
+`password_encryption` is set explicitly for the same reason as the RPM path: it
+makes the stored hash format independent of the server default, which differs
+between PostgreSQL versions.
 
 Ubuntu's default `pg_hba.conf` already allows `scram-sha-256` for
 `host all all 127.0.0.1/32`, so no edit is needed unless you customized it.
 Verify:
 
 ```bash
-PGPASSWORD='replace-with-a-strong-password' \
-  psql -h 127.0.0.1 -U openwatch -d openwatch -c '\conninfo'
+PGPASSWORD='replace-with-a-strong-password' psql -h 127.0.0.1 -U openwatch -d openwatch -c '\conninfo'
 ```
 
 ### Step 3: Install the packages
@@ -322,8 +406,7 @@ sudo journalctl -u openwatch -o cat | jq .       # pretty-print JSON
 ### Inspect the resolved config
 
 ```bash
-sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) \
-    openwatch check-config
+sudo -u openwatch env $(cat /etc/openwatch/secrets.env | xargs) openwatch check-config
 ```
 
 ### Replace the demo TLS cert
@@ -497,10 +580,8 @@ the TLS material; remove those manually if needed.
 Removing the package does **not** touch PostgreSQL. To reclaim that space:
 
 ```bash
-sudo -u postgres psql <<'SQL'
-DROP DATABASE openwatch;
-DROP ROLE openwatch;
-SQL
+sudo -u postgres psql -c "DROP DATABASE openwatch"
+sudo -u postgres psql -c "DROP ROLE openwatch"
 ```
 
 ---

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,6 +187,25 @@ func RenderPlan(w func(string, ...any), p Plan, checks []Check, planned []Planne
 	w("")
 }
 
+// PauseError stops the run for a manual step the operator chose to own,
+// rather than for a failure.
+//
+// The distinction is not cosmetic. Without it, declining to manage pg_hba.conf
+// means setup writes the DSN, then fails at the migration step with "Ident
+// authentication failed for user openwatch" -- an error two steps downstream of
+// its cause, naming the role rather than the host-based authentication rules.
+// Halting at the step that needs the operator keeps the message next to the
+// problem, and because every step is idempotent, re-running afterwards
+// continues from here.
+type PauseError struct {
+	Step   string
+	Reason string
+}
+
+func (e *PauseError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Step, e.Reason)
+}
+
 // Execute applies the steps that are not already satisfied.
 func Execute(ctx context.Context, r *Run, planned []PlannedStep) error {
 	for _, ps := range planned {
@@ -286,15 +306,59 @@ func portFree(port int) bool {
 // ResolveSecrets fills the run's credentials from their declared sources. It
 // is the only place a secret enters the process, and nothing here writes one
 // to the plan, the receipt, or the log.
-func ResolveSecrets(r *Run, prompt func(label string) (string, error)) error {
+func ResolveSecrets(ctx context.Context, r *Run, prompt func(label string) (string, error)) error {
 	var err error
-	if r.DBPassword, err = resolveSecret("database password", r.Plan.Database.Password, prompt); err != nil {
+	if r.DBPassword, err = resolveDBPassword(ctx, r.Plan, prompt); err != nil {
 		return err
 	}
 	if r.AdminPassword, err = resolveSecret("admin password", r.Plan.Admin.Password, prompt); err != nil {
 		return err
 	}
 	return nil
+}
+
+// resolveDBPassword reuses the password already in secrets.env when the role
+// exists and the plan asks for a generated one.
+//
+// Without this, a second run generates a fresh password, skips the role step
+// because the role already exists, and writes the new password into the DSN.
+// The role then holds the old password and the DSN the new one, and the next
+// step fails with "password authentication failed for user openwatch" -- the
+// same symptom as a mistyped password, from an installer that had just
+// succeeded. Reuse also means re-running setup does not silently rotate a
+// credential that other things may depend on.
+func resolveDBPassword(ctx context.Context, p Plan, prompt func(string) (string, error)) (string, error) {
+	if p.Database.Password.Source == SecretGenerate {
+		if pw, ok := existingDSNPassword(secretsEnvPath); ok && roleExists(ctx, p.Database.RoleName) {
+			return pw, nil
+		}
+	}
+	return resolveSecret("database password", p.Database.Password, prompt)
+}
+
+// existingDSNPassword recovers the password from a previously written
+// secrets.env. Parsed as a URI rather than by string surgery, so a password
+// containing reserved characters is decoded the same way the server decodes it.
+func existingDSNPassword(path string) (string, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimSpace(line)
+		raw, found := strings.CutPrefix(line, "OPENWATCH_DATABASE_DSN=")
+		if !found {
+			continue
+		}
+		u, err := url.Parse(strings.Trim(raw, `"'`))
+		if err != nil || u.User == nil {
+			return "", false
+		}
+		if pw, set := u.User.Password(); set && pw != "" {
+			return pw, true
+		}
+	}
+	return "", false
 }
 
 func resolveSecret(label string, s Secret, prompt func(string) (string, error)) (string, error) {

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -259,7 +259,10 @@ func WriteReceipt(r *Run, version string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(ReceiptPath), 0o750); err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(ReceiptPath, append(b, '\n'), 0o640); err != nil {
+	// Root-only. The receipt carries no credential (C-02), but it does name
+	// every path the installer touched, and nothing reads it as the service
+	// user, so there is no reason to widen it.
+	if err := os.WriteFile(ReceiptPath, append(b, '\n'), 0o600); err != nil {
 		return "", err
 	}
 	return ReceiptPath, nil

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -232,12 +232,11 @@ type Receipt struct {
 	URL       string   `json:"url"`
 }
 
-// WriteReceipt records what happened, for support and for audit.
-func WriteReceipt(r *Run, version string) (string, error) {
-	if r.DryRun {
-		return "", nil
-	}
-	rec := Receipt{
+// newReceipt assembles the record from the run. Split out from WriteReceipt so
+// the no-secrets property (C-02) can be asserted against the real thing rather
+// than against a hand-built copy of it.
+func newReceipt(r *Run, version string) Receipt {
+	return Receipt{
 		AppliedAt: time.Now().UTC().Format(time.RFC3339),
 		Version:   version,
 		Platform:  r.Plan.Platform,
@@ -245,6 +244,14 @@ func WriteReceipt(r *Run, version string) (string, error) {
 		Changes:   r.Changes,
 		URL:       fmt.Sprintf("https://%s:%d/", hostnameOr(r.Plan.Service.ListenHost), r.Plan.Service.ListenPort),
 	}
+}
+
+// WriteReceipt records what happened, for support and for audit.
+func WriteReceipt(r *Run, version string) (string, error) {
+	if r.DryRun {
+		return "", nil
+	}
+	rec := newReceipt(r, version)
 	b, err := json.MarshalIndent(rec, "", "  ")
 	if err != nil {
 		return "", err

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -284,14 +284,39 @@ func RenderSummary(w func(string, ...any), r *Run, receipt string) {
 	}
 }
 
+// hostnameOr renders the address an operator should actually browse to.
+//
+// A wildcard listen address is not usable in a URL, so it has to be resolved
+// to something. os.Hostname alone is not enough: it returns the kernel's
+// transient hostname, which on a real RHEL host was observed to be the single
+// letter "i" while the static hostname was a proper FQDN. Printing
+// https://i:8443/ helps nobody. Prefer a routable address, which is what the
+// operator will type, and fall back through the hostname to loopback.
 func hostnameOr(listen string) string {
-	if listen == "0.0.0.0" || listen == "::" || listen == "" {
-		if h, err := os.Hostname(); err == nil && h != "" {
-			return h
-		}
-		return "127.0.0.1"
+	if listen != "0.0.0.0" && listen != "::" && listen != "" {
+		return listen
 	}
-	return listen
+	if ip := primaryIP(); ip != "" {
+		return ip
+	}
+	if h, err := os.Hostname(); err == nil && strings.Contains(h, ".") {
+		return h
+	}
+	return "127.0.0.1"
+}
+
+// primaryIP returns the address the host would use to reach the outside world,
+// found without sending anything: a UDP "connection" only selects a route.
+func primaryIP() string {
+	c, err := net.Dial("udp", "192.0.2.1:9")
+	if err != nil {
+		return ""
+	}
+	defer c.Close()
+	if addr, ok := c.LocalAddr().(*net.UDPAddr); ok && addr.IP != nil && !addr.IP.IsLoopback() {
+		return addr.IP.String()
+	}
+	return ""
 }
 
 func portFree(port int) bool {

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -1,0 +1,325 @@
+// Preflight, plan rendering, execution, and the receipt.
+//
+// The shape is deliberate and borrowed from tools that change infrastructure:
+// detect, show what will happen, ask, then act, then prove it worked and write
+// down what was touched. OpenWatch is a compliance product, so "what did the
+// installer change on this host" is a question its own buyers' auditors ask.
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ReceiptPath is where the record of an applied run lands.
+const ReceiptPath = "/var/lib/openwatch/setup-receipt.json"
+
+// Check is one preflight result.
+type Check struct {
+	Name string
+	OK   bool
+	// Fatal marks a failure that stops the run; a non-fatal failure is a
+	// warning the operator should see but can proceed past.
+	Fatal  bool
+	Detail string
+}
+
+// Preflight inspects the host before anything is planned. It never mutates.
+//
+// AllowUntested lets a recognised-but-unverified distro proceed: refusing
+// outright would block Rocky and Alma users running identical paths, while
+// claiming to support them would be a promise CI does not keep.
+func Preflight(ctx context.Context, p Plan, allowUntested bool) []Check {
+	var out []Check
+
+	root := os.Geteuid() == 0
+	rootCheck := Check{Name: "running as root", OK: root, Fatal: true}
+	if !root {
+		rootCheck.Detail = "setup installs packages, writes to /etc/openwatch, and manages " +
+			"systemd units. Re-run with sudo"
+	}
+	out = append(out, rootCheck)
+
+	switch p.Platform.Support {
+	case SupportTested:
+		out = append(out, Check{Name: "platform " + p.Platform.String(), OK: true, Detail: "tested"})
+	case SupportUntested:
+		out = append(out, Check{
+			Name: "platform " + p.Platform.String(), OK: allowUntested, Fatal: true,
+			Detail: "recognised but NOT covered by CI. Re-run with --allow-untested to proceed, " +
+				"and please report the result",
+		})
+	default:
+		out = append(out, Check{
+			Name: "platform " + p.Platform.String(), OK: false, Fatal: true,
+			Detail: "unsupported: setup does not know this distribution's PostgreSQL layout",
+		})
+	}
+
+	_, binErr := os.Stat(openwatchBin)
+	binCheck := Check{Name: "openwatch binary installed", OK: binErr == nil, Fatal: true}
+	if binErr != nil {
+		binCheck.Detail = openwatchBin + " not found. Install the package first: setup " +
+			"configures OpenWatch, it does not install it"
+	}
+	out = append(out, binCheck)
+
+	// A port held by openwatch itself is not a conflict: that is a re-run.
+	free := portFree(p.Service.ListenPort)
+	ours := serviceActive("openwatch")
+	portCheck := Check{
+		Name:  fmt.Sprintf("port %d available", p.Service.ListenPort),
+		OK:    free || ours,
+		Fatal: true,
+	}
+	switch {
+	case !portCheck.OK:
+		portCheck.Detail = "another process is listening; choose a different port with " +
+			"--listen-port, or stop it"
+	case ours && !free:
+		portCheck.Detail = "held by the running openwatch service (this is a re-run)"
+	}
+	out = append(out, portCheck)
+
+	// A fapolicyd host denies execution of anything absent from its trust
+	// database, which is built from the package database. A packaged install
+	// is fine; a hand-copied binary is not, and the failure looks like a
+	// permission error rather than a policy one.
+	if p.Platform.Fapolicyd {
+		out = append(out, Check{
+			Name: "fapolicyd is active", OK: true,
+			Detail: "packaged installs are trusted; a hand-copied binary would be denied",
+		})
+	}
+
+	// A FIPS host running a non-FIPS build defeats the point of the host.
+	if p.Platform.FIPS {
+		out = append(out, Check{
+			Name: "kernel FIPS mode enabled", OK: true,
+			Detail: "install the FIPS build (openwatch-fips) if this host has FIPS obligations; " +
+				"note md5 password authentication cannot work here, which is why setup " +
+				"always hashes scram-sha-256",
+		})
+	}
+
+	if p.Platform.SELinux == "enforcing" {
+		out = append(out, Check{Name: "SELinux enforcing", OK: true,
+			Detail: "the packaged install ships with the file contexts it needs"})
+	}
+	return out
+}
+
+// FatalFailures returns the checks that block the run.
+func FatalFailures(checks []Check) []Check {
+	var bad []Check
+	for _, c := range checks {
+		if !c.OK && c.Fatal {
+			bad = append(bad, c)
+		}
+	}
+	return bad
+}
+
+// PlannedStep pairs a step with its current status, so the rendered plan can
+// distinguish what will happen from what is already true.
+type PlannedStep struct {
+	Step   Step
+	Status StepStatus
+}
+
+// Resolve inspects every step without mutating, producing the plan to show.
+func Resolve(ctx context.Context, p Plan) []PlannedStep {
+	steps := Steps(p)
+	out := make([]PlannedStep, 0, len(steps))
+	for _, s := range steps {
+		out = append(out, PlannedStep{Step: s, Status: s.Status(ctx, p)})
+	}
+	return out
+}
+
+// RenderPlan writes the human-facing plan.
+func RenderPlan(w func(string, ...any), p Plan, checks []Check, planned []PlannedStep) {
+	w("OpenWatch setup — %s", p.Platform.String())
+	w("")
+	w("Preflight")
+	for _, c := range checks {
+		mark := "ok"
+		if !c.OK {
+			mark = "FAIL"
+			if !c.Fatal {
+				mark = "warn"
+			}
+		}
+		w("  [%-4s] %s", mark, c.Name)
+		if !c.OK || c.Detail != "" {
+			w("           %s", c.Detail)
+		}
+	}
+	w("")
+	w("Plan")
+	n := 0
+	for _, ps := range planned {
+		if ps.Status.Done {
+			w("  [skip] %s", ps.Status.Detail)
+			continue
+		}
+		n++
+		w("  %2d. %s", n, ps.Step.Describe(p))
+		if ps.Status.Detail != "" {
+			w("      (%s)", ps.Status.Detail)
+		}
+	}
+	if n == 0 {
+		w("  nothing to do; this host is already configured")
+	}
+	w("")
+	w("Database   %s@%s:%d/%s (sslmode=%s)",
+		p.Database.RoleName, p.Database.Host, p.Database.Port, p.Database.Name, p.Database.SSLMode)
+	w("Service    https://%s:%d/", p.Service.ListenHost, p.Service.ListenPort)
+	w("Admin      %s <%s>", p.Admin.Username, p.Admin.Email)
+	w("")
+}
+
+// Execute applies the steps that are not already satisfied.
+func Execute(ctx context.Context, r *Run, planned []PlannedStep) error {
+	for _, ps := range planned {
+		if ps.Status.Done {
+			r.logf("  [skip] %s", ps.Step.ID())
+			continue
+		}
+		r.logf("  [ run] %s", ps.Step.ID())
+		if err := ps.Step.Apply(ctx, r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Receipt is the record of an applied run. It holds no secrets: the resolved
+// plan records how each credential was obtained, never what it was.
+type Receipt struct {
+	AppliedAt string   `json:"applied_at"`
+	Version   string   `json:"openwatch_version"`
+	Platform  Platform `json:"platform"`
+	Plan      Plan     `json:"plan"`
+	Changes   []Change `json:"changes"`
+	URL       string   `json:"url"`
+}
+
+// WriteReceipt records what happened, for support and for audit.
+func WriteReceipt(r *Run, version string) (string, error) {
+	if r.DryRun {
+		return "", nil
+	}
+	rec := Receipt{
+		AppliedAt: time.Now().UTC().Format(time.RFC3339),
+		Version:   version,
+		Platform:  r.Plan.Platform,
+		Plan:      r.Plan,
+		Changes:   r.Changes,
+		URL:       fmt.Sprintf("https://%s:%d/", hostnameOr(r.Plan.Service.ListenHost), r.Plan.Service.ListenPort),
+	}
+	b, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(ReceiptPath), 0o750); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(ReceiptPath, append(b, '\n'), 0o640); err != nil {
+		return "", err
+	}
+	return ReceiptPath, nil
+}
+
+// RenderSummary prints what an operator needs after a successful run.
+func RenderSummary(w func(string, ...any), r *Run, receipt string) {
+	w("")
+	w("Done.")
+	w("")
+	w("  URL       https://%s:%d/", hostnameOr(r.Plan.Service.ListenHost), r.Plan.Service.ListenPort)
+	w("  Admin     %s <%s>", r.Plan.Admin.Username, r.Plan.Admin.Email)
+	w("  Database  %s@%s:%d/%s", r.Plan.Database.RoleName, r.Plan.Database.Host,
+		r.Plan.Database.Port, r.Plan.Database.Name)
+	if len(r.Changes) > 0 {
+		w("")
+		w("  Changed:")
+		for _, c := range r.Changes {
+			line := fmt.Sprintf("    %-10s %s %s", c.Step, c.Action, c.Target)
+			if c.Backup != "" {
+				line += fmt.Sprintf("  (backup: %s)", c.Backup)
+			}
+			w("%s", line)
+		}
+	}
+	if receipt != "" {
+		w("")
+		w("  Receipt: %s", receipt)
+	}
+}
+
+func hostnameOr(listen string) string {
+	if listen == "0.0.0.0" || listen == "::" || listen == "" {
+		if h, err := os.Hostname(); err == nil && h != "" {
+			return h
+		}
+		return "127.0.0.1"
+	}
+	return listen
+}
+
+func portFree(port int) bool {
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+// ResolveSecrets fills the run's credentials from their declared sources. It
+// is the only place a secret enters the process, and nothing here writes one
+// to the plan, the receipt, or the log.
+func ResolveSecrets(r *Run, prompt func(label string) (string, error)) error {
+	var err error
+	if r.DBPassword, err = resolveSecret("database password", r.Plan.Database.Password, prompt); err != nil {
+		return err
+	}
+	if r.AdminPassword, err = resolveSecret("admin password", r.Plan.Admin.Password, prompt); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveSecret(label string, s Secret, prompt func(string) (string, error)) (string, error) {
+	switch s.Source {
+	case SecretGenerate:
+		return generatePassword(s.Length)
+	case SecretPrompt:
+		if prompt == nil {
+			return "", fmt.Errorf("%s: source is prompt but this run is non-interactive; "+
+				"use source generate, env, or file", label)
+		}
+		return prompt(label)
+	case SecretEnv:
+		v, ok := os.LookupEnv(s.Ref)
+		if !ok || v == "" {
+			return "", fmt.Errorf("%s: environment variable %s is unset or empty", label, s.Ref)
+		}
+		return v, nil
+	case SecretFile:
+		b, err := os.ReadFile(s.Ref)
+		if err != nil {
+			return "", fmt.Errorf("%s: read %s: %w", label, s.Ref, err)
+		}
+		return strings.TrimRight(string(b), "\r\n"), nil
+	default:
+		return "", fmt.Errorf("%s: unknown source %q", label, s.Source)
+	}
+}

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -146,7 +146,7 @@ func Resolve(ctx context.Context, p Plan) []PlannedStep {
 
 // RenderPlan writes the human-facing plan.
 func RenderPlan(w func(string, ...any), p Plan, checks []Check, planned []PlannedStep) {
-	w("OpenWatch setup — %s", p.Platform.String())
+	w("OpenWatch setup: %s", p.Platform.String())
 	w("")
 	w("Preflight")
 	for _, c := range checks {

--- a/internal/setup/plan.go
+++ b/internal/setup/plan.go
@@ -1,0 +1,273 @@
+// The setup plan: one object, three ways to fill it.
+//
+// Express fills it from detection plus defaults, guided fills it by prompting
+// with those same values pre-filled, and unattended fills it from a file. All
+// three then run identical validation and identical steps. That is deliberate:
+// the alternative is a "quick install" path and a "real install" path that
+// drift, where the automated one is exercised least and breaks quietly.
+//
+// NO SECRETS ARE STORED HERE. Every credential is a source, never a value, so
+// a plan file is safe to commit, attach to a ticket, or send to support. It is
+// also what makes fleet replay work: run guided once, save the plan, apply it
+// unattended everywhere else.
+package setup
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// PlanAPIVersion is bumped when the schema changes incompatibly, so an old
+// saved plan is rejected with a version message rather than mis-parsed.
+const PlanAPIVersion = "openwatch.hanalyx.com/v1alpha1"
+
+// SecretSource says where a credential comes from at apply time.
+type SecretSource string
+
+const (
+	// SecretGenerate mints a random value. The default for the database role,
+	// because a generated password is built into the DSN by the same code that
+	// creates the role, so the two cannot disagree and the operator never has
+	// to think about URI encoding.
+	SecretGenerate SecretSource = "generate"
+	// SecretPrompt reads it interactively.
+	SecretPrompt SecretSource = "prompt"
+	// SecretEnv reads it from an environment variable named by SecretRef.
+	SecretEnv SecretSource = "env"
+	// SecretFile reads it from the file named by SecretRef.
+	SecretFile SecretSource = "file"
+)
+
+// Secret describes how to obtain a credential without recording it.
+type Secret struct {
+	Source SecretSource `yaml:"source"`
+	// Ref names the env var or file path for the env/file sources.
+	Ref string `yaml:"ref,omitempty"`
+	// Length is the generated length; ignored for other sources.
+	Length int `yaml:"length,omitempty"`
+}
+
+// DatabaseMode selects how much of PostgreSQL's lifecycle setup owns.
+type DatabaseMode string
+
+const (
+	// DBProvision installs PostgreSQL if absent, initialises the cluster,
+	// starts it, and creates the role and database.
+	DBProvision DatabaseMode = "provision"
+	// DBExisting connects to a PostgreSQL that already runs, creating only
+	// the role and database if they are missing.
+	DBExisting DatabaseMode = "existing"
+)
+
+// DatabasePlan is everything about reaching and owning the database.
+type DatabasePlan struct {
+	Mode     DatabaseMode `yaml:"mode"`
+	Host     string       `yaml:"host"`
+	Port     int          `yaml:"port"`
+	Name     string       `yaml:"name"`
+	RoleName string       `yaml:"role_name"`
+	Password Secret       `yaml:"password"`
+	// SSLMode is forced to at least "require" when Host is not loopback; a
+	// remote database over cleartext is not something to allow by accident.
+	SSLMode string `yaml:"sslmode"`
+	// ManagePgHba is opt-in. Editing pg_hba.conf is the single most effective
+	// way to lock an operator out of their own database, so the default is to
+	// print the required lines and re-check rather than to write them.
+	ManagePgHba bool `yaml:"manage_pg_hba"`
+}
+
+// ServicePlan covers the unit and how it listens.
+type ServicePlan struct {
+	ListenHost string `yaml:"listen_host"`
+	ListenPort int    `yaml:"listen_port"`
+	// BindCapability is DERIVED from ListenPort, never authored: a port below
+	// 1024 needs CAP_NET_BIND_SERVICE because the service runs unprivileged.
+	BindCapability bool `yaml:"bind_capability"`
+	EnableOnBoot   bool `yaml:"enable_on_boot"`
+	StartNow       bool `yaml:"start_now"`
+}
+
+// AdminPlan is the first login.
+type AdminPlan struct {
+	Username string `yaml:"username"`
+	Email    string `yaml:"email"`
+	Password Secret `yaml:"password"`
+}
+
+// Plan is the whole intent. Platform is detected rather than authored and is
+// re-detected on apply.
+type Plan struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Platform   Platform     `yaml:"platform"`
+	Database   DatabasePlan `yaml:"database"`
+	Service    ServicePlan  `yaml:"service"`
+	Admin      AdminPlan    `yaml:"admin"`
+	Migrate    bool         `yaml:"migrate"`
+}
+
+// DefaultPlan returns the plan a bare `openwatch setup` would apply on this
+// host. Guided mode renders these as pre-filled answers, so holding Enter and
+// running --yes produce the same result.
+func DefaultPlan(p Platform) Plan {
+	return Plan{
+		APIVersion: PlanAPIVersion,
+		Platform:   p,
+		Database: DatabasePlan{
+			Mode:     DBProvision,
+			Host:     "127.0.0.1",
+			Port:     5432,
+			Name:     "openwatch",
+			RoleName: "openwatch",
+			Password: Secret{Source: SecretGenerate, Length: 32},
+			SSLMode:  "disable",
+			// Opt-in by design; see DatabasePlan.ManagePgHba.
+			ManagePgHba: false,
+		},
+		Service: ServicePlan{
+			ListenHost:   "0.0.0.0",
+			ListenPort:   8443,
+			EnableOnBoot: true,
+			StartNow:     true,
+		},
+		Admin: AdminPlan{
+			Username: "admin",
+			Email:    "admin@example.com",
+			Password: Secret{Source: SecretPrompt},
+		},
+		Migrate: true,
+	}
+}
+
+// IsLoopback reports whether the database lives on this machine.
+func (d DatabasePlan) IsLoopback() bool {
+	return d.Host == "127.0.0.1" || d.Host == "::1" || d.Host == "localhost"
+}
+
+// Derive recomputes the fields that follow from other answers. Called after
+// every edit in guided mode so the operator sees a consequence at the moment
+// of the choice rather than when the service fails to start.
+func (p *Plan) Derive() {
+	p.APIVersion = PlanAPIVersion
+	p.Service.BindCapability = p.Service.ListenPort > 0 && p.Service.ListenPort < 1024
+	// A non-loopback database must not be reached in cleartext. Upgrading
+	// silently would be its own surprise, so Validate reports it; this only
+	// fixes the default nobody edited.
+	if !p.Database.IsLoopback() && p.Database.SSLMode == "disable" {
+		p.Database.SSLMode = "require"
+	}
+	if p.Database.Password.Source == SecretGenerate && p.Database.Password.Length <= 0 {
+		p.Database.Password.Length = 32
+	}
+}
+
+// DSN builds the connection string for a resolved password.
+//
+// The password is passed raw and encoded here, by net/url, which is the whole
+// point: a DSN is a URI, and a password containing '@' or '/' silently changes
+// what the URI means. Hand-assembling this string is how an install ends up
+// authenticating as something other than what the operator typed.
+func (d DatabasePlan) DSN(password string) string {
+	u := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(d.RoleName, password),
+		Host:   fmt.Sprintf("%s:%d", d.Host, d.Port),
+		Path:   "/" + d.Name,
+	}
+	q := u.Query()
+	q.Set("sslmode", d.SSLMode)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// Validate reports every problem at once, so an operator fixes one round of
+// answers instead of discovering them one prompt at a time.
+func (p Plan) Validate() []error {
+	var errs []error
+	if p.APIVersion != PlanAPIVersion {
+		errs = append(errs, fmt.Errorf("plan apiVersion is %q, this binary understands %q",
+			p.APIVersion, PlanAPIVersion))
+	}
+	switch p.Database.Mode {
+	case DBProvision, DBExisting:
+	default:
+		errs = append(errs, fmt.Errorf("database.mode is %q, want provision or existing", p.Database.Mode))
+	}
+	if p.Database.Mode == DBProvision && !p.Database.IsLoopback() {
+		errs = append(errs, fmt.Errorf(
+			"database.mode is provision but host is %q: setup only provisions a local "+
+				"PostgreSQL. Use mode existing for a remote server", p.Database.Host))
+	}
+	if p.Database.Port < 1 || p.Database.Port > 65535 {
+		errs = append(errs, fmt.Errorf("database.port %d is out of range", p.Database.Port))
+	}
+	if !validIdent(p.Database.Name) {
+		errs = append(errs, fmt.Errorf("database.name %q must be a plain identifier "+
+			"(letters, digits, underscore, not starting with a digit)", p.Database.Name))
+	}
+	if !validIdent(p.Database.RoleName) {
+		errs = append(errs, fmt.Errorf("database.role_name %q must be a plain identifier", p.Database.RoleName))
+	}
+	switch p.Database.SSLMode {
+	case "disable", "allow", "prefer", "require", "verify-ca", "verify-full":
+	default:
+		errs = append(errs, fmt.Errorf("database.sslmode %q is not a PostgreSQL sslmode", p.Database.SSLMode))
+	}
+	if !p.Database.IsLoopback() && p.Database.SSLMode == "disable" {
+		errs = append(errs, fmt.Errorf(
+			"database.sslmode is disable for remote host %q: credentials would cross "+
+				"the network in cleartext", p.Database.Host))
+	}
+	if p.Service.ListenPort < 1 || p.Service.ListenPort > 65535 {
+		errs = append(errs, fmt.Errorf("service.listen_port %d is out of range", p.Service.ListenPort))
+	}
+	if p.Admin.Username == "" {
+		errs = append(errs, fmt.Errorf("admin.username is empty"))
+	}
+	if !strings.Contains(p.Admin.Email, "@") {
+		errs = append(errs, fmt.Errorf("admin.email %q is not an address", p.Admin.Email))
+	}
+	errs = append(errs, validateSecret("database.password", p.Database.Password)...)
+	errs = append(errs, validateSecret("admin.password", p.Admin.Password)...)
+	return errs
+}
+
+func validateSecret(field string, s Secret) []error {
+	switch s.Source {
+	case SecretGenerate:
+		if s.Length > 0 && s.Length < 16 {
+			return []error{fmt.Errorf("%s.length %d is too short; use at least 16", field, s.Length)}
+		}
+	case SecretPrompt:
+	case SecretEnv, SecretFile:
+		if s.Ref == "" {
+			return []error{fmt.Errorf("%s.source is %q but ref is empty", field, s.Source)}
+		}
+	default:
+		return []error{fmt.Errorf("%s.source %q is not generate, prompt, env, or file", field, s.Source)}
+	}
+	return nil
+}
+
+// validIdent guards the identifiers that reach SQL. Role and database names
+// are interpolated into CREATE statements, which cannot be parameterised, so
+// they are restricted to a character set that needs no quoting rather than
+// escaped. Rejecting the input is safer than trusting an escape.
+func validIdent(s string) bool {
+	if s == "" || len(s) > 63 {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r == '_':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/setup/plan.go
+++ b/internal/setup/plan.go
@@ -86,6 +86,11 @@ type ServicePlan struct {
 	BindCapability bool `yaml:"bind_capability"`
 	EnableOnBoot   bool `yaml:"enable_on_boot"`
 	StartNow       bool `yaml:"start_now"`
+	// OpenFirewall allows inbound traffic to ListenPort. Default true: the
+	// health check runs over loopback, where the firewall does not apply, so
+	// without this an install can report itself healthy while being
+	// unreachable from every other machine.
+	OpenFirewall bool `yaml:"open_firewall"`
 }
 
 // AdminPlan is the first login.
@@ -129,6 +134,7 @@ func DefaultPlan(p Platform) Plan {
 			ListenPort:   8443,
 			EnableOnBoot: true,
 			StartNow:     true,
+			OpenFirewall: true,
 		},
 		Admin: AdminPlan{
 			Username: "admin",

--- a/internal/setup/plan_test.go
+++ b/internal/setup/plan_test.go
@@ -1,0 +1,163 @@
+package setup
+
+import (
+	"net/url"
+	"testing"
+)
+
+// The guarantee the whole design rests on: the operator types a raw password
+// and never thinks about URI encoding, because the DSN is assembled by code
+// that encodes correctly.
+//
+// This is not hypothetical. A v0.7.0 install failed exactly here: the guide had
+// the operator paste a password containing '@' straight into a DSN template,
+// net/url split the URI at the wrong '@', and the resulting authentication
+// failure named the database role. Nothing pointed at the connection string.
+func TestDSN_PasswordRoundTripsWhateverItContains(t *testing.T) {
+	d := DatabasePlan{
+		Host: "127.0.0.1", Port: 5432, Name: "openwatch",
+		RoleName: "openwatch", SSLMode: "disable",
+	}
+	passwords := []string{
+		"WindoW2005@@", // the real one, two trailing at-signs
+		"p@ss@word",
+		"a/b?c#d",
+		"colon:pass",
+		"percent%40literal", // must NOT be double-decoded
+		"[brackets]",
+		"sp ace",
+		"simple",
+	}
+	for _, pw := range passwords {
+		dsn := d.DSN(pw)
+		u, err := url.Parse(dsn)
+		if err != nil {
+			t.Errorf("password %q produced an unparseable DSN: %v", pw, err)
+			continue
+		}
+		got, set := u.User.Password()
+		if !set || got != pw {
+			t.Errorf("password %q round-tripped as %q; the DSN does not carry the "+
+				"password the operator supplied", pw, got)
+		}
+		if u.Host != "127.0.0.1:5432" {
+			t.Errorf("password %q corrupted the host: got %q, want 127.0.0.1:5432; "+
+				"an unencoded character moved the URI boundary", pw, u.Host)
+		}
+		if u.User.Username() != "openwatch" {
+			t.Errorf("password %q corrupted the username: got %q", pw, u.User.Username())
+		}
+	}
+}
+
+func TestPlan_DeriveComputesDependentFields(t *testing.T) {
+	t.Run("privileged port needs the bind capability", func(t *testing.T) {
+		p := DefaultPlan(Platform{})
+		p.Service.ListenPort = 443
+		p.Derive()
+		if !p.Service.BindCapability {
+			t.Error("port 443 must derive bind_capability=true; the service runs " +
+				"unprivileged and cannot otherwise bind below 1024")
+		}
+		p.Service.ListenPort = 8443
+		p.Derive()
+		if p.Service.BindCapability {
+			t.Error("port 8443 must not request CAP_NET_BIND_SERVICE")
+		}
+	})
+
+	t.Run("remote database is not left in cleartext", func(t *testing.T) {
+		p := DefaultPlan(Platform{})
+		p.Database.Host = "db.internal"
+		p.Derive()
+		if p.Database.SSLMode == "disable" {
+			t.Error("a non-loopback host must not keep sslmode=disable; credentials " +
+				"would cross the network in cleartext")
+		}
+	})
+}
+
+func TestPlan_ValidateRejectsUnsafeCombinations(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(*Plan)
+		want string
+	}{
+		{"provision a remote host", func(p *Plan) {
+			p.Database.Mode = DBProvision
+			p.Database.Host = "db.internal"
+		}, "only provisions a local"},
+		{"remote cleartext", func(p *Plan) {
+			p.Database.Mode = DBExisting
+			p.Database.Host = "db.internal"
+			p.Database.SSLMode = "disable"
+		}, "cleartext"},
+		{"sql-unsafe database name", func(p *Plan) {
+			p.Database.Name = "open;DROP TABLE users--"
+		}, "plain identifier"},
+		{"sql-unsafe role name", func(p *Plan) {
+			p.Database.RoleName = `open"watch`
+		}, "plain identifier"},
+		{"identifier starting with a digit", func(p *Plan) {
+			p.Database.Name = "9lives"
+		}, "plain identifier"},
+		{"port out of range", func(p *Plan) { p.Service.ListenPort = 70000 }, "out of range"},
+		{"bad sslmode", func(p *Plan) { p.Database.SSLMode = "sorta" }, "sslmode"},
+		{"email without @", func(p *Plan) { p.Admin.Email = "nobody" }, "not an address"},
+		{"env secret with no ref", func(p *Plan) {
+			p.Admin.Password = Secret{Source: SecretEnv}
+		}, "ref is empty"},
+		{"generated secret too short", func(p *Plan) {
+			p.Database.Password = Secret{Source: SecretGenerate, Length: 4}
+		}, "too short"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := DefaultPlan(Platform{})
+			c.edit(&p)
+			// Deliberately NOT calling Derive: Derive fixes defaults nobody
+			// edited, and Validate must still catch a value someone set.
+			errs := p.Validate()
+			if len(errs) == 0 {
+				t.Fatalf("expected a validation error mentioning %q, got none", c.want)
+			}
+			found := false
+			for _, e := range errs {
+				if contains(e.Error(), c.want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("no error mentioned %q; got %v", c.want, errs)
+			}
+		})
+	}
+}
+
+func TestPlan_DefaultIsValid(t *testing.T) {
+	p := DefaultPlan(Platform{ID: "rhel", VersionID: "9.8", Major: 9, Family: FamilyRHEL, Support: SupportTested})
+	p.Derive()
+	if errs := p.Validate(); len(errs) != 0 {
+		t.Errorf("the default plan must validate; got %v", errs)
+	}
+	// The default must not edit pg_hba.conf. Editing it by hand is what locked
+	// an operator out of local postgres access during a v0.7.0 install, so the
+	// destructive option is opt-in.
+	if p.Database.ManagePgHba {
+		t.Error("manage_pg_hba must default to false")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || len(haystack) >= len(needle) &&
+		(haystack == needle || indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(h, n string) int {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/setup/plan_test.go
+++ b/internal/setup/plan_test.go
@@ -1,3 +1,8 @@
+// @spec system-setup
+//
+//	AC-01  TestDSN_PasswordRoundTripsWhateverItContains
+//	AC-02  TestPlan_DeriveComputesDependentFields
+//	AC-03  TestPlan_ValidateRejectsUnsafeCombinations, TestPlan_DefaultIsValid
 package setup
 
 import (
@@ -13,45 +18,49 @@ import (
 // the operator paste a password containing '@' straight into a DSN template,
 // net/url split the URI at the wrong '@', and the resulting authentication
 // failure named the database role. Nothing pointed at the connection string.
+// @ac AC-01
 func TestDSN_PasswordRoundTripsWhateverItContains(t *testing.T) {
-	d := DatabasePlan{
-		Host: "127.0.0.1", Port: 5432, Name: "openwatch",
-		RoleName: "openwatch", SSLMode: "disable",
-	}
-	passwords := []string{
-		"WindoW2005@@", // the real one, two trailing at-signs
-		"p@ss@word",
-		"a/b?c#d",
-		"colon:pass",
-		"percent%40literal", // must NOT be double-decoded
-		"[brackets]",
-		"sp ace",
-		"simple",
-	}
-	for _, pw := range passwords {
-		dsn := d.DSN(pw)
-		u, err := url.Parse(dsn)
-		if err != nil {
-			t.Errorf("password %q produced an unparseable DSN: %v", pw, err)
-			continue
+	t.Run("system-setup/AC-01", func(t *testing.T) {
+		d := DatabasePlan{
+			Host: "127.0.0.1", Port: 5432, Name: "openwatch",
+			RoleName: "openwatch", SSLMode: "disable",
 		}
-		got, set := u.User.Password()
-		if !set || got != pw {
-			t.Errorf("password %q round-tripped as %q; the DSN does not carry the "+
-				"password the operator supplied", pw, got)
+		passwords := []string{
+			"WindoW2005@@", // the real one, two trailing at-signs
+			"p@ss@word",
+			"a/b?c#d",
+			"colon:pass",
+			"percent%40literal", // must NOT be double-decoded
+			"[brackets]",
+			"sp ace",
+			"simple",
 		}
-		if u.Host != "127.0.0.1:5432" {
-			t.Errorf("password %q corrupted the host: got %q, want 127.0.0.1:5432; "+
-				"an unencoded character moved the URI boundary", pw, u.Host)
+		for _, pw := range passwords {
+			dsn := d.DSN(pw)
+			u, err := url.Parse(dsn)
+			if err != nil {
+				t.Errorf("password %q produced an unparseable DSN: %v", pw, err)
+				continue
+			}
+			got, set := u.User.Password()
+			if !set || got != pw {
+				t.Errorf("password %q round-tripped as %q; the DSN does not carry the "+
+					"password the operator supplied", pw, got)
+			}
+			if u.Host != "127.0.0.1:5432" {
+				t.Errorf("password %q corrupted the host: got %q, want 127.0.0.1:5432; "+
+					"an unencoded character moved the URI boundary", pw, u.Host)
+			}
+			if u.User.Username() != "openwatch" {
+				t.Errorf("password %q corrupted the username: got %q", pw, u.User.Username())
+			}
 		}
-		if u.User.Username() != "openwatch" {
-			t.Errorf("password %q corrupted the username: got %q", pw, u.User.Username())
-		}
-	}
+	})
 }
 
+// @ac AC-02
 func TestPlan_DeriveComputesDependentFields(t *testing.T) {
-	t.Run("privileged port needs the bind capability", func(t *testing.T) {
+	t.Run("system-setup/AC-02", func(t *testing.T) {
 		p := DefaultPlan(Platform{})
 		p.Service.ListenPort = 443
 		p.Derive()
@@ -66,7 +75,7 @@ func TestPlan_DeriveComputesDependentFields(t *testing.T) {
 		}
 	})
 
-	t.Run("remote database is not left in cleartext", func(t *testing.T) {
+	t.Run("system-setup/AC-02/remote database is not left in cleartext", func(t *testing.T) {
 		p := DefaultPlan(Platform{})
 		p.Database.Host = "db.internal"
 		p.Derive()
@@ -77,6 +86,7 @@ func TestPlan_DeriveComputesDependentFields(t *testing.T) {
 	})
 }
 
+// @ac AC-03
 func TestPlan_ValidateRejectsUnsafeCombinations(t *testing.T) {
 	cases := []struct {
 		name string
@@ -112,7 +122,7 @@ func TestPlan_ValidateRejectsUnsafeCombinations(t *testing.T) {
 		}, "too short"},
 	}
 	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+		t.Run("system-setup/AC-03/"+c.name, func(t *testing.T) {
 			p := DefaultPlan(Platform{})
 			c.edit(&p)
 			// Deliberately NOT calling Derive: Derive fixes defaults nobody
@@ -134,18 +144,21 @@ func TestPlan_ValidateRejectsUnsafeCombinations(t *testing.T) {
 	}
 }
 
+// @ac AC-03
 func TestPlan_DefaultIsValid(t *testing.T) {
-	p := DefaultPlan(Platform{ID: "rhel", VersionID: "9.8", Major: 9, Family: FamilyRHEL, Support: SupportTested})
-	p.Derive()
-	if errs := p.Validate(); len(errs) != 0 {
-		t.Errorf("the default plan must validate; got %v", errs)
-	}
-	// The default must not edit pg_hba.conf. Editing it by hand is what locked
-	// an operator out of local postgres access during a v0.7.0 install, so the
-	// destructive option is opt-in.
-	if p.Database.ManagePgHba {
-		t.Error("manage_pg_hba must default to false")
-	}
+	t.Run("system-setup/AC-03", func(t *testing.T) {
+		p := DefaultPlan(Platform{ID: "rhel", VersionID: "9.8", Major: 9, Family: FamilyRHEL, Support: SupportTested})
+		p.Derive()
+		if errs := p.Validate(); len(errs) != 0 {
+			t.Errorf("the default plan must validate; got %v", errs)
+		}
+		// The default must not edit pg_hba.conf. Editing it by hand is what locked
+		// an operator out of local postgres access during a v0.7.0 install, so the
+		// destructive option is opt-in.
+		if p.Database.ManagePgHba {
+			t.Error("manage_pg_hba must default to false")
+		}
+	})
 }
 
 func contains(haystack, needle string) bool {

--- a/internal/setup/platform.go
+++ b/internal/setup/platform.go
@@ -1,0 +1,211 @@
+// Platform detection for `openwatch setup`.
+//
+// WHY THIS EXISTS: setup writes to pg_hba.conf, installs packages, and enables
+// services. Every one of those is distro-specific, and guessing wrong means
+// writing to a path that belongs to something else. So the platform is
+// detected once, carries a support tier, and gates the run: a distro CI does
+// not cover is refused by default rather than approximated.
+//
+// The tier is deliberately three-valued. Claiming a support matrix that CI
+// does not exercise is how documentation starts lying; refusing everything
+// unrecognised would block the Rocky and Alma users who are, in practice,
+// running the same paths as RHEL. "untested" says both things honestly: it
+// runs with --allow-untested and reports itself in the receipt.
+package setup
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// Support states how much confidence the project has in a platform.
+type Support string
+
+const (
+	// SupportTested means CI exercises this platform. v0.7.0: RHEL 9 only.
+	SupportTested Support = "tested"
+	// SupportUntested means the family is recognised and the paths are
+	// believed correct, but nothing proves it. Requires --allow-untested.
+	SupportUntested Support = "untested"
+	// SupportUnsupported means setup will not run: unknown family, or a
+	// version whose layout differs in ways this code does not model.
+	SupportUnsupported Support = "unsupported"
+)
+
+// Family groups distributions that share package manager and file layout.
+type Family string
+
+const (
+	FamilyRHEL    Family = "rhel"
+	FamilyDebian  Family = "debian"
+	FamilyUnknown Family = "unknown"
+)
+
+// Platform is the detected host. Every field is measured, never authored: a
+// saved plan replayed on another machine re-detects and compares, so a plan
+// captured on RHEL cannot be silently applied to Ubuntu.
+type Platform struct {
+	// ID is the os-release ID, e.g. "rhel", "rocky", "almalinux", "ubuntu".
+	ID string `yaml:"id"`
+	// VersionID is the os-release VERSION_ID, e.g. "9.8".
+	VersionID string `yaml:"version_id"`
+	// Major is VersionID's leading integer, e.g. 9. Zero when unparseable.
+	Major int `yaml:"major"`
+	// Family determines package manager and PostgreSQL layout.
+	Family Family `yaml:"family"`
+	// Arch is the Go architecture, e.g. "amd64".
+	Arch string `yaml:"arch"`
+	// Support gates the run.
+	Support Support `yaml:"support"`
+	// SELinux is "enforcing", "permissive", "disabled", or "" when absent.
+	SELinux string `yaml:"selinux,omitempty"`
+	// FIPS reports the kernel-level FIPS switch (/proc/sys/crypto/fips_enabled).
+	FIPS bool `yaml:"fips"`
+	// Fapolicyd reports whether the file-access policy daemon is active. It
+	// blocks execution of anything absent from its trust database, which is
+	// derived from the package database, so a non-packaged install is denied.
+	Fapolicyd bool `yaml:"fapolicyd"`
+}
+
+// String renders the platform for a plan header.
+func (p Platform) String() string {
+	return fmt.Sprintf("%s %s (%s)", p.ID, p.VersionID, p.Arch)
+}
+
+// DetectPlatform reads the host's identity. It never fails: an unrecognised
+// host is returned with Support unsupported so the caller reports it rather
+// than a detection error the operator cannot act on.
+func DetectPlatform() Platform {
+	p := Platform{
+		Arch:      runtime.GOARCH,
+		Family:    FamilyUnknown,
+		Support:   SupportUnsupported,
+		SELinux:   detectSELinux(),
+		FIPS:      detectKernelFIPS(),
+		Fapolicyd: serviceActive("fapolicyd"),
+	}
+	osRelease := readOSRelease("/etc/os-release")
+	p.ID = osRelease["ID"]
+	p.VersionID = osRelease["VERSION_ID"]
+	p.Major = majorOf(p.VersionID)
+	p.Family = familyOf(p.ID, osRelease["ID_LIKE"])
+	p.Support = supportOf(p.ID, p.Major, p.Family)
+	return p
+}
+
+// familyOf maps a distribution to its layout family, consulting ID_LIKE so a
+// derivative that names its parent is placed correctly without this list
+// needing to know every rebuild.
+func familyOf(id, idLike string) Family {
+	known := map[string]Family{
+		"rhel": FamilyRHEL, "centos": FamilyRHEL, "rocky": FamilyRHEL,
+		"almalinux": FamilyRHEL, "ol": FamilyRHEL, "oracle": FamilyRHEL,
+		"fedora": FamilyRHEL,
+		"debian": FamilyDebian, "ubuntu": FamilyDebian,
+	}
+	if f, ok := known[id]; ok {
+		return f
+	}
+	for _, like := range strings.Fields(idLike) {
+		if f, ok := known[like]; ok {
+			return f
+		}
+	}
+	return FamilyUnknown
+}
+
+// supportOf assigns the confidence tier.
+//
+// v0.7.0 ships with RHEL 9 tested and nothing else. The RHEL-family rebuilds
+// at the same major are untested rather than unsupported because they share
+// the paths this code uses; Debian-family is untested because the PostgreSQL
+// layout genuinely differs (versioned clusters) and has not been exercised.
+func supportOf(id string, major int, family Family) Support {
+	if family == FamilyUnknown || major == 0 {
+		return SupportUnsupported
+	}
+	if id == "rhel" && major == 9 {
+		return SupportTested
+	}
+	switch family {
+	case FamilyRHEL:
+		if major >= 8 && major <= 10 {
+			return SupportUntested
+		}
+	case FamilyDebian:
+		return SupportUntested
+	}
+	return SupportUnsupported
+}
+
+// readOSRelease parses the shell-fragment format of os-release. Values may be
+// quoted; unquoting is done here so callers compare bare strings.
+func readOSRelease(path string) map[string]string {
+	out := map[string]string{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		out[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+	return out
+}
+
+// majorOf extracts the leading integer of a version string ("9.8" -> 9).
+func majorOf(version string) int {
+	major, _, _ := strings.Cut(version, ".")
+	n := 0
+	for _, r := range major {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	if major == "" {
+		return 0
+	}
+	return n
+}
+
+// detectSELinux reports the current mode, or "" where SELinux is absent.
+func detectSELinux() string {
+	out, err := exec.Command("getenforce").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(string(out)))
+}
+
+// detectKernelFIPS reads the kernel FIPS switch. This is the system-wide
+// setting, entirely separate from whether this binary was built with the Go
+// FIPS module; a FIPS host running a non-FIPS binary is a real and dangerous
+// combination, so setup reports both.
+func detectKernelFIPS() bool {
+	b, err := os.ReadFile("/proc/sys/crypto/fips_enabled")
+	return err == nil && strings.TrimSpace(string(b)) == "1"
+}
+
+// serviceActive reports whether a systemd unit is active, treating any error
+// as inactive: absence of systemctl means absence of the service.
+func serviceActive(unit string) bool {
+	out, err := exec.Command("systemctl", "is-active", unit).Output()
+	if err != nil && len(out) == 0 {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "active"
+}

--- a/internal/setup/run.go
+++ b/internal/setup/run.go
@@ -96,6 +96,13 @@ func (r *Run) mutate(ctx context.Context, step, what string, name string, args .
 
 // psql runs SQL as the PostgreSQL superuser over the local socket.
 //
+// runuser rather than sudo. setup already runs as root, so there is no
+// privilege to acquire, and sudo drags in a PAM stack that is not guaranteed
+// to be configured: on minimal AlmaLinux and Oracle Linux images `sudo -u
+// postgres` fails with "PAM account management error: Authentication service
+// cannot retrieve authentication info" while runuser works. It also removes a
+// dependency on sudo being installed at all.
+//
 // Deliberately invoked from a directory the postgres user can read: running it
 // from root's home produces "could not change directory to /root: Permission
 // denied" on every call, which is harmless but reads as a failure and has sent
@@ -103,7 +110,27 @@ func (r *Run) mutate(ctx context.Context, step, what string, name string, args .
 func psql(ctx context.Context, sql string) cmdResult {
 	cctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	cmd := exec.CommandContext(cctx, "sudo", "-u", "postgres", "psql", "-tAqc", sql)
+	cmd := exec.CommandContext(cctx, "runuser", "-u", "postgres", "--", "psql", "-tAqc", sql)
+	cmd.Dir = "/tmp"
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return cmdResult{Stdout: strings.TrimSpace(stdout.String()), Stderr: strings.TrimSpace(stderr.String()), Err: err}
+}
+
+// psqlIn runs SQL against a NAMED database as the superuser.
+//
+// psql without -d connects to the "postgres" maintenance database. The cluster
+// objects (roles, databases, settings) live there, but the application's own
+// tables do not, so an idempotence check for a row in the openwatch database
+// has to say so. Getting this wrong is silent: the query errors with "relation
+// does not exist", the step reads that as not-yet-done, and re-running the
+// installer tries to create something that is already there.
+func psqlIn(ctx context.Context, database, sql string) cmdResult {
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "runuser", "-u", "postgres", "--", "psql", "-d", database, "-tAqc", sql)
 	cmd.Dir = "/tmp"
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout

--- a/internal/setup/run.go
+++ b/internal/setup/run.go
@@ -1,0 +1,207 @@
+// Execution context and command helpers for `openwatch setup`.
+//
+// Every mutation the installer makes goes through Run, so that three things
+// are true without each step remembering to do them: the command is recorded
+// for the receipt, --dry-run performs no writes, and a step that has already
+// been applied is skipped rather than repeated.
+//
+// Idempotence is not a nicety here. The most common moment to run setup is
+// after a previous attempt failed part-way, which is exactly when a
+// fresh-machine-only installer is useless.
+package setup
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Change records one mutation for the receipt, so an operator (or an auditor)
+// can answer "what did this touch" without reconstructing it from logs.
+type Change struct {
+	Step   string `json:"step"`
+	Action string `json:"action"`
+	Target string `json:"target,omitempty"`
+	Backup string `json:"backup,omitempty"`
+}
+
+// Run carries everything a step needs and everything it produces.
+type Run struct {
+	Plan Plan
+	// DryRun performs detection and planning but no writes.
+	DryRun bool
+	// Secrets resolved at apply time. Never serialised anywhere.
+	DBPassword    string
+	AdminPassword string
+
+	// Changes accumulates what actually happened.
+	Changes []Change
+	// Out receives progress lines.
+	Out func(format string, args ...any)
+}
+
+func (r *Run) logf(format string, args ...any) {
+	if r.Out != nil {
+		r.Out(format, args...)
+	}
+}
+
+func (r *Run) record(step, action, target, backup string) {
+	r.Changes = append(r.Changes, Change{Step: step, Action: action, Target: target, Backup: backup})
+}
+
+// cmdResult is the outcome of one external command.
+type cmdResult struct {
+	Stdout string
+	Stderr string
+	Err    error
+}
+
+// run executes a command, capturing both streams. It does NOT respect DryRun:
+// callers use it for detection (which must run in dry-run) and use mutate()
+// for changes.
+func run(ctx context.Context, name string, args ...string) cmdResult {
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, name, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return cmdResult{Stdout: strings.TrimSpace(stdout.String()), Stderr: strings.TrimSpace(stderr.String()), Err: err}
+}
+
+// mutate runs a state-changing command, or reports what it would run when
+// DryRun is set. Every write in the installer goes through here.
+func (r *Run) mutate(ctx context.Context, step, what string, name string, args ...string) error {
+	if r.DryRun {
+		r.logf("    would run: %s %s", name, strings.Join(args, " "))
+		return nil
+	}
+	res := run(ctx, name, args...)
+	if res.Err != nil {
+		detail := res.Stderr
+		if detail == "" {
+			detail = res.Stdout
+		}
+		return fmt.Errorf("%s: %s failed: %v: %s", step, what, res.Err, firstLine(detail))
+	}
+	return nil
+}
+
+// psql runs SQL as the PostgreSQL superuser over the local socket.
+//
+// Deliberately invoked from a directory the postgres user can read: running it
+// from root's home produces "could not change directory to /root: Permission
+// denied" on every call, which is harmless but reads as a failure and has sent
+// more than one operator down the wrong path.
+func psql(ctx context.Context, sql string) cmdResult {
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "sudo", "-u", "postgres", "psql", "-tAqc", sql)
+	cmd.Dir = "/tmp"
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return cmdResult{Stdout: strings.TrimSpace(stdout.String()), Stderr: strings.TrimSpace(stderr.String()), Err: err}
+}
+
+// psqlMutate runs superuser SQL honouring DryRun.
+func (r *Run) psqlMutate(ctx context.Context, step, what, sql string) error {
+	if r.DryRun {
+		r.logf("    would run SQL: %s", firstLine(sql))
+		return nil
+	}
+	if res := psql(ctx, sql); res.Err != nil {
+		detail := res.Stderr
+		if detail == "" {
+			detail = res.Stdout
+		}
+		return fmt.Errorf("%s: %s failed: %s", step, what, firstLine(detail))
+	}
+	return nil
+}
+
+// writeFile writes a file with an explicit mode, honouring DryRun, backing up
+// any existing content first so a mistake is recoverable.
+func (r *Run) writeFile(step, path string, content []byte, mode os.FileMode) error {
+	if r.DryRun {
+		r.logf("    would write %s (mode %#o, %d bytes)", path, mode, len(content))
+		return nil
+	}
+	backup := ""
+	if existing, err := os.ReadFile(path); err == nil {
+		backup = fmt.Sprintf("%s.bak-%s", path, timestamp())
+		if err := os.WriteFile(backup, existing, 0o600); err != nil {
+			return fmt.Errorf("%s: back up %s: %w", step, path, err)
+		}
+	}
+	if err := os.WriteFile(path, content, mode); err != nil {
+		return fmt.Errorf("%s: write %s: %w", step, path, err)
+	}
+	// WriteFile does not apply the mode to an existing file.
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("%s: chmod %s: %w", step, path, err)
+	}
+	r.record(step, "write", path, backup)
+	return nil
+}
+
+// generatePassword returns a random password from an alphabet chosen to avoid
+// shell and URI trouble entirely.
+//
+// The DSN builder encodes correctly regardless (see DatabasePlan.DSN), so this
+// is belt and braces: a generated password also ends up in systemd's
+// EnvironmentFile, gets pasted into terminals by operators debugging, and
+// appears in support tickets. Excluding quotes, backslashes and the URI
+// reserved set removes a class of confusion that is not worth the entropy.
+func generatePassword(n int) (string, error) {
+	if n <= 0 {
+		n = 32
+	}
+	const alphabet = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789-_."
+	b := make([]byte, n)
+	for i := range b {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphabet))))
+		if err != nil {
+			return "", fmt.Errorf("generate password: %w", err)
+		}
+		b[i] = alphabet[idx.Int64()]
+	}
+	return string(b), nil
+}
+
+func timestamp() string {
+	return time.Now().UTC().Format("20060102T150405Z")
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
+// sqlLiteral quotes a string for inclusion in SQL, doubling embedded quotes.
+// Used only for passwords: identifiers are restricted by validIdent instead,
+// because rejecting a hostile identifier is safer than escaping one.
+func sqlLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// sleep waits, but returns early if the context is cancelled so a Ctrl-C
+// during the verify poll is responsive.
+func sleep(ctx context.Context, seconds int) {
+	t := time.NewTimer(time.Duration(seconds) * time.Second)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -14,7 +14,7 @@
 //	AC-10  TestSetup_ContainerVerificationIsRecorded
 //	AC-11  TestSetup_LiveVerificationIsRecorded
 //	AC-12  TestSetup_RoleSQLForcesScram
-//	AC-13  TestSetup_NoCredentialInPlanOrReceipt
+//	AC-13  TestSetup_NoCredentialInPlanOrReceipt + TestSetup_ArtifactFileModes
 package setup
 
 import (
@@ -396,6 +396,44 @@ func TestSetup_NoCredentialInPlanOrReceipt(t *testing.T) {
 			if strings.Contains(decl, field) {
 				t.Errorf("Secret declares %q; it must record the source, never the value", field)
 			}
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13 (companion): the modes those two artifacts are written with.
+//
+// Content and permission are the same question asked twice: who can read what
+// the run left behind. The values below were a lint finding before they were a
+// requirement, which is precisely why they are pinned here.
+func TestSetup_ArtifactFileModes(t *testing.T) {
+	t.Run("system-setup/AC-13", func(t *testing.T) {
+		// Root-only. Neither file has a reader that is not root, and setup
+		// writes them as root into paths the operator chooses, so anything
+		// wider is a default nobody asked for.
+		for _, c := range []struct{ file, call string }{
+			{"execute.go", "os.WriteFile(ReceiptPath, append(b, '\\n'), 0o600)"},
+			{"../../cmd/openwatch/setup.go", "os.WriteFile(*savePlan, append([]byte(header), b...), 0o600)"},
+		} {
+			body, err := os.ReadFile(c.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(body), c.call) {
+				t.Errorf("%s no longer writes its artifact 0600; the call this pins is %q",
+					c.file, c.call)
+			}
+		}
+		// secrets.env is the exception, and it is one on purpose: the service
+		// reads the DSN as the openwatch group. Pinned so that a later sweep
+		// toward 0600 everywhere cannot break the service silently.
+		steps, err := os.ReadFile("steps.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(steps), `r.writeFile(s.ID(), secretsEnvPath, []byte(content), 0o640)`) {
+			t.Error("secrets.env is no longer written 0640; the service user must be able " +
+				"to read the DSN, and the file is chowned root:openwatch for that reason")
 		}
 	})
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -13,9 +13,12 @@
 //	AC-09  TestSetup_PgHbaPausesWhenUnmanaged
 //	AC-10  TestSetup_ContainerVerificationIsRecorded
 //	AC-11  TestSetup_LiveVerificationIsRecorded
+//	AC-12  TestSetup_RoleSQLForcesScram
+//	AC-13  TestSetup_NoCredentialInPlanOrReceipt
 package setup
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -300,6 +303,99 @@ func TestSetup_LiveVerificationIsRecorded(t *testing.T) {
 		// something an operator can open. "i" was the kernel hostname there.
 		if got := hostnameOr("0.0.0.0"); got == "" || got == "0.0.0.0" {
 			t.Errorf("hostnameOr(0.0.0.0) = %q, want a usable address", got)
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: the role is hashed scram-sha-256 whatever the server default is.
+//
+// PostgreSQL 13 defaults password_encryption to md5 and RHEL 9 still ships 13,
+// so a role created without the SET cannot authenticate against the
+// scram-sha-256 pg_hba rules this same installer writes. The failure surfaces
+// two steps later as "password authentication failed", which reads as a wrong
+// password rather than a wrong hash.
+func TestSetup_RoleSQLForcesScram(t *testing.T) {
+	t.Run("system-setup/AC-12", func(t *testing.T) {
+		// Both verbs matter: ALTER is the path taken for a role found already
+		// hashed md5, which is exactly the role that must be re-hashed.
+		for _, verb := range []string{"CREATE ROLE", "ALTER ROLE"} {
+			sql := roleSQL(verb, "openwatch", "pw")
+			if !strings.HasPrefix(sql, "SET password_encryption = 'scram-sha-256';") {
+				t.Errorf("%s: %q does not set password_encryption first", verb, sql)
+			}
+			// One statement, one session. Splitting them lets the SET land in a
+			// session that no longer exists when the role is created.
+			if strings.Contains(sql, "\n") || !strings.Contains(sql, "; "+verb+" ") {
+				t.Errorf("%s: the SET and the role mutation must share one session: %q", verb, sql)
+			}
+		}
+		// The password is a quoted literal, not an identifier: passwords are the
+		// one input that cannot be restricted to plain identifiers.
+		if got := roleSQL("CREATE ROLE", "openwatch", "it's"); !strings.HasSuffix(got, `'it''s'`) {
+			t.Errorf("password literal is not quote-doubled: %q", got)
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: no credential value reaches the plan or the receipt.
+//
+// This is what makes a plan safe to commit or attach to a ticket and a receipt
+// safe to hand to support. Secret describes where a credential comes from; the
+// resolved value lives on Run and is never copied into either structure.
+func TestSetup_NoCredentialInPlanOrReceipt(t *testing.T) {
+	t.Run("system-setup/AC-13", func(t *testing.T) {
+		const dbPw = "db-secret-Ic4WdA"
+		const adminPw = "admin-secret-Zq7Lme"
+
+		r := &Run{
+			Plan:          DefaultPlan(Platform{ID: "rhel", Major: 9, Family: FamilyRHEL}),
+			DBPassword:    dbPw,
+			AdminPassword: adminPw,
+		}
+		r.record("database-role", "create role", "openwatch", "")
+		r.record("secrets-env", "write", secretsEnvPath, "")
+
+		planJSON, err := json.Marshal(r.Plan)
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiptJSON, err := json.Marshal(newReceipt(r, "0.7.0"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range []struct{ what, body string }{
+			{"plan", string(planJSON)},
+			{"receipt", string(receiptJSON)},
+		} {
+			for _, credential := range []string{dbPw, adminPw} {
+				if strings.Contains(c.body, credential) {
+					t.Errorf("the %s carries a credential value (see C-02)", c.what)
+				}
+			}
+		}
+
+		// The structural half: Secret has no field able to hold a value, so a
+		// future field cannot reintroduce the leak without failing here.
+		b, err := os.ReadFile("plan.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := string(b)
+		const typeDecl = "type Secret struct {"
+		i := strings.Index(src, typeDecl)
+		if i < 0 {
+			t.Fatal("the Secret type has moved; this check is stale")
+		}
+		decl := src[i+len(typeDecl):]
+		if end := strings.Index(decl, "\n}"); end > 0 {
+			decl = decl[:end]
+		}
+		for _, field := range []string{"Value", "Password", "Secret "} {
+			if strings.Contains(decl, field) {
+				t.Errorf("Secret declares %q; it must record the source, never the value", field)
+			}
 		}
 	})
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -12,6 +12,7 @@
 //	AC-08  TestSetup_NoSudoInvocations
 //	AC-09  TestSetup_PgHbaPausesWhenUnmanaged
 //	AC-10  TestSetup_ContainerVerificationIsRecorded
+//	AC-11  TestSetup_LiveVerificationIsRecorded
 package setup
 
 import (
@@ -270,6 +271,35 @@ func TestSetup_ContainerVerificationIsRecorded(t *testing.T) {
 				t.Errorf("%s %s is %q; the recorded run used --allow-untested, which "+
 					"only makes sense for untested", c.id, c.ver, got)
 			}
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: the live RHEL 9.8 result, recorded with the assumptions it rests on.
+//
+// The run that produced it went from no cluster to a signed-in administrator in
+// one invocation, and a second invocation left that administrator able to log
+// in. Both depend on facts this test can still check: that RHEL 9 is a tested
+// platform needing no override, and that the default plan does not rotate a
+// generated password by regenerating it on every run.
+func TestSetup_LiveVerificationIsRecorded(t *testing.T) {
+	t.Run("system-setup/AC-11", func(t *testing.T) {
+		if got := supportOf("rhel", 9, FamilyRHEL); got != SupportTested {
+			t.Errorf("RHEL 9 is %q; the live run used no --allow-untested, which only "+
+				"holds while it is tested", got)
+		}
+		// The reuse path is what kept the administrator able to log in after the
+		// second run. It only engages for a generated password.
+		p := DefaultPlan(Platform{ID: "rhel", Major: 9, Family: FamilyRHEL})
+		if p.Database.Password.Source != SecretGenerate {
+			t.Errorf("default database password source is %q; the recorded re-run "+
+				"result depends on the generate-then-reuse path", p.Database.Password.Source)
+		}
+		// The live host listened on the wildcard, and the summary URL has to be
+		// something an operator can open. "i" was the kernel hostname there.
+		if got := hostnameOr("0.0.0.0"); got == "" || got == "0.0.0.0" {
+			t.Errorf("hostnameOr(0.0.0.0) = %q, want a usable address", got)
 		}
 	})
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,275 @@
+// @spec system-setup
+//
+// Unit coverage for the installer. The end-to-end behaviour these back up was
+// verified in systemd containers across the RHEL family; see AC-10 for what
+// that run proved and TestSetup_ContainerVerificationIsRecorded for why it is
+// recorded rather than executed here.
+//
+//	AC-04  TestSetup_PlatformSupportTiers
+//	AC-05  TestSetup_PgHbaBlockGoesAboveTheCatchAll
+//	AC-06  TestSetup_ExistingDSNPasswordIsRecovered
+//	AC-07  TestSetup_DetectsExistingHbaRules
+//	AC-08  TestSetup_NoSudoInvocations
+//	AC-09  TestSetup_PgHbaPausesWhenUnmanaged
+//	AC-10  TestSetup_ContainerVerificationIsRecorded
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// @ac AC-04
+// AC-04: support tiers gate which hosts setup will run on.
+func TestSetup_PlatformSupportTiers(t *testing.T) {
+	t.Run("system-setup/AC-04", func(t *testing.T) {
+		cases := []struct {
+			id, idLike, version string
+			wantFamily          Family
+			wantSupport         Support
+		}{
+			{"rhel", "fedora", "9.8", FamilyRHEL, SupportTested},
+			{"rocky", "rhel centos fedora", "9.3", FamilyRHEL, SupportUntested},
+			{"almalinux", "rhel centos fedora", "9.8", FamilyRHEL, SupportUntested},
+			{"ol", "fedora", "9.8", FamilyRHEL, SupportUntested},
+			{"almalinux", "rhel", "8.10", FamilyRHEL, SupportUntested},
+			{"almalinux", "rhel", "10.2", FamilyRHEL, SupportUntested},
+			{"ubuntu", "debian", "24.04", FamilyDebian, SupportUntested},
+			{"debian", "", "12", FamilyDebian, SupportUntested},
+			// An unlisted derivative is placed by ID_LIKE rather than needing
+			// this code to know every rebuild by name.
+			{"navylinux", "rhel", "9.4", FamilyRHEL, SupportUntested},
+			{"plan9", "", "4", FamilyUnknown, SupportUnsupported},
+			{"rhel", "fedora", "notaversion", FamilyRHEL, SupportUnsupported},
+			// Outside the modelled majors: the layout is not known to be the same.
+			{"rocky", "rhel", "7.9", FamilyRHEL, SupportUnsupported},
+		}
+		for _, c := range cases {
+			gotFamily := familyOf(c.id, c.idLike)
+			major := majorOf(c.version)
+			gotSupport := supportOf(c.id, major, gotFamily)
+			if gotFamily != c.wantFamily {
+				t.Errorf("familyOf(%q, %q) = %q, want %q", c.id, c.idLike, gotFamily, c.wantFamily)
+			}
+			if gotSupport != c.wantSupport {
+				t.Errorf("supportOf(%q, %d, %q) = %q, want %q",
+					c.id, major, gotFamily, gotSupport, c.wantSupport)
+			}
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: the pg_hba block must precede the first existing rule.
+//
+// The bug this pins cost a full container run. Appending is the obvious
+// implementation, and on a stock RHEL file it is silently useless: the default
+//
+//	host    all    all    127.0.0.1/32    ident
+//
+// matches first, so the connection fails with "Ident authentication failed for
+// user openwatch", naming a mechanism nobody selected.
+func TestSetup_PgHbaBlockGoesAboveTheCatchAll(t *testing.T) {
+	t.Run("system-setup/AC-05", func(t *testing.T) {
+		stock := `# PostgreSQL Client Authentication Configuration File
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             all                                     peer
+host    all             all             127.0.0.1/32            ident
+host    all             all             ::1/128                 ident
+`
+		got := insertHbaBlock(stock, pgHbaLines("openwatch", "openwatch"))
+
+		ourIdx := strings.Index(got, "# BEGIN OpenWatch")
+		catchAll := strings.Index(got, "host    all             all             127.0.0.1/32")
+		localIdx := strings.Index(got, "local   all             all")
+		if ourIdx < 0 {
+			t.Fatal("the OpenWatch block was not inserted at all")
+		}
+		if ourIdx > catchAll {
+			t.Error("the OpenWatch block is BELOW the catch-all host rule; pg_hba is " +
+				"first-match-wins, so it would never be reached")
+		}
+		if ourIdx > localIdx {
+			t.Error("the OpenWatch block must precede the first active rule of any type")
+		}
+		// Comments before the first rule must survive, and nothing existing
+		// may be dropped.
+		for _, keep := range []string{"# PostgreSQL Client Authentication", "peer", "::1/128"} {
+			if !strings.Contains(got, keep) {
+				t.Errorf("insertHbaBlock lost existing content %q", keep)
+			}
+		}
+
+		// A file with no active rules at all still gets the block.
+		if out := insertHbaBlock("# only comments\n", pgHbaLines("openwatch", "openwatch")); !strings.Contains(out, "# BEGIN OpenWatch") {
+			t.Error("a comment-only file must still receive the block")
+		}
+	})
+}
+
+// @ac AC-06
+// AC-06: a re-run recovers the password already in secrets.env.
+//
+// Without this the second run generates a fresh password, skips the role
+// because it exists, and writes the new value into the DSN. Role and DSN then
+// hold different secrets and the next step fails with "password authentication
+// failed" from an installer that had just succeeded.
+func TestSetup_ExistingDSNPasswordIsRecovered(t *testing.T) {
+	t.Run("system-setup/AC-06", func(t *testing.T) {
+		dir := t.TempDir()
+		d := DatabasePlan{Host: "127.0.0.1", Port: 5432, Name: "openwatch",
+			RoleName: "openwatch", SSLMode: "disable"}
+
+		for _, pw := range []string{"simple", "WindoW2005@@", "a/b?c#d", "pct%40literal"} {
+			path := filepath.Join(dir, "secrets.env")
+			body := "# comment\nOPENWATCH_DATABASE_DSN=" + d.DSN(pw) + "\n"
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, ok := existingDSNPassword(path)
+			if !ok {
+				t.Errorf("password %q: not recovered from secrets.env", pw)
+				continue
+			}
+			if got != pw {
+				t.Errorf("password %q recovered as %q; the reused value must match "+
+					"the one the role was created with", pw, got)
+			}
+		}
+
+		if _, ok := existingDSNPassword(filepath.Join(dir, "absent")); ok {
+			t.Error("a missing file must report not-found, not a bogus password")
+		}
+		noDSN := filepath.Join(dir, "other.env")
+		_ = os.WriteFile(noDSN, []byte("SOMETHING_ELSE=1\n"), 0o600)
+		if _, ok := existingDSNPassword(noDSN); ok {
+			t.Error("a file without a DSN line must report not-found")
+		}
+	})
+}
+
+// @ac AC-07
+// AC-07: rule detection tolerates formatting but not absence.
+func TestSetup_DetectsExistingHbaRules(t *testing.T) {
+	t.Run("system-setup/AC-07", func(t *testing.T) {
+		present := "host openwatch openwatch 127.0.0.1/32 scram-sha-256\n" +
+			"host   openwatch   openwatch   ::1/128   scram-sha-256\n"
+		if !hasOpenWatchHbaRules(present, "openwatch", "openwatch") {
+			t.Error("both rules present with irregular spacing must be detected")
+		}
+		// The wildcard form a hand-written file may use.
+		wild := "host all all 127.0.0.1/32 scram-sha-256\nhost all all ::1/128 scram-sha-256\n"
+		if !hasOpenWatchHbaRules(wild, "openwatch", "openwatch") {
+			t.Error("the all/all wildcard form must satisfy the requirement")
+		}
+		// Commented-out rules are not rules.
+		commented := "#host openwatch openwatch 127.0.0.1/32 scram-sha-256\n" +
+			"#host openwatch openwatch ::1/128 scram-sha-256\n"
+		if hasOpenWatchHbaRules(commented, "openwatch", "openwatch") {
+			t.Error("commented rules must not count as present")
+		}
+		// IPv4 only is incomplete: the service may resolve localhost to ::1.
+		v4only := "host openwatch openwatch 127.0.0.1/32 scram-sha-256\n"
+		if hasOpenWatchHbaRules(v4only, "openwatch", "openwatch") {
+			t.Error("only the IPv4 rule present must not count as complete")
+		}
+		// The wrong method is not a match: ident cannot authenticate a password.
+		identOnly := "host openwatch openwatch 127.0.0.1/32 ident\n" +
+			"host openwatch openwatch ::1/128 ident\n"
+		if hasOpenWatchHbaRules(identOnly, "openwatch", "openwatch") {
+			t.Error("ident rules must not satisfy a scram-sha-256 requirement")
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08: privilege drops use runuser.
+//
+// sudo needs a PAM stack that minimal AlmaLinux and Oracle Linux images do not
+// configure; `sudo -u postgres` there fails with "PAM account management
+// error" while runuser works. setup already runs as root, so sudo buys nothing.
+func TestSetup_NoSudoInvocations(t *testing.T) {
+	t.Run("system-setup/AC-08", func(t *testing.T) {
+		entries, err := os.ReadDir(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			b, err := os.ReadFile(e.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), `"sudo"`) {
+				t.Errorf("%s invokes sudo; use runuser (see C-08)", e.Name())
+			}
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09: declining to manage pg_hba.conf halts rather than continuing.
+func TestSetup_PgHbaPausesWhenUnmanaged(t *testing.T) {
+	t.Run("system-setup/AC-09", func(t *testing.T) {
+		b, err := os.ReadFile("steps.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := string(b)
+		i := strings.Index(src, "if !r.Plan.Database.ManagePgHba {")
+		if i < 0 {
+			t.Fatal("the unmanaged pg_hba branch has moved; this check is stale")
+		}
+		// Within that branch, the function must return a PauseError. Returning
+		// nil lets every later step run against a role that cannot yet
+		// authenticate, and the run dies at the migration step naming ident.
+		branch := src[i:]
+		if end := strings.Index(branch, "\n\t}"); end > 0 {
+			branch = branch[:end]
+		}
+		if !strings.Contains(branch, "&PauseError{") {
+			t.Error("the unmanaged pg_hba branch must return a PauseError so the run " +
+				"halts at the step that needs the operator, not two steps later")
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: the end-to-end matrix, recorded because it cannot run here.
+//
+// Unit tests cannot install PostgreSQL, drive systemd, or bind a port. The
+// behaviour was verified in privileged systemd containers using the shipped
+// RPM, and this test pins the claim so the recorded result and the code cannot
+// drift apart silently: the constants it asserts are the ones the run depended
+// on.
+func TestSetup_ContainerVerificationIsRecorded(t *testing.T) {
+	t.Run("system-setup/AC-10", func(t *testing.T) {
+		// AlmaLinux 8 was refused because its default PostgreSQL is 10. That
+		// refusal is only correct while the floor is above 10.
+		if minPostgresMajor <= 10 {
+			t.Errorf("minPostgresMajor is %d; the recorded AlmaLinux 8 refusal "+
+				"(PostgreSQL 10) no longer follows from it", minPostgresMajor)
+		}
+		// Rocky 9, Alma 9 and Oracle 9 all ship PostgreSQL 13, which passed
+		// while warning. That depends on 13 sitting between the two floors.
+		if minPostgresMajor > 13 || supportedPostgresMajor <= 13 {
+			t.Errorf("floors are min=%d supported=%d; the recorded RHEL 9 result "+
+				"(PostgreSQL 13 accepted with a warning) no longer follows",
+				minPostgresMajor, supportedPostgresMajor)
+		}
+		// Every distribution in the matrix except RHEL itself needed
+		// --allow-untested, which is only true while they are untested.
+		for _, c := range []struct{ id, ver string }{
+			{"rocky", "9.3"}, {"almalinux", "9.8"}, {"ol", "9.8"}, {"almalinux", "10.2"},
+		} {
+			if got := supportOf(c.id, majorOf(c.ver), FamilyRHEL); got != SupportUntested {
+				t.Errorf("%s %s is %q; the recorded run used --allow-untested, which "+
+					"only makes sense for untested", c.id, c.ver, got)
+			}
+		}
+	})
+}

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -628,7 +628,7 @@ func (s stepVerify) Apply(ctx context.Context, r *Run) error {
 // -------------------------------------------------------------- detection
 
 const (
-	secretsEnvPath = "/etc/openwatch/secrets.env"
+	secretsEnvPath = "/etc/openwatch/secrets.env" //nolint:gosec // G101: a file path, not a credential
 	openwatchBin   = "/usr/bin/openwatch"
 )
 

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -256,18 +256,25 @@ func (s stepRole) Apply(ctx context.Context, r *Run) error {
 	if exists.Err == nil && strings.TrimSpace(exists.Stdout) == "1" {
 		verb = "ALTER ROLE"
 	}
-	// password_encryption is SET in the same session, so the hash format does
-	// not depend on the server default. That default changed from md5 to
-	// scram-sha-256 in PostgreSQL 14, and RHEL 9 still ships 13, so relying on
-	// it produces a role that cannot authenticate against the pg_hba rules
-	// this installer also writes.
-	sql := fmt.Sprintf("SET password_encryption = 'scram-sha-256'; %s %s WITH LOGIN PASSWORD %s",
-		verb, name, sqlLiteral(r.DBPassword))
+	sql := roleSQL(verb, name, r.DBPassword)
 	if err := r.psqlMutate(ctx, s.ID(), strings.ToLower(verb), sql); err != nil {
 		return err
 	}
 	r.record(s.ID(), strings.ToLower(verb), name, "")
 	return nil
+}
+
+// roleSQL builds the role mutation.
+//
+// password_encryption is SET in the same session, so the hash format does not
+// depend on the server default. That default changed from md5 to scram-sha-256
+// in PostgreSQL 14, and RHEL 9 still ships 13, so relying on it produces a role
+// that cannot authenticate against the pg_hba rules this installer also writes.
+// The same statement re-hashes a role that was found already hashed md5,
+// because the verb is ALTER ROLE in that case and the SET still applies.
+func roleSQL(verb, name, password string) string {
+	return fmt.Sprintf("SET password_encryption = 'scram-sha-256'; %s %s WITH LOGIN PASSWORD %s",
+		verb, name, sqlLiteral(password))
 }
 
 type stepDatabase struct{}

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -138,7 +138,23 @@ func (s stepPostgresCluster) Apply(ctx context.Context, r *Run) error {
 		return err
 	}
 	r.record(s.ID(), "enable", "postgresql.service", "")
-	return nil
+	if r.DryRun {
+		return nil
+	}
+	// systemctl returns once the unit is active, which is not the same as the
+	// server accepting connections. The gap is small enough that a fast host
+	// wins the race and a slower one does not, which is the worst kind of
+	// difference: the next step fails with "cannot determine the PostgreSQL
+	// server version" on some distributions and not others, from identical
+	// code. Wait for the socket rather than trusting the unit state.
+	for i := 0; i < 30; i++ {
+		if postgresReachable(ctx) {
+			return nil
+		}
+		sleep(ctx, 1)
+	}
+	return fmt.Errorf("%s: postgresql started but did not accept connections within 30s; "+
+		"check `systemctl status postgresql` and `journalctl -u postgresql`", s.ID())
 }
 
 type stepPostgresVersion struct{}
@@ -196,19 +212,31 @@ func (stepRole) Describe(p Plan) string {
 		p.Database.RoleName, verb)
 }
 
+// Status never reports Done, deliberately.
+//
+// The role's password and the password inside the DSN this run will write must
+// be the same value, and the only way to guarantee that from any starting state
+// is to set both every time. Skipping the role because it "already exists"
+// leaves whatever password it happened to have, which need not be the one about
+// to be written to secrets.env; the result is "password authentication failed
+// for user openwatch" from an installer that just reported success. ALTER ROLE
+// with the same password is harmless, so converging always is cheaper than
+// detecting divergence.
+//
+// The reported detail still distinguishes the cases, because an md5-hashed role
+// is worth naming: it can never authenticate against the scram-sha-256 rules
+// this installer also writes.
 func (stepRole) Status(ctx context.Context, p Plan) StepStatus {
 	res := psql(ctx, fmt.Sprintf(
 		"SELECT substring(rolpassword,1,13) FROM pg_authid WHERE rolname=%s", sqlLiteral(p.Database.RoleName)))
-	if res.Err != nil || res.Stdout == "" {
+	switch {
+	case res.Err != nil || res.Stdout == "":
 		return StepStatus{}
+	case strings.HasPrefix(strings.ToLower(res.Stdout), "md5"):
+		return StepStatus{Detail: "exists but hashed md5; will be re-set as scram-sha-256"}
+	default:
+		return StepStatus{Detail: "exists; password will be set to match the DSN"}
 	}
-	// A role hashed as md5 against pg_hba rules demanding scram can never
-	// authenticate, and the only symptom is "password authentication failed"
-	// pointing at the role. Treat it as not-done so Apply re-hashes it.
-	if strings.HasPrefix(strings.ToLower(res.Stdout), "md5") {
-		return StepStatus{Detail: "exists but hashed md5; password will be re-set as scram-sha-256"}
-	}
-	return StepStatus{Done: true, Detail: "role exists with a scram-sha-256 password"}
 }
 
 func (s stepRole) Apply(ctx context.Context, r *Run) error {
@@ -306,16 +334,19 @@ func (s stepPgHba) Apply(ctx context.Context, r *Run) error {
 		r.logf("      sudo systemctl reload postgresql")
 		r.logf("")
 		r.logf("    Re-run setup afterwards, or pass --manage-pg-hba to have setup do it.")
-		return nil
+		// Halt rather than continue. Every later step authenticates as this
+		// role, so proceeding guarantees a failure at the migration step whose
+		// message names the role and not the missing rules.
+		return &PauseError{Step: s.ID(), Reason: "pg_hba.conf needs the rules above before " +
+			"the database role can authenticate"}
 	}
 
 	existing, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("%s: read %s: %w", s.ID(), path, err)
 	}
-	block := "\n# BEGIN OpenWatch (added by `openwatch setup`)\n" +
-		strings.Join(lines, "\n") + "\n# END OpenWatch\n"
-	if err := r.writeFile(s.ID(), path, append(existing, []byte(block)...), 0o600); err != nil {
+	updated := insertHbaBlock(string(existing), lines)
+	if err := r.writeFile(s.ID(), path, []byte(updated), 0o600); err != nil {
 		return err
 	}
 	if err := r.mutate(ctx, s.ID(), "reload postgresql", "systemctl", "reload", "postgresql"); err != nil {
@@ -376,7 +407,7 @@ func (stepMigrate) ID() string { return "migrate" }
 func (stepMigrate) Describe(Plan) string { return "apply database migrations" }
 
 func (stepMigrate) Status(ctx context.Context, p Plan) StepStatus {
-	res := psql(ctx, "SELECT max(version_id) FROM goose_db_version")
+	res := psqlIn(ctx, p.Database.Name, "SELECT max(version_id) FROM goose_db_version")
 	if res.Err == nil && res.Stdout != "" && res.Stdout != "0" {
 		return StepStatus{Detail: "schema at version " + res.Stdout + "; pending migrations will be applied"}
 	}
@@ -384,7 +415,7 @@ func (stepMigrate) Status(ctx context.Context, p Plan) StepStatus {
 }
 
 func (s stepMigrate) Apply(ctx context.Context, r *Run) error {
-	return r.mutate(ctx, s.ID(), "openwatch migrate", "sudo", "-u", "openwatch",
+	return r.mutate(ctx, s.ID(), "openwatch migrate", "runuser", "-u", "openwatch", "--",
 		"env", "OPENWATCH_DATABASE_DSN="+r.Plan.Database.DSN(r.DBPassword),
 		openwatchBin, "migrate")
 }
@@ -398,7 +429,9 @@ func (stepAdmin) Describe(p Plan) string {
 }
 
 func (stepAdmin) Status(ctx context.Context, p Plan) StepStatus {
-	res := psql(ctx, fmt.Sprintf("SELECT 1 FROM users WHERE username=%s", sqlLiteral(p.Admin.Username)))
+	res := psqlIn(ctx, p.Database.Name,
+		fmt.Sprintf("SELECT 1 FROM users WHERE username=%s AND deleted_at IS NULL",
+			sqlLiteral(p.Admin.Username)))
 	// A missing users table means migrations have not run yet, which is not
 	// an error at plan time: the migrate step precedes this one.
 	if res.Err == nil && strings.TrimSpace(res.Stdout) == "1" {
@@ -408,7 +441,7 @@ func (stepAdmin) Status(ctx context.Context, p Plan) StepStatus {
 }
 
 func (s stepAdmin) Apply(ctx context.Context, r *Run) error {
-	return r.mutate(ctx, s.ID(), "create-admin", "sudo", "-u", "openwatch",
+	return r.mutate(ctx, s.ID(), "create-admin", "runuser", "-u", "openwatch", "--",
 		"env", "OPENWATCH_DATABASE_DSN="+r.Plan.Database.DSN(r.DBPassword),
 		openwatchBin, "create-admin",
 		"--username", r.Plan.Admin.Username,
@@ -526,6 +559,12 @@ func postgresMajor(ctx context.Context) int {
 	return n / 10000
 }
 
+// roleExists reports whether the login role is already present.
+func roleExists(ctx context.Context, name string) bool {
+	res := psql(ctx, fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname=%s", sqlLiteral(name)))
+	return res.Err == nil && strings.TrimSpace(res.Stdout) == "1"
+}
+
 func postgresReachable(ctx context.Context) bool {
 	return psql(ctx, "SELECT 1").Err == nil
 }
@@ -559,6 +598,46 @@ func pgHbaLines(dbName, roleName string) []string {
 		fmt.Sprintf("host    %-12s %-12s 127.0.0.1/32    scram-sha-256", dbName, roleName),
 		fmt.Sprintf("host    %-12s %-12s ::1/128         scram-sha-256", dbName, roleName),
 	}
+}
+
+// insertHbaBlock places the rules ABOVE the first existing authentication
+// rule, never at the end of the file.
+//
+// pg_hba.conf is first-match-wins, and the stock RHEL file contains
+//
+//	host    all    all    127.0.0.1/32    ident
+//
+// so a block appended to the end is unreachable: ident matches first and the
+// connection fails with "Ident authentication failed for user openwatch",
+// naming a mechanism the operator never chose. Appending is the intuitive
+// implementation and it silently does nothing useful.
+func insertHbaBlock(content string, lines []string) string {
+	block := []string{"# BEGIN OpenWatch (added by `openwatch setup`)"}
+	block = append(block, lines...)
+	block = append(block, "# END OpenWatch", "")
+
+	src := strings.Split(content, "\n")
+	insertAt := -1
+	for i, line := range src {
+		f := strings.Fields(strings.TrimSpace(line))
+		if len(f) == 0 || strings.HasPrefix(f[0], "#") {
+			continue
+		}
+		// The first active connection-type rule; everything below it is
+		// shadowed for the tuples we care about.
+		if f[0] == "local" || f[0] == "host" || f[0] == "hostssl" || f[0] == "hostnossl" {
+			insertAt = i
+			break
+		}
+	}
+	if insertAt < 0 {
+		return content + "\n" + strings.Join(block, "\n")
+	}
+	out := make([]string, 0, len(src)+len(block))
+	out = append(out, src[:insertAt]...)
+	out = append(out, block...)
+	out = append(out, src[insertAt:]...)
+	return strings.Join(out, "\n")
 }
 
 // hasOpenWatchHbaRules reports whether both loopback rules are present and

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -147,14 +147,24 @@ func (s stepPostgresCluster) Apply(ctx context.Context, r *Run) error {
 	// difference: the next step fails with "cannot determine the PostgreSQL
 	// server version" on some distributions and not others, from identical
 	// code. Wait for the socket rather than trusting the unit state.
+	var last cmdResult
 	for i := 0; i < 30; i++ {
-		if postgresReachable(ctx) {
+		last = psql(ctx, "SELECT 1")
+		if last.Err == nil {
 			return nil
+		}
+		// A server that is up but refusing this connection is a different
+		// problem from one that has not started, and the remedies share
+		// nothing. Reporting the first as the second sends the operator to
+		// `systemctl status`, which says active, and the trail ends there.
+		if diag := diagnosePsqlRefusal(last); diag != "" {
+			return fmt.Errorf("%s: %s", s.ID(), diag)
 		}
 		sleep(ctx, 1)
 	}
 	return fmt.Errorf("%s: postgresql started but did not accept connections within 30s; "+
-		"check `systemctl status postgresql` and `journalctl -u postgresql`", s.ID())
+		"check `systemctl status postgresql` and `journalctl -u postgresql`. Last error: %s",
+		s.ID(), firstLine(last.Stderr))
 }
 
 type stepPostgresVersion struct{}
@@ -256,7 +266,7 @@ func (s stepRole) Apply(ctx context.Context, r *Run) error {
 	if err := r.psqlMutate(ctx, s.ID(), strings.ToLower(verb), sql); err != nil {
 		return err
 	}
-	r.record(s.ID(), strings.ToLower(verb), "role "+name, "")
+	r.record(s.ID(), strings.ToLower(verb), name, "")
 	return nil
 }
 
@@ -557,6 +567,33 @@ func postgresMajor(ctx context.Context) int {
 		return 0
 	}
 	return n / 10000
+}
+
+// diagnosePsqlRefusal turns a connection rejection into an actionable
+// sentence, or returns "" when the failure is not a rejection.
+//
+// setup reaches PostgreSQL as the postgres superuser over the local socket for
+// every check it makes, so a pg_hba.conf without a local rule disables the
+// installer completely. That file having been edited by hand is exactly how
+// this state arises, and the raw error names a socket rather than the rule.
+func diagnosePsqlRefusal(res cmdResult) string {
+	msg := res.Stderr + res.Stdout
+	switch {
+	case strings.Contains(msg, "no pg_hba.conf entry"):
+		return "PostgreSQL is running but refuses local superuser connections: " +
+			"pg_hba.conf has no rule for local connections by the postgres user. " +
+			"setup needs that access for every check it makes. Add the line " +
+			"`local   all   all   peer` above the other rules in pg_hba.conf, run " +
+			"`systemctl reload postgresql`, and run setup again. This state usually " +
+			"follows a hand-edit that replaced the file's default rules rather than " +
+			"adding to them"
+	case strings.Contains(msg, "authentication failed"):
+		return "PostgreSQL is running but rejected the postgres superuser's " +
+			"credentials. Check the local rule's method in pg_hba.conf; peer is " +
+			"expected for the postgres user"
+	default:
+		return ""
+	}
 }
 
 // roleExists reports whether the login role is already present.

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -63,7 +63,7 @@ func Steps(p Plan) []Step {
 	if p.Migrate {
 		s = append(s, stepMigrate{})
 	}
-	s = append(s, stepAdmin{}, stepService{}, stepVerify{})
+	s = append(s, stepAdmin{}, stepFirewall{}, stepService{}, stepVerify{})
 	return s
 }
 
@@ -459,6 +459,67 @@ func (s stepAdmin) Apply(ctx context.Context, r *Run) error {
 		"--password", r.AdminPassword)
 }
 
+type stepFirewall struct{}
+
+func (stepFirewall) ID() string { return "firewall" }
+
+func (stepFirewall) Describe(p Plan) string {
+	if !p.Service.OpenFirewall {
+		return fmt.Sprintf("report whether port %d is reachable through the firewall "+
+			"(not changing it; --no-firewall was passed)", p.Service.ListenPort)
+	}
+	return fmt.Sprintf("allow inbound %d/tcp through the host firewall", p.Service.ListenPort)
+}
+
+func (stepFirewall) Status(ctx context.Context, p Plan) StepStatus {
+	switch {
+	case !firewalldActive():
+		return StepStatus{Done: true, Detail: "no active host firewall to configure"}
+	case firewalldAllowsPort(ctx, p.Service.ListenPort):
+		return StepStatus{Done: true, Detail: fmt.Sprintf("firewalld already allows %d/tcp", p.Service.ListenPort)}
+	default:
+		return StepStatus{Detail: fmt.Sprintf("firewalld is active and does NOT allow %d/tcp", p.Service.ListenPort)}
+	}
+}
+
+// Apply opens the port the service listens on.
+//
+// WHY THIS IS A STEP AT ALL: without it the installer finishes, reports the API
+// healthy, and prints a URL nobody can open. The health check runs over
+// loopback, where the firewall does not apply, so a fully firewalled host looks
+// identical to a working one. That was observed on a live RHEL 9.8 install:
+// every internal check passed and the service was unreachable from any other
+// machine with "No route to host".
+//
+// Opening it is default rather than opt-in, unlike the pg_hba edit. The two
+// risks are not comparable: a pg_hba mistake removes access the operator
+// already had, whereas allowing the port a web application listens on is the
+// access they asked for by installing it. The plan states it before it happens
+// and --no-firewall declines it.
+func (s stepFirewall) Apply(ctx context.Context, r *Run) error {
+	port := r.Plan.Service.ListenPort
+	if !firewalldActive() {
+		return nil
+	}
+	if !r.Plan.Service.OpenFirewall {
+		r.logf("    firewalld is active and does not allow %d/tcp, so the service will", port)
+		r.logf("    not be reachable from other hosts. To allow it:")
+		r.logf("")
+		r.logf("      sudo firewall-cmd --permanent --add-port=%d/tcp", port)
+		r.logf("      sudo firewall-cmd --reload")
+		return nil
+	}
+	if err := r.mutate(ctx, s.ID(), "add firewall port", "firewall-cmd",
+		"--permanent", fmt.Sprintf("--add-port=%d/tcp", port)); err != nil {
+		return err
+	}
+	if err := r.mutate(ctx, s.ID(), "reload firewalld", "firewall-cmd", "--reload"); err != nil {
+		return err
+	}
+	r.record(s.ID(), "allow", fmt.Sprintf("%d/tcp", port), "")
+	return nil
+}
+
 type stepService struct{}
 
 func (stepService) ID() string { return "service" }
@@ -527,6 +588,11 @@ func (s stepVerify) Apply(ctx context.Context, r *Run) error {
 	if r.DryRun || !r.Plan.Service.StartNow {
 		return nil
 	}
+	// Loopback deliberately: this proves the service is serving and reached
+	// its database. It does NOT prove the host is reachable from elsewhere,
+	// because the firewall does not apply to loopback. The firewall step above
+	// owns that, and this reports what remains unproven rather than implying
+	// more than it checked.
 	url := fmt.Sprintf("https://127.0.0.1:%d/api/v1/health", r.Plan.Service.ListenPort)
 	var last string
 	for i := 0; i < 15; i++ {
@@ -536,6 +602,11 @@ func (s stepVerify) Apply(ctx context.Context, r *Run) error {
 			if !strings.Contains(res.Stdout, `"db_connected":true`) {
 				return fmt.Errorf("%s: the service is up but reports db_connected=false; "+
 					"check the DSN in %s", s.ID(), secretsEnvPath)
+			}
+			if firewalldActive() && !firewalldAllowsPort(ctx, r.Plan.Service.ListenPort) {
+				r.logf("    NOTE: checked over loopback only. firewalld does not allow %d/tcp,",
+					r.Plan.Service.ListenPort)
+				r.logf("    so this service is not reachable from any other host.")
 			}
 			return nil
 		}
@@ -600,6 +671,32 @@ func diagnosePsqlRefusal(res cmdResult) string {
 func roleExists(ctx context.Context, name string) bool {
 	res := psql(ctx, fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname=%s", sqlLiteral(name)))
 	return res.Err == nil && strings.TrimSpace(res.Stdout) == "1"
+}
+
+// firewalldActive reports whether firewalld is managing the host. ufw is not
+// handled: Debian-family support is untested, and guessing at a firewall is
+// worse than reporting it.
+func firewalldActive() bool { return serviceActive("firewalld") }
+
+// firewalldAllowsPort reports whether inbound traffic to the port is already
+// permitted, by port or by a service definition covering it.
+func firewalldAllowsPort(ctx context.Context, port int) bool {
+	want := fmt.Sprintf("%d/tcp", port)
+	res := run(ctx, "firewall-cmd", "--list-ports")
+	if res.Err == nil {
+		for _, f := range strings.Fields(res.Stdout) {
+			if f == want {
+				return true
+			}
+		}
+	}
+	// A service definition (for example https on 443) can cover the port
+	// without it appearing in --list-ports.
+	if res := run(ctx, "firewall-cmd", "--list-all"); res.Err == nil &&
+		strings.Contains(res.Stdout, want) {
+		return true
+	}
+	return false
 }
 
 func postgresReachable(ctx context.Context) bool {

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -1,0 +1,591 @@
+// The steps `openwatch setup` performs, in order.
+//
+// Each step answers three questions independently: is it already done
+// (Status), what would doing it mean (Describe), and do it (Apply). Keeping
+// Status separate is what makes the whole run idempotent and what lets the
+// plan be shown before anything is touched.
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// PostgreSQL floors. These mirror internal/db: the hard floor is what the
+// migrations actually require (gen_random_uuid became a built-in in 13), the
+// supported floor is policy (14 reaches end of life in November 2026, inside
+// this release's service life). setup checks before installing so the operator
+// finds out at the start rather than at the migration step.
+const (
+	minPostgresMajor       = 13
+	supportedPostgresMajor = 15
+)
+
+// StepStatus is the result of a step's idempotence check.
+type StepStatus struct {
+	// Done means the desired state already holds; Apply will be skipped.
+	Done bool
+	// Detail is shown in the plan, e.g. "already exists" or the version found.
+	Detail string
+}
+
+// Step is one unit of the install.
+type Step interface {
+	ID() string
+	// Describe says what applying it would do, for the plan.
+	Describe(p Plan) string
+	// Status reports whether it is already satisfied. Must not mutate.
+	Status(ctx context.Context, p Plan) StepStatus
+	// Apply performs it.
+	Apply(ctx context.Context, r *Run) error
+}
+
+// Steps returns the ordered steps for a plan. Order matters and is not
+// configurable: the database must exist before migrations, migrations before
+// the admin user, and the service starts last so it never boots against a
+// schema that is not there.
+func Steps(p Plan) []Step {
+	var s []Step
+	if p.Database.Mode == DBProvision {
+		s = append(s, stepPostgresInstall{}, stepPostgresCluster{})
+	}
+	s = append(s,
+		stepPostgresVersion{},
+		stepRole{},
+		stepDatabase{},
+		stepPgHba{},
+		stepSecretsEnv{},
+	)
+	if p.Migrate {
+		s = append(s, stepMigrate{})
+	}
+	s = append(s, stepAdmin{}, stepService{}, stepVerify{})
+	return s
+}
+
+// ---------------------------------------------------------------- postgres
+
+type stepPostgresInstall struct{}
+
+func (stepPostgresInstall) ID() string { return "postgres-install" }
+
+func (stepPostgresInstall) Describe(p Plan) string {
+	if p.Platform.Family == FamilyDebian {
+		return "install PostgreSQL (apt-get install postgresql postgresql-contrib)"
+	}
+	return "install PostgreSQL (dnf install postgresql-server postgresql-contrib)"
+}
+
+func (stepPostgresInstall) Status(ctx context.Context, p Plan) StepStatus {
+	if v := postgresMajor(ctx); v > 0 {
+		return StepStatus{Done: true, Detail: fmt.Sprintf("PostgreSQL %d already installed", v)}
+	}
+	return StepStatus{}
+}
+
+func (s stepPostgresInstall) Apply(ctx context.Context, r *Run) error {
+	if r.Plan.Platform.Family == FamilyDebian {
+		if err := r.mutate(ctx, s.ID(), "apt-get update", "apt-get", "update"); err != nil {
+			return err
+		}
+		if err := r.mutate(ctx, s.ID(), "install postgresql", "apt-get", "install", "-y",
+			"postgresql", "postgresql-contrib"); err != nil {
+			return err
+		}
+	} else {
+		if err := r.mutate(ctx, s.ID(), "install postgresql-server", "dnf", "install", "-y",
+			"postgresql-server", "postgresql-contrib"); err != nil {
+			return err
+		}
+	}
+	r.record(s.ID(), "install", "postgresql", "")
+	return nil
+}
+
+type stepPostgresCluster struct{}
+
+func (stepPostgresCluster) ID() string { return "postgres-cluster" }
+
+func (stepPostgresCluster) Describe(p Plan) string {
+	if p.Platform.Family == FamilyDebian {
+		return "enable and start postgresql (Debian initialises the cluster on install)"
+	}
+	return "initialise the data directory and enable postgresql"
+}
+
+func (stepPostgresCluster) Status(ctx context.Context, p Plan) StepStatus {
+	if postgresReachable(ctx) {
+		return StepStatus{Done: true, Detail: "cluster is running"}
+	}
+	return StepStatus{}
+}
+
+func (s stepPostgresCluster) Apply(ctx context.Context, r *Run) error {
+	// RHEL ships an uninitialised data directory; Debian initialises on
+	// install. initdb is only safe when the directory is genuinely empty, so
+	// this checks rather than relying on the family alone.
+	if r.Plan.Platform.Family == FamilyRHEL && !postgresDataDirInitialised() {
+		if err := r.mutate(ctx, s.ID(), "initdb", "postgresql-setup", "--initdb"); err != nil {
+			return err
+		}
+		r.record(s.ID(), "initdb", "/var/lib/pgsql/data", "")
+	}
+	if err := r.mutate(ctx, s.ID(), "enable postgresql", "systemctl", "enable", "--now", "postgresql"); err != nil {
+		return err
+	}
+	r.record(s.ID(), "enable", "postgresql.service", "")
+	return nil
+}
+
+type stepPostgresVersion struct{}
+
+func (stepPostgresVersion) ID() string { return "postgres-version" }
+
+func (stepPostgresVersion) Describe(Plan) string {
+	return fmt.Sprintf("verify PostgreSQL >= %d (supported >= %d)", minPostgresMajor, supportedPostgresMajor)
+}
+
+func (stepPostgresVersion) Status(ctx context.Context, p Plan) StepStatus {
+	v := postgresMajor(ctx)
+	switch {
+	case v == 0:
+		return StepStatus{}
+	case v < minPostgresMajor:
+		return StepStatus{Detail: fmt.Sprintf("PostgreSQL %d is BELOW the minimum %d", v, minPostgresMajor)}
+	case v < supportedPostgresMajor:
+		return StepStatus{Done: true, Detail: fmt.Sprintf("PostgreSQL %d (below supported %d, will warn)", v, supportedPostgresMajor)}
+	default:
+		return StepStatus{Done: true, Detail: fmt.Sprintf("PostgreSQL %d", v)}
+	}
+}
+
+func (s stepPostgresVersion) Apply(ctx context.Context, r *Run) error {
+	v := postgresMajor(ctx)
+	if v == 0 {
+		return fmt.Errorf("%s: cannot determine the PostgreSQL server version", s.ID())
+	}
+	if v < minPostgresMajor {
+		return fmt.Errorf(
+			"%s: PostgreSQL %d is too old; OpenWatch requires %d or newer because the "+
+				"schema uses gen_random_uuid as a column default. Upgrade the server, or "+
+				"on RHEL enable a newer module stream (dnf module list postgresql)",
+			s.ID(), v, minPostgresMajor)
+	}
+	if v < supportedPostgresMajor {
+		r.logf("    WARNING: PostgreSQL %d is below the supported minimum %d. It will work, "+
+			"but note that %d defaults password_encryption to md5 where 14+ default to "+
+			"scram-sha-256", v, supportedPostgresMajor, v)
+	}
+	return nil
+}
+
+type stepRole struct{}
+
+func (stepRole) ID() string { return "database-role" }
+
+func (stepRole) Describe(p Plan) string {
+	verb := map[SecretSource]string{
+		SecretGenerate: "a generated", SecretPrompt: "an operator-supplied",
+		SecretEnv: "an environment-supplied", SecretFile: "a file-supplied",
+	}[p.Database.Password.Source]
+	return fmt.Sprintf("create role %q with %s password, hashed scram-sha-256",
+		p.Database.RoleName, verb)
+}
+
+func (stepRole) Status(ctx context.Context, p Plan) StepStatus {
+	res := psql(ctx, fmt.Sprintf(
+		"SELECT substring(rolpassword,1,13) FROM pg_authid WHERE rolname=%s", sqlLiteral(p.Database.RoleName)))
+	if res.Err != nil || res.Stdout == "" {
+		return StepStatus{}
+	}
+	// A role hashed as md5 against pg_hba rules demanding scram can never
+	// authenticate, and the only symptom is "password authentication failed"
+	// pointing at the role. Treat it as not-done so Apply re-hashes it.
+	if strings.HasPrefix(strings.ToLower(res.Stdout), "md5") {
+		return StepStatus{Detail: "exists but hashed md5; password will be re-set as scram-sha-256"}
+	}
+	return StepStatus{Done: true, Detail: "role exists with a scram-sha-256 password"}
+}
+
+func (s stepRole) Apply(ctx context.Context, r *Run) error {
+	name := r.Plan.Database.RoleName
+	exists := psql(ctx, fmt.Sprintf("SELECT 1 FROM pg_roles WHERE rolname=%s", sqlLiteral(name)))
+	verb := "CREATE ROLE"
+	if exists.Err == nil && strings.TrimSpace(exists.Stdout) == "1" {
+		verb = "ALTER ROLE"
+	}
+	// password_encryption is SET in the same session, so the hash format does
+	// not depend on the server default. That default changed from md5 to
+	// scram-sha-256 in PostgreSQL 14, and RHEL 9 still ships 13, so relying on
+	// it produces a role that cannot authenticate against the pg_hba rules
+	// this installer also writes.
+	sql := fmt.Sprintf("SET password_encryption = 'scram-sha-256'; %s %s WITH LOGIN PASSWORD %s",
+		verb, name, sqlLiteral(r.DBPassword))
+	if err := r.psqlMutate(ctx, s.ID(), strings.ToLower(verb), sql); err != nil {
+		return err
+	}
+	r.record(s.ID(), strings.ToLower(verb), "role "+name, "")
+	return nil
+}
+
+type stepDatabase struct{}
+
+func (stepDatabase) ID() string { return "database" }
+
+func (stepDatabase) Describe(p Plan) string {
+	return fmt.Sprintf("create database %q owned by %q", p.Database.Name, p.Database.RoleName)
+}
+
+func (stepDatabase) Status(ctx context.Context, p Plan) StepStatus {
+	res := psql(ctx, fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname=%s", sqlLiteral(p.Database.Name)))
+	if res.Err == nil && strings.TrimSpace(res.Stdout) == "1" {
+		return StepStatus{Done: true, Detail: "database exists"}
+	}
+	return StepStatus{}
+}
+
+func (s stepDatabase) Apply(ctx context.Context, r *Run) error {
+	sql := fmt.Sprintf("CREATE DATABASE %s OWNER %s", r.Plan.Database.Name, r.Plan.Database.RoleName)
+	if err := r.psqlMutate(ctx, s.ID(), "create database", sql); err != nil {
+		return err
+	}
+	r.record(s.ID(), "create", "database "+r.Plan.Database.Name, "")
+	return nil
+}
+
+// ------------------------------------------------------------------ pg_hba
+
+type stepPgHba struct{}
+
+func (stepPgHba) ID() string { return "pg-hba" }
+
+func (stepPgHba) Describe(p Plan) string {
+	if !p.Database.ManagePgHba {
+		return "check pg_hba.conf for the required host rules and print them if missing (not editing; pass --manage-pg-hba to write them)"
+	}
+	return "append the OpenWatch host rules to pg_hba.conf, after backing it up"
+}
+
+func (stepPgHba) Status(ctx context.Context, p Plan) StepStatus {
+	path := pgHbaPath(ctx)
+	if path == "" {
+		return StepStatus{}
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return StepStatus{}
+	}
+	if hasOpenWatchHbaRules(string(b), p.Database.Name, p.Database.RoleName) {
+		return StepStatus{Done: true, Detail: "rules already present in " + path}
+	}
+	return StepStatus{Detail: "rules missing from " + path}
+}
+
+func (s stepPgHba) Apply(ctx context.Context, r *Run) error {
+	path := pgHbaPath(ctx)
+	if path == "" {
+		return fmt.Errorf("%s: cannot locate pg_hba.conf", s.ID())
+	}
+	lines := pgHbaLines(r.Plan.Database.Name, r.Plan.Database.RoleName)
+
+	if !r.Plan.Database.ManagePgHba {
+		// The default. Editing this file by hand is how an operator locks
+		// themselves out of local postgres access, and doing it automatically
+		// carries the same risk, so setup asks rather than assumes.
+		r.logf("    pg_hba.conf needs these lines. Add them ABOVE any catch-all")
+		r.logf("    'host all all' rule (pg_hba is first-match-wins), then reload:")
+		r.logf("")
+		for _, l := range lines {
+			r.logf("      %s", l)
+		}
+		r.logf("")
+		r.logf("      sudo systemctl reload postgresql")
+		r.logf("")
+		r.logf("    Re-run setup afterwards, or pass --manage-pg-hba to have setup do it.")
+		return nil
+	}
+
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("%s: read %s: %w", s.ID(), path, err)
+	}
+	block := "\n# BEGIN OpenWatch (added by `openwatch setup`)\n" +
+		strings.Join(lines, "\n") + "\n# END OpenWatch\n"
+	if err := r.writeFile(s.ID(), path, append(existing, []byte(block)...), 0o600); err != nil {
+		return err
+	}
+	if err := r.mutate(ctx, s.ID(), "reload postgresql", "systemctl", "reload", "postgresql"); err != nil {
+		// A pg_hba.conf that does not parse leaves PostgreSQL refusing every
+		// connection, so put the original back rather than leave the operator
+		// locked out of a database they could previously reach.
+		if !r.DryRun {
+			_ = os.WriteFile(path, existing, 0o600)
+			r.logf("    reload failed; pg_hba.conf restored to its previous contents")
+		}
+		return err
+	}
+	return nil
+}
+
+// ------------------------------------------------------------- app config
+
+type stepSecretsEnv struct{}
+
+func (stepSecretsEnv) ID() string { return "secrets-env" }
+
+func (stepSecretsEnv) Describe(Plan) string {
+	return "write /etc/openwatch/secrets.env with the database DSN (0640 root:openwatch)"
+}
+
+func (stepSecretsEnv) Status(ctx context.Context, p Plan) StepStatus {
+	b, err := os.ReadFile(secretsEnvPath)
+	if err != nil {
+		return StepStatus{}
+	}
+	if strings.Contains(string(b), "OPENWATCH_DATABASE_DSN=") {
+		return StepStatus{Done: false, Detail: "exists and will be rewritten (previous file backed up)"}
+	}
+	return StepStatus{}
+}
+
+func (s stepSecretsEnv) Apply(ctx context.Context, r *Run) error {
+	// The DSN is assembled by DatabasePlan.DSN, which percent-encodes the
+	// password. Hand-assembling it is how a password containing '@' silently
+	// changes what the URI means.
+	content := fmt.Sprintf("OPENWATCH_DATABASE_DSN=%s\n", r.Plan.Database.DSN(r.DBPassword))
+	if err := os.MkdirAll(filepath.Dir(secretsEnvPath), 0o750); err != nil && !r.DryRun {
+		return fmt.Errorf("%s: %w", s.ID(), err)
+	}
+	if err := r.writeFile(s.ID(), secretsEnvPath, []byte(content), 0o640); err != nil {
+		return err
+	}
+	if r.DryRun {
+		return nil
+	}
+	return r.mutate(ctx, s.ID(), "chown secrets.env", "chown", "root:openwatch", secretsEnvPath)
+}
+
+type stepMigrate struct{}
+
+func (stepMigrate) ID() string { return "migrate" }
+
+func (stepMigrate) Describe(Plan) string { return "apply database migrations" }
+
+func (stepMigrate) Status(ctx context.Context, p Plan) StepStatus {
+	res := psql(ctx, "SELECT max(version_id) FROM goose_db_version")
+	if res.Err == nil && res.Stdout != "" && res.Stdout != "0" {
+		return StepStatus{Detail: "schema at version " + res.Stdout + "; pending migrations will be applied"}
+	}
+	return StepStatus{}
+}
+
+func (s stepMigrate) Apply(ctx context.Context, r *Run) error {
+	return r.mutate(ctx, s.ID(), "openwatch migrate", "sudo", "-u", "openwatch",
+		"env", "OPENWATCH_DATABASE_DSN="+r.Plan.Database.DSN(r.DBPassword),
+		openwatchBin, "migrate")
+}
+
+type stepAdmin struct{}
+
+func (stepAdmin) ID() string { return "admin-user" }
+
+func (stepAdmin) Describe(p Plan) string {
+	return fmt.Sprintf("create the first admin user %q (%s)", p.Admin.Username, p.Admin.Email)
+}
+
+func (stepAdmin) Status(ctx context.Context, p Plan) StepStatus {
+	res := psql(ctx, fmt.Sprintf("SELECT 1 FROM users WHERE username=%s", sqlLiteral(p.Admin.Username)))
+	// A missing users table means migrations have not run yet, which is not
+	// an error at plan time: the migrate step precedes this one.
+	if res.Err == nil && strings.TrimSpace(res.Stdout) == "1" {
+		return StepStatus{Done: true, Detail: "user already exists"}
+	}
+	return StepStatus{}
+}
+
+func (s stepAdmin) Apply(ctx context.Context, r *Run) error {
+	return r.mutate(ctx, s.ID(), "create-admin", "sudo", "-u", "openwatch",
+		"env", "OPENWATCH_DATABASE_DSN="+r.Plan.Database.DSN(r.DBPassword),
+		openwatchBin, "create-admin",
+		"--username", r.Plan.Admin.Username,
+		"--email", r.Plan.Admin.Email,
+		"--password", r.AdminPassword)
+}
+
+type stepService struct{}
+
+func (stepService) ID() string { return "service" }
+
+func (stepService) Describe(p Plan) string {
+	what := "enable openwatch.service"
+	if p.Service.StartNow {
+		what = "enable and start openwatch.service"
+	}
+	if p.Service.BindCapability {
+		what += fmt.Sprintf("; port %d is privileged, so add AmbientCapabilities=CAP_NET_BIND_SERVICE", p.Service.ListenPort)
+	}
+	return what
+}
+
+func (stepService) Status(ctx context.Context, p Plan) StepStatus {
+	if serviceActive("openwatch") {
+		return StepStatus{Done: false, Detail: "already running; will be restarted"}
+	}
+	return StepStatus{}
+}
+
+func (s stepService) Apply(ctx context.Context, r *Run) error {
+	if r.Plan.Service.BindCapability {
+		dir := "/etc/systemd/system/openwatch.service.d"
+		if err := os.MkdirAll(dir, 0o755); err != nil && !r.DryRun {
+			return fmt.Errorf("%s: %w", s.ID(), err)
+		}
+		drop := "[Service]\nAmbientCapabilities=CAP_NET_BIND_SERVICE\n"
+		if err := r.writeFile(s.ID(), filepath.Join(dir, "10-bind-privileged-port.conf"),
+			[]byte(drop), 0o644); err != nil {
+			return err
+		}
+		if err := r.mutate(ctx, s.ID(), "daemon-reload", "systemctl", "daemon-reload"); err != nil {
+			return err
+		}
+	}
+	verb := "enable"
+	args := []string{"enable", "openwatch"}
+	if r.Plan.Service.StartNow {
+		verb = "enable --now"
+		args = []string{"enable", "--now", "openwatch"}
+	}
+	if err := r.mutate(ctx, s.ID(), "systemctl "+verb, "systemctl", args...); err != nil {
+		return err
+	}
+	r.record(s.ID(), verb, "openwatch.service", "")
+	return nil
+}
+
+type stepVerify struct{}
+
+func (stepVerify) ID() string { return "verify" }
+
+func (stepVerify) Describe(p Plan) string {
+	return fmt.Sprintf("confirm the API answers on https://%s:%d/api/v1/health",
+		p.Service.ListenHost, p.Service.ListenPort)
+}
+
+func (stepVerify) Status(context.Context, Plan) StepStatus { return StepStatus{} }
+
+// Apply proves the install rather than declaring it finished. An installer
+// that ends with "done" when the service is not actually serving is worse than
+// one that fails, because the failure surfaces later and further away.
+func (s stepVerify) Apply(ctx context.Context, r *Run) error {
+	if r.DryRun || !r.Plan.Service.StartNow {
+		return nil
+	}
+	url := fmt.Sprintf("https://127.0.0.1:%d/api/v1/health", r.Plan.Service.ListenPort)
+	var last string
+	for i := 0; i < 15; i++ {
+		res := run(ctx, "curl", "-sk", "--max-time", "5", url)
+		if res.Err == nil && strings.Contains(res.Stdout, `"status"`) {
+			r.logf("    %s", firstLine(res.Stdout))
+			if !strings.Contains(res.Stdout, `"db_connected":true`) {
+				return fmt.Errorf("%s: the service is up but reports db_connected=false; "+
+					"check the DSN in %s", s.ID(), secretsEnvPath)
+			}
+			return nil
+		}
+		last = firstLine(res.Stdout + res.Stderr)
+		sleep(ctx, 2)
+	}
+	return fmt.Errorf("%s: %s did not become healthy; last response %q. "+
+		"Check `systemctl status openwatch` and `journalctl -u openwatch -n 50`",
+		s.ID(), url, last)
+}
+
+// -------------------------------------------------------------- detection
+
+const (
+	secretsEnvPath = "/etc/openwatch/secrets.env"
+	openwatchBin   = "/usr/bin/openwatch"
+)
+
+// postgresMajor returns the running server's major version, or 0 when it
+// cannot be determined. Uses server_version_num, which is stable, rather than
+// the version string, which carries vendor suffixes.
+func postgresMajor(ctx context.Context) int {
+	res := psql(ctx, "SELECT current_setting('server_version_num')")
+	if res.Err != nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(res.Stdout))
+	if err != nil {
+		return 0
+	}
+	return n / 10000
+}
+
+func postgresReachable(ctx context.Context) bool {
+	return psql(ctx, "SELECT 1").Err == nil
+}
+
+// postgresDataDirInitialised reports whether the RHEL data directory already
+// holds a cluster. initdb against a populated directory fails, and running it
+// against one that merely looks empty would destroy nothing but waste time.
+func postgresDataDirInitialised() bool {
+	_, err := os.Stat("/var/lib/pgsql/data/PG_VERSION")
+	return err == nil
+}
+
+// pgHbaPath asks the server where its configuration lives rather than guessing.
+// The path differs by family (RHEL /var/lib/pgsql/data, Debian
+// /etc/postgresql/<major>/main) and Debian can host several clusters at once,
+// so the running server is the only reliable source.
+func pgHbaPath(ctx context.Context) string {
+	if res := psql(ctx, "SHOW hba_file"); res.Err == nil && res.Stdout != "" {
+		return strings.TrimSpace(res.Stdout)
+	}
+	for _, candidate := range []string{"/var/lib/pgsql/data/pg_hba.conf"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func pgHbaLines(dbName, roleName string) []string {
+	return []string{
+		fmt.Sprintf("host    %-12s %-12s 127.0.0.1/32    scram-sha-256", dbName, roleName),
+		fmt.Sprintf("host    %-12s %-12s ::1/128         scram-sha-256", dbName, roleName),
+	}
+}
+
+// hasOpenWatchHbaRules reports whether both loopback rules are present and
+// uncommented. Deliberately tolerant of whitespace, since an operator may have
+// reformatted them.
+func hasOpenWatchHbaRules(content, dbName, roleName string) bool {
+	var v4, v6 bool
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Fields(line)
+		if len(f) < 5 || f[0] != "host" {
+			continue
+		}
+		matchesDB := f[1] == dbName || f[1] == "all"
+		matchesRole := f[2] == roleName || f[2] == "all"
+		if !matchesDB || !matchesRole || f[4] != "scram-sha-256" {
+			continue
+		}
+		switch f[3] {
+		case "127.0.0.1/32":
+			v4 = true
+		case "::1/128":
+			v6 = true
+		}
+	}
+	return v4 && v6
+}

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -246,3 +246,29 @@ spec:
         the remedy.
       priority: critical
       references_constraints: [C-07, C-09, C-12]
+    - id: AC-11
+      description: >
+        Live verification on RHEL 9.8, recorded here for the same reason as
+        AC-10. One invocation went from no cluster to a signed-in
+        administrator, and a second invocation left that administrator able to
+        log in. The assumptions it rests on are still checkable: RHEL 9 is a
+        tested platform needing no override, the default plan generates and
+        then reuses the database password rather than rotating it per run, and
+        the completion summary resolves a wildcard listen address to something
+        an operator can open.
+      priority: critical
+      references_constraints: [C-04, C-10, C-13]
+    - id: AC-12
+      description: >
+        The role mutation sets password_encryption to scram-sha-256 in the same
+        statement as CREATE ROLE or ALTER ROLE, so the hash does not depend on
+        the server default, and a role found already hashed md5 is re-hashed by
+        the ALTER path. The password is a quote-doubled literal.
+      priority: critical
+      references_constraints: [C-03]
+    - id: AC-13
+      description: >
+        Neither the serialised plan nor the receipt contains a credential
+        value, and the Secret type declares no field able to hold one.
+      priority: critical
+      references_constraints: [C-02]

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -152,6 +152,22 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-13
+      description: >
+        setup MUST allow the listen port through an active host firewall, and
+        the completion summary MUST NOT imply reachability it did not check.
+        The health check runs over loopback, where the firewall does not apply,
+        so a fully firewalled host is indistinguishable from a working one: a
+        live RHEL 9.8 install passed every internal check and was unreachable
+        from every other machine with "No route to host". Opening the port is
+        the default rather than opt-in, unlike the pg_hba edit, because the two
+        risks differ in kind: a pg_hba mistake removes access the operator
+        already had, whereas allowing the port a web application listens on is
+        the access they requested by installing it. --no-firewall declines it,
+        and when the port is left closed the run says so explicitly.
+      type: technical
+      enforcement: error
+
   acceptance_criteria:
     - id: AC-01
       description: >

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -269,6 +269,10 @@ spec:
     - id: AC-13
       description: >
         Neither the serialised plan nor the receipt contains a credential
-        value, and the Secret type declares no field able to hold one.
+        value, and the Secret type declares no field able to hold one. Both
+        files are written root-only (0600): they are the two artifacts the run
+        leaves behind for a human, setup writes them as root, and neither has a
+        reader that is not root. secrets.env is the deliberate exception at
+        0640, because it is chowned to the service group that must read the DSN.
       priority: critical
       references_constraints: [C-02]

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -1,0 +1,232 @@
+spec:
+  id: system-setup
+  title: Guided installer (openwatch setup)
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch
+    feature: One-command install
+    description: >
+      `openwatch setup` takes a host with the packages installed to a running,
+      signed-in OpenWatch: provision PostgreSQL, create the role and database,
+      write the DSN, migrate, create the first admin, start the service, and
+      prove it answers. It detects, shows a plan, asks, applies only what is
+      missing, and records what it touched.
+    related_specs:
+      - release-package-build
+      - system-db
+      - system-config
+
+  objective:
+    summary: >
+      Every failure observed in a v0.7.0 install walkthrough was a
+      transcription or an assumption rather than a misunderstanding: an
+      indented heredoc terminator, trailing whitespace after a line
+      continuation, an unencoded '@' in a DSN, a password_encryption default
+      that differs by PostgreSQL version, a pg_hba.conf edit that removed the
+      local rule, and a distro default of PostgreSQL 13 under a guide asking
+      for 14. None concerned OpenWatch itself. A document copied by hand cannot
+      remove that class of error; a program can.
+    scope:
+      includes:
+        - Detection of distribution, PostgreSQL, SELinux, FIPS, fapolicyd
+        - A plan shown before any change, with per-step already-done status
+        - Guided, --yes, and --plan fill modes over one plan object
+        - Provisioning PostgreSQL, role, database, DSN, migrations, admin, service
+        - A health check that proves the install rather than declaring it
+        - A receipt recording every change
+      excludes:
+        - Installing the OpenWatch packages themselves (the package ships setup)
+        - Non-systemd init systems
+        - Remote PostgreSQL provisioning (mode existing validates, never provisions)
+
+  constraints:
+    - id: C-01
+      description: >
+        The DSN MUST be assembled by net/url from a raw password, never by
+        string concatenation. A DSN is a URI: an unencoded '@', '/' or ':' in
+        the password silently relocates the URI boundaries, and the resulting
+        failure names the role or the host rather than the connection string.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: >
+        The plan MUST record only where each credential comes from, never its
+        value, and the receipt MUST NOT contain a credential. This is what
+        makes a plan file safe to commit, attach to a ticket, or replay across
+        a fleet.
+      type: security
+      enforcement: error
+    - id: C-03
+      description: >
+        CREATE ROLE MUST set password_encryption to scram-sha-256 in the same
+        session. The server default changed from md5 in PostgreSQL 14 and RHEL
+        9 still ships 13, so inheriting it produces a role that cannot
+        authenticate against the pg_hba rules setup itself requires. A role
+        found already hashed md5 MUST be re-hashed.
+      type: security
+      enforcement: error
+    - id: C-04
+      description: >
+        The database role's password and the password written into the DSN MUST
+        be the same value after every run. A generated password that is not
+        reused across runs, or a role step skipped because the role exists,
+        produces a role and a DSN holding different secrets and a
+        "password authentication failed" error from an installer that just
+        reported success.
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: >
+        pg_hba.conf MUST NOT be modified unless --manage-pg-hba is passed.
+        Editing it is the most effective way to lock an operator out of their
+        own database. When managed, setup MUST back the file up, insert its
+        block ABOVE the first existing authentication rule (pg_hba is
+        first-match-wins, and the stock RHEL file matches 127.0.0.1/32 with
+        ident before any appended block), validate by reload, and restore the
+        original if the reload fails.
+      type: security
+      enforcement: error
+    - id: C-06
+      description: >
+        Declining to manage pg_hba.conf MUST halt the run at that step with the
+        required lines, not continue. Every later step authenticates as the
+        role, so proceeding guarantees a failure two steps downstream whose
+        message names ident authentication rather than the missing rules.
+      type: technical
+      enforcement: error
+    - id: C-07
+      description: >
+        Every step MUST report whether it is already satisfied before it acts,
+        and MUST be safe to re-run. The usual moment to run an installer is
+        after a previous attempt failed part-way. Status checks against
+        application tables MUST target the application database: psql without
+        -d connects to the postgres maintenance database, where those tables do
+        not exist, and the resulting error reads as not-yet-done.
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: >
+        Privilege drops MUST use runuser, not sudo. setup already runs as root,
+        so there is nothing to acquire, and sudo requires a PAM stack that is
+        not always configured: on minimal AlmaLinux and Oracle Linux images
+        `sudo -u postgres` fails with a PAM account management error while
+        runuser succeeds.
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: >
+        After starting PostgreSQL, setup MUST wait for the server to accept
+        connections rather than trusting systemctl's return. The unit becomes
+        active before the socket is ready, and the gap is wide enough that some
+        distributions win the race and others do not, producing an
+        inconsistent "cannot determine the PostgreSQL server version" from
+        identical code.
+      type: technical
+      enforcement: error
+    - id: C-10
+      description: >
+        Platform support MUST be three-valued and enforced in code: tested runs,
+        untested requires --allow-untested, unsupported refuses. Publishing a
+        support matrix that CI does not exercise is how a support statement
+        starts lying; refusing every unrecognised host would block derivatives
+        running identical paths.
+      type: technical
+      enforcement: error
+    - id: C-11
+      description: >
+        Role and database names reaching SQL MUST be restricted to plain
+        identifiers rather than escaped. These are interpolated into CREATE
+        statements, which cannot be parameterised; rejecting a hostile
+        identifier is safer than trusting an escape.
+      type: security
+      enforcement: error
+    - id: C-12
+      description: >
+        The run MUST end by confirming the API answers and reports
+        db_connected, not by declaring success. An installer that reports done
+        when the service is not serving moves the failure later and further
+        from its cause.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: >
+        A password containing any URI-reserved character round-trips through
+        DatabasePlan.DSN: parsing the result recovers the exact password and
+        leaves username, host and port intact.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: >
+        Derive computes dependent fields: a listen port below 1024 sets
+        bind_capability, and a non-loopback database host raises sslmode off
+        disable.
+      priority: high
+    - id: AC-03
+      description: >
+        Validate rejects provisioning a remote host, cleartext to a remote
+        host, identifiers that are not plain, out-of-range ports, unknown
+        sslmodes, an address without '@', a secret source of env or file with
+        no ref, and a generated length under 16. The default plan validates and
+        does NOT manage pg_hba.conf.
+      priority: critical
+      references_constraints: [C-11]
+    - id: AC-04
+      description: >
+        Platform support tiers resolve correctly: RHEL 9 is tested, other
+        RHEL-family majors 8 to 10 and Debian-family are untested, unknown
+        families and unparseable versions are unsupported. ID_LIKE is consulted
+        so an unlisted derivative naming its parent is placed correctly.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-05
+      description: >
+        insertHbaBlock places its block above the first active authentication
+        rule, never at the end. Given a stock file whose first rule is
+        "host all all 127.0.0.1/32 ident", the OpenWatch rules precede it.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-06
+      description: >
+        existingDSNPassword recovers the password from a previously written
+        secrets.env by URI parsing, so a password containing reserved
+        characters is decoded exactly as the server decodes it, and returns not
+        found for a missing file or a line without a DSN.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-07
+      description: >
+        hasOpenWatchHbaRules detects both loopback rules regardless of
+        whitespace, ignores commented lines, and accepts the "all" wildcards
+        that a hand-written file may use.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-08
+      description: >
+        Source inspection: no invocation of "sudo" remains in internal/setup;
+        privilege drops use runuser.
+      priority: high
+      references_constraints: [C-08]
+    - id: AC-09
+      description: >
+        Source inspection: the pg_hba step returns a PauseError when the rules
+        are missing and ManagePgHba is false, rather than returning nil and
+        letting later steps proceed.
+      priority: critical
+      references_constraints: [C-06]
+    - id: AC-10
+      description: >
+        Container verification across the RHEL family, recorded here because it
+        cannot run in unit tests. With the shipped RPM on systemd containers,
+        `openwatch setup --yes --allow-untested --manage-pg-hba` completes and
+        the health endpoint reports db_connected on Rocky 9, AlmaLinux 9,
+        Oracle Linux 9 and AlmaLinux 10; a second identical run also exits zero,
+        proving idempotence. AlmaLinux 8 is correctly refused because its
+        default PostgreSQL is 10, below the floor of 13, with a message naming
+        the remedy.
+      priority: critical
+      references_constraints: [C-07, C-09, C-12]

--- a/specter.yaml
+++ b/specter.yaml
@@ -23,6 +23,7 @@ domains:
             - system-idempotency
             - system-license-features
             - system-license-validation
+            - system-setup
             - system-rbac
             - system-job-queue
             - system-policy


### PR DESCRIPTION
## What

`openwatch setup` takes a host with the packages installed to a running,
signed-in OpenWatch: provision PostgreSQL, create the role and database, write
the DSN, migrate, create the first admin, open the listen port, start the
service, and prove it answers. It detects, shows a plan, asks, applies only what
is missing, and records what it touched in a receipt.

`docs/guides/INSTALLATION.md` makes it the documented install path.

## Why

Every failure observed in a v0.7.0 install walkthrough was a transcription or an
assumption rather than a misunderstanding: an indented heredoc terminator,
trailing whitespace after a line continuation, an unencoded `@` in a DSN, a
`password_encryption` default that differs by PostgreSQL version, a pg_hba.conf
edit that removed the local rule, and a distro default of PostgreSQL 13 under a
guide asking for 14. None concerned OpenWatch itself. A document copied by hand
cannot remove that class of error; a program can.

## Verification

Container-tested with the shipped RPM on systemd containers across the RHEL
family: `--yes --allow-untested --manage-pg-hba` completes and `/health` reports
`db_connected` on Rocky 9, AlmaLinux 9, Oracle Linux 9 and AlmaLinux 10; a second
identical run also exits zero, proving idempotence. AlmaLinux 8 is correctly
refused (default PostgreSQL 10, below the floor of 13) with a message naming the
remedy. Also verified live on RHEL 9.8: no cluster to signed-in administrator in
one invocation, and the administrator still able to log in after a second.

Six defects found by that container testing and one found by the live run are
fixed in the commits here rather than left for a follow-up.

## Spec

New `specs/system/setup.spec.yaml` (`system-setup`, 13 constraints, 13 ACs),
registered in `specter.yaml`. `specter check --test` and `specter coverage
--strictness annotation` pass at 118 specs.

## Release

This is intended for **v0.7.0-rc.3**. The guides on `main` already point at
`openwatch setup`, so until this merges the documented install path is not in any
built package.

## Known follow-up, deliberately not in scope

`Run.DryRun` is never set by the CLI (`--dry-run` returns after rendering the
plan, before secrets are resolved), so the `DryRun` branches inside the step
implementations are unreachable. One of them, `psqlMutate`, would log the role
statement including the password literal if it ever became reachable. Inert
today; worth either wiring `--dry-run` through execution or deleting the
branches, and that is a change to execution paths that does not belong in a
release candidate.