### PR TITLE
chore(release): record the RHEL 9 install evidence for rc.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -345,6 +345,9 @@ frontend_test.log
 !scripts/test_*.py
 !scripts/test_*.sh
 
+# Byte-code left behind by running the script test suites.
+__pycache__/
+
 # ...but scripts/ holds real, tracked tooling whose names contain "test". The
 # blanket patterns above silently swallowed scripts/test-db.sh: `git add`
 # refused it, the Makefile shipped referencing a script that was never

--- a/release/attestations/clean-install-rhel9-c13e183b.toml
+++ b/release/attestations/clean-install-rhel9-c13e183b.toml
@@ -1,0 +1,62 @@
+# Attestation: clean install on the RHEL 9 family, v0.7.0-rc.4.
+#
+# Supersedes the rc.3 attestation, which went STALE when rc.4 rebuilt the
+# binary. Both are kept: the checker matches on artifact digest, so an old one
+# neither helps nor harms a candidate it does not describe.
+#
+# artifact_sha256 needs a `pragma: allowlist secret` comment. detect-secrets
+# reads any 64-character hex string as a possible credential; this one is a
+# published checksum, byte-identical to the line in the release's SHA256SUMS.
+
+kind = "clean-install"
+platform = "rhel9"
+tag = "v0.7.0-rc.4"
+artifact = "openwatch-0.7.0-1.x86_64.rpm"
+artifact_sha256 = "c13e183b83fb3dc397def1f6f9751835e0e621f84bdb1ab2ca97a8b8033a3af1"  # pragma: allowlist secret
+
+method = "vm"
+performed_by = "openwatch-agent"
+performed_at = "2026-07-31"
+host = "owas-rhlowserv01, RHEL 9.8 (Plow), x86_64, SELinux enforcing, fapolicyd active, firewalld active, restored from a clean snapshot"
+
+observed = """
+Preconditions verified clean after snapshot restore: no openwatch, kensa-rules
+or postgresql-server package; no /var/lib/pgsql, /etc/openwatch or
+/var/lib/openwatch; nothing listening on 5432 or 8443.
+
+Artifacts verified before install: gpg --verify SHA256SUMS.asc reported a good
+signature from the release key, sha256sum -c passed for both packages, and
+rpm -K reported "digests signatures OK" for both.
+
+Both packages installed in one dnf transaction, which also pulled
+postgresql-server 13.23. The binary reports commit e0e2e5a0, which is the rc.4
+tag. Setup detected rhel 9.8 amd64 as tested and required no --allow-untested.
+
+`openwatch setup --yes` with no credential source was refused in preflight with
+"admin password source" as the first check, naming --admin-password-from, and
+exited 1 having changed nothing. This is the PKG-7 fix (C-14 / AC-14) observed
+on real hardware.
+
+Run without --manage-pg-hba halted at the pg-hba step with exit 3 and recorded
+progress to the receipt. Run with --manage-pg-hba completed exit 0, with the
+verify step reporting {"db_connected":true,"status":"healthy","version":"0.7.0"}.
+pg_hba.conf was backed up to pg_hba.conf.bak-20260731T122512Z before editing.
+
+Reachability confirmed from a separate machine, not loopback: HTTP 200 on
+/api/v1/health. POST /api/v1/auth/login returned a token and /api/v1/auth/me
+reported username admin, role admin, email admin@hanalyx.local.
+
+File modes on disk: setup-receipt.json 0600 root:root, secrets.env 0640
+root:openwatch. The receipt recorded credential sources only, and a search of
+the serialised receipt for the admin password literal returned false.
+"""
+
+caveats = """
+The interactive path was not exercised. Prompts need a TTY, so this ran with
+--yes and --admin-password-from file:. The plain `sudo openwatch setup` that
+the install guide leads with remains unverified end to end.
+
+PostgreSQL 13 came from the RHEL 9 default stream, below the supported minimum
+of 15. This exercises the scram-sha-256 SET that the md5 default makes
+necessary, but covers no PostgreSQL 15+ host.
+"""

