### PR TITLE
feat(release): add a gate manifest and a go/no-go readiness check

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -191,6 +191,14 @@ jobs:
         if: steps.paths.outputs.go == 'true'
         run: make vuln
 
+      # The release readiness checker decides go/no-go for a candidate, so its
+      # own guards have to hold: evidence tied to an artifact digest goes
+      # stale when the bits change, an unreadable checksum list fails closed,
+      # and an agent cannot satisfy a gate that requires a human observer.
+      # Stdlib only and no network, so this runs unconditionally and fast.
+      - name: release gate checker tests
+        run: python3 scripts/test_release_status.py
+
       # Annotation hygiene: cross-reference every test's @spec / @ac
       # annotation against the spec registry and fail on a dangling spec
       # ref, unknown AC id, malformed AC id, or unreachable annotation

--- a/.gitignore
+++ b/.gitignore
@@ -339,6 +339,12 @@ frontend_test.log
 *test*.js
 *test*.cjs
 
+# Committed test suites, which the blanket patterns above would otherwise
+# swallow silently: `git add` refuses and prints nothing unless you look.
+# scripts/test_release_status.py was lost this way once.
+!scripts/test_*.py
+!scripts/test_*.sh
+
 # ...but scripts/ holds real, tracked tooling whose names contain "test". The
 # blanket patterns above silently swallowed scripts/test-db.sh: `git add`
 # refused it, the Makefile shipped referencing a script that was never

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,12 @@ spec-check:
 release-status:
 	python3 scripts/release-status.py $(if $(TAG),--tag $(TAG),)
 
+# release-status-test: the checker's own guards. Stdlib only, no network,
+# runs in milliseconds. CI runs this in the Quality gates job.
+.PHONY: release-status-test
+release-status-test:
+	python3 scripts/test_release_status.py
+
 # docs-style: the Hanalyx documentation style gate (em dashes, emojis, AI
 # speak). Mirrors CI's "Doc Style" job. Single-file python3 script, no
 # dependencies. Canonical rules: Context Plane dev/DEVELOPER_DOCUMENTATION_STYLE_GUIDE.

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,19 @@ spec-check:
 	specter check --test
 	specter coverage --strictness annotation
 
+# release-status: render release/gates.toml for a candidate and return a
+# go/no-go verdict. Needs `gh` authenticated to read check runs and assets.
+#
+# The script exits 0 for GO, 1 for NO-GO and 2 for a lookup error. make
+# collapses any recipe failure to its own status, so anything automated should
+# call scripts/release-status.py directly to tell a NO-GO from a broken lookup.
+#
+#   make release-status                  # most recent tag
+#   make release-status TAG=v0.7.0-rc.3
+.PHONY: release-status
+release-status:
+	python3 scripts/release-status.py $(if $(TAG),--tag $(TAG),)
+
 # docs-style: the Hanalyx documentation style gate (em dashes, emojis, AI
 # speak). Mirrors CI's "Doc Style" job. Single-file python3 script, no
 # dependencies. Canonical rules: Context Plane dev/DEVELOPER_DOCUMENTATION_STYLE_GUIDE.

