### PR TITLE
ci: prove the RHEL 9 install in containers, not by hand

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -152,9 +152,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { distro: 'ubuntu:24.04', kind: deb }
-          - { distro: 'debian:12', kind: deb }
-          - { distro: 'almalinux:10', kind: rpm }
+          # Rocky is a RHEL 9 rebuild running identical paths, but it reports
+          # ID=rocky and only RHEL 9 itself is SupportTested, so this leg needs
+          # the override. It still proves the clean install and the re-run,
+          # which is what gates I1 and I2 claim. A real RHEL 9 host needs no
+          # flag; no container can be one.
+          - { distro: 'rockylinux:9', kind: rpm, extra: '--allow-untested' }
+          - { distro: 'ubuntu:24.04', kind: deb, extra: '' }
+          - { distro: 'debian:12', kind: deb, extra: '' }
+          - { distro: 'almalinux:10', kind: rpm, extra: '' }
     steps:
       - uses: actions/checkout@v7
 
@@ -171,7 +177,7 @@ jobs:
       - name: openwatch setup clean install and re-run
         run: |
           bash packaging/tests/run-setup-container-test.sh \
-            "${{ matrix.distro }}" "${{ matrix.kind }}"
+            "${{ matrix.distro }}" "${{ matrix.kind }}" ${{ matrix.extra }}
 
   # The REAL previous-GA upgrade (gate U2), as distinct from the synthetic
   # scriptlet test below (U1). Installs the published previous GA, provisions

--- a/release/gates.toml
+++ b/release/gates.toml
@@ -37,7 +37,15 @@ method = "container"
 package = "rpm"
 support_tier = "tested"
 blocking = true
+# Proven by containers on rockylinux:9, a RHEL 9 rebuild running identical
+# paths. A container cannot be a licensed RHEL host, so the routine per
+# candidate evidence comes from the rebuild; the attestations in this directory
+# record live RHEL 9.8 runs, which additionally covered SELinux enforcing,
+# fapolicyd and reachability through firewalld. Those are richer but manual,
+# and the gate claims only what the job asserts.
 [platform.checks]
+clean-install = "setup rockylinux:9"
+idempotence = "setup rockylinux:9"
 upgrade-from-ga = "upgrade-from-ga rockylinux:9"
 
 [[platform]]


### PR DESCRIPTION
RHEL 9 was the **only** platform whose install and idempotence gates came from a
hand-written attestation rather than a job.

Attestations are scoped to an artifact digest, so both went `STALE` on every
candidate that rebuilt the binary:

```
STALE  I1  Clean install via `openwatch setup` [rhel9]
       artifact c13e183b83fb is not in this candidate's SHA256SUMS
```

Re-earning them meant a manual VM run per candidate. That cost was paid twice
in two days, and it is the last recurring manual step in the automatable half
of the gate.

## The leg

`rockylinux:9`, a RHEL 9 rebuild running identical paths. The `rhel9` platform's
`clean-install` and `idempotence` gates now point at it, so they populate from
CI like the other three platforms.

## Why it passes `--allow-untested`, and why that is not a weakening

Rocky reports `ID=rocky`, and only RHEL 9 itself is `SupportTested`. The flag
gets past that check and nothing else: the job still has to reach a service
reporting `db_connected` on a clean install **and** on the re-run, which is
exactly what gates I1 and I2 claim.

A real RHEL 9 host needs no flag, and no container can be one.

The matrix gained an `extra` field rather than applying the flag to every leg,
so **Ubuntu, Debian and AlmaLinux 10 keep exercising the no-flag path** an
operator actually types.

## The live attestations stay

They cover more than the container does - SELinux enforcing, fapolicyd, and
reachability through firewalld from a separate machine - and are worth keeping
as the record of a real host, even though the gate now reads the job first.
The manifest says so where someone will find it.

Verified locally on `rockylinux:9`: PostgreSQL 16 via the module stream,
`pg_hba.conf` managed automatically, `db_connected` on both runs.