### PR TITLE
feat(ci): cover AlmaLinux 10 in the install and upgrade matrices

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -67,6 +67,7 @@ jobs:
           - { distro: 'oraclelinux:9', kind: rpm }
           - { distro: 'ubuntu:24.04', kind: deb }
           - { distro: 'debian:12', kind: deb }
+          - { distro: 'almalinux:10', kind: rpm }
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -180,6 +181,7 @@ jobs:
       matrix:
         include:
           - { distro: 'rockylinux:9', kind: rpm }
+          - { distro: 'almalinux:10', kind: rpm }
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v4

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -144,6 +144,7 @@ jobs:
         include:
           - { distro: 'ubuntu:24.04', kind: deb }
           - { distro: 'debian:12', kind: deb }
+          - { distro: 'almalinux:10', kind: rpm }
     steps:
       - uses: actions/checkout@v7
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -216,8 +216,8 @@ itself.
 
 | Platform | Behaviour |
 |---|---|
-| RHEL 9, Debian 12, Ubuntu 24.04 | Runs. Covered by testing. |
-| Rocky, AlmaLinux, Oracle Linux 8-10 | Requires `--allow-untested` |
+| RHEL 9, AlmaLinux 10, Debian 12, Ubuntu 24.04 | Runs. Covered by testing. |
+| Rocky, Oracle Linux 8-10, AlmaLinux 8-9, RHEL 10 | Requires `--allow-untested` |
 | Ubuntu 22.04, other Debian releases | Requires `--allow-untested` |
 | Anything else | Refused |
 

