### PR TITLE
feat(setup): promote Ubuntu 24.04 and Debian 12 to tested

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -151,13 +151,15 @@ jobs:
           name: packages
           path: dist
 
-      # --allow-untested because the Debian family is SupportUntested in
-      # internal/setup/platform.go today. This job passing is the evidence
-      # that would justify promoting it; until that lands, the flag stays.
+      # No --allow-untested: these platforms are SupportTested in
+      # internal/setup/platform.go precisely because this job runs. Passing no
+      # flag is also what an operator does, so the job exercises the real
+      # invocation. If someone demotes a platform, this fails loudly rather
+      # than quietly testing a different code path.
       - name: openwatch setup clean install and re-run
         run: |
           bash packaging/tests/run-setup-container-test.sh \
-            "${{ matrix.distro }}" "${{ matrix.kind }}" --allow-untested
+            "${{ matrix.distro }}" "${{ matrix.kind }}"
 
   upgrade:
     name: Package upgrade (rpm -U auto-migrate)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -201,35 +201,35 @@
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 340
+        "line_number": 343
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 377
+        "line_number": 380
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 425
+        "line_number": 428
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c761ff698fa44c8d7f1a8e30816441866cbf7f76",
         "is_verified": false,
-        "line_number": 446
+        "line_number": 449
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 798
+        "line_number": 801
       }
     ],
     "docs/guides/PRODUCTION_DEPLOYMENT.md": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T13:22:59Z"
+  "generated_at": "2026-07-31T19:44:20Z"
 }

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -216,14 +216,17 @@ itself.
 
 | Platform | Behaviour |
 |---|---|
-| RHEL 9 | Runs. Covered by testing. |
+| RHEL 9, Debian 12, Ubuntu 24.04 | Runs. Covered by testing. |
 | Rocky, AlmaLinux, Oracle Linux 8-10 | Requires `--allow-untested` |
-| Debian 12, Ubuntu 22.04 and 24.04 | Requires `--allow-untested` |
+| Ubuntu 22.04, other Debian releases | Requires `--allow-untested` |
 | Anything else | Refused |
 
 `untested` means the code recognises the layout and is expected to work, but it
 is not covered by automated testing. It runs with `--allow-untested`; please
 report the result.
+
+Ubuntu is matched on the full version rather than the major. 24.04 is covered;
+24.10 is a different release and is not.
 
 ### Exit codes
 

--- a/internal/setup/platform.go
+++ b/internal/setup/platform.go
@@ -93,7 +93,7 @@ func DetectPlatform() Platform {
 	p.VersionID = osRelease["VERSION_ID"]
 	p.Major = majorOf(p.VersionID)
 	p.Family = familyOf(p.ID, osRelease["ID_LIKE"])
-	p.Support = supportOf(p.ID, p.Major, p.Family)
+	p.Support = supportOf(p.ID, p.VersionID, p.Major, p.Family)
 	return p
 }
 
