### PR TITLE
feat(ci): run `openwatch setup` end to end on Ubuntu and Debian containers

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -121,10 +121,44 @@ jobs:
   # then in a rockylinux:9 container install the old one, stand up Postgres,
   # roll the schema back one migration, and `rpm -U` the new one — asserting
   # the %post scriptlet migrates the DB to head, takes a pre-upgrade backup,
-  # and stop/starts the service. This is the half the per-distro `smoke` job
-  # (a fresh install) does not cover. The driver script builds both RPMs and
-  # runs the container; it uses --network host (so the container's dnf reaches
-  # mirrors) and a throwaway Postgres on port 55432.
+  # `openwatch setup` end to end, per distro. This is the gate evidence for
+  # release/gates.toml I1 (clean install) and I2 (idempotence).
+  #
+  # It exists because the `smoke` job above cannot prove what it looks like it
+  # proves: smoke installs the packages and runs `openwatch check-config` as
+  # ROOT, never starting the service and never running as the openwatch user.
+  # That blind spot hid a defect where the DEB shipped /etc/openwatch as
+  # root:root, so the service user could not read its own config and no Debian
+  # install could ever have worked.
+  #
+  # Needs a real init, because setup drives systemctl for both PostgreSQL and
+  # its own unit, so this runs docker itself rather than using `container:`.
+  setup-install:
+    name: setup ${{ matrix.distro }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { distro: 'ubuntu:24.04', kind: deb }
+          - { distro: 'debian:12', kind: deb }
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages
+          path: dist
+
+      # --allow-untested because the Debian family is SupportUntested in
+      # internal/setup/platform.go today. This job passing is the evidence
+      # that would justify promoting it; until that lands, the flag stays.
+      - name: openwatch setup clean install and re-run
+        run: |
+          bash packaging/tests/run-setup-container-test.sh \
+            "${{ matrix.distro }}" "${{ matrix.kind }}" --allow-untested
+
   upgrade:
     name: Package upgrade (rpm -U auto-migrate)
     runs-on: ubuntu-latest

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -11,6 +11,19 @@ if [ "$1" = "configure" ]; then
         # Enable the daily pre-upgrade-backup cleanup timer (install + upgrade).
         systemctl enable --now openwatch-backup-cleanup.timer >/dev/null 2>&1 || :
     fi
+    # Give the service group read access to its own configuration.
+    #
+    # dpkg-deb records the ownership of the staging tree, which is built as
+    # root, so everything under /etc/openwatch ships root:root. The RPM sets
+    # %attr(0640, root, openwatch) in the spec and has no such problem. Without
+    # this the service, which runs as User=openwatch, cannot read
+    # openwatch.toml and exits immediately with "permission denied" -- and so
+    # does `openwatch migrate`, which setup runs through runuser.
+    #
+    # preinst created the user and group already.
+    chgrp -R openwatch /etc/openwatch
+    chmod 0750 /etc/openwatch /etc/openwatch/keys /etc/openwatch/tls
+
     # Generate-if-absent, so reconfigure/upgrade never clobbers live keys.
     # preinst already created the openwatch user/group. Not guarded: a real
     # failure should abort configure rather than leave an unbootable service.

--- a/packaging/tests/run-setup-container-test.sh
+++ b/packaging/tests/run-setup-container-test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Host-side driver for the `openwatch setup` install test. Starts a systemd
+# container for the requested image, feeds it the built packages, and runs
+# packaging/tests/setup-container-test.sh inside it.
+#
+#   bash packaging/tests/run-setup-container-test.sh ubuntu:24.04 deb
+#   bash packaging/tests/run-setup-container-test.sh debian:12    deb
+#   bash packaging/tests/run-setup-container-test.sh rockylinux:9 rpm
+#
+# Why a systemd container rather than the plain `container:` job the smoke
+# matrix uses: setup drives systemctl for both PostgreSQL and its own unit, so
+# a container without a real init cannot exercise it at all. The base images do
+# not ship systemd as PID 1, so the entrypoint installs it and execs into it,
+# which makes systemd PID 1 without needing a purpose-built image.
+#
+# --privileged and the cgroup mount are what systemd needs to run in a
+# container. This is a throwaway test container on a CI runner, which is the
+# one place that trade is reasonable.
+#
+# Deliberately NOT --network host, unlike the upgrade driver. Sharing the
+# host's network namespace makes Debian's postgresql-common allocate the next
+# free port instead of 5432 (it sees the host's clusters), while setup's DSN
+# still says 5432 -- so the install reaches the HOST's PostgreSQL and fails
+# with "password authentication failed for user openwatch". The test then
+# reads as a product bug when it is a harness bug, which cost an hour once.
+# Bridge networking reaches the package mirrors perfectly well.
+set -euo pipefail
+
+IMAGE="${1:?usage: run-setup-container-test.sh <image> <deb|rpm> [extra setup args]}"
+KIND="${2:?usage: run-setup-container-test.sh <image> <deb|rpm> [extra setup args]}"
+shift 2
+EXTRA_ARGS="${*:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$APP_DIR"
+
+command -v docker >/dev/null || { echo "docker is required" >&2; exit 1; }
+
+case "$(uname -m)" in
+    x86_64)        RPM_ARCH=x86_64; DEB_ARCH=amd64 ;;
+    aarch64|arm64) RPM_ARCH=aarch64; DEB_ARCH=arm64 ;;
+    *) echo "unsupported host arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+# Stage exactly the packages for this arch and kind. dist/ can hold
+# cross-built artifacts of the other arch, and installing two arches of the
+# same package collides on /usr/bin/openwatch.
+PKGS="$(mktemp -d)"
+CONTAINER=""
+cleanup() {
+    [ -n "$CONTAINER" ] && docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    rm -rf "$PKGS"
+}
+trap cleanup EXIT
+
+if [ "$KIND" = deb ]; then
+    cp dist/openwatch_*_"${DEB_ARCH}".deb dist/kensa-rules_*_all.deb "$PKGS/"
+else
+    cp dist/openwatch-*."${RPM_ARCH}".rpm dist/kensa-rules-*.noarch.rpm "$PKGS/"
+fi
+echo ">> staged $(ls "$PKGS" | tr '\n' ' ')"
+
+# Installing systemd then exec'ing it makes it PID 1 in place. Ubuntu and
+# Debian need systemd-sysv for /sbin/init; the RHEL family already has it.
+case "$KIND" in
+    deb) BOOT='export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq systemd systemd-sysv >/dev/null && exec /sbin/init' ;;
+    rpm) BOOT='dnf install -y -q systemd >/dev/null 2>&1 || true; exec /sbin/init' ;;
+    *)   echo "kind must be deb or rpm" >&2; exit 1 ;;
+esac
+
+echo ">> booting $IMAGE with systemd as PID 1"
+CONTAINER="$(docker run -d --privileged --cgroupns=host \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    -v "$PKGS:/pkgs:ro" \
+    -v "$APP_DIR/packaging/tests/setup-container-test.sh:/test.sh:ro" \
+    "$IMAGE" bash -c "$BOOT")"
+
+echo ">> running the setup test in $CONTAINER"
+docker exec \
+    -e PKG_DIR=/pkgs \
+    -e PKG_KIND="$KIND" \
+    -e ADMIN_PW='Container-Verify!Ow2026' \
+    -e EXTRA_ARGS="$EXTRA_ARGS" \
+    "$CONTAINER" bash /test.sh

