### PR TITLE
feat(ci): upgrade the real previous GA to the candidate under systemd

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -161,6 +161,38 @@ jobs:
           bash packaging/tests/run-setup-container-test.sh \
             "${{ matrix.distro }}" "${{ matrix.kind }}"
 
+  # The REAL previous-GA upgrade (gate U2), as distinct from the synthetic
+  # scriptlet test below (U1). Installs the published previous GA, provisions
+  # it by hand because `openwatch setup` did not exist then, and upgrades to
+  # the candidate with both packages in one transaction under real systemd.
+  #
+  # RHEL family only, on purpose. v0.6.0's DEB shipped /etc/openwatch as
+  # root:root, so the service user could not read its config and no Debian
+  # install of it could ever have run. There is no working previous GA on that
+  # family to upgrade from; v0.7.0 is the first. release/gates.toml records
+  # that as not-applicable rather than pretending the coverage exists.
+  upgrade-from-ga:
+    name: upgrade-from-ga ${{ matrix.distro }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { distro: 'rockylinux:9', kind: rpm }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v4
+        with:
+          name: packages
+          path: dist
+      - name: upgrade the previous GA to the candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash packaging/tests/run-upgrade-from-ga-test.sh \
+            "${{ matrix.distro }}" "${{ matrix.kind }}" v0.6.0
+
   upgrade:
     name: Package upgrade (rpm -U auto-migrate)
     runs-on: ubuntu-latest

--- a/packaging/tests/run-setup-container-test.sh
+++ b/packaging/tests/run-setup-container-test.sh
@@ -54,10 +54,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Pin the VERSION as well as the arch. A CI runner's dist/ holds only the
+# current build, but a developer's accumulates every historical one, and a
+# glob that matches thirteen packages installs whichever the package manager
+# happens to prefer.
+VERSION="$(. packaging/version.env && echo "$VERSION")"
+KENSA_DEB="$(ls -1 dist/kensa-rules_*_all.deb | sort -V | tail -1)"
+KENSA_RPM="$(ls -1 dist/kensa-rules-*.noarch.rpm | sort -V | tail -1)"
 if [ "$KIND" = deb ]; then
-    cp dist/openwatch_*_"${DEB_ARCH}".deb dist/kensa-rules_*_all.deb "$PKGS/"
+    cp "dist/openwatch_${VERSION}_${DEB_ARCH}.deb" "$KENSA_DEB" "$PKGS/"
 else
-    cp dist/openwatch-*."${RPM_ARCH}".rpm dist/kensa-rules-*.noarch.rpm "$PKGS/"
+    cp "dist/openwatch-${VERSION}-1.${RPM_ARCH}.rpm" "$KENSA_RPM" "$PKGS/"
 fi
 echo ">> staged $(ls "$PKGS" | tr '\n' ' ')"
 

--- a/packaging/tests/run-upgrade-from-ga-test.sh
+++ b/packaging/tests/run-upgrade-from-ga-test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Host-side driver for the previous-GA upgrade test (gate U2). Downloads the
+# previous GA's published packages, stages the candidate's from dist/, boots a
+# systemd container and runs packaging/tests/upgrade-from-ga-container-test.sh
+# inside it.
+#
+#   bash packaging/tests/run-upgrade-from-ga-test.sh ubuntu:24.04 deb v0.6.0
+#   bash packaging/tests/run-upgrade-from-ga-test.sh rockylinux:9 rpm v0.6.0
+#
+# The previous GA is downloaded rather than rebuilt, deliberately. Rebuilding
+# the old version from a tag proves the upgrade works from something that was
+# never shipped; operators upgrade from the artifact on the releases page, and
+# that is the only artifact whose scriptlets and file ownership are the ones
+# actually in the field.
+#
+# Not --network host: see run-setup-container-test.sh for why that quietly
+# breaks the Debian family.
+set -euo pipefail
+
+IMAGE="${1:?usage: run-upgrade-from-ga-test.sh <image> <deb|rpm> <prev-tag>}"
+KIND="${2:?usage: run-upgrade-from-ga-test.sh <image> <deb|rpm> <prev-tag>}"
+PREV_TAG="${3:?usage: run-upgrade-from-ga-test.sh <image> <deb|rpm> <prev-tag>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$APP_DIR"
+
+command -v docker >/dev/null || { echo "docker is required" >&2; exit 1; }
+command -v gh >/dev/null || { echo "gh is required to download the previous GA" >&2; exit 1; }
+
+case "$(uname -m)" in
+    x86_64)        RPM_ARCH=x86_64; DEB_ARCH=amd64 ;;
+    aarch64|arm64) RPM_ARCH=aarch64; DEB_ARCH=arm64 ;;
+    *) echo "unsupported host arch $(uname -m)" >&2; exit 1 ;;
+esac
+
+OLD="$(mktemp -d)"; NEW="$(mktemp -d)"
+CONTAINER=""
+cleanup() {
+    [ -n "$CONTAINER" ] && docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    rm -rf "$OLD" "$NEW"
+}
+trap cleanup EXIT
+
+OLD_VER="${PREV_TAG#v}"
+NEW_VER="$(. packaging/version.env && echo "$VERSION")"
+[ "$OLD_VER" != "$NEW_VER" ] || { echo "previous GA and candidate are both $NEW_VER" >&2; exit 1; }
+
+echo ">> downloading the previous GA ($PREV_TAG) packages"
+if [ "$KIND" = deb ]; then
+    gh release download "$PREV_TAG" -D "$OLD" \
+        -p "openwatch_*_${DEB_ARCH}.deb" -p 'kensa-rules_*_all.deb'
+    cp "dist/openwatch_${NEW_VER}_${DEB_ARCH}.deb" \
+       "$(ls -1 dist/kensa-rules_*_all.deb | sort -V | tail -1)" "$NEW/"
+else
+    gh release download "$PREV_TAG" -D "$OLD" \
+        -p "openwatch-*.${RPM_ARCH}.rpm" -p 'kensa-rules-*.noarch.rpm'
+    cp "dist/openwatch-${NEW_VER}-1.${RPM_ARCH}.rpm" \
+       "$(ls -1 dist/kensa-rules-*.noarch.rpm | sort -V | tail -1)" "$NEW/"
+fi
+echo "   old: $(ls "$OLD" | tr '\n' ' ')"
+echo "   new: $(ls "$NEW" | tr '\n' ' ')"
+
+case "$KIND" in
+    deb) BOOT='export DEBIAN_FRONTEND=noninteractive; apt-get update -qq && apt-get install -y -qq systemd systemd-sysv >/dev/null && exec /sbin/init' ;;
+    rpm) BOOT='dnf install -y -q systemd >/dev/null 2>&1 || true; exec /sbin/init' ;;
+    *)   echo "kind must be deb or rpm" >&2; exit 1 ;;
+esac
+
+echo ">> booting $IMAGE with systemd as PID 1"
+CONTAINER="$(docker run -d --privileged --cgroupns=host \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+    -v "$OLD:/old:ro" -v "$NEW:/new:ro" \
+    -v "$APP_DIR/packaging/tests/upgrade-from-ga-container-test.sh:/test.sh:ro" \
+    "$IMAGE" bash -c "$BOOT")"
+
+echo ">> upgrading $OLD_VER to $NEW_VER in $CONTAINER"
+docker exec \
+    -e OLD_DIR=/old -e NEW_DIR=/new -e PKG_KIND="$KIND" \
+    -e OLD_VER="$OLD_VER" -e NEW_VER="$NEW_VER" \
+    "$CONTAINER" bash /test.sh

