### PR TITLE
feat(setup): raise the PostgreSQL floor above end of life, and install 16

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -19,6 +19,16 @@ on:
       - 'packaging/**'
       - '.github/workflows/package-smoke.yml'
       - '.github/scripts/install-rpmbuild.sh'
+      # The installer itself. Without these, a change to how setup provisions
+      # PostgreSQL or edits pg_hba.conf does not run the jobs that prove setup
+      # works, and the regression surfaces only when a candidate is tagged.
+      # This filter was found too narrow by a PR that rewrote the PostgreSQL
+      # install path and ran none of them.
+      - 'internal/setup/**'
+      - 'cmd/openwatch/setup.go'
+      # The upgrade job asserts the schema advances, so a migration change is
+      # a change to what it proves.
+      - 'internal/db/migrations/**'
   workflow_dispatch:
 
 permissions:

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -37,6 +37,14 @@ connection string, applies migrations, creates your first administrator, opens
 the firewall port, starts the service, and confirms the API answers. It shows
 you the whole plan and waits for confirmation before changing anything.
 
+**You do not need to pick a PostgreSQL version yourself.** On RHEL and its
+derivatives the default is still PostgreSQL 13, which is past end of life, so
+`setup` enables the `postgresql:16` module stream before installing. If you have
+already enabled a stream, it uses that one and does not overrule your choice.
+If PostgreSQL is already installed and older than 15, `setup` refuses and prints
+the commands to move it, because changing a cluster's major version needs
+`pg_upgrade` and is your decision rather than an installer's.
+
 **This is the supported way to install OpenWatch.** The
 [manual procedure](#manual-installation-rhel-family-rpm) documents every step
 `setup` performs, for operators who need to stage the work differently, satisfy
@@ -58,10 +66,13 @@ On a host that already runs PostgreSQL, either takes about five minutes.
 - **CPU/RAM:** 1 vCPU / 512 MB for the service itself; size up for large fleets.
 - **Disk:** 500 MB for the binary plus database growth sized to your retention.
 - **PostgreSQL:** 15 or newer. The package depends on the PostgreSQL
-  client/server but does **not** create a database. You do that in Step 2.
-  PostgreSQL 14 reaches end of life in November 2026, within this release's
-  service life, so it is not a supported target for a new install. RHEL 9
-  defaults to PostgreSQL 13 and needs a newer module stream enabled: see Step 1.
+  client/server but does **not** create a database. `openwatch setup` creates
+  it; if you are installing by hand, you do that in Step 2.
+  OpenWatch will not stand up a database that is past upstream end of life.
+  PostgreSQL 13 left support in November 2025 and 14 does so in November 2026,
+  within this release's service life, so neither is a supported target for a new
+  install. RHEL 9 still defaults to PostgreSQL 13: `openwatch setup` enables a
+  supported module stream for you, and the manual path covers it in Step 1.
 - **Network:**
   - TCP/8443 inbound for the API and UI.
   - TCP/22 outbound from this host to every managed host (Kensa scans over SSH).
@@ -118,12 +129,12 @@ Preflight
   [ok  ] SELinux enforcing
 
 Plan
-   1. install PostgreSQL (dnf install postgresql-server)
+   1. install PostgreSQL 16 (dnf module enable postgresql:16, then dnf install postgresql-server)
    2. initialise the data directory and enable postgresql
-   3. verify PostgreSQL >= 13 (supported >= 15)
+   3. verify PostgreSQL >= 15 (14 is end of life)
    4. create role "openwatch" with a generated password, hashed scram-sha-256
    5. create database "openwatch" owned by "openwatch"
-   6. check pg_hba.conf for the required host rules
+   6. write the OpenWatch host rules to pg_hba.conf if this run provisions the cluster
    7. write /etc/openwatch/secrets.env with the database DSN
    8. apply database migrations
    9. create the first admin user "admin"

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -17,6 +17,7 @@
 //	AC-13  TestSetup_NoCredentialInPlanOrReceipt + TestSetup_ArtifactFileModes
 //	AC-14  TestSetup_NonInteractivePromptSourceIsRefused
 //	AC-15  TestSetup_ProvisionedClusterManagesPgHba
+//	AC-16  TestSetup_PostgresFloorExcludesEndOfLife
 package setup
 
 import (
@@ -266,12 +267,14 @@ func TestSetup_ContainerVerificationIsRecorded(t *testing.T) {
 			t.Errorf("minPostgresMajor is %d; the recorded AlmaLinux 8 refusal "+
 				"(PostgreSQL 10) no longer follows from it", minPostgresMajor)
 		}
-		// Rocky 9, Alma 9 and Oracle 9 all ship PostgreSQL 13, which passed
-		// while warning. That depends on 13 sitting between the two floors.
-		if minPostgresMajor > 13 || supportedPostgresMajor <= 13 {
-			t.Errorf("floors are min=%d supported=%d; the recorded RHEL 9 result "+
-				"(PostgreSQL 13 accepted with a warning) no longer follows",
-				minPostgresMajor, supportedPostgresMajor)
+		// The recorded runs accepted the distribution default, PostgreSQL 13,
+		// with a warning. That is no longer the behaviour: 13 is end of life
+		// and now below the floor, and setup enables a supported module stream
+		// rather than installing the default. The rest of the record still
+		// holds; this clause does not, and AC-16 owns the floor.
+		if minPostgresMajor <= 13 {
+			t.Errorf("minPostgresMajor is %d; the floor must exclude the end-of-life 13",
+				minPostgresMajor)
 		}
 		// Every distribution in the matrix except RHEL itself needed
 		// --allow-untested, which is only true while they are untested.
@@ -536,6 +539,51 @@ func TestSetup_ProvisionedClusterManagesPgHba(t *testing.T) {
 		r.record("postgres-cluster", "enable", "postgresql.service", "")
 		if r.provisionedCluster() {
 			t.Error("merely starting an existing cluster must not count as provisioning it")
+		}
+	})
+}
+
+// @ac AC-16
+// AC-16: the floor is a support statement, so it excludes dead versions.
+//
+// The dates are the reason this is pinned rather than left to judgement.
+// PostgreSQL 13 left support in November 2025 and 14 does so in November 2026,
+// so a floor at either ships regulated customers an unsupported database. The
+// distribution default is not an argument: RHEL 9's is still 13.
+func TestSetup_PostgresFloorExcludesEndOfLife(t *testing.T) {
+	t.Run("system-setup/AC-16", func(t *testing.T) {
+		// Upstream end-of-life majors as of this release. Update deliberately,
+		// with the date, when one more falls off.
+		const lastEOLMajor = 14 // 14 reaches EOL 2026-11
+		if minPostgresMajor <= lastEOLMajor {
+			t.Errorf("minPostgresMajor is %d, which is end of life or reaches it "+
+				"within this release's life; the floor must be above %d",
+				minPostgresMajor, lastEOLMajor)
+		}
+		// What setup stands up must not be merely acceptable, or every install
+		// starts one major from needing attention.
+		if preferredPostgresMajor <= minPostgresMajor {
+			t.Errorf("preferred %d is not newer than the floor %d; a fresh install "+
+				"should not land on the oldest still-supported version",
+				preferredPostgresMajor, minPostgresMajor)
+		}
+
+		// The refusal has to tell an operator what to do. A floor that only
+		// says no turns into a support ticket.
+		b, err := os.ReadFile("steps.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := string(b)
+		for _, want := range []string{"pg_upgrade", "dnf module", "no longer receives security fixes"} {
+			if !strings.Contains(src, want) {
+				t.Errorf("the below-floor refusal does not mention %q", want)
+			}
+		}
+		// Never in place: changing a cluster's major version is the operator's
+		// call, and doing it silently under their data is unrecoverable.
+		if !strings.Contains(src, "setup will not change its major") {
+			t.Error("the refusal must say setup will not change the cluster's major version")
 		}
 	})
 }

--- a/internal/setup/steps.go
+++ b/internal/setup/steps.go
@@ -21,8 +21,17 @@ import (
 // this release's service life). setup checks before installing so the operator
 // finds out at the start rather than at the migration step.
 const (
-	minPostgresMajor       = 13
-	supportedPostgresMajor = 15
+	// minPostgresMajor is a support floor, not a compatibility floor. The
+	// schema runs on 13, but 13 reached end of life in November 2025 and 14
+	// does so in November 2026. Hanalyx ships third-party software into
+	// regulated estates; standing up an unsupported database as part of an
+	// install is not defensible there, whatever the distribution's default is.
+	// 15 is supported until November 2027 and is the lowest stream el9 offers.
+	minPostgresMajor = 15
+	// preferredPostgresMajor is what setup installs when it provisions. Newer
+	// than the floor on purpose: an install done today should not need
+	// revisiting in a year. Supported until November 2028.
+	preferredPostgresMajor = 16
 )
 
 // StepStatus is the result of a step's idempotence check.
@@ -77,7 +86,7 @@ func (stepPostgresInstall) Describe(p Plan) string {
 	if p.Platform.Family == FamilyDebian {
 		return "install PostgreSQL (apt-get install postgresql)"
 	}
-	return "install PostgreSQL (dnf install postgresql-server)"
+	return fmt.Sprintf("install PostgreSQL %d (dnf module enable postgresql:%d, then dnf install postgresql-server)", preferredPostgresMajor, preferredPostgresMajor)
 }
 
 func (stepPostgresInstall) Status(ctx context.Context, p Plan) StepStatus {
@@ -97,6 +106,26 @@ func (s stepPostgresInstall) Apply(ctx context.Context, r *Run) error {
 			return err
 		}
 	} else {
+		// Bare postgresql-server on el9 resolves to the non-modular 13, which
+		// is end of life. The supported versions are module streams, so one
+		// has to be selected before installing or the install quietly lands on
+		// a database nobody upstream supports any more.
+		//
+		// An operator who has already enabled a stream has made a choice, and
+		// setup does not overrule it; the version check afterwards enforces the
+		// floor either way. `module` is absent on distributions without
+		// modularity (and on el10), so a failure here is not fatal: fall
+		// through, install, and let the version check speak.
+		if !postgresStreamEnabled(ctx) {
+			stream := fmt.Sprintf("postgresql:%d", preferredPostgresMajor)
+			if err := r.mutate(ctx, s.ID(), "enable "+stream, "dnf", "module", "enable",
+				"-y", stream); err != nil {
+				r.logf("    could not enable %s (%v); installing the distribution default",
+					stream, err)
+			} else {
+				r.record(s.ID(), "module enable", stream, "")
+			}
+		}
 		if err := r.mutate(ctx, s.ID(), "install postgresql-server", "dnf", "install", "-y",
 			"postgresql-server"); err != nil {
 			return err
@@ -172,7 +201,7 @@ type stepPostgresVersion struct{}
 func (stepPostgresVersion) ID() string { return "postgres-version" }
 
 func (stepPostgresVersion) Describe(Plan) string {
-	return fmt.Sprintf("verify PostgreSQL >= %d (supported >= %d)", minPostgresMajor, supportedPostgresMajor)
+	return fmt.Sprintf("verify PostgreSQL >= %d (%d is end of life)", minPostgresMajor, minPostgresMajor-1)
 }
 
 func (stepPostgresVersion) Status(ctx context.Context, p Plan) StepStatus {
@@ -181,9 +210,9 @@ func (stepPostgresVersion) Status(ctx context.Context, p Plan) StepStatus {
 	case v == 0:
 		return StepStatus{}
 	case v < minPostgresMajor:
-		return StepStatus{Detail: fmt.Sprintf("PostgreSQL %d is BELOW the minimum %d", v, minPostgresMajor)}
-	case v < supportedPostgresMajor:
-		return StepStatus{Done: true, Detail: fmt.Sprintf("PostgreSQL %d (below supported %d, will warn)", v, supportedPostgresMajor)}
+		return StepStatus{Detail: fmt.Sprintf("PostgreSQL %d is BELOW the supported minimum %d (end of life)", v, minPostgresMajor)}
+	case v < minPostgresMajor:
+		return StepStatus{Detail: fmt.Sprintf("PostgreSQL %d is BELOW the supported minimum %d (end of life)", v, minPostgresMajor)}
 	default:
 		return StepStatus{Done: true, Detail: fmt.Sprintf("PostgreSQL %d", v)}
 	}
@@ -196,15 +225,18 @@ func (s stepPostgresVersion) Apply(ctx context.Context, r *Run) error {
 	}
 	if v < minPostgresMajor {
 		return fmt.Errorf(
-			"%s: PostgreSQL %d is too old; OpenWatch requires %d or newer because the "+
-				"schema uses gen_random_uuid as a column default. Upgrade the server, or "+
-				"on RHEL enable a newer module stream (dnf module list postgresql)",
-			s.ID(), v, minPostgresMajor)
-	}
-	if v < supportedPostgresMajor {
-		r.logf("    WARNING: PostgreSQL %d is below the supported minimum %d. It will work, "+
-			"but note that %d defaults password_encryption to md5 where 14+ default to "+
-			"scram-sha-256", v, supportedPostgresMajor, v)
+			"%s: PostgreSQL %d is below the supported minimum of %d.\n"+
+				"    PostgreSQL %d no longer receives security fixes upstream, so OpenWatch "+
+				"will not build an install on it.\n"+
+				"    This cluster already holds data, so setup will not change its major "+
+				"version: switching streams under an existing cluster needs pg_upgrade and "+
+				"is your decision, not the installer's.\n"+
+				"    On RHEL and derivatives:\n"+
+				"      sudo dnf module list postgresql          # see the streams offered\n"+
+				"      sudo dnf module switch-to postgresql:%d  # then pg_upgrade the cluster\n"+
+				"    On Debian and Ubuntu, install the newer server package and migrate with "+
+				"pg_upgradecluster.",
+			s.ID(), v, minPostgresMajor, v, preferredPostgresMajor)
 	}
 	return nil
 }
@@ -834,4 +866,18 @@ func hasOpenWatchHbaRules(content, dbName, roleName string) bool {
 		}
 	}
 	return v4 && v6
+}
+
+// postgresStreamEnabled reports whether a postgresql module stream is already
+// selected on this host.
+//
+// An operator who enabled a stream has chosen a version deliberately, and an
+// installer that overrules that would be changing a decision it did not make.
+// The version check enforces the floor regardless of who chose.
+func postgresStreamEnabled(ctx context.Context) bool {
+	res := run(ctx, "dnf", "module", "list", "--enabled", "postgresql")
+	if res.Err != nil {
+		return false
+	}
+	return strings.Contains(res.Stdout, "postgresql")
 }

--- a/packaging/tests/upgrade-from-ga-container-test.sh
+++ b/packaging/tests/upgrade-from-ga-container-test.sh
@@ -59,6 +59,11 @@ install_pkgs() {
     fi
 }
 
+# Deliberately the distribution default, even though it is below the floor
+# setup now enforces. That floor governs what setup BUILDS; this test is about
+# what already exists in the field, and v0.6.0 accepted PostgreSQL 13, so real
+# installs are running it. Provisioning a supported version here would test a
+# state few upgrading operators are actually in.
 echo ">> installing PostgreSQL and the previous GA ($OLD_VER)"
 if [ "$PKG_KIND" = deb ]; then
     export DEBIAN_FRONTEND=noninteractive

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -204,7 +204,11 @@ spec:
         operator has already selected. An existing cluster below the floor MUST
         be refused with the commands that move it, never upgraded in place:
         changing a cluster's major version needs pg_upgrade and is the
-        operator's decision.
+        operator's decision. The floor governs what setup BUILDS, not what
+        OpenWatch tolerates: an existing deployment whose database predates the
+        floor keeps working and keeps upgrading, because refusing to migrate it
+        would strand the operators most in need of the new version. They are
+        told, not blocked.
       type: technical
       enforcement: error
 

--- a/specs/system/setup.spec.yaml
+++ b/specs/system/setup.spec.yaml
@@ -190,6 +190,24 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-15
+      description: >
+        The PostgreSQL floor MUST exclude versions that have reached upstream
+        end of life, and setup MUST NOT stand one up. This is a support policy,
+        not a compatibility one: the schema runs on 13, but 13 left support in
+        November 2025 and 14 does so in November 2026. Hanalyx ships
+        third-party software into regulated estates, where installing an
+        unsupported database as part of an install is not defensible whatever
+        the distribution default is. On distributions whose default is
+        end of life, setup MUST select a supported version when it provisions
+        rather than accepting that default, and MUST NOT overrule a version the
+        operator has already selected. An existing cluster below the floor MUST
+        be refused with the commands that move it, never upgraded in place:
+        changing a cluster's major version needs pg_upgrade and is the
+        operator's decision.
+      type: technical
+      enforcement: error
+
   acceptance_criteria:
     - id: AC-01
       description: >
@@ -295,6 +313,14 @@ spec:
         the ALTER path. The password is a quote-doubled literal.
       priority: critical
       references_constraints: [C-03]
+    - id: AC-16
+      description: >
+        The floor excludes every end-of-life PostgreSQL, and the version setup
+        installs when it provisions is newer still. A server below the floor is
+        refused with a message naming pg_upgrade and the module commands, not
+        upgraded in place. A stream the operator already enabled is left alone.
+      priority: critical
+      references_constraints: [C-15]
     - id: AC-15
       description: >
         A run that installed PostgreSQL or initialised the cluster manages


### PR DESCRIPTION
The floor was **13, which reached upstream end of life in November 2025**. RHEL
9 still defaults to it, so a fresh install stood up an unsupported database and
merely warned. Hanalyx ships third-party software into regulated estates; the
distribution's default is not a defence there.

## The numbers, and why 14 is not a middle step

| Version | Upstream EOL |
|---|---|
| 13 | November 2025 (already dead) |
| 14 | November 2026 (inside this release's service life) |
| **15** | November 2027 - the floor |
| **16** | November 2028 - what `setup` installs |
| 18 | ~2030 |

15 is the floor and the lowest stream el9 offers. 16 is what `setup` provisions,
so an install done today does not need attention in a year.

## Selecting a stream, without overruling the operator

Bare `postgresql-server` on el9 resolves to the non-modular 13, so provisioning
now enables `postgresql:16` first.

- **A stream the operator already enabled is left alone.** That is a choice
  `setup` did not make, and the floor check enforces the outcome either way.
- **Distributions without modularity, including el10,** fail that command
  harmlessly and fall through to the plain install.
- **An existing cluster below the floor is refused, never upgraded in place.**

## The refusal has to be actionable

```
openwatch setup: postgres-version: PostgreSQL 13 is below the supported minimum of 15.
    PostgreSQL 13 no longer receives security fixes upstream, so OpenWatch will not build an install on it.
    This cluster already holds data, so setup will not change its major version: switching streams
    under an existing cluster needs pg_upgrade and is your decision, not the installer's.
    On RHEL and derivatives:
      sudo dnf module list postgresql          # see the streams offered
      sudo dnf module switch-to postgresql:16  # then pg_upgrade the cluster
    On Debian and Ubuntu, install the newer server package and migrate with pg_upgradecluster.
```

Changing a cluster's major version under an operator's data is not an
installer's decision, and a floor that only says no becomes a support ticket.

## Verified both ways on rockylinux:9

Fresh host:

```
   1. install PostgreSQL 16 (dnf module enable postgresql:16, then dnf install postgresql-server)
   3. verify PostgreSQL >= 15 (14 is end of life)
    postgres-install module enable postgresql:16
   health: {"db_connected":true,"status":"healthy","version":"0.7.0"}
```

Pre-existing PG 13 cluster: refused, exit 1, nothing changed.

## Spec and docs

`C-15` states the policy as a support rule rather than a compatibility one.
`AC-16` pins it, and **the test names the end-of-life majors with their dates**,
so raising the floor again is a deliberate edit rather than a drift.

`AC-10`'s recorded container run said 13 was accepted with a warning. That is no
longer true, so the clause is replaced and the rest of the record stands.

The two constants collapse into one: the old supported-versus-minimum warning
band existed to describe 13 as working-but-old, and there is no longer a band.

The install guide already documented the module steps for the manual path and
was ahead of the code. The gap was the `setup` path, where an operator never
reads Step 1 - that now states what version it installs, that an enabled stream
is respected, and what happens to an older existing cluster.