--- a/release/attestations/clean-install-rhel9-190350f3.toml
+++ b/release/attestations/clean-install-rhel9-190350f3.toml
@@ -1,0 +1,62 @@
+# Attestation: clean install on the RHEL 9 family.
+#
+# Scoped to the artifact digest, not to the tag. A later candidate that ships
+# the identical package inherits this evidence; one that rebuilds the binary
+# does not, and the checker will report the gate unmet again.
+#
+# artifact_sha256 needs a `pragma: allowlist secret` comment. detect-secrets
+# reads any 64-character hex string as a possible credential; this one is a
+# published checksum, byte-identical to the line in the release's SHA256SUMS.
+
+kind = "clean-install"
+platform = "rhel9"
+tag = "v0.7.0-rc.3"
+artifact = "openwatch-0.7.0-1.x86_64.rpm"
+artifact_sha256 = "190350f3fb4ca52d3bc9d75854156d6cb25f4514d0dff9f64b89581516a4714b"  # pragma: allowlist secret
+
+method = "vm"
+performed_by = "openwatch-agent"
+performed_at = "2026-07-31"
+host = "owas-rhlowserv01, RHEL 9.8 (Plow), x86_64, SELinux enforcing, fapolicyd active, firewalld active"
+
+observed = """
+Preconditions verified clean: no openwatch, kensa-rules or postgresql-server
+package; no /var/lib/pgsql, /etc/openwatch or /var/lib/openwatch; nothing
+listening but sshd.
+
+Artifacts verified before install: gpg --verify SHA256SUMS.asc reported a good
+signature from the release key, and rpm -Kv reported "Header V4 RSA/SHA256
+Signature, key ID ff7e515e: OK" with all digests OK.
+
+Both packages installed in one dnf transaction, which also pulled
+postgresql-server 13.23. Setup detected rhel 9.8 amd64 as tested and required
+no --allow-untested.
+
+Run without --manage-pg-hba halted at the pg-hba step with exit 3, printing the
+two required rules, the reload command and both remedies, and recorded progress
+to the receipt. Re-run resumed with postgres-install, postgres-cluster,
+postgres-version and database all skipped.
+
+Run with --manage-pg-hba completed exit 0. The verify step reported
+{"db_connected":true,"status":"healthy","version":"0.7.0"}. pg_hba.conf was
+backed up to pg_hba.conf.bak-20260731T110227Z before being edited.
+
+Reachability confirmed from a separate machine, not loopback: HTTP 200 on
+/api/v1/health and on the UI root. POST /api/v1/auth/login returned 200 with a
+token; /api/v1/auth/me reported role admin; /api/v1/capabilities returned 200.
+
+File modes on disk: setup-receipt.json 0600 root:root, secrets.env 0640
+root:openwatch. The receipt recorded the database password as
+{"Source":"generate","Length":32} with no value.
+"""
+
+caveats = """
+The interactive path was not exercised. Prompts need a TTY, so this ran with
+--yes and --admin-password-from file:. The plain `sudo openwatch setup` that
+the install guide leads with remains unverified end to end.
+
+PostgreSQL 13 came from the RHEL 9 default stream, below the supported minimum
+of 15. That is the path where the server default password_encryption is md5,
+so this run does exercise the scram-sha-256 SET, but it does not cover a
+PostgreSQL 15+ host.
+"""

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -1,0 +1,226 @@
+# Release readiness gates.
+#
+# This file is the single list of what must be true before a candidate is
+# promoted to GA. `make release-status TAG=vX.Y.Z` renders it and returns a
+# verdict; a NO-GO names every unmet gate.
+#
+# The rule this file exists to enforce: every gate has either a machine
+# checkable evidence source or a dated human attestation tied to a specific
+# artifact. No gate may be satisfied by someone's recollection.
+#
+# Evidence kinds:
+#   github-check  a named check run on the candidate tag's commit
+#   release-asset an asset published by release.yml for the tag
+#   per-platform  expands over [[platform]] below; satisfied by a container
+#                 job or a human attestation, either scoped to the artifact
+#   attestation   a file in release/attestations/ naming what was observed
+#
+# Adding a platform here without adding it to release.yml's build matrix is a
+# configuration error the checker reports, not a silent pass.
+
+version = 1
+
+# ---------------------------------------------------------------- platforms
+
+# The install matrix. `method` records how the evidence is meant to be
+# produced; an attestation from a real VM also satisfies a container gate,
+# because both prove the same claim. What is never allowed is no evidence.
+#
+# Keep this list and internal/setup/platform.go's supportOf() in agreement.
+# A platform that is blocking here and passing is what justifies
+# SupportTested there; anything else is a support claim CI does not back.
+
+[[platform]]
+id = "rhel9"
+title = "RHEL 9 family (RHEL, Rocky, AlmaLinux, Oracle Linux 9)"
+method = "container"
+package = "rpm"
+support_tier = "tested"
+blocking = true
+
+[[platform]]
+id = "el10"
+title = "AlmaLinux 10 / RHEL 10"
+method = "container"
+package = "rpm"
+support_tier = "untested"
+blocking = true
+
+[[platform]]
+id = "ubuntu2404"
+title = "Ubuntu 24.04 LTS"
+method = "container"
+package = "deb"
+support_tier = "untested"
+blocking = true
+
+[[platform]]
+id = "debian12"
+title = "Debian 12"
+method = "container"
+package = "deb"
+support_tier = "untested"
+blocking = true
+
+# -------------------------------------------------------------------- gates
+
+# Quality. These already run in CI; the checker collects them rather than
+# re-running them, so a green pipeline populates this section for free.
+
+[[gate]]
+id = "Q1"
+title = "Quality and security gates"
+proves = "gofmt, vet, golangci-lint incl. gosec, govulncheck, race tests, frontend build"
+evidence = "github-check"
+check = "Quality + security gates"
+blocking = true
+
+[[gate]]
+id = "Q2"
+title = "CodeQL static analysis"
+proves = "No new CodeQL findings on the candidate commit"
+evidence = "github-check"
+check = "Analyze Code (javascript)"
+blocking = true
+
+[[gate]]
+id = "Q3"
+title = "Documentation style"
+proves = "Changed Markdown is free of em dashes, emojis and AI speak"
+evidence = "github-check"
+check = "Doc Style"
+blocking = true
+
+# Package installability, per distro. Already automated by
+# package-smoke.yml. Note what this does NOT prove: the job never runs
+# `openwatch setup`, never stands up PostgreSQL and never starts the service.
+# It asserts files, the system user, a >=500 rule corpus, valid identity keys,
+# and that the binary runs check-config. The setup path is gate I1.
+
+[[gate]]
+id = "P1"
+title = "Packages install cleanly, per distro"
+proves = "Both packages install in one transaction; files, system user, rule corpus and identity keys are correct; the binary runs check-config"
+evidence = "github-check-all"
+checks = [
+  "rockylinux:9",
+  "almalinux:9",
+  "oraclelinux:9",
+  "fedora:41",
+  "ubuntu:24.04",
+  "debian:12",
+]
+blocking = true
+
+# Release integrity.
+
+[[gate]]
+id = "R1"
+title = "Signed artifacts published"
+proves = "release.yml produced RPM and DEB for both arches with SBOMs"
+evidence = "release-asset"
+assets = [
+  "openwatch-*.x86_64.rpm",
+  "openwatch-*.aarch64.rpm",
+  "openwatch_*_amd64.deb",
+  "openwatch_*_arm64.deb",
+  "kensa-rules-*.noarch.rpm",
+  "kensa-rules_*_all.deb",
+]
+blocking = true
+
+[[gate]]
+id = "R2"
+title = "Checksums and signature published"
+proves = "SHA256SUMS is present and detached-signed with the release key"
+evidence = "release-asset"
+assets = ["SHA256SUMS", "SHA256SUMS.asc", "KEYS"]
+blocking = true
+
+[[gate]]
+id = "R3"
+title = "Tag is GPG signed"
+proves = "The candidate tag carries a good signature from the release key"
+evidence = "signed-tag"
+blocking = true
+
+# Install and upgrade. These expand over [[platform]].
+
+[[gate]]
+id = "I1"
+title = "Clean install via `openwatch setup`"
+proves = "From a host with no OpenWatch and no PostgreSQL, setup reaches a running service whose /health reports db_connected"
+evidence = "per-platform"
+kind = "clean-install"
+blocking = true
+
+[[gate]]
+id = "I2"
+title = "Second setup run is idempotent"
+proves = "Re-running setup on a completed install exits 0 and changes nothing that breaks it"
+evidence = "per-platform"
+kind = "idempotence"
+blocking = true
+
+[[gate]]
+id = "U1"
+title = "Package upgrade scriptlet auto-migrates"
+proves = "rpm -U runs the %post scriptlet: pre-upgrade backup taken, schema migrated to head, service stop/started"
+evidence = "github-check"
+check = "Package upgrade (rpm -U auto-migrate)"
+blocking = true
+
+# U1 covers the mechanism on rockylinux:9 with RPM, between two synthetic
+# builds of the same version. It does not cover DEB, other distros, or the
+# real previous-GA-to-candidate jump, which is what an operator actually does.
+# That is U2, and no automation produces it yet.
+
+[[gate]]
+id = "U2"
+title = "Upgrade from the previous GA release"
+proves = "The previous GA installed and running, then upgraded to the candidate with both packages in one transaction; migrations apply and the service returns healthy"
+evidence = "per-platform"
+kind = "upgrade-from-ga"
+blocking = true
+
+# Functional. Container jobs cannot prove these; they need real managed hosts.
+# Each names the surface it checks, because "functional walkthrough" is not
+# falsifiable and this has to be refusable by a person in a few minutes.
+
+[[gate]]
+id = "F1"
+title = "Scan a real host end to end"
+proves = "A scan against a live fleet host completes and reports per-rule results"
+evidence = "attestation"
+kind = "fleet-scan"
+human_required = true
+blocking = true
+
+[[gate]]
+id = "F2"
+title = "Staged remediation renders correctly"
+proves = "On a host whose `auditctl -s` reports `enabled 2`, remediating an audit_rule_set rule shows amber 'Staged, reboot required' with a working Roll back, not a red failure"
+evidence = "attestation"
+kind = "fleet-staged-remediation"
+human_required = true
+blocking = true
+
+[[gate]]
+id = "F3"
+title = "Scan variables populate on a packaged install"
+proves = "Settings > Compliance policies lists scan variables; a blank panel means the rule corpus did not resolve"
+evidence = "attestation"
+kind = "fleet-scan-variables"
+human_required = true
+blocking = true
+
+# Sign off.
+
+[[gate]]
+id = "H1"
+title = "Release captain signature"
+proves = "A named human accepts the release against the release-admin-signoff DoD"
+evidence = "attestation"
+kind = "release-captain"
+human_required = true
+blocking = true