@@ -124,11 +124,27 @@ func familyOf(id, idLike string) Family {
 // at the same major are untested rather than unsupported because they share
 // the paths this code uses; Debian-family is untested because the PostgreSQL
 // layout genuinely differs (versioned clusters) and has not been exercised.
-func supportOf(id string, major int, family Family) Support {
+// versionID is carried alongside major because the Debian family needs it.
+// "24" identifies no Ubuntu release: 24.04 is an LTS that CI installs on every
+// push, and 24.10 is a different, interim release nobody has run. Matching on
+// the major alone would extend a tested claim to a distribution the matrix
+// never touches, which is the support statement starting to lie that C-10
+// warns about. RHEL 9.x point releases are one product line and keep the
+// coarser match.
+func supportOf(id, versionID string, major int, family Family) Support {
 	if family == FamilyUnknown || major == 0 {
 		return SupportUnsupported
 	}
+	// Tested means a CI job installs here on every push and asserts the API
+	// answers, not that someone tried it once. Each entry below corresponds
+	// to a blocking platform in release/gates.toml.
 	if id == "rhel" && major == 9 {
+		return SupportTested
+	}
+	if id == "ubuntu" && versionID == "24.04" {
+		return SupportTested
+	}
+	if id == "debian" && major == 12 {
 		return SupportTested
 	}
 	switch family {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -41,8 +41,12 @@ func TestSetup_PlatformSupportTiers(t *testing.T) {
 			{"ol", "fedora", "9.8", FamilyRHEL, SupportUntested},
 			{"almalinux", "rhel", "8.10", FamilyRHEL, SupportUntested},
 			{"almalinux", "rhel", "10.2", FamilyRHEL, SupportUntested},
-			{"ubuntu", "debian", "24.04", FamilyDebian, SupportUntested},
-			{"debian", "", "12", FamilyDebian, SupportUntested},
+			{"ubuntu", "debian", "24.04", FamilyDebian, SupportTested},
+			// 24.10 shares the major and is a different release CI never runs.
+			{"ubuntu", "debian", "24.10", FamilyDebian, SupportUntested},
+			{"ubuntu", "debian", "22.04", FamilyDebian, SupportUntested},
+			{"debian", "", "12", FamilyDebian, SupportTested},
+			{"debian", "", "11", FamilyDebian, SupportUntested},
 			// An unlisted derivative is placed by ID_LIKE rather than needing
 			// this code to know every rebuild by name.
 			{"navylinux", "rhel", "9.4", FamilyRHEL, SupportUntested},
@@ -54,7 +58,7 @@ func TestSetup_PlatformSupportTiers(t *testing.T) {
 		for _, c := range cases {
 			gotFamily := familyOf(c.id, c.idLike)
 			major := majorOf(c.version)
-			gotSupport := supportOf(c.id, major, gotFamily)
+			gotSupport := supportOf(c.id, c.version, major, gotFamily)
 			if gotFamily != c.wantFamily {
 				t.Errorf("familyOf(%q, %q) = %q, want %q", c.id, c.idLike, gotFamily, c.wantFamily)
 			}
@@ -271,7 +275,7 @@ func TestSetup_ContainerVerificationIsRecorded(t *testing.T) {
 		for _, c := range []struct{ id, ver string }{
 			{"rocky", "9.3"}, {"almalinux", "9.8"}, {"ol", "9.8"}, {"almalinux", "10.2"},
 		} {
-			if got := supportOf(c.id, majorOf(c.ver), FamilyRHEL); got != SupportUntested {
+			if got := supportOf(c.id, c.ver, majorOf(c.ver), FamilyRHEL); got != SupportUntested {
 				t.Errorf("%s %s is %q; the recorded run used --allow-untested, which "+
 					"only makes sense for untested", c.id, c.ver, got)
 			}
@@ -289,7 +293,7 @@ func TestSetup_ContainerVerificationIsRecorded(t *testing.T) {
 // generated password by regenerating it on every run.
 func TestSetup_LiveVerificationIsRecorded(t *testing.T) {
 	t.Run("system-setup/AC-11", func(t *testing.T) {
-		if got := supportOf("rhel", 9, FamilyRHEL); got != SupportTested {
+		if got := supportOf("rhel", "9.8", 9, FamilyRHEL); got != SupportTested {
 			t.Errorf("RHEL 9 is %q; the live run used no --allow-untested, which only "+
 				"holds while it is tested", got)
 		}

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -51,7 +51,7 @@ id = "ubuntu2404"
 title = "Ubuntu 24.04 LTS"
 method = "container"
 package = "deb"
-support_tier = "untested"
+support_tier = "tested"
 blocking = true
 # Which CI job proves which gate kind. Scoped per kind on purpose: the
 # setup-install job asserts a clean install AND a re-run, so it proves both
@@ -66,7 +66,7 @@ id = "debian12"
 title = "Debian 12"
 method = "container"
 package = "deb"
-support_tier = "untested"
+support_tier = "tested"
 blocking = true
 [platform.checks]
 clean-install = "setup debian:12"

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -132,7 +132,9 @@ spec:
         untested requires --allow-untested, unsupported refuses. Publishing a
         support matrix that CI does not exercise is how a support statement
         starts lying; refusing every unrecognised host would block derivatives
-        running identical paths.
+        running identical paths. A platform is tested only while a CI job
+        installs on it and asserts the API answers, so promoting one means
+        adding that job, not editing the constant.
       type: technical
       enforcement: error
     - id: C-11
@@ -208,10 +210,14 @@ spec:
       references_constraints: [C-11]
     - id: AC-04
       description: >
-        Platform support tiers resolve correctly: RHEL 9 is tested, other
-        RHEL-family majors 8 to 10 and Debian-family are untested, unknown
-        families and unparseable versions are unsupported. ID_LIKE is consulted
-        so an unlisted derivative naming its parent is placed correctly.
+        Platform support tiers resolve correctly: RHEL 9, Ubuntu 24.04 and
+        Debian 12 are tested, because a CI job installs on each of them on
+        every push and asserts the API answers. Other RHEL-family majors 8 to
+        10 and other Debian-family releases are untested, and unknown families
+        and unparseable versions are unsupported. Ubuntu is matched on the full
+        version rather than the major, because 24.10 shares the major with
+        24.04 and is a different release CI never runs. ID_LIKE is consulted so
+        an unlisted derivative naming its parent is placed correctly.
       priority: critical
       references_constraints: [C-10]
     - id: AC-05


### PR DESCRIPTION
Resolves the standing contradiction where the install guide presents Debian and
Ubuntu as supported while `openwatch setup` refuses to run on them without
`--allow-untested`.

The code was the honest half. Nothing tested those platforms, so claiming
support would have been the lie. #780 added a CI job that installs on both on
every push and asserts `/health` reports `db_connected`, so the claim is now
backed by something that re-runs, and the code can say so.

## Version-exact for Ubuntu

`supportOf` matched on the major only, and Ubuntu's major is a year. `24`
identifies no Ubuntu release: **24.04** is an LTS the matrix installs on, and
**24.10** is a different interim release nobody has run. Promoting on the major
would have extended a tested claim to a distribution CI never touches, which is
exactly the failure C-10 names. So `supportOf` now takes the version id, and
Ubuntu matches `24.04` exactly.

Debian 12 and RHEL 9.x keep the coarser major match, because those are single
product lines rather than distinct releases sharing a number.

Ubuntu 22.04 and other Debian releases stay `untested`, because no job runs
them. The test asserts that explicitly, including 24.10 and 22.04 as negative
cases, so a later careless widening fails.

## The CI job drops `--allow-untested`

It is now unnecessary, and passing no flag is what an operator actually types,
so the job exercises the real invocation rather than one with an extra escape
hatch. If a platform is ever demoted, the job fails loudly instead of quietly
testing a different code path.

## Spec

`system-setup` AC-04 updated. C-10 now states outright that a platform is
tested only while a CI job installs on it and asserts the API answers, so
promoting one means adding that job, not editing a constant. That is the rule
this PR is trying to make hard to break next time.

The guide's support matrix is corrected, including a note that Ubuntu is
matched on the full version.

## Verified before landing

Both distros complete a clean install and a re-run with **no flags at all**,
reporting `platform ... tested` in preflight:

```
  [ok  ] platform debian 12 (amd64)
           tested
   health: {"db_connected":true,"status":"healthy","version":"0.7.0"}
>> OK: clean install and re-run both reached a serving instance
```