### PR TITLE
fix(setup): refuse an unpromptable run in preflight, not at secret resolution

### DIFF
--- a/cmd/openwatch/setup.go
+++ b/cmd/openwatch/setup.go
@@ -27,7 +27,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
-		yes           = fs.Bool("yes", false, "accept every default without prompting")
+		yes           = fs.Bool("yes", false, "run without prompting; needs --admin-password-from, since the default admin password is an interactive prompt")
 		dryRun        = fs.Bool("dry-run", false, "show the plan and change nothing")
 		planPath      = fs.String("plan", "", "apply a saved plan file (implies non-interactive)")
 		savePlan      = fs.String("save-plan", "", "write the resolved plan to this path and exit")
@@ -122,7 +122,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		return 0
 	}
 
-	checks := setup.Preflight(ctx, plan, *allowUntested)
+	checks := setup.Preflight(ctx, plan, *allowUntested, interactive)
 	planned := setup.Resolve(ctx, plan)
 	setup.RenderPlan(out, plan, checks, planned)
 

--- a/internal/setup/execute.go
+++ b/internal/setup/execute.go
@@ -31,13 +31,60 @@ type Check struct {
 	Detail string
 }
 
+// credentialSourceCheck refuses a run that cannot obtain a credential it
+// will need.
+//
+// The default plan reads the admin password from an interactive prompt, so a
+// run that cannot prompt is doomed from the start. Left to itself it fails at
+// ResolveSecrets, which is after the full plan has been rendered: the operator
+// reads twelve steps and then an error about step zero. Worse, --yes advertises
+// itself as accepting every default, and accepting the default admin password
+// source is exactly what makes it fail.
+//
+// The fix is refusal here rather than a silent generate. There is no
+// password-reset command, so a generated admin password that the operator
+// never sees produces an account nobody can log into, and printing a
+// credential to stdout to avoid that is not an improvement. An unattended
+// install has to say where its credentials come from.
+func credentialSourceCheck(p Plan, interactive bool) (Check, bool) {
+	if interactive {
+		return Check{}, false
+	}
+	for _, c := range []struct {
+		what, flag string
+		src        SecretSource
+	}{
+		{"admin password", "--admin-password-from", p.Admin.Password.Source},
+		{"database password", "--db-password-from", p.Database.Password.Source},
+	} {
+		if c.src == SecretPrompt {
+			return Check{
+				Name:  c.what + " source",
+				OK:    false,
+				Fatal: true,
+				Detail: "this run cannot prompt (--yes, --plan, or stdin is not a " +
+					"terminal) but the " + c.what + " comes from an interactive " +
+					"prompt. Pass " + c.flag + " with generate, env:NAME or file:PATH",
+			}, true
+		}
+	}
+	return Check{}, false
+}
+
 // Preflight inspects the host before anything is planned. It never mutates.
 //
 // AllowUntested lets a recognised-but-unverified distro proceed: refusing
 // outright would block Rocky and Alma users running identical paths, while
 // claiming to support them would be a promise CI does not keep.
