### PR TITLE
fix(setup): stop installing postgresql-contrib, which nothing needs

### DIFF
--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -118,7 +118,7 @@ Preflight
   [ok  ] SELinux enforcing
 
 Plan
-   1. install PostgreSQL (dnf install postgresql-server postgresql-contrib)
+   1. install PostgreSQL (dnf install postgresql-server)
    2. initialise the data directory and enable postgresql
    3. verify PostgreSQL >= 13 (supported >= 15)
    4. create role "openwatch" with a generated password, hashed scram-sha-256
@@ -320,7 +320,7 @@ sudo dnf module enable -y postgresql:16
 Then install, initialise, and start:
 
 ```bash
-sudo dnf install -y postgresql-server postgresql-contrib
+sudo dnf install -y postgresql-server
 sudo postgresql-setup --initdb
 sudo systemctl enable --now postgresql
 ```
@@ -559,7 +559,7 @@ The flow is identical to the RPM path; only Steps 1–3 differ.
 
 ```bash
 sudo apt update
-sudo apt install -y postgresql postgresql-contrib
+sudo apt install -y postgresql
 sudo systemctl enable --now postgresql
 ```
 

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -75,9 +75,9 @@ func (stepPostgresInstall) ID() string { return "postgres-install" }
 
 func (stepPostgresInstall) Describe(p Plan) string {
 	if p.Platform.Family == FamilyDebian {
-		return "install PostgreSQL (apt-get install postgresql postgresql-contrib)"
+		return "install PostgreSQL (apt-get install postgresql)"
 	}
-	return "install PostgreSQL (dnf install postgresql-server postgresql-contrib)"
+	return "install PostgreSQL (dnf install postgresql-server)"
 }
 
 func (stepPostgresInstall) Status(ctx context.Context, p Plan) StepStatus {
@@ -93,12 +93,12 @@ func (s stepPostgresInstall) Apply(ctx context.Context, r *Run) error {
 			return err
 		}
 		if err := r.mutate(ctx, s.ID(), "install postgresql", "apt-get", "install", "-y",
-			"postgresql", "postgresql-contrib"); err != nil {
+			"postgresql"); err != nil {
 			return err
 		}
 	} else {
 		if err := r.mutate(ctx, s.ID(), "install postgresql-server", "dnf", "install", "-y",
-			"postgresql-server", "postgresql-contrib"); err != nil {
+			"postgresql-server"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Found during live install testing: setup's plan step 1 installs
`postgresql-contrib`, but it never appeared in the package dependency list.
Good catch, and the answer is that it is not required at all.

## Evidence, checked against the schema rather than the docs

- **No `CREATE EXTENSION` of any kind** in any migration. No `pgcrypto`,
  `uuid-ossp`, `citext`, `hstore` or `pg_trgm` anywhere in the tree.
- The three migrations calling `gen_random_uuid()` rely on a function that has
  been **built into core PostgreSQL since 13**, already the floor. That is
  almost certainly the origin: before 13 it lived in `pgcrypto`, and the
  requirement outlived its reason.
- Neither package declares it. The RPM requires `postgresql-server`, the DEB
  requires `postgresql-client` - which is exactly why it never showed up as a
  dependency while setup installed it anyway.
- `psql`, which setup shells out to, comes from the client package.

## Change

Dropped from the RHEL and Debian install steps, from the plan text, and from
all three places the install guide recommended it.

One fewer package and its surface on every install, which on a compliance
product is the kind of thing a buyer's auditor asks about.