### PR TITLE
docs(release): record the Debian fix and the platform coverage in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ the host.
 
 ### Changed
 
+- **Debian 12, Ubuntu 24.04 and AlmaLinux 10 are now covered by automated
+  testing,** so `openwatch setup` runs on them without `--allow-untested`. Each
+  is installed from scratch in CI on every change, and the installer is re-run
+  to confirm it is safe to repeat. RHEL 10 and Ubuntu 22.04 are recognised but
+  still uncovered, and continue to need the flag.
 - **The paid tier is now OpenWatch Enterprise and the free tier is OpenWatch
   Community.** Wherever the API reports a license tier, the enum is now
   `free | enterprise` rather than `free | openwatch_plus`. Update any client
@@ -105,6 +110,18 @@ the host.
 
 ### Fixed
 
+- **OpenWatch now runs on Debian and Ubuntu. Earlier `.deb` packages could not
+  start at all.** The DEB shipped `/etc/openwatch` owned by `root:root`, and the
+  service runs as the `openwatch` user, so it exited immediately with a
+  permission error reading its own configuration. The RPM was unaffected.
+  v0.7.0 is the first release that works from the `.deb`.
+- **`openwatch setup --yes` always failed.** The default plan reads the
+  administrator password from an interactive prompt, and `--yes` makes the run
+  non-interactive, so the two could never be combined. It now stops in preflight
+  and names the flag that resolves it, rather than failing later after printing
+  the whole plan. The same applies to any run without a terminal, such as
+  `ssh host 'openwatch setup'`. Pass `--admin-password-from` with `generate`,
+  `env:NAME` or `file:PATH` for an unattended install.
 - **Settings > Compliance policies showed an empty "Scan variables" section
   with no explanation** when the Kensa rule corpus could not be loaded. It now
   reports that the corpus is unavailable and names the package and path to


### PR DESCRIPTION
The v0.7.0 changelog entry was written before any of this existed. Two changes
since rc.4 are things an operator needs told, and one of them is arguably the
most significant line in the release.

## The Debian fix deserves a plain statement

The DEB shipped `/etc/openwatch` as `root:root` while the service runs as the
`openwatch` user, so it exited immediately reading its own config. **v0.7.0 is
the first release that works from the `.deb` at all.** That is better said
outright than left as an implied improvement, and it explains why there is no
upgrade path from v0.6.0 on that family.

## `--yes`

Documented with the detail that matters: the failure applies to any run without
a terminal, such as `ssh host 'openwatch setup'`, not just to that flag.

## Platform coverage

Debian 12, Ubuntu 24.04 and AlmaLinux 10 no longer need `--allow-untested`, and
the entry says what "covered" means: installed from scratch in CI on every
change, then re-run to confirm repeating it is safe. RHEL 10 and Ubuntu 22.04
are called out as still needing the flag.

Version-string agreement tests and the doc-style gate both pass.