--- a/internal/setup/platform.go
+++ b/internal/setup/platform.go
@@ -147,6 +147,11 @@ func supportOf(id, versionID string, major int, family Family) Support {
 	if id == "debian" && major == 12 {
 		return SupportTested
 	}
+	// AlmaLinux 10, not the whole family's major 10. RHEL 10 has no image in
+	// the matrix and no job, so it stays untested until one exists.
+	if id == "almalinux" && major == 10 {
+		return SupportTested
+	}
 	switch family {
 	case FamilyRHEL:
 		if major >= 8 && major <= 10 {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -40,7 +40,9 @@ func TestSetup_PlatformSupportTiers(t *testing.T) {
 			{"almalinux", "rhel centos fedora", "9.8", FamilyRHEL, SupportUntested},
 			{"ol", "fedora", "9.8", FamilyRHEL, SupportUntested},
 			{"almalinux", "rhel", "8.10", FamilyRHEL, SupportUntested},
-			{"almalinux", "rhel", "10.2", FamilyRHEL, SupportUntested},
+			{"almalinux", "rhel", "10.2", FamilyRHEL, SupportTested},
+			// RHEL 10 shares the major but has no job; it must not inherit.
+			{"rhel", "fedora", "10.0", FamilyRHEL, SupportUntested},
 			{"ubuntu", "debian", "24.04", FamilyDebian, SupportTested},
 			// 24.10 shares the major and is a different release CI never runs.
 			{"ubuntu", "debian", "24.10", FamilyDebian, SupportUntested},
@@ -272,8 +274,12 @@ func TestSetup_ContainerVerificationIsRecorded(t *testing.T) {
 		}
 		// Every distribution in the matrix except RHEL itself needed
 		// --allow-untested, which is only true while they are untested.
+		// AlmaLinux 10 is deliberately absent: the recorded run used
+		// --allow-untested, but a CI job now installs on almalinux:10 on
+		// every push, so it is tested and AC-04 owns that claim. The rest of
+		// the recorded matrix is still untested and still needed the flag.
 		for _, c := range []struct{ id, ver string }{
-			{"rocky", "9.3"}, {"almalinux", "9.8"}, {"ol", "9.8"}, {"almalinux", "10.2"},
+			{"rocky", "9.3"}, {"almalinux", "9.8"}, {"ol", "9.8"},
 		} {
 			if got := supportOf(c.id, c.ver, majorOf(c.ver), FamilyRHEL); got != SupportUntested {
 				t.Errorf("%s %s is %q; the recorded run used --allow-untested, which "+

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -131,6 +131,7 @@ checks = [
   "fedora:41",
   "ubuntu:24.04",
   "debian:12",
+  "almalinux:10",
 ]
 blocking = true
 

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -42,11 +42,17 @@ upgrade-from-ga = "upgrade-from-ga rockylinux:9"
 
 [[platform]]
 id = "el10"
-title = "AlmaLinux 10 / RHEL 10"
+# AlmaLinux 10 specifically. RHEL 10 shares the major but has no image in the
+# matrix, so it is not covered and internal/setup/platform.go does not claim it.
+title = "AlmaLinux 10"
 method = "container"
 package = "rpm"
-support_tier = "untested"
+support_tier = "tested"
 blocking = true
+[platform.checks]
+clean-install = "setup almalinux:10"
+idempotence = "setup almalinux:10"
+upgrade-from-ga = "upgrade-from-ga almalinux:10"
 
 [[platform]]
 id = "ubuntu2404"

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -210,9 +210,10 @@ spec:
       references_constraints: [C-11]
     - id: AC-04
       description: >
-        Platform support tiers resolve correctly: RHEL 9, Ubuntu 24.04 and
-        Debian 12 are tested, because a CI job installs on each of them on
-        every push and asserts the API answers. Other RHEL-family majors 8 to
+        Platform support tiers resolve correctly: RHEL 9, Ubuntu 24.04,
+        Debian 12 and AlmaLinux 10 are tested, because a CI job installs on
+        each of them on every push and asserts the API answers. RHEL 10 shares
+        AlmaLinux 10's major but has no job, so it does not inherit the claim. Other RHEL-family majors 8 to
         10 and other Debian-family releases are untested, and unknown families
         and unparseable versions are unsupported. Ubuntu is matched on the full
         version rather than the major, because 24.10 shares the major with
@@ -262,7 +263,9 @@ spec:
         `openwatch setup --yes --allow-untested --manage-pg-hba` completes and
         the health endpoint reports db_connected on Rocky 9, AlmaLinux 9,
         Oracle Linux 9 and AlmaLinux 10; a second identical run also exits zero,
-        proving idempotence. AlmaLinux 8 is correctly refused because its
+        proving idempotence. AlmaLinux 10 has since been promoted to tested and
+        is covered continuously by a CI job, so this record no longer carries
+        it; the other three remain untested and still need the flag. AlmaLinux 8 is correctly refused because its
         default PostgreSQL is 10, below the floor of 13, with a message naming
         the remedy.
       priority: critical


### PR DESCRIPTION
Adds `almalinux:10` to both container matrices (`setup-install` and
`upgrade-from-ga`) and promotes it to `SupportTested`.

Same evidence-first rule the Debian family followed: the job runs on every push
and asserts the API answers, and that is what justifies the support claim
rather than an edit to a constant.

## Promoted precisely

**RHEL 10 shares AlmaLinux 10's major**, has no image in the matrix and no job,
so it stays `untested`. The AC-04 test asserts that explicitly, so a later
widening to the whole major fails rather than quietly claiming a distribution
nobody runs. Same reasoning as Ubuntu 24.04 versus 24.10.

`release/gates.toml` retitles the platform from "AlmaLinux 10 / RHEL 10" to
"AlmaLinux 10" for the same reason: the manifest should not imply coverage the
matrix does not have.

## A spec record that had to be corrected

`AC-10` records a one-off container run that used `--allow-untested` across
Rocky 9, AlmaLinux 9, Oracle Linux 9 and AlmaLinux 10. That rationale no longer
holds for AlmaLinux 10, which CI now installs on continuously, so the record
drops it and AC-04 owns the claim. The other three remain untested and still
need the flag.

**The AC-10 test caught this**, not a human reading the diff:

```
almalinux 10.2 is "tested"; the recorded run used --allow-untested,
which only makes sense for untested
```

That is a test asserting the reasoning behind a record still follows, which is
the kind that usually does not exist.

## Verified locally before landing

Clean install and re-run on `almalinux:10` with **no flags at all**:

```
  [ok  ] platform almalinux 10.2 (amd64)
           tested
>> OK: clean install and re-run both reached a serving instance
```

And the previous GA upgrade:

```
   0.6.0 health: {"db_connected":true,"status":"healthy","version":"0.6.0"}
   0.7.0 health: {"db_connected":true,"status":"healthy","version":"0.7.0"}
   schema after upgrade: 54
>> OK: 0.6.0 upgraded to 0.7.0 in place, schema advanced, data preserved
```

The install guide's support matrix is updated to match.