--- a/scripts/release-status.py
+++ b/scripts/release-status.py
@@ -91,11 +91,17 @@ def release_assets(tag):
 
 
 def release_digests(tag):
-    """sha256 -> filename, from the candidate's published SHA256SUMS."""
+    """sha256 -> filename, from the candidate's published SHA256SUMS.
+
+    Returns None when the list could not be read at all, which callers must
+    treat as "cannot verify" rather than "nothing to check against". An
+    unreachable checksum list is the one case where a stale attestation would
+    otherwise sail through as PASS.
+    """
     rc, out = sh("gh", "release", "download", tag, "--pattern", "SHA256SUMS",
                  "--output", "-")
     if rc != 0:
-        return {}
+        return None
     digests = {}
     for line in out.splitlines():
         parts = line.split()
@@ -135,7 +141,13 @@ def eval_attestation(att, digests, human_required):
     sha = att.get("artifact_sha256")
     if not sha:
         return FAIL, f"{att['_file']}: no artifact_sha256"
-    if digests and sha not in digests:
+    if digests is None:
+        # Fail closed. If the candidate's SHA256SUMS cannot be read, the
+        # attestation cannot be tied to these bits, and an unverifiable claim
+        # is not evidence.
+        return ERROR, (f"{att['_file']}: cannot read SHA256SUMS for this "
+                       "candidate, so the attested artifact is unverifiable")
+    if sha not in digests:
         return STALE, (f"{att['_file']}: artifact {sha[:12]} is not in this "
                        "candidate's SHA256SUMS")
     who = att.get("performed_by", "?")