-func Preflight(ctx context.Context, p Plan, allowUntested bool) []Check {
+//
+// Interactive says whether this run can prompt, which decides whether a
+// prompt-sourced credential is obtainable.
+func Preflight(ctx context.Context, p Plan, allowUntested, interactive bool) []Check {
 	var out []Check
+
+	if c, bad := credentialSourceCheck(p, interactive); bad {
+		out = append(out, c)
+	}
 
 	root := os.Geteuid() == 0
 	rootCheck := Check{Name: "running as root", OK: root, Fatal: true}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -15,6 +15,7 @@
 //	AC-11  TestSetup_LiveVerificationIsRecorded
 //	AC-12  TestSetup_RoleSQLForcesScram
 //	AC-13  TestSetup_NoCredentialInPlanOrReceipt + TestSetup_ArtifactFileModes
+//	AC-14  TestSetup_NonInteractivePromptSourceIsRefused
 package setup
 
 import (
@@ -434,6 +435,57 @@ func TestSetup_ArtifactFileModes(t *testing.T) {
 		if !strings.Contains(string(steps), `r.writeFile(s.ID(), secretsEnvPath, []byte(content), 0o640)`) {
 			t.Error("secrets.env is no longer written 0640; the service user must be able " +
 				"to read the DSN, and the file is chowned root:openwatch for that reason")
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14: a run that cannot prompt is refused in preflight.
+//
+// `--yes` advertises accepting every default, and the default admin password
+// source is an interactive prompt, so `openwatch setup --yes` alone could never
+// succeed. It used to fail at secret resolution, after the plan had printed,
+// which reads as a late surprise rather than a flag mistake. The plan still
+// renders; what changed is that the reason now appears as the first preflight
+// check rather than as an error after everything.
+func TestSetup_NonInteractivePromptSourceIsRefused(t *testing.T) {
+	t.Run("system-setup/AC-14", func(t *testing.T) {
+		rhel := Platform{ID: "rhel", Major: 9, Family: FamilyRHEL}
+
+		// The default plan, non-interactively: refused, naming the flag.
+		c, bad := credentialSourceCheck(DefaultPlan(rhel), false)
+		if !bad {
+			t.Fatal("the default plan is not obtainable without a prompt; it must be refused")
+		}
+		if !c.Fatal || c.OK {
+			t.Errorf("check must be a fatal failure, got OK=%v Fatal=%v", c.OK, c.Fatal)
+		}
+		if !strings.Contains(c.Detail, "--admin-password-from") {
+			t.Errorf("the message must name the flag that fixes it: %q", c.Detail)
+		}
+
+		// The same plan interactively: the prompt is available, so no refusal.
+		if _, bad := credentialSourceCheck(DefaultPlan(rhel), true); bad {
+			t.Error("an interactive run can prompt; it must not be refused")
+		}
+
+		// Non-interactive with a resolvable source: allowed.
+		p := DefaultPlan(rhel)
+		p.Admin.Password = Secret{Source: SecretFile, Ref: "/root/pw"} // pragma: allowlist secret
+		if _, bad := credentialSourceCheck(p, false); bad {
+			t.Error("a file-sourced admin password needs no prompt; it must not be refused")
+		}
+
+		// The database password is checked too, not just the admin one.
+		p = DefaultPlan(rhel)
+		p.Admin.Password = Secret{Source: SecretGenerate, Length: 32} // pragma: allowlist secret
+		p.Database.Password = Secret{Source: SecretPrompt}            // pragma: allowlist secret
+		c, bad = credentialSourceCheck(p, false)
+		if !bad {
+			t.Fatal("a prompt-sourced database password must be refused too")
+		}
+		if !strings.Contains(c.Detail, "--db-password-from") {
+			t.Errorf("the message must name the database flag: %q", c.Detail)
 		}
 	})
 }

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -168,6 +168,21 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-14
+      description: >
+        A run that cannot prompt MUST be refused in preflight when a credential
+        it needs comes from an interactive prompt, naming the flag that
+        resolves it. The default plan sources the admin password from a prompt,
+        so `--yes` alone is doomed from the start; left to itself it fails at
+        secret resolution, after the whole plan has been rendered, so the
+        operator reads twelve steps and then an error about step zero. Refusing
+        is correct rather than silently generating one: there is no
+        password-reset command, so a generated admin password the operator
+        never sees produces an account nobody can log into, and printing a
+        credential to stdout to avoid that is not an improvement.
+      type: technical
+      enforcement: error
+
   acceptance_criteria:
     - id: AC-01
       description: >
@@ -266,6 +281,15 @@ spec:
         the ALTER path. The password is a quote-doubled literal.
       priority: critical
       references_constraints: [C-03]
+    - id: AC-14
+      description: >
+        A non-interactive run whose admin or database password is sourced from
+        a prompt produces a fatal preflight check naming the flag that fixes
+        it. The same plan run interactively produces no such check, and a
+        non-interactive run whose sources are all non-prompt produces none
+        either.
+      priority: critical
+      references_constraints: [C-14]
     - id: AC-13
       description: >
         Neither the serialised plan nor the receipt contains a credential


### PR DESCRIPTION
Closes PKG-7, found on the live rc.3 install to a clean RHEL 9.8 host.

## The defect

`openwatch setup --yes` could never succeed. `DefaultPlan` sources the admin
password from an interactive prompt; `--yes` makes the run non-interactive; so
every invocation died at `ResolveSecrets`:

```
openwatch setup: admin password: source is prompt but this run is
non-interactive; use source generate, env, or file
```

The flag's help said "accept every default without prompting", and accepting
that particular default is precisely what broke it.

The condition is broader than the flag, which is why this is worth fixing
rather than documenting. `interactive` is
`!yes && planPath == "" && isTerminal(stdin)`, so a piped invocation or an
`ssh host 'openwatch setup'` without a TTY hits it with no flag involved.

It also failed late: after the full twelve-step plan had printed.

## The fix

A preflight check, so the reason is the first line of output rather than an
error after everything:

```
Preflight
  [FAIL] admin password source
           this run cannot prompt (--yes, --plan, or stdin is not a terminal)
           but the admin password comes from an interactive prompt. Pass
           --admin-password-from with generate, env:NAME or file:PATH
```

The database password is checked on the same rule. The `--yes` help text no
longer claims what it cannot do.

## Why refuse rather than default to `generate`

Making `--yes` imply a generated admin password would make the flag work, and
it was my first instinct. It is wrong here: there is no password-reset command
anywhere in the product, so a generated admin password the operator never sees
produces an account nobody can log into. The alternative, printing the
credential to stdout, puts it in scrollback and CI logs. An unattended install
should have to say where its credentials come from.

## Verification

`system-setup` C-14 and AC-14, with `TestSetup_NonInteractivePromptSourceIsRefused`
covering the default plan refused non-interactively, the same plan accepted
interactively, a file-sourced password accepted non-interactively, and the
database password checked on its own.

The guard was mutation-checked: making `credentialSourceCheck` always return
"fine" fails the new test. `specter check --test` and
`specter coverage --strictness annotation` both clean.

Observed directly:

```
$ go run ./cmd/openwatch setup --yes
Preflight
  [FAIL] admin password source
           ...Pass --admin-password-from with generate, env:NAME or file:PATH
```

## Note for the release

This changes the binary, so the rc.3 clean-install attestation in
`release/attestations/` will correctly go STALE against rc.4 and `I1 [rhel9]`
returns to unmet. That is the mechanism working, not a regression, but it does
mean the RHEL install needs re-running against the new artifact before that
gate is satisfied again.