--- a/packaging/tests/upgrade-from-ga-container-test.sh
+++ b/packaging/tests/upgrade-from-ga-container-test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Runs INSIDE a systemd container. Installs the previous GA, provisions it by
+# hand, then upgrades to the candidate with both packages in one transaction
+# and proves the result is a serving instance on the SAME database.
+#
+# Gate evidence for release/gates.toml U2.
+#
+# This is a different claim from the existing upgrade test, which builds two
+# synthetic releases of the same version, shims systemctl, and proves the
+# scriptlet mechanism (gate U1). This one runs the real published previous GA
+# against the real candidate under real systemd, which is what an operator
+# actually does.
+#
+# The previous GA is provisioned by hand because it has to be: `openwatch
+# setup` did not exist in v0.6.0. Every upgrading operator therefore has an
+# install built from the manual procedure, which is what this reproduces.
+#
+# Expects, from the driver:
+#   OLD_DIR    directory holding the previous GA packages
+#   NEW_DIR    directory holding the candidate packages
+#   PKG_KIND   deb | rpm
+#   OLD_VER    the previous GA version string, e.g. 0.6.0
+#   NEW_VER    the candidate version string, e.g. 0.7.0
+set -euo pipefail
+
+: "${OLD_DIR:?}" "${NEW_DIR:?}" "${PKG_KIND:?}" "${OLD_VER:?}" "${NEW_VER:?}"
+
+# A failure with no diagnostics is a failure someone has to reproduce by hand,
+# and this runs in CI where nobody can attach to the container.
+diagnose() {
+    echo "--- systemctl status openwatch ---" >&2
+    systemctl status openwatch --no-pager 2>&1 | head -20 >&2 || true
+    echo "--- journalctl -u openwatch ---" >&2
+    journalctl -u openwatch -n 30 --no-pager 2>&1 | tail -30 >&2 || true
+}
+fail() { echo "FAIL: $*" >&2; diagnose; exit 1; }
+
+# curl exits non-zero when nothing is listening, and under set -e that kills
+# the script with curl's status before any assertion runs, which reads as a
+# harness crash rather than a product failure. Capture, then judge.
+health() { curl -sk --max-time 20 https://127.0.0.1:8443/api/v1/health 2>/dev/null || true; }
+
+echo ">> waiting for systemd"
+for _ in $(seq 1 60); do
+    case "$(systemctl is-system-running 2>/dev/null || true)" in
+        running|degraded) break ;;
+    esac
+    sleep 1
+done
+
+# Not quiet. The package manager's quiet mode also suppresses scriptlet
+# output, so a %post failure reduces to "Error in POSTIN scriptlet" with no
+# reason, which is the least actionable message in the whole pipeline.
+install_pkgs() {
+    if [ "$PKG_KIND" = deb ]; then
+        apt-get install -y "$1"/openwatch_*.deb "$1"/kensa-rules_*.deb
+    else
+        dnf install -y "$1"/openwatch-*.rpm "$1"/kensa-rules-*.rpm
+    fi
+}
+
+echo ">> installing PostgreSQL and the previous GA ($OLD_VER)"
+if [ "$PKG_KIND" = deb ]; then
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq curl ca-certificates postgresql postgresql-contrib >/dev/null
+else
+    # Not curl: the RHEL-family images ship curl-minimal, which provides the
+    # binary and conflicts with the full package.
+    command -v curl >/dev/null || dnf install -y -q curl >/dev/null
+    dnf install -y -q postgresql-server postgresql-contrib >/dev/null
+    [ -f /var/lib/pgsql/data/PG_VERSION ] || postgresql-setup --initdb >/dev/null
+fi
+systemctl enable --now postgresql >/dev/null 2>&1 || fail "postgresql did not start"
+for _ in $(seq 1 30); do runuser -u postgres -- psql -tAqc 'SELECT 1' >/dev/null 2>&1 && break; sleep 1; done
+
+install_pkgs "$OLD_DIR"
+openwatch --version | head -1
+
+# Provision by hand: this is the manual procedure the v0.6.0 guide documented,
+# and the state every upgrading operator is actually in.
+echo ">> provisioning the previous GA by hand (setup did not exist in $OLD_VER)"
+runuser -u postgres -- psql -tAqc \
+    "SET password_encryption='scram-sha-256'; CREATE ROLE openwatch WITH LOGIN PASSWORD 'u2pass';"  # pragma: allowlist secret
+runuser -u postgres -- psql -tAqc "CREATE DATABASE openwatch OWNER openwatch;"
+HBA="$(runuser -u postgres -- psql -tAqc 'SHOW hba_file')"
+printf 'host openwatch openwatch 127.0.0.1/32 scram-sha-256\nhost openwatch openwatch ::1/128 scram-sha-256\n%s\n' \
+    "$(cat "$HBA")" > "$HBA.new" && mv "$HBA.new" "$HBA"
+chown postgres:postgres "$HBA"; chmod 640 "$HBA"
+systemctl reload postgresql
+mkdir -p /etc/openwatch
+DSN="postgres://openwatch:u2pass@127.0.0.1:5432/openwatch?sslmode=disable"  # pragma: allowlist secret
+echo "OPENWATCH_DATABASE_DSN=$DSN" > /etc/openwatch/secrets.env
+chgrp openwatch /etc/openwatch/secrets.env && chmod 640 /etc/openwatch/secrets.env
+OPENWATCH_DATABASE_DSN="$DSN" openwatch migrate >/dev/null || fail "migrating the previous GA failed"
+
+before="$(runuser -u postgres -- psql -d openwatch -tAqc 'SELECT max(version_id) FROM goose_db_version')"
+echo "   schema before upgrade: $before"
+
+# A marker in the database itself. If the upgrade drops and recreates rather
+# than migrating in place, this vanishes -- which is the difference between an
+# upgrade and a reinstall that happens to end up healthy.
+#
+# Created as the APPLICATION role, not the superuser. The pre-upgrade backup
+# runs pg_dump as openwatch, and a table owned by postgres makes it fail with
+# "permission denied for table u2_marker" -- the harness breaking the upgrade
+# it is trying to observe, and reading exactly like a product defect.
+PGPASSWORD=u2pass psql -h 127.0.0.1 -U openwatch -d openwatch -tAqc \
+    "CREATE TABLE u2_marker(note text); INSERT INTO u2_marker VALUES ('survived-from-$OLD_VER');" >/dev/null
+
+systemctl enable --now openwatch >/dev/null 2>&1 || fail "the previous GA service did not start"
+for _ in $(seq 1 30); do
+    curl -sk --max-time 5 https://127.0.0.1:8443/api/v1/health 2>/dev/null | grep -q db_connected && break
+    sleep 2
+done
+old_health="$(health)"
+echo "   $OLD_VER health: $old_health"
+case "$old_health" in
+    *"\"version\":\"$OLD_VER\""*) ;;
+    *) fail "the previous GA is not serving $OLD_VER: $old_health" ;;
+esac
+
+echo ">> upgrading to the candidate ($NEW_VER), both packages in one transaction"
+install_pkgs "$NEW_DIR"
+
+echo ">> asserting the upgrade"
+for _ in $(seq 1 45); do
+    curl -sk --max-time 5 https://127.0.0.1:8443/api/v1/health 2>/dev/null | grep -q db_connected && break
+    sleep 2
+done
+new_health="$(health)"
+echo "   $NEW_VER health: $new_health"
+case "$new_health" in
+    *'"db_connected":true'*) ;;
+    *) fail "the service is not serving after the upgrade: $new_health" ;;
+esac
+case "$new_health" in
+    *"\"version\":\"$NEW_VER\""*) ;;
+    *) fail "still reporting the old version after the upgrade: $new_health" ;;
+esac
+
+after="$(runuser -u postgres -- psql -d openwatch -tAqc 'SELECT max(version_id) FROM goose_db_version')"
+echo "   schema after upgrade: $after"
+[ "$after" -gt "$before" ] || fail "the schema did not advance ($before -> $after)"
+
+marker="$(PGPASSWORD=u2pass psql -h 127.0.0.1 -U openwatch -d openwatch -tAqc 'SELECT note FROM u2_marker' 2>/dev/null || true)"
+[ "$marker" = "survived-from-$OLD_VER" ] || \
+    fail "the pre-upgrade marker is gone; the database was replaced, not migrated"
+
+# The scriptlet takes a pg_dump before migrating. Without it a failed migration
+# on a real fleet has no way back.
+ls /var/lib/openwatch/backups/* >/dev/null 2>&1 || \
+    fail "no pre-upgrade backup was taken"
+echo "   backup: $(ls /var/lib/openwatch/backups/ | head -1)"
+
+systemctl is-active --quiet openwatch || fail "the service is not active after the upgrade"
+echo ">> OK: $OLD_VER upgraded to $NEW_VER in place, schema advanced, data preserved"

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -37,6 +37,8 @@ method = "container"
 package = "rpm"
 support_tier = "tested"
 blocking = true
+[platform.checks]
+upgrade-from-ga = "upgrade-from-ga rockylinux:9"
 
 [[platform]]
 id = "el10"
@@ -60,6 +62,8 @@ blocking = true
 [platform.checks]
 clean-install = "setup ubuntu:24.04"
 idempotence = "setup ubuntu:24.04"
+[platform.not_applicable]
+upgrade-from-ga = "v0.6.0 could not run on this platform at all: its DEB shipped /etc/openwatch as root:root, so the service user could not read its own config. There is no working previous GA here to upgrade from, and v0.7.0 is the first release that runs on the Debian family."
 
 [[platform]]
 id = "debian12"
@@ -71,6 +75,8 @@ blocking = true
 [platform.checks]
 clean-install = "setup debian:12"
 idempotence = "setup debian:12"
+[platform.not_applicable]
+upgrade-from-ga = "v0.6.0 could not run on this platform at all: its DEB shipped /etc/openwatch as root:root, so the service user could not read its own config. There is no working previous GA here to upgrade from, and v0.7.0 is the first release that runs on the Debian family."
 
 # -------------------------------------------------------------------- gates
 

--- a/scripts/release-status.py
+++ b/scripts/release-status.py
@@ -37,6 +37,9 @@ GATES = REPO / "release" / "gates.toml"
 ATTEST_DIR = REPO / "release" / "attestations"
 
 PASS, FAIL, MISSING, STALE, ERROR = "PASS", "FAIL", "MISSING", "STALE", "ERROR"
+# N/A is not a pass and not a failure: the claim cannot apply to this platform,
+# and the manifest has to carry the reason so nobody re-opens it as a gap.
+NA = "N/A"
 BAD = {FAIL, MISSING, STALE, ERROR}
 
 
@@ -220,6 +223,13 @@ def evaluate(gates, tag, commit):
                 # it re-runs on every candidate, so it cannot go stale the way
                 # a hand-recorded observation can. Only gates that need a human
                 # observer refuse it.
+                # A claim that cannot apply here. Recorded with its reason
+                # rather than left MISSING, which would read as unfinished
+                # work forever, or marked PASS, which would be a lie.
+                na = p.get("not_applicable", {}).get(g["kind"])
+                if na:
+                    yield gid, label, NA, na
+                    continue
                 # Scoped per gate kind: a job proves the claims it actually
                 # asserts and no others. A job that installs cleanly says
                 # nothing about upgrading from the previous GA.

--- a/scripts/test_release_status.py
+++ b/scripts/test_release_status.py
@@ -137,15 +137,31 @@ class PlatformCheckWiring(unittest.TestCase):
                         self.assertIn(
                             kind, {"clean-install", "idempotence"},
                             f"the setup-install job cannot prove {kind!r}")
+                    if check.startswith("upgrade-from-ga "):
+                        self.assertEqual(
+                            kind, "upgrade-from-ga",
+                            f"the upgrade job cannot prove {kind!r}")
+
+    def test_not_applicable_carries_a_reason(self):
+        """N/A suppresses a blocking gate, so it has to say why in enough
+        detail that a reader can challenge it."""
+        for p in self.gates["platform"]:
+            for kind, reason in p.get("not_applicable", {}).items():
+                with self.subTest(platform=p["id"], kind=kind):
+                    self.assertGreater(
+                        len(reason), 60,
+                        "an N/A reason must explain itself, not assert itself")
+                    self.assertNotIn(kind, p.get("checks", {}),
+                                     "a kind cannot be both N/A and proven")
 
     def test_platform_check_names_match_a_real_matrix_leg(self):
         for p in self.gates["platform"]:
             for check in p.get("checks", {}).values():
                 with self.subTest(platform=p["id"], check=check):
                     # Names are "setup <distro>" from the setup-install job.
-                    self.assertTrue(
-                        check.startswith("setup "),
-                        f"{check!r} does not look like the setup-install job name")
+                    self.assertRegex(
+                        check, r"^(setup|upgrade-from-ga) ",
+                        f"{check!r} does not look like a matrix job name")
                     self.assertIn(
                         check.split(" ", 1)[1], self.distros,
                         f"{check!r} names a distro the matrix does not run")


### PR DESCRIPTION
Gate **U2**. Nothing anywhere tested upgrading from a release that actually
shipped.

The existing `rpm -U` job (U1) builds two synthetic releases of the *same*
version and shims `systemctl`. That proves the scriptlet mechanism. It does not
prove the transition an operator performs.

## What this does

Installs the published **v0.6.0**, provisions it by hand because `openwatch
setup` did not exist then, and upgrades to the candidate with both packages in
one transaction under real systemd. It asserts:

- the previous GA serves **its own** version first, so the baseline is real
- the candidate serves after the upgrade
- the schema advanced (53 to 54)
- a pre-upgrade backup exists
- a row written before the upgrade is still there

That last one is what separates an upgrade from a reinstall that happens to end
up healthy.

```
   0.6.0 health: {"db_connected":true,"status":"healthy","version":"0.6.0"}
>> upgrading to the candidate (0.7.0), both packages in one transaction
   0.7.0 health: {"db_connected":true,"status":"healthy","version":"0.7.0"}
   schema after upgrade: 54
   backup: openwatch-pre-upgrade-0.7.0-20260731T202459Z.sql
>> OK: 0.6.0 upgraded to 0.7.0 in place, schema advanced, data preserved
```

## RHEL family only, and the reason is a finding

**v0.6.0's DEB shipped `/etc/openwatch` as `root:root`**, so the service user
could not read its own config and no Debian install of it could ever have run.
I verified this against the published v0.6.0 artifact: its postinst contains
zero `chgrp`/`chown`.

So there is no working previous GA on that family to upgrade *from*, and
**v0.7.0 is the first release that runs on Debian or Ubuntu at all**. The
manifest records that as `N/A` with the reason attached, rather than leaving a
gate MISSING forever or marking it PASS. A test requires an N/A reason to
actually explain itself and forbids a kind being both N/A and proven.

## Three harness defects, each of which first read as a product bug

Worth reviewing, because the pattern matters more than the fixes:

1. **The marker table was created as the superuser.** The pre-upgrade `pg_dump`
   runs as `openwatch` and failed with "permission denied for table u2_marker",
   which surfaced as `MIGRATION FAILED` and looked exactly like a broken
   upgrade path. I nearly reported it as a release blocker.
2. **Package globs matched every historical build** in a developer's `dist/`,
   staging thirteen packages and letting the manager pick. Both drivers now pin
   the version. **The same latent bug was in the setup driver merged in #780** -
   CI never hit it because a runner's `dist/` holds only the current build.
3. **`-q` also suppresses scriptlet output**, reducing a `%post` failure to
   "Error in POSTIN scriptlet" with no reason. Now verbose.

## One genuinely good result

The fail-safe behaved correctly under a real induced failure: it refused to
migrate, left the service stopped rather than running a new binary against an
old schema, took the backup, and printed the recovery steps. That path had
never been exercised outside a shimmed test.