--- a/scripts/release-status.py
+++ b/scripts/release-status.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Render the release gates for a candidate tag and return a go/no-go verdict.
+
+    scripts/release-status.py --tag v0.7.0-rc.3
+
+Exit status is the verdict: 0 for GO, 1 for NO-GO, 2 for a configuration or
+lookup error. That makes it usable as a gate in its own right, so CI can call
+exactly what a human calls and neither can reach a different answer.
+
+Single file, standard library only, matching scripts/check-doc-style.py. TOML
+is read with the stdlib tomllib rather than PyYAML so the checker has no
+install step of its own.
+
+Evidence comes from three places and nowhere else:
+
+  github-check   check runs on the tag's commit, via `gh api`
+  release-asset  assets on the GitHub release for the tag, via `gh release`
+  attestation    files under release/attestations/, scoped to an artifact
+                 digest so evidence follows the bits rather than the tag
+
+An attestation whose artifact_sha256 does not appear in the candidate's
+SHA256SUMS is reported STALE, not PASS. That is the whole point: re-cutting a
+candidate with a rebuilt binary silently invalidates prior install evidence,
+which is the failure mode this tool exists to prevent.
+"""
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+GATES = REPO / "release" / "gates.toml"
+ATTEST_DIR = REPO / "release" / "attestations"
+
+PASS, FAIL, MISSING, STALE, ERROR = "PASS", "FAIL", "MISSING", "STALE", "ERROR"
+BAD = {FAIL, MISSING, STALE, ERROR}
+
+
+def sh(*args, check=False):
+    """Run a command, returning (rc, stdout). Never raises on non-zero."""
+    p = subprocess.run(args, capture_output=True, text=True)
+    if check and p.returncode != 0:
+        die(f"{' '.join(args)}: {p.stderr.strip()}")
+    return p.returncode, p.stdout.strip()
+
+
+def die(msg):
+    print(f"release-status: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+# ------------------------------------------------------------------ evidence
+
+
+def tag_commit(tag):
+    rc, out = sh("git", "rev-list", "-n", "1", tag)
+    if rc != 0 or not out:
+        die(f"tag {tag} not found locally; fetch it first")
+    return out
+
+
+def check_runs(commit):
+    """Map check-run name -> conclusion for a commit."""
+    rc, out = sh(
+        "gh", "api", "--paginate",
+        f"repos/{{owner}}/{{repo}}/commits/{commit}/check-runs",
+        "--jq", ".check_runs[] | [.name, .conclusion] | @tsv",
+    )
+    if rc != 0:
+        return None
+    runs = {}
+    for line in out.splitlines():
+        if "\t" in line:
+            name, conclusion = line.split("\t", 1)
+            # A name can appear more than once across re-runs; success wins,
+            # because a passing re-run is what the tree is at.
+            if runs.get(name) != "success":
+                runs[name] = conclusion
+    return runs
+
+
+def release_assets(tag):
+    rc, out = sh("gh", "release", "view", tag, "--json", "assets")
+    if rc != 0:
+        return None
+    return [a["name"] for a in json.loads(out).get("assets", [])]
+
+
+def release_digests(tag):
+    """sha256 -> filename, from the candidate's published SHA256SUMS."""
+    rc, out = sh("gh", "release", "download", tag, "--pattern", "SHA256SUMS",
+                 "--output", "-")
+    if rc != 0:
+        return {}
+    digests = {}
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 2:
+            digests[parts[0]] = parts[1]
+    return digests
+
+
+def tag_is_signed(tag):
+    rc, _ = sh("git", "tag", "-v", tag)
+    return rc == 0
+
+
+def load_attestations():
+    if not ATTEST_DIR.is_dir():
+        return []
+    out = []
+    for f in sorted(ATTEST_DIR.glob("*.toml")):
+        try:
+            with f.open("rb") as fh:
+                a = tomllib.load(fh)
+        except tomllib.TOMLDecodeError as e:
+            die(f"{f.name}: {e}")
+        a["_file"] = f.name
+        out.append(a)
+    return out
+
+
+# --------------------------------------------------------------- evaluation
+
+
+def eval_attestation(att, digests, human_required):
+    """Return (status, note) for one matched attestation."""
+    if human_required and att.get("performed_by", "").endswith("-agent"):
+        return FAIL, (f"{att['_file']}: performed_by is an agent; this gate "
+                      "requires a human observer")
+    sha = att.get("artifact_sha256")
+    if not sha:
+        return FAIL, f"{att['_file']}: no artifact_sha256"
+    if digests and sha not in digests:
+        return STALE, (f"{att['_file']}: artifact {sha[:12]} is not in this "
+                       "candidate's SHA256SUMS")
+    who = att.get("performed_by", "?")
+    when = att.get("performed_at", "?")
+    return PASS, f"{att['_file']} ({who}, {when})"
+
+
+def evaluate(gates, tag, commit):
+    """Yield (gate_id, label, status, note) rows."""
+    runs = check_runs(commit)
+    assets = release_assets(tag)
+    digests = release_digests(tag)
+    atts = load_attestations()
+    platforms = gates.get("platform", [])
+
+    for g in gates.get("gate", []):
+        gid, kind = g["id"], g.get("evidence")
+
+        if kind == "github-check":
+            name = g["check"]
+            if runs is None:
+                yield gid, g["title"], ERROR, "could not read check runs (gh auth?)"
+            elif name not in runs:
+                yield gid, g["title"], MISSING, f"no check run named {name!r}"
+            elif runs[name] == "success":
+                yield gid, g["title"], PASS, f"{name} on {commit[:8]}"
+            else:
+                yield gid, g["title"], FAIL, f"{name}: {runs[name]}"
+
+        elif kind == "github-check-all":
+            # One gate, many named check runs. Every one must pass, and a
+            # name that produced no run at all is a miss rather than a pass:
+            # a matrix leg that silently stopped running is exactly the kind
+            # of erosion this catches.
+            if runs is None:
+                yield gid, g["title"], ERROR, "could not read check runs (gh auth?)"
+                continue
+            absent = [c for c in g["checks"] if c not in runs]
+            failed = [c for c in g["checks"]
+                      if c in runs and runs[c] != "success"]
+            if absent:
+                yield gid, g["title"], MISSING, "no run for: " + ", ".join(absent)
+            elif failed:
+                yield gid, g["title"], FAIL, "failed: " + ", ".join(failed)
+            else:
+                yield (gid, g["title"], PASS,
+                       f"{len(g['checks'])}/{len(g['checks'])} legs on {commit[:8]}")
+
+        elif kind == "release-asset":
+            if assets is None:
+                yield gid, g["title"], MISSING, f"no published release for {tag}"
+                continue
+            absent = [p for p in g["assets"]
+                      if not any(fnmatch.fnmatch(a, p) for a in assets)]
+            if absent:
+                yield gid, g["title"], FAIL, "missing: " + ", ".join(absent)
+            else:
+                yield gid, g["title"], PASS, f"{len(g['assets'])} patterns matched"
+
+        elif kind == "signed-tag":
+            if tag_is_signed(tag):
+                yield gid, g["title"], PASS, "good signature"
+            else:
+                yield gid, g["title"], FAIL, "tag is unsigned or unverifiable"
+
+        elif kind == "per-platform":
+            for p in platforms:
+                label = f"{g['title']} [{p['id']}]"
+                match = [a for a in atts
+                         if a.get("kind") == g["kind"]
+                         and a.get("platform") == p["id"]]
+                if not match:
+                    yield (gid, label, MISSING,
+                           f"no {g['kind']} attestation for {p['id']} "
+                           f"({p['method']})")
+                    continue
+                status, note = eval_attestation(
+                    match[-1], digests, g.get("human_required", False))
+                yield gid, label, status, note
+
+        elif kind == "attestation":
+            match = [a for a in atts if a.get("kind") == g["kind"]]
+            if not match:
+                yield gid, g["title"], MISSING, f"no {g['kind']} attestation"
+                continue
+            status, note = eval_attestation(
+                match[-1], digests, g.get("human_required", False))
+            yield gid, label_of(g), status, note
+
+        else:
+            yield gid, g["title"], ERROR, f"unknown evidence kind {kind!r}"
+
+
+def label_of(g):
+    return g["title"]
+
+
+# ------------------------------------------------------------------- output
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tag", help="candidate tag (default: most recent tag)")
+    ap.add_argument("--verbose", action="store_true",
+                    help="print what each gate proves")
+    args = ap.parse_args()
+
+    if not GATES.is_file():
+        die(f"{GATES} not found")
+    with GATES.open("rb") as fh:
+        gates = tomllib.load(fh)
+
+    tag = args.tag
+    if not tag:
+        _, tag = sh("git", "describe", "--tags", "--abbrev=0")
+        if not tag:
+            die("no tag given and none found")
+    commit = tag_commit(tag)
+
+    rows = list(evaluate(gates, tag, commit))
+    width = max(len(r[1]) for r in rows) + 2
+
+    print(f"\nRelease readiness: {tag} ({commit[:8]})\n")
+    print(f"{'':4} {'GATE'.ljust(width)} {'STATUS':8} EVIDENCE")
+    print("-" * (width + 60))
+    for gid, label, status, note in rows:
+        print(f"{gid:4} {label.ljust(width)} {status:8} {note}")
+
+    blocking = [r for r in rows if r[2] in BAD]
+    print()
+    if blocking:
+        print(f"VERDICT: NO-GO ({len(blocking)} blocking "
+              f"{'gate' if len(blocking) == 1 else 'gates'} unmet)")
+        for gid, label, status, _ in blocking:
+            print(f"  {status:8} {gid}  {label}")
+        return 1
+
+    print("VERDICT: GO")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_release_status.py
+++ b/scripts/test_release_status.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Tests for the release readiness checker.
+
+    python3 scripts/test_release_status.py     (or: make release-status-test)
+
+These cover the two behaviours the verdict actually rests on, because a guard
+that has never been observed to fail is not known to work:
+
+  staleness       evidence is tied to an artifact digest, so a candidate that
+                  does not contain that artifact must not inherit it
+  human_required  an agent can record that a container install succeeded; it
+                  must not be able to sign off that something rendered
+                  correctly on a screen
+
+Standard library only, and no network: the checker's evidence gathering is
+already separated from its judgement, so eval_attestation can be driven
+directly with the inputs those functions would have returned.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+# The script has a hyphen in its name, so it cannot be imported by name.
+_path = Path(__file__).resolve().parent / "release-status.py"
+_spec = importlib.util.spec_from_file_location("release_status", _path)
+rs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rs)
+
+GOOD_SHA = "a" * 64
+OTHER_SHA = "b" * 64
+DIGESTS = {GOOD_SHA: "openwatch-0.7.0-1.x86_64.rpm"}
+
+
+def att(**kw):
+    """An otherwise-valid attestation, overridden per test."""
+    base = {
+        "_file": "test.toml",
+        "kind": "clean-install",
+        "platform": "rhel9",
+        "artifact_sha256": GOOD_SHA,
+        "performed_by": "a.human",
+        "performed_at": "2026-07-31",
+    }
+    base.update(kw)
+    return base
+
+
+class Staleness(unittest.TestCase):
+    def test_matching_digest_passes(self):
+        status, note = rs.eval_attestation(att(), DIGESTS, False)
+        self.assertEqual(status, rs.PASS, note)
+
+    def test_digest_absent_from_candidate_is_stale(self):
+        """The core property: rebuilt bits do not inherit old evidence."""
+        status, note = rs.eval_attestation(
+            att(artifact_sha256=OTHER_SHA), DIGESTS, False)
+        self.assertEqual(status, rs.STALE, note)
+        self.assertIn("not in this candidate", note)
+
+    def test_unreadable_checksums_fail_closed(self):
+        """digests=None means the list could not be read.
+
+        This must not pass. Treating "nothing to compare against" as "nothing
+        wrong" would let every stale attestation through whenever the release
+        lookup broke, which is exactly when nobody is looking.
+        """
+        status, note = rs.eval_attestation(att(), None, False)
+        self.assertEqual(status, rs.ERROR, note)
+        self.assertIn("unverifiable", note)
+
+    def test_missing_digest_field_fails(self):
+        a = att()
+        del a["artifact_sha256"]
+        status, _ = rs.eval_attestation(a, DIGESTS, False)
+        self.assertEqual(status, rs.FAIL)
+
+
+class HumanRequired(unittest.TestCase):
+    def test_agent_cannot_satisfy_a_human_gate(self):
+        status, note = rs.eval_attestation(
+            att(performed_by="openwatch-agent"), DIGESTS, True)
+        self.assertEqual(status, rs.FAIL, note)
+        self.assertIn("requires a human observer", note)
+
+    def test_any_agent_suffix_is_refused(self):
+        """The rule is the -agent suffix, not one hardcoded name."""
+        for who in ("kensa-agent", "some-other-agent"):
+            with self.subTest(who=who):
+                status, _ = rs.eval_attestation(
+                    att(performed_by=who), DIGESTS, True)
+                self.assertEqual(status, rs.FAIL)
+
+    def test_human_satisfies_a_human_gate(self):
+        status, note = rs.eval_attestation(att(), DIGESTS, True)
+        self.assertEqual(status, rs.PASS, note)
+
+    def test_agent_may_satisfy_a_non_human_gate(self):
+        """A container job is equally non-human; install gates accept both."""
+        status, note = rs.eval_attestation(
+            att(performed_by="openwatch-agent"), DIGESTS, False)
+        self.assertEqual(status, rs.PASS, note)
+
+    def test_staleness_is_checked_even_for_a_human(self):
+        """A human signature does not excuse evidence for the wrong bits."""
+        status, _ = rs.eval_attestation(
+            att(artifact_sha256=OTHER_SHA), DIGESTS, True)
+        self.assertEqual(status, rs.STALE)
+
+
+class ManifestIsLoadable(unittest.TestCase):
+    """The shipped manifest must parse and reference only known evidence
+    kinds, so a typo in gates.toml surfaces here rather than as a gate that
+    silently never applies."""
+
+    KINDS = {"github-check", "github-check-all", "release-asset",
+             "signed-tag", "per-platform", "attestation"}
+
+    def setUp(self):
+        import tomllib
+        with rs.GATES.open("rb") as fh:
+            self.gates = tomllib.load(fh)
+
+    def test_every_gate_has_a_known_evidence_kind(self):
+        for g in self.gates["gate"]:
+            with self.subTest(gate=g["id"]):
+                self.assertIn(g.get("evidence"), self.KINDS)
+
+    def test_gate_ids_are_unique(self):
+        ids = [g["id"] for g in self.gates["gate"]]
+        self.assertEqual(len(ids), len(set(ids)), "duplicate gate id")
+
+    def test_per_platform_gates_declare_a_kind(self):
+        for g in self.gates["gate"]:
+            if g.get("evidence") in ("per-platform", "attestation"):
+                with self.subTest(gate=g["id"]):
+                    self.assertIn("kind", g)
+
+    def test_shipped_attestations_parse(self):
+        for a in rs.load_attestations():
+            with self.subTest(f=a["_file"]):
+                self.assertIn("kind", a)
+                self.assertIn("artifact_sha256", a)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, argv=[sys.argv[0]])