--- a/packaging/tests/setup-container-test.sh
+++ b/packaging/tests/setup-container-test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Runs INSIDE a systemd container. Proves that `openwatch setup` takes a host
+# with nothing on it to a service answering /health with db_connected, and that
+# running it a second time is safe.
+#
+# This is the gate evidence for release/gates.toml I1 (clean install) and I2
+# (idempotence). It deliberately asserts more than "exit 0": an installer that
+# reports success while the API is not serving is the specific failure the
+# setup spec's C-12 exists to prevent.
+#
+# Expects, from the driver:
+#   PKG_DIR    directory holding the packages to install
+#   PKG_KIND   deb | rpm
+#   ADMIN_PW   the admin password to create and then log in with
+#   EXTRA_ARGS extra setup flags (e.g. --allow-untested)
+set -euo pipefail
+
+PKG_DIR="${PKG_DIR:-/pkgs}"
+PKG_KIND="${PKG_KIND:?PKG_KIND must be deb or rpm}"
+ADMIN_PW="${ADMIN_PW:?ADMIN_PW must be set}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo ">> waiting for systemd to finish booting"
+for _ in $(seq 1 60); do
+    state="$(systemctl is-system-running 2>/dev/null || true)"
+    case "$state" in
+        running|degraded) break ;;
+    esac
+    sleep 1
+done
+# degraded is acceptable in a container: units irrelevant here (and often
+# unmaskable, like systemd-logind's dependencies) fail without affecting
+# PostgreSQL or openwatch. What matters is that systemctl works at all.
+systemctl is-system-running >/dev/null 2>&1 || \
+    [ "$(systemctl is-system-running || true)" = degraded ] || \
+    fail "systemd never came up; setup drives systemctl and cannot work here"
+
+echo ">> installing packages"
+if [ "$PKG_KIND" = deb ]; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq curl ca-certificates >/dev/null
+    apt-get install -y "$PKG_DIR"/openwatch_*.deb "$PKG_DIR"/kensa-rules_*.deb
+else
+    dnf install -y -q "$PKG_DIR"/openwatch-*.rpm "$PKG_DIR"/kensa-rules-*.rpm
+fi
+command -v openwatch >/dev/null || fail "openwatch is not on PATH after install"
+openwatch --version
+
+# The state that makes this a CLEAN install test rather than a re-run test.
+# If a base image ever starts shipping a cluster, this catches it rather than
+# quietly weakening the claim.
+[ ! -e /etc/openwatch/secrets.env ] || fail "secrets.env exists before setup ran"
+[ ! -e /var/lib/openwatch/setup-receipt.json ] || fail "a receipt exists before setup ran"
+
+# system-setup C-14 / AC-14: a run that cannot prompt is refused in preflight,
+# naming the flag, rather than dying later at secret resolution.
+echo ">> --yes without a credential source must be refused"
+if openwatch setup --yes $EXTRA_ARGS >/tmp/refused.log 2>&1; then
+    fail "--yes with no credential source succeeded; it cannot obtain an admin password"
+fi
+grep -q "admin password source" /tmp/refused.log || \
+    fail "the refusal is not a preflight check; PKG-7 has regressed"
+[ ! -e /etc/openwatch/secrets.env ] || fail "the refused run still changed the host"
+
+umask 077
+printf %s "$ADMIN_PW" > /root/admin-pw
+
+run_setup() {
+    openwatch setup --yes --manage-pg-hba $EXTRA_ARGS \
+        --admin-password-from file:/root/admin-pw \
+        --admin-email admin@example.com
+}
+
+assert_healthy() {
+    local body
+    body="$(curl -sk --max-time 20 https://127.0.0.1:8443/api/v1/health)" || \
+        fail "the API did not answer: $1"
+    echo "   health: $body"
+    case "$body" in
+        *'"db_connected":true'*) ;;
+        *) fail "db_connected is not true: $1" ;;
+    esac
+}
+
+echo ">> clean install (gate I1)"
+run_setup
+assert_healthy "after the first run"
+
+echo ">> logging in as the admin setup created"
+token="$(curl -sk --max-time 20 -X POST https://127.0.0.1:8443/api/v1/auth/login \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PW\"}" \
+    | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')"
+[ -n "$token" ] || fail "login failed; the admin account setup created is unusable"
+curl -sk --max-time 20 https://127.0.0.1:8443/api/v1/auth/me \
+    -H "Authorization: Bearer $token" | grep -q '"role":"admin"' || \
+    fail "the created account is not an admin"
+
+echo ">> file modes (system-setup AC-13)"
+[ "$(stat -c '%a' /var/lib/openwatch/setup-receipt.json)" = 600 ] || \
+    fail "the receipt is not 0600"
+[ "$(stat -c '%a' /etc/openwatch/secrets.env)" = 640 ] || \
+    fail "secrets.env is not 0640"
+grep -q "$ADMIN_PW" /var/lib/openwatch/setup-receipt.json && \
+    fail "the receipt contains the admin password"
+
+echo ">> second run (gate I2, idempotence)"
+run_setup
+assert_healthy "after the second run"
+systemctl is-active --quiet openwatch || fail "the service is not active after a re-run"
+
+echo ">> OK: clean install and re-run both reached a serving instance"

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -52,6 +52,10 @@ title = "Ubuntu 24.04 LTS"
 method = "container"
 package = "deb"
 support_tier = "untested"