--- a/release/attestations/idempotence-rhel9-c13e183b.toml
+++ b/release/attestations/idempotence-rhel9-c13e183b.toml
@@ -1,0 +1,45 @@
+# Attestation: re-running setup on a completed install, v0.7.0-rc.4.
+#
+# artifact_sha256 needs a `pragma: allowlist secret` comment; see the
+# clean-install attestation for the same artifact.
+
+kind = "idempotence"
+platform = "rhel9"
+tag = "v0.7.0-rc.4"
+artifact = "openwatch-0.7.0-1.x86_64.rpm"
+artifact_sha256 = "c13e183b83fb3dc397def1f6f9751835e0e621f84bdb1ab2ca97a8b8033a3af1"  # pragma: allowlist secret
+
+method = "vm"
+performed_by = "openwatch-agent"
+performed_at = "2026-07-31"
+host = "owas-rhlowserv01, RHEL 9.8 (Plow), x86_64"
+
+observed = """
+Immediately after the completed install recorded in
+clean-install-rhel9-c13e183b.toml, the identical command was run again:
+
+  openwatch setup --yes --manage-pg-hba \\
+    --admin-password-from file:/root/.ow-admin-pw \\
+    --admin-email admin@hanalyx.local
+
+It exited 0 and the verify step again reported
+{"db_connected":true,"status":"healthy","version":"0.7.0"}, so the service was
+still serving after the re-run rather than merely still installed.
+
+The steps that report themselves already satisfied skipped: postgres-install,
+postgres-cluster, postgres-version, database, pg-hba, admin-user and firewall.
+The steps that converge deliberately re-ran: database-role, which never reports
+Done because the role password and the DSN must be set together (C-04),
+secrets-env, migrate and service.
+
+Re-entrancy from a partial state was also observed on this artifact: the run
+that halted at pg-hba was resumed by a later invocation, which skipped
+everything before that step rather than repeating it.
+"""
+
+caveats = """
+Idempotence was checked twice in a row on one host, not across a reboot, and
+not after an external change to the database or configuration. A re-run that
+follows someone else editing pg_hba.conf or rotating the role password is not
+covered here.
+"""


### PR DESCRIPTION
Re-verification of the RHEL 9 install against rc.4, plus the two attestations
that satisfy `I1 [rhel9]` and `I2 [rhel9]`.

## Why this was needed

rc.4 rebuilt the binary, so the rc.3 attestation went `STALE` and `I1 [rhel9]`
returned to unmet:

```
STALE  I1  Clean install via `openwatch setup` [rhel9]
       artifact 190350f3fb4c is not in this candidate's SHA256SUMS
```

That is the artifact scoping introduced in #777 working on its first real use.
The answer is to re-run the install, not to loosen the rule.

## What was verified

Host restored from a clean snapshot and confirmed clean before starting: no
`openwatch`, `kensa-rules` or `postgresql-server`; no `/var/lib/pgsql`,
`/etc/openwatch` or `/var/lib/openwatch`; nothing listening but sshd.

- Signatures checked three ways: detached `SHA256SUMS.asc`, `sha256sum -c`, and
  `rpm -K` header signatures on both packages.
- Both packages installed in one dnf transaction. Binary reports commit
  `e0e2e5a0`, the rc.4 tag.
- **The PKG-7 fix observed on real hardware.** `openwatch setup --yes` with no
  credential source is refused in preflight as the first check, naming
  `--admin-password-from`, exit 1, nothing changed.
- Pause path: run without `--manage-pg-hba` halted at `pg-hba` with exit 3 and
  recorded progress.
- Full run completed exit 0 with
  `{"db_connected":true,"status":"healthy","version":"0.7.0"}`.
- Re-run exited 0 and the service was still serving, not merely still installed.
- Reachable from a separate machine (HTTP 200), admin login returned a token,
  `/auth/me` reported role admin.
- Modes on disk: receipt `0600 root:root`, `secrets.env` `0640 root:openwatch`.
  The receipt records credential sources only; a search of the serialised
  receipt for the admin password literal returned false.

## What is deliberately recorded as NOT covered

Both attestations carry caveats, which is the part that matters when someone
reads them in three months:

- The interactive `sudo openwatch setup` path still has no evidence anywhere.
  Prompts need a TTY, so this ran with `--yes` and `--admin-password-from file:`.
- PostgreSQL 13 from the RHEL 9 default stream, so no PostgreSQL 15+ coverage.
  It does exercise the scram-sha-256 SET that the md5 default makes necessary.
- Idempotence was checked twice in a row on one host, not across a reboot and
  not after an external change to the database or pg_hba.

## Effect

rc.4 goes from NO-GO on 16 gates to NO-GO on 14. The remaining install gates are
the three platforms that want container jobs rather than a VM.

Also ignores `__pycache__`, which the script test suites leave behind.