### PR DESCRIPTION
## Why

"Is v0.X.Y ready for release?" is currently answered by reading a prose runbook
and recalling what was tested. That is not reproducible, and evidence for one
candidate silently carries over to the next. This makes the answer derivable
without asking anyone.

```
$ make release-status TAG=v0.7.0-rc.3

Q1  Quality and security gates                     PASS   Quality + security gates on ba5f259c
P1  Packages install cleanly, per distro           PASS   6/6 legs on ba5f259c
R3  Tag is GPG signed                              PASS   good signature
I1  Clean install via `openwatch setup` [rhel9]    PASS   clean-install-rhel9-190350f3.toml
I1  Clean install via `openwatch setup` [debian12] MISSING no clean-install attestation
U1  Package upgrade scriptlet auto-migrates        PASS   Package upgrade (rpm -U auto-migrate)
U2  Upgrade from the previous GA release [rhel9]   MISSING no upgrade-from-ga attestation
...
VERDICT: NO-GO (16 blocking gates unmet)
```

## What

- `release/gates.toml` lists what must be true, with the OS matrix the install
  gates expand over.
- `scripts/release-status.py` renders it and exits 0 GO / 1 NO-GO / 2 lookup
  error, so CI and a local run cannot disagree. Single file, stdlib only, TOML
  via `tomllib`, matching `check-doc-style.py`.
