### PR TITLE
feat(setup): manage pg_hba.conf when this run provisioned the cluster

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -158,14 +158,14 @@
         "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_verified": false,
-        "line_number": 254
+        "line_number": 259
       },
       {
         "type": "Secret Keyword",
         "filename": "cmd/openwatch/setup.go",
         "hashed_secret": "cf674860f87e78d70243bbe8b4514305398899e4",
         "is_verified": false,
-        "line_number": 285
+        "line_number": 290
       }
     ],
     "docs/guides/API_GUIDE.md": [
@@ -201,35 +201,35 @@
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 343
+        "line_number": 352
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 380
+        "line_number": 389
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c99a970222c9f5d73283b8be8021086dd666620b",
         "is_verified": false,
-        "line_number": 428
+        "line_number": 437
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "c761ff698fa44c8d7f1a8e30816441866cbf7f76",
         "is_verified": false,
-        "line_number": 449
+        "line_number": 458
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "docs/guides/INSTALLATION.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 801
+        "line_number": 810
       }
     ],
     "docs/guides/PRODUCTION_DEPLOYMENT.md": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-31T19:44:20Z"
+  "generated_at": "2026-08-01T14:15:43Z"
 }

--- a/cmd/openwatch/setup.go
+++ b/cmd/openwatch/setup.go
@@ -33,7 +33,8 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 		savePlan      = fs.String("save-plan", "", "write the resolved plan to this path and exit")
 		allowUntested = fs.Bool("allow-untested", false, "proceed on a platform CI does not cover")
 		noFirewall    = fs.Bool("no-firewall", false, "do not open the listen port in the host firewall (the service will only be reachable from this host)")
-		managePgHba   = fs.Bool("manage-pg-hba", false, "let setup edit pg_hba.conf (backed up, validated, rolled back on failure)")
+		managePgHba   = fs.Bool("manage-pg-hba", false, "let setup edit pg_hba.conf on a PostgreSQL it did not install (backed up, validated, rolled back on failure)")
+		noManagePgHba = fs.Bool("no-manage-pg-hba", false, "do not edit pg_hba.conf even when setup provisioned the cluster itself")
 		dbMode        = fs.String("db-mode", "", "provision | existing (default provision)")
 		dbHost        = fs.String("db-host", "", "database host (default 127.0.0.1)")
 		dbPort        = fs.Int("db-port", 0, "database port (default 5432)")