+# The package-smoke job that installs and re-runs setup here. A passing run
+# satisfies both I1 and I2, because the job asserts both: it checks /health
+# reports db_connected after the first run AND after the second.
+check = "setup ubuntu:24.04"
 blocking = true
 
 [[platform]]
@@ -60,6 +64,7 @@ title = "Debian 12"
 method = "container"
 package = "deb"
 support_tier = "untested"
+check = "setup debian:12"
 blocking = true
 
 # -------------------------------------------------------------------- gates

--- a/scripts/release-status.py
+++ b/scripts/release-status.py
@@ -216,6 +216,21 @@ def evaluate(gates, tag, commit):
         elif kind == "per-platform":
             for p in platforms:
                 label = f"{g['title']} [{p['id']}]"
+                # A CI job that proves this platform outranks an attestation:
+                # it re-runs on every candidate, so it cannot go stale the way
+                # a hand-recorded observation can. Only gates that need a human
+                # observer refuse it.
+                if p.get("check") and not g.get("human_required"):
+                    if runs is None:
+                        yield gid, label, ERROR, "could not read check runs (gh auth?)"
+                    elif p["check"] not in runs:
+                        yield (gid, label, MISSING,
+                               f"no run for {p['check']!r} on this commit")
+                    elif runs[p["check"]] == "success":
+                        yield gid, label, PASS, f"{p['check']} on {commit[:8]}"
+                    else:
+                        yield gid, label, FAIL, f"{p['check']}: {runs[p['check']]}"
+                    continue
                 match = [a for a in atts
                          if a.get("kind") == g["kind"]
                          and a.get("platform") == p["id"]]

--- a/scripts/test_release_status.py
+++ b/scripts/test_release_status.py
@@ -109,6 +109,35 @@ class HumanRequired(unittest.TestCase):
         self.assertEqual(status, rs.STALE)
 
 
+class PlatformCheckWiring(unittest.TestCase):
+    """A platform proven by a CI job names a check run, and that name has to
+    match a job the workflow actually produces. A typo here reads as MISSING
+    forever, which looks like unfinished work rather than a broken manifest."""
+
+    def setUp(self):
+        import re
+        import tomllib
+        with rs.GATES.open("rb") as fh:
+            self.gates = tomllib.load(fh)
+        wf = (rs.REPO / ".github" / "workflows" / "package-smoke.yml").read_text()
+        # The job's `name:` is a template over the matrix, so collect the
+        # matrix values it expands to rather than parsing YAML semantics.
+        self.distros = set(re.findall(r"distro:\s*'([^']+)'", wf))
+
+    def test_platform_check_names_match_a_real_matrix_leg(self):
+        for p in self.gates["platform"]:
+            check = p.get("check")
+            if not check:
+                continue
+            with self.subTest(platform=p["id"]):
+                # Names are "setup <distro>" from the setup-install job.
+                self.assertTrue(
+                    check.startswith("setup "),
+                    f"{check!r} does not look like the setup-install job name")
+                self.assertIn(check.split(" ", 1)[1], self.distros,
+                              f"{check!r} names a distro the matrix does not run")
+
+
 class ManifestIsLoadable(unittest.TestCase):
     """The shipped manifest must parse and reference only known evidence
     kinds, so a typo in gates.toml surfaces here rather than as a gate that


### PR DESCRIPTION
Builds the container matrix for the Debian family, and fixes the release
blocking defect it found on its first execution.

## The defect it found

**The DEB has never produced a working install.**

`dpkg-deb` records the ownership of the staging tree, which is built as root,
so everything under `/etc/openwatch` ships `root:root`. The RPM sets
`%attr(0640, root, openwatch)` in the spec and has no such problem. The service
runs as `User=openwatch` and reads `/etc/openwatch/openwatch.toml`, so on Debian
and Ubuntu it could only ever have exited with permission denied:

```
migrate: openwatch migrate failed: config: load /etc/openwatch/openwatch.toml:
permission denied
```

`postinst` now `chgrp`s `/etc/openwatch` to the group `preinst` already creates.

**CI could not have caught this.** The per-distro smoke job installs the
packages and runs `openwatch check-config` as ROOT, which can read the file, and
never starts the service or runs anything as the `openwatch` user. That is the
precise shape of the blind spot: a job that looks like install coverage but
proves only that files landed.

## The job

`packaging/tests/setup-container-test.sh` runs inside a systemd container and
asserts what an operator cares about, not just exit 0:

- both packages install
- `--yes` with no credential source is refused in preflight (C-14 / PKG-7)
- a clean run reaches `/health` reporting `db_connected`
- the admin account it created can log in, and `/auth/me` says role admin
- receipt is `0600`, `secrets.env` is `0640`, and the receipt holds no credential
- a second identical run still leaves the service serving

Matrix: `ubuntu:24.04` and `debian:12`. Both verified locally before this
landed.

## Two implementation notes worth review

**A real init is required.** setup drives `systemctl` for both PostgreSQL and
its own unit, so a `container:` job cannot exercise it at all. This runs docker
itself; the entrypoint installs systemd and `exec`s into it, so systemd becomes
PID 1 without a purpose-built image.

**Deliberately not `--network host`,** unlike the upgrade driver. Sharing the
host network makes Debian's `postgresql-common` allocate the next free port
instead of 5432, while setup's DSN still says 5432 - so the install silently
reaches the HOST's PostgreSQL and fails with "password authentication failed
for user openwatch". That reads as a product bug when it is a harness bug. It
cost an hour here, and the reasoning is recorded in the script.

## Gate wiring

A platform may now name the CI job that proves it, and a passing run satisfies
I1 and I2 with no hand-written attestation. A CI job outranks an attestation
because it re-runs on every candidate and cannot go stale. Gates marked
`human_required` still refuse it.

A test asserts every platform's check name matches a distro the matrix actually
runs, so a typo surfaces as a failure rather than as a gate that reads MISSING
forever. Mutation-checked: pointing a platform at `setup debian:11` fails it.

## Follow-up, deliberately not here

The job still passes `--allow-untested`, because the Debian family is
`SupportUntested` in `internal/setup/platform.go`. **This job passing on main is
the evidence that justifies promoting it to `SupportTested`**, which is what
resolves the standing contradiction where the install guide presents Debian and
Ubuntu as supported while `openwatch setup` refuses to run on them without a
flag. That promotion changes `system-setup` AC-04 and the support contract, so
it belongs in its own change with its own argument.