- `release/attestations/` holds evidence for what CI cannot prove.
- `make release-status [TAG=...]`.

Evidence comes from check runs on the tag's commit, assets on the release, and
attestation files. Nothing else counts.

## Two properties worth reviewing carefully

**Evidence is scoped to the artifact digest, not the tag.** An attestation
records the sha256 it tested. Run the checker against a candidate that does not
contain that artifact and it reports `STALE`, not `PASS`. Verified: the RHEL
attestation passes for `v0.7.0-rc.3` and goes STALE against `v0.6.0`. Re-cutting
with a rebuilt binary invalidates install evidence automatically; a docs-only
re-cut keeps it.

**An agent cannot satisfy a human gate.** F1-F3 and H1 set `human_required`, and
the checker refuses any attestation whose `performed_by` ends in `-agent`. An
agent can record that a container install succeeded; it cannot attest that a
staged remediation rendered amber on screen.

## What writing this corrected

Two beliefs about what CI already proves turned out to be wrong in both
directions.

`package-smoke.yml` already runs a six-distro matrix (including `ubuntu:24.04`
and `debian:12`) plus an `rpm -U auto-migrate` job, all green on rc.3 - more
coverage than assumed. But those legs never invoke `openwatch setup`, never
start PostgreSQL and never read `/health`, and the upgrade job is one distro,
RPM only, between two synthetic builds of the same version rather than from the
real previous GA.

So the manifest separates package installability (**P1**, passing) from the
setup path (**I1/I2**, evidence only for RHEL 9), and scriptlet migration
(**U1**, passing) from a real previous-GA upgrade (**U2**, no evidence). Folding
those together is the specific over-claim this tool exists to prevent.

## Scope

Manifest and checker only. The container jobs that would satisfy I1/I2 and U2
are the next increment and are deliberately not here - they extend
`package-smoke.yml` rather than starting fresh. Landing those is also what would
let Debian move to `SupportTested` in `internal/setup/platform.go` on evidence
rather than by editing a constant.

The included attestation records the clean RHEL 9.8 install of rc.3 verified
today, with its caveats: the interactive `sudo openwatch setup` path was never
exercised, and PostgreSQL 13 rather than 15+ was the server under test.