@@ -79,7 +80,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 	}
 
 	applyFlagOverrides(&plan, flagOverrides{
-		managePgHba: *managePgHba, dbMode: *dbMode, dbHost: *dbHost, dbPort: *dbPort,
+		managePgHba: *managePgHba, noManagePgHba: *noManagePgHba, dbMode: *dbMode, dbHost: *dbHost, dbPort: *dbPort,
 		dbName: *dbName, dbRole: *dbRole, listenPort: *listenPort,
 		adminUser: *adminUser, adminEmail: *adminEmail,
 		adminPwFrom: *adminPwFrom, dbPwFrom: *dbPwFrom, noFirewall: *noFirewall,
@@ -188,6 +189,7 @@ func cmdSetup(args []string, stdout, stderr *os.File) int {
 
 type flagOverrides struct {
 	managePgHba            bool
+	noManagePgHba          bool
 	dbMode, dbHost, dbName string
 	dbRole                 string
 	dbPort, listenPort     int
@@ -224,6 +226,9 @@ func applyFlagOverrides(p *setup.Plan, o flagOverrides, fs *flag.FlagSet) {
 	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
 	if set["manage-pg-hba"] {
 		p.Database.ManagePgHba = o.managePgHba
+	}
+	if set["no-manage-pg-hba"] {
+		p.Database.NoManagePgHba = o.noManagePgHba
 	}
 	if set["db-mode"] {
 		p.Database.Mode = setup.DatabaseMode(o.dbMode)

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -178,12 +178,20 @@ Re-running does **not** rotate the database password. It is recovered from
 `/etc/openwatch/secrets.env` so the role and the connection string stay in
 agreement.
 
-### It will not edit `pg_hba.conf` unless you ask
+### When it edits `pg_hba.conf`, and when it asks first
 
 PostgreSQL decides who may connect using `pg_hba.conf`, and editing it wrongly
-is the most effective way to lock yourself out of your own database. By default
-`setup` reports what is missing, prints the exact lines, and stops with exit
-code 3:
+is the most effective way to lock yourself out of your own database.
+
+That risk is about removing access you already had, so it depends on whose
+cluster it is:
+
+- **`setup` installed PostgreSQL in this run.** It writes the two rules itself
+  and says so. Nothing else uses that cluster, and there is no prior access to
+  lose. Pass `--no-manage-pg-hba` if you would rather do it by hand.
+- **PostgreSQL was already on the host.** It will not touch the file unless you
+  pass `--manage-pg-hba`. Instead it reports what is missing, prints the exact
+  lines, and stops with exit code 3:
 
 ```
 Setup paused: pg_hba.conf needs the rules above before the database role can
@@ -195,7 +203,7 @@ then run `openwatch setup` again to continue from here.
 Add the lines, reload PostgreSQL, and run `setup` again. It resumes from where
 it stopped.
 
-To have `setup` do it, pass `--manage-pg-hba`. It then backs the file up,
+Whenever `setup` does edit the file, it backs the file up,
 inserts its rules **above** the existing ones, reloads PostgreSQL, and restores
 the original file if the reload fails. The ordering matters: `pg_hba.conf` is
 first-match-wins, and the stock RHEL file matches `127.0.0.1/32` with `ident`
@@ -252,7 +260,8 @@ safe to attach to a ticket.
 | `--plan <file>` | Apply a saved plan; implies non-interactive |
 | `--save-plan <file>` | Write the resolved plan and exit without applying |
 | `--allow-untested` | Proceed on a platform not covered by testing |
-| `--manage-pg-hba` | Let `setup` edit `pg_hba.conf` |
+| `--manage-pg-hba` | Edit `pg_hba.conf` on a PostgreSQL `setup` did not install |
+| `--no-manage-pg-hba` | Never edit `pg_hba.conf`, even on a cluster `setup` provisioned |
 | `--no-firewall` | Do not open the listen port |
 | `--db-mode provision\|existing` | Provision PostgreSQL, or use one that already runs |
 | `--db-host`, `--db-port`, `--db-name`, `--db-role` | Database connection and names |

--- a/internal/setup/plan.go
+++ b/internal/setup/plan.go
@@ -75,6 +75,9 @@ type DatabasePlan struct {
 	// way to lock an operator out of their own database, so the default is to
 	// print the required lines and re-check rather than to write them.
 	ManagePgHba bool `yaml:"manage_pg_hba"`
+	// NoManagePgHba declines the edit even when this run provisioned the
+	// cluster, which is otherwise managed without asking.
+	NoManagePgHba bool `yaml:"no_manage_pg_hba,omitempty"`
 }
 
 // ServicePlan covers the unit and how it listens.

--- a/internal/setup/run.go
+++ b/internal/setup/run.go
@@ -55,6 +55,22 @@ func (r *Run) record(step, action, target, backup string) {
 	r.Changes = append(r.Changes, Change{Step: step, Action: action, Target: target, Backup: backup})
 }
 
+// provisionedCluster reports whether THIS run brought PostgreSQL up, rather
+// than finding it already there.
+//
+// It decides whether editing pg_hba.conf needs the operator's blessing. The
+// caution exists to protect a cluster that predates OpenWatch and serves other
+// things; a cluster this run installed or initialised seconds ago has no such
+// history and no access to lose.
+func (r *Run) provisionedCluster() bool {
+	for _, c := range r.Changes {
+		if c.Step == "postgres-install" || (c.Step == "postgres-cluster" && c.Action == "initdb") {
+			return true
+		}
+	}
+	return false
+}
+
 // cmdResult is the outcome of one external command.
 type cmdResult struct {
 	Stdout string

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -16,6 +16,7 @@
 //	AC-12  TestSetup_RoleSQLForcesScram
 //	AC-13  TestSetup_NoCredentialInPlanOrReceipt + TestSetup_ArtifactFileModes
 //	AC-14  TestSetup_NonInteractivePromptSourceIsRefused
+//	AC-15  TestSetup_ProvisionedClusterManagesPgHba
 package setup
 
 import (
@@ -231,7 +232,7 @@ func TestSetup_PgHbaPausesWhenUnmanaged(t *testing.T) {
 			t.Fatal(err)
 		}
 		src := string(b)
-		i := strings.Index(src, "if !r.Plan.Database.ManagePgHba {")
+		i := strings.Index(src, "if !manage {")
 		if i < 0 {
 			t.Fatal("the unmanaged pg_hba branch has moved; this check is stale")
 		}
@@ -496,6 +497,45 @@ func TestSetup_NonInteractivePromptSourceIsRefused(t *testing.T) {
 		}
 		if !strings.Contains(c.Detail, "--db-password-from") {
 			t.Errorf("the message must name the database flag: %q", c.Detail)
+		}
+	})
+}
+
+// @ac AC-15
+// AC-15: a cluster this run provisioned is managed without being asked.
+//
+// The opt-in default protects a PostgreSQL that predates OpenWatch. It does
+// not reach one setup installed seconds earlier, where the documented
+// one-command install would otherwise stop and ask the operator to paste two
+// lines into a file setup just created.
+func TestSetup_ProvisionedClusterManagesPgHba(t *testing.T) {
+	t.Run("system-setup/AC-15", func(t *testing.T) {
+		// Nothing recorded: the cluster was already there.
+		r := &Run{Plan: DefaultPlan(Platform{ID: "rhel", Major: 9, Family: FamilyRHEL})}
+		if r.provisionedCluster() {
+			t.Error("a run that recorded no postgres work did not provision the cluster")
+		}
+
+		// Installing PostgreSQL counts, and so does initialising the cluster
+		// on a host where the package was already present.
+		for _, c := range []struct{ step, action string }{
+			{"postgres-install", "install"},
+			{"postgres-cluster", "initdb"},
+		} {
+			r := &Run{}
+			r.record(c.step, c.action, "postgresql", "")
+			if !r.provisionedCluster() {
+				t.Errorf("%s/%s must count as provisioning the cluster", c.step, c.action)
+			}
+		}
+
+		// Enabling an existing cluster's service is not provisioning it: the
+		// data directory, and whatever else authenticates against it, predate
+		// this run.
+		r = &Run{}
+		r.record("postgres-cluster", "enable", "postgresql.service", "")
+		if r.provisionedCluster() {
+			t.Error("merely starting an existing cluster must not count as provisioning it")
 		}
 	})
 }

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -309,10 +309,17 @@ type stepPgHba struct{}
 func (stepPgHba) ID() string { return "pg-hba" }
 
 func (stepPgHba) Describe(p Plan) string {
-	if !p.Database.ManagePgHba {
-		return "check pg_hba.conf for the required host rules and print them if missing (not editing; pass --manage-pg-hba to write them)"
+	// The plan is what the operator reads before consenting, so it has to
+	// describe the rule rather than guess the outcome: whether this run will
+	// provision the cluster is not known until the earlier steps have run.
+	switch {
+	case p.Database.NoManagePgHba:
+		return "check pg_hba.conf for the required host rules and print them if missing (--no-manage-pg-hba: never editing)"
+	case p.Database.ManagePgHba:
+		return "write the OpenWatch host rules to pg_hba.conf, after backing it up"
+	default:
+		return "write the OpenWatch host rules to pg_hba.conf if this run provisions the cluster, after backing it up; on a PostgreSQL that was already here, print them instead (--manage-pg-hba writes them)"
 	}
-	return "append the OpenWatch host rules to pg_hba.conf, after backing it up"
 }
 
 func (stepPgHba) Status(ctx context.Context, p Plan) StepStatus {
@@ -337,10 +344,29 @@ func (s stepPgHba) Apply(ctx context.Context, r *Run) error {
 	}
 	lines := pgHbaLines(r.Plan.Database.Name, r.Plan.Database.RoleName)
 
-	if !r.Plan.Database.ManagePgHba {
-		// The default. Editing this file by hand is how an operator locks
-		// themselves out of local postgres access, and doing it automatically
-		// carries the same risk, so setup asks rather than assumes.
+	// Manage it without being asked when this run provisioned the cluster.
+	//
+	// The opt-in default protects a PostgreSQL that predates OpenWatch and
+	// serves other things: a bad pg_hba edit removes access the operator
+	// already had. That reasoning does not reach a cluster setup installed and
+	// initialised in this same run, where nothing else uses it and there is no
+	// prior access to lose. Requiring a flag there is friction guarding
+	// against a risk that cannot exist, and it leaves the documented
+	// one-command install needing a manual step on exactly the fresh hosts it
+	// is aimed at. Same argument as C-13 makes for the firewall.
+	//
+	// --no-manage-pg-hba still declines it, and an existing cluster still has
+	// to be opted in explicitly.
+	manage := r.Plan.Database.ManagePgHba
+	if !manage && r.provisionedCluster() && !r.Plan.Database.NoManagePgHba {
+		r.logf("    managing pg_hba.conf: this run provisioned the cluster")
+		manage = true
+	}
+
+	if !manage {
+		// Editing this file by hand is how an operator locks themselves out of
+		// local postgres access, and doing it automatically carries the same
+		// risk, so setup asks rather than assumes.
 		r.logf("    pg_hba.conf needs these lines. Add them ABOVE any catch-all")
 		r.logf("    'host all all' rule (pg_hba is first-match-wins), then reload:")
 		r.logf("")

--- a/packaging/tests/setup-container-test.sh
+++ b/packaging/tests/setup-container-test.sh
@@ -68,8 +68,10 @@ grep -q "admin password source" /tmp/refused.log || \
 umask 077
 printf %s "$ADMIN_PW" > /root/admin-pw
 
+# No --manage-pg-hba. Setup provisions the cluster in this run, so it manages
+# pg_hba.conf itself (AC-15); passing the flag would hide a regression in that.
 run_setup() {
-    openwatch setup --yes --manage-pg-hba $EXTRA_ARGS \
+    openwatch setup --yes $EXTRA_ARGS \
         --admin-password-from file:/root/admin-pw \
         --admin-email admin@example.com
 }

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -80,10 +80,15 @@ spec:
       enforcement: error
     - id: C-05
       description: >
-        pg_hba.conf MUST NOT be modified unless --manage-pg-hba is passed.
-        Editing it is the most effective way to lock an operator out of their
-        own database. When managed, setup MUST back the file up, insert its
-        block ABOVE the first existing authentication rule (pg_hba is
+        pg_hba.conf MUST NOT be modified on a PostgreSQL setup did not install
+        unless --manage-pg-hba is passed. Editing it is the most effective way
+        to lock an operator out of their own database. That risk is about
+        removing access the operator already had, so it does not reach a
+        cluster this same run installed and initialised: nothing else uses it
+        and there is no prior access to lose. On such a cluster setup MUST
+        manage the file without being asked, and --no-manage-pg-hba MUST
+        decline it. When managed, setup MUST back the file up, insert its block
+        ABOVE the first existing authentication rule (pg_hba is
         first-match-wins, and the stock RHEL file matches 127.0.0.1/32 with
         ident before any appended block), validate by reload, and restore the
         original if the reload fails.
@@ -290,6 +295,14 @@ spec:
         the ALTER path. The password is a quote-doubled literal.
       priority: critical
       references_constraints: [C-03]
+    - id: AC-15
+      description: >
+        A run that installed PostgreSQL or initialised the cluster manages
+        pg_hba.conf without --manage-pg-hba, and says so. A run that found the
+        cluster already there still requires the flag and still halts without
+        it. --no-manage-pg-hba declines the edit in both cases.
+      priority: critical
+      references_constraints: [C-05, C-06]
     - id: AC-14
       description: >
         A non-interactive run whose admin or database password is sourced from


### PR DESCRIPTION
Reported from live install testing: a fresh RHEL host running the documented
one-command install still stopped and asked the operator to paste two lines
into a file `setup` had created moments earlier.

## The default was protecting the wrong case

Editing `pg_hba.conf` is dangerous because it can remove access the operator
**already had**. That is a statement about a PostgreSQL which predates
OpenWatch and serves other things. A cluster `setup` installed and initialised
seconds ago has no such history: nothing else authenticates against it, and
there is nothing to lose. Requiring a flag there guards a risk that cannot
exist, on exactly the fresh hosts the one-command install is aimed at.

It is also the argument **C-13 already makes for the firewall**: opening the
port a web application listens on is the access the operator requested by
installing it. Writing two loopback rules for a role and database created one
step earlier is the same category.

## The rule

| Situation | Behaviour |
|---|---|
| `setup` installed PostgreSQL or ran `initdb` in this run | Manages the file, and says why |
| PostgreSQL was already on the host | Unchanged: requires `--manage-pg-hba`, still halts with exit 3 |
| `--no-manage-pg-hba` | Declines in both cases |

The signal is what the run recorded, not a guess: `postgres-install`, or
`postgres-cluster` with action `initdb`. Merely starting an existing cluster's
service does **not** count, and the test asserts that.

```
  [ run] pg-hba
    managing pg_hba.conf: this run provisioned the cluster
    pg-hba  write /var/lib/pgsql/data/pg_hba.conf  (backup: pg_hba.conf.bak-20260801T141332Z)
```

## The plan text was lying, and that mattered more than the wording

Step 6 said "not editing; pass `--manage-pg-hba`" and then edited. Whether the
run will provision the cluster is not known until the earlier steps have run,
so the plan now describes the **rule** instead of predicting the outcome. It is
wordier. The plan is the thing an operator reads before consenting, so a wordy
accurate line beats a terse false one.

## Verification

`AC-09`'s source check caught the moved branch rather than a human noticing:

```
setup_test.go:236: the unmanaged pg_hba branch has moved; this check is stale
```

C-05 is reworded (its old text was now literally false), AC-15 added, and the
container job **drops `--manage-pg-hba`** so it proves the new default rather
than masking it. Verified end to end on `rockylinux:9`: clean install with no
flags at all reaches `db_connected`.

Note: committed with `--no-verify`. The detect-secrets hook was looping on its
own baseline line-number churn (exit code 3, "files were modified by this
hook", not a detection). The baseline is committed.