### PR TITLE
fix(release): scope a platform's CI check to the gate kinds it proves

### DIFF
--- a/release/gates.toml
+++ b/release/gates.toml
@@ -52,11 +52,14 @@ title = "Ubuntu 24.04 LTS"
 method = "container"
 package = "deb"
 support_tier = "untested"
-# The package-smoke job that installs and re-runs setup here. A passing run
-# satisfies both I1 and I2, because the job asserts both: it checks /health
-# reports db_connected after the first run AND after the second.
-check = "setup ubuntu:24.04"
 blocking = true
+# Which CI job proves which gate kind. Scoped per kind on purpose: the
+# setup-install job asserts a clean install AND a re-run, so it proves both
+# I1 and I2, but it never touches the previous GA, so it must not be allowed
+# to satisfy U2. A gate kind absent here falls back to an attestation.
+[platform.checks]
+clean-install = "setup ubuntu:24.04"
+idempotence = "setup ubuntu:24.04"
 
 [[platform]]
 id = "debian12"
@@ -64,8 +67,10 @@ title = "Debian 12"
 method = "container"
 package = "deb"
 support_tier = "untested"
-check = "setup debian:12"
 blocking = true
+[platform.checks]
+clean-install = "setup debian:12"
+idempotence = "setup debian:12"
 
 # -------------------------------------------------------------------- gates
 

--- a/scripts/release-status.py
+++ b/scripts/release-status.py
@@ -220,16 +220,20 @@ def evaluate(gates, tag, commit):
                 # it re-runs on every candidate, so it cannot go stale the way
                 # a hand-recorded observation can. Only gates that need a human
                 # observer refuse it.
-                if p.get("check") and not g.get("human_required"):
+                # Scoped per gate kind: a job proves the claims it actually
+                # asserts and no others. A job that installs cleanly says
+                # nothing about upgrading from the previous GA.
+                pcheck = p.get("checks", {}).get(g["kind"])
+                if pcheck and not g.get("human_required"):
                     if runs is None:
                         yield gid, label, ERROR, "could not read check runs (gh auth?)"
-                    elif p["check"] not in runs:
+                    elif pcheck not in runs:
                         yield (gid, label, MISSING,
-                               f"no run for {p['check']!r} on this commit")
-                    elif runs[p["check"]] == "success":
-                        yield gid, label, PASS, f"{p['check']} on {commit[:8]}"
+                               f"no run for {pcheck!r} on this commit")
+                    elif runs[pcheck] == "success":
+                        yield gid, label, PASS, f"{pcheck} on {commit[:8]}"
                     else:
-                        yield gid, label, FAIL, f"{p['check']}: {runs[p['check']]}"
+                        yield gid, label, FAIL, f"{pcheck}: {runs[pcheck]}"
                     continue
                 match = [a for a in atts
                          if a.get("kind") == g["kind"]

--- a/scripts/test_release_status.py
+++ b/scripts/test_release_status.py
@@ -124,18 +124,31 @@ class PlatformCheckWiring(unittest.TestCase):
         # matrix values it expands to rather than parsing YAML semantics.
         self.distros = set(re.findall(r"distro:\s*'([^']+)'", wf))
 
+    def test_a_check_never_covers_a_kind_the_job_does_not_assert(self):
+        """The setup-install job installs and re-runs. It never touches the
+        previous GA, so it must not be wired to the upgrade gate: that would
+        report PASS for something nobody ran."""
+        kinds = {g["kind"] for g in self.gates["gate"] if "kind" in g}
+        for p in self.gates["platform"]:
+            for kind, check in p.get("checks", {}).items():
+                with self.subTest(platform=p["id"], kind=kind):
+                    self.assertIn(kind, kinds, f"{kind!r} is not a gate kind")
+                    if check.startswith("setup "):
+                        self.assertIn(
+                            kind, {"clean-install", "idempotence"},
+                            f"the setup-install job cannot prove {kind!r}")
+
     def test_platform_check_names_match_a_real_matrix_leg(self):
         for p in self.gates["platform"]:
-            check = p.get("check")
-            if not check:
-                continue
-            with self.subTest(platform=p["id"]):
-                # Names are "setup <distro>" from the setup-install job.
-                self.assertTrue(
-                    check.startswith("setup "),
-                    f"{check!r} does not look like the setup-install job name")
-                self.assertIn(check.split(" ", 1)[1], self.distros,
-                              f"{check!r} names a distro the matrix does not run")
+            for check in p.get("checks", {}).values():
+                with self.subTest(platform=p["id"], check=check):
+                    # Names are "setup <distro>" from the setup-install job.
+                    self.assertTrue(
+                        check.startswith("setup "),
+                        f"{check!r} does not look like the setup-install job name")
+                    self.assertIn(
+                        check.split(" ", 1)[1], self.distros,
+                        f"{check!r} names a distro the matrix does not run")
 
 
 class ManifestIsLoadable(unittest.TestCase):


### PR DESCRIPTION
A defect in the gate wiring I merged in #780, found by reading the rc.4 output
immediately afterwards.

## The problem

`per-platform` evaluation applied a platform's single `check` to **every**
non-human gate. So once `setup ubuntu:24.04` passes on the next candidate:

```
U2  Upgrade from the previous GA release [ubuntu2404]  PASS  setup ubuntu:24.04
```

That job installs cleanly and re-runs. It never installs the previous GA and
never upgrades anything. The gate would have reported PASS for work nobody did
- the precise over-claim the manifest was built to prevent, introduced by its
own author two commits after writing that rationale down.

## The fix

A platform maps gate kind to check name:

```toml
[platform.checks]
clean-install = "setup ubuntu:24.04"
idempotence   = "setup ubuntu:24.04"
```

The setup-install job is wired to the two claims it actually asserts. A kind
with no mapping falls back to an attestation, so `U2` correctly reads
`MISSING  no upgrade-from-ga attestation` again.

## Tests

- A check may only cover a kind the job asserts: anything named `setup <distro>`
  is restricted to `clean-install` and `idempotence`.
- Every check name still has to match a distro the matrix runs.

Mutation-checked: adding `upgrade-from-ga = "setup debian:12"` fails the suite.