### PR TITLE
feat(remediation): carry the per-phase Kensa journal through to the API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5839,6 +5839,10 @@ components:
         note: {type: string, description: Optional reviewer note}
 
     RemediationStep:
+      description: |
+        One rule's Kensa transaction. Note that a "step" here is a RULE, not a
+        phase: the Capture/Apply/Validate/Commit phases are in `phases`, one
+        level below.
       type: object
       required: [id, rule_id, dry_run]
       properties:
@@ -5846,11 +5850,77 @@ components:
         rule_id:   {type: string}
         mechanism: {type: string}
         phase_result:
+          description: |
+            Terminal outcome of the rule's transaction. Widened past
+            committed/rolled_back/skipped by the v0.7.0 outcome vocabulary.
           type: string
           nullable: true
-          enum: [committed, rolled_back, skipped]
+          enum: [committed, rolled_back, skipped, staged, partially_applied, not_applied]
         dry_run:    {type: boolean}
         applied_at: {type: string, format: date-time, nullable: true}
+        phases:
+          description: |
+            The per-phase journal Kensa returned, in execution order. `detail`
+            is the engine's own account of what each phase did, and is the
+            answer to why a remediation failed.
+          type: array
+          items: {$ref: '#/components/schemas/RemediationPhase'}
+        pre_state:
+          description: |
+            The state captured before any change, one entry per phase, in phase
+            order.
+          type: array
+          items: {$ref: '#/components/schemas/RemediationPreState'}
+
+    RemediationPreState:
+      description: |
+        One phase's captured pre-change state.
+
+        `data` is mechanism-specific and is passed through from Kensa without
+        interpretation. OpenWatch has no schema for it and deliberately does
+        not decode it: each capturable handler defines its own layout, so
+        reading it here would couple this contract to Kensa handler internals.
+        Clients should treat it as opaque evidence unless they know the
+        mechanism.
+      type: object
+      required: [index, mechanism, capturable]
+      properties:
+        index:     {type: integer}
+        mechanism: {type: string}
+        capturable:
+          description: False for phases whose mechanism cannot capture pre-state; `data` is then empty.
+          type: boolean
+        data:
+          type: object
+          additionalProperties: true
+
+    RemediationPhase:
+      description: One Capture/Apply/Validate/Commit phase of a rule's transaction.
+      type: object
+      required: [index, mechanism, success, capturable, staged, stranded]
+      properties:
+        index:     {type: integer}
+        mechanism: {type: string}
+        detail:
+          description: Human-readable account of what this phase did, or why it did not.
+          type: string
+        success:   {type: boolean}
+        capturable:
+          description: |
+            False when this phase's mechanism cannot record pre-state, which is
+            what makes a rule non-rollbackable.
+          type: boolean
+        staged:
+          description: |
+            True when the change was written to the persist layer but the
+            running host has not converged, so a re-scan still reports the rule
+            failing until reboot.
+          type: boolean
+        stranded:
+          description: |
+            True for a non-capturable phase that succeeded before a later
+            failure. Rollback does NOT reverse it.
+          type: boolean
 
     RemediationStepList:
       type: object

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3825,16 +3825,79 @@ export interface components {
             /** @description Optional reviewer note */
             note?: string;
         };
+        /**
+         * @description One rule's Kensa transaction. Note that a "step" here is a RULE, not a
+         *     phase: the Capture/Apply/Validate/Commit phases are in `phases`, one
+         *     level below.
+         */
         RemediationStep: {
             /** Format: uuid */
             id: string;
             rule_id: string;
             mechanism?: string;
-            /** @enum {string|null} */
-            phase_result?: "committed" | "rolled_back" | "skipped" | null;
+            /**
+             * @description Terminal outcome of the rule's transaction. Widened past
+             *     committed/rolled_back/skipped by the v0.7.0 outcome vocabulary.
+             * @enum {string|null}
+             */
+            phase_result?: "committed" | "rolled_back" | "skipped" | "staged" | "partially_applied" | "not_applied" | null;
             dry_run: boolean;
             /** Format: date-time */
             applied_at?: string | null;
+            /**
+             * @description The per-phase journal Kensa returned, in execution order. `detail`
+             *     is the engine's own account of what each phase did, and is the
+             *     answer to why a remediation failed.
+             */
+            phases?: components["schemas"]["RemediationPhase"][];
+            /**
+             * @description The state captured before any change, one entry per phase, in phase
+             *     order.
+             */
+            pre_state?: components["schemas"]["RemediationPreState"][];
+        };
+        /**
+         * @description One phase's captured pre-change state.
+         *
+         *     `data` is mechanism-specific and is passed through from Kensa without
+         *     interpretation. OpenWatch has no schema for it and deliberately does
+         *     not decode it: each capturable handler defines its own layout, so
+         *     reading it here would couple this contract to Kensa handler internals.
+         *     Clients should treat it as opaque evidence unless they know the
+         *     mechanism.
+         */
+        RemediationPreState: {
+            index: number;
+            mechanism: string;
+            /** @description False for phases whose mechanism cannot capture pre-state; `data` is then empty. */
+            capturable: boolean;
+            data?: {
+                [key: string]: unknown;
+            };
+        };
+        /** @description One Capture/Apply/Validate/Commit phase of a rule's transaction. */
+        RemediationPhase: {
+            index: number;
+            mechanism: string;
+            /** @description Human-readable account of what this phase did, or why it did not. */
+            detail?: string;
+            success: boolean;
+            /**
+             * @description False when this phase's mechanism cannot record pre-state, which is
+             *     what makes a rule non-rollbackable.
+             */
+            capturable: boolean;
+            /**
+             * @description True when the change was written to the persist layer but the
+             *     running host has not converged, so a re-scan still reports the rule
+             *     failing until reboot.
+             */
+            staged: boolean;
+            /**
+             * @description True for a non-capturable phase that succeeded before a later
+             *     failure. Rollback does NOT reverse it.
+             */
+            stranded: boolean;
         };
         RemediationStepList: {
             steps: components["schemas"]["RemediationStep"][];

--- a/internal/db/migrations/0055_remediation_step_journal.sql
+++ b/internal/db/migrations/0055_remediation_step_journal.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Persist the per-phase Kensa transaction journal.
+--
+-- Kensa returns TransactionResult.Steps (one StepResult per Capture/Apply/
+-- Validate/Commit phase, each carrying a human-readable Detail) and
+-- TransactionResult.PreStates (the captured pre-change state). OpenWatch
+-- discarded both: mapTxns reduced the journal to a step COUNT in the evidence
+-- summary, so a failed remediation could report only "reverted, host
+-- unchanged" while the reason sat unread in Detail.
+--
+-- pre_state and mechanism are NOT added here. Both columns have existed since
+-- migration 0037 and have never been written; the insert now populates them.
+ALTER TABLE remediation_transactions
+    ADD COLUMN IF NOT EXISTS steps JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN remediation_transactions.steps IS
+    'Per-phase Kensa journal: [{index, mechanism, detail, success, capturable, staged, stranded}]. Detail is the failure reason.';
+
+COMMENT ON COLUMN remediation_transactions.pre_state IS
+    'Captured pre-change state per step, from Kensa PreStates. Data is mechanism-specific and opaque to OpenWatch.';
+
+-- +goose Down
+ALTER TABLE remediation_transactions DROP COLUMN IF EXISTS steps;

--- a/internal/kensa/journal_test.go
+++ b/internal/kensa/journal_test.go
@@ -1,0 +1,98 @@
+// @spec api-remediation
+//
+//	AC-12  TestKensa_JournalSurvivesTheBoundary
+package kensa
+
+import (
+	"testing"
+	"time"
+
+	kensaapi "github.com/Hanalyx/kensa/api"
+	"github.com/google/uuid"
+)
+
+// @ac AC-12
+// AC-12: the per-phase journal survives mapping.
+//
+// This is the regression that made remediation a black box. mapTxns kept five
+// fields and threw the rest away, and txnEvidence recorded len(t.Steps) -- the
+// COUNT of steps -- so a failed remediation could say "reverted, host
+// unchanged" and nothing else, while Kensa's own explanation sat in
+// StepResult.Detail, a field its documentation describes as suitable for UI.
+func TestKensa_JournalSurvivesTheBoundary(t *testing.T) {
+	t.Run("api-remediation/AC-12", func(t *testing.T) {
+		committed := time.Now()
+		in := []kensaapi.TransactionResult{{
+			TransactionID: uuid.Must(uuid.NewV7()),
+			Status:        kensaapi.StatusRolledBack,
+			StartedAt:     committed.Add(-2 * time.Second),
+			FinishedAt:    committed,
+			CommittedAt:   &committed,
+			Steps: []kensaapi.StepResult{
+				{StepIndex: 0, Mechanism: "config_set", Capturable: true, Success: true,
+					Detail: "captured /etc/login.defs PASS_MAX_DAYS 99999"},
+				{StepIndex: 1, Mechanism: "config_set", Capturable: true, Success: false,
+					Detail: "validate failed: PASS_MAX_DAYS still 99999 after apply"},
+				{StepIndex: 2, Mechanism: "service_enabled", Capturable: false,
+					Success: true, Stranded: true, Staged: true,
+					Detail: "auditd immutable (enabled 2); persisted, reboot required"},
+			},
+			PreStates: []kensaapi.PreState{
+				{StepIndex: 0, Mechanism: "config_set", Capturable: true,
+					Data: map[string]any{"line": "PASS_MAX_DAYS 99999"}},
+				{StepIndex: 2, Mechanism: "service_enabled", Capturable: false},
+			},
+		}}
+
+		got := mapTxns(in)
+		if len(got) != 1 {
+			t.Fatalf("mapTxns returned %d transactions, want 1", len(got))
+		}
+		txn := got[0]
+
+		if len(txn.Steps) != 3 {
+			t.Fatalf("carried %d steps, want 3; the journal is being dropped again",
+				len(txn.Steps))
+		}
+
+		// The reason a remediation failed is the whole point.
+		want := "validate failed: PASS_MAX_DAYS still 99999 after apply"
+		if txn.Steps[1].Detail != want {
+			t.Errorf("step 1 detail = %q, want %q", txn.Steps[1].Detail, want)
+		}
+		if txn.Steps[1].Success {
+			t.Error("the failing step is reported as successful")
+		}
+
+		// Flags an operator cannot infer from the outcome alone: a stranded
+		// step is NOT reversed by rollback, and a staged one means the running
+		// host has not converged even though the change was written.
+		if !txn.Steps[2].Stranded {
+			t.Error("stranded lost; rollback will not reverse that step and nobody would know")
+		}
+		if !txn.Steps[2].Staged {
+			t.Error("staged lost; a re-scan will report the rule failing with no explanation")
+		}
+		if txn.Steps[2].Capturable {
+			t.Error("capturable lost; this is what makes a rule non-rollbackable")
+		}
+
+		// The capture: what the host looked like before anything changed.
+		if len(txn.PreStates) != 2 {
+			t.Fatalf("carried %d pre-states, want 2", len(txn.PreStates))
+		}
+		if txn.PreStates[0].Data["line"] != "PASS_MAX_DAYS 99999" {
+			t.Errorf("pre-state data = %v, want the captured line verbatim",
+				txn.PreStates[0].Data)
+		}
+		// Carried, not interpreted. A non-capturable step is a marker with no
+		// data, and must still appear so the gap is visible.
+		if txn.PreStates[1].Capturable || len(txn.PreStates[1].Data) != 0 {
+			t.Error("a non-capturable pre-state must be carried as an empty marker")
+		}
+
+		if txn.StartedAt.IsZero() || txn.FinishedAt.IsZero() || txn.CommittedAt.IsZero() {
+			t.Error("phase timings lost; the journal cannot show how long anything took")
+		}
+	})
+}

--- a/internal/kensa/remediatefunc.go
+++ b/internal/kensa/remediatefunc.go
@@ -62,6 +62,55 @@ type RemediationTxn struct {
 	// HostUnchanged mirrors api.TransactionResult.HostUnchanged: true if and
 	// only if Kensa can prove the host is in its pre-transaction state.
 	HostUnchanged bool
+	// Steps is the per-phase journal Kensa returns. Until this existed the
+	// engine's own account of what it did was reduced to a step COUNT, so a
+	// failed remediation could report only "reverted, host unchanged" while
+	// the reason sat unread in StepResult.Detail.
+	Steps []RemediationStep
+	// PreStates is the captured pre-change state, one entry per step. This is
+	// the "what was captured" half of the transaction; the remediation_
+	// transactions.pre_state column has existed since migration 0037 and has
+	// never been written.
+	PreStates []RemediationPreState
+	// StartedAt and FinishedAt bound the transaction; CommittedAt is non-zero
+	// only for a committed one.
+	StartedAt   time.Time
+	FinishedAt  time.Time
+	CommittedAt time.Time
+}
+
+// RemediationStep is one phase of a Kensa transaction, as OpenWatch stores it.
+// Field-for-field from api.StepResult, whose Detail is documented as "suitable
+// for logs and UI" and is the answer to "why did this fail".
+type RemediationStep struct {
+	Index     int    `json:"index"`
+	Mechanism string `json:"mechanism"`
+	Detail    string `json:"detail,omitempty"`
+	Success   bool   `json:"success"`
+	// Capturable is false when this step's mechanism cannot record pre-state,
+	// which is what makes a rule non-rollbackable.
+	Capturable bool `json:"capturable"`
+	// Staged marks a reboot-deferred write: the persist layer changed but the
+	// running host has not, so a re-scan still reports the rule failing.
+	Staged bool `json:"staged"`
+	// Stranded marks a non-capturable step that succeeded before a later
+	// failure. Rollback does NOT reverse it, so an operator has to know.
+	Stranded bool `json:"stranded"`
+}
+
+// RemediationPreState is one step's captured pre-change state.
+//
+// Data is mechanism-specific and opaque to OpenWatch: each capturable handler
+// defines its own layout, and Kensa exposes no schema or display projection
+// for it. It is stored verbatim so the evidence is not lost, but rendering it
+// as "the prior config line" means either decoding per mechanism here, which
+// couples this repo to Kensa handler internals, or Kensa growing a
+// display-ready form.
+type RemediationPreState struct {
+	Index      int            `json:"index"`
+	Mechanism  string         `json:"mechanism"`
+	Capturable bool           `json:"capturable"`
+	Data       map[string]any `json:"data,omitempty"`
 }
 
 // RollbackRunResult is the OpenWatch-side view of a kensa RollbackResult.
@@ -215,6 +264,13 @@ func mapTxns(in []kensaapi.TransactionResult) []RemediationTxn {
 			Status:        string(t.Status),
 			Evidence:      txnEvidence(t),
 			HostUnchanged: t.HostUnchanged,
+			Steps:         mapSteps(t.Steps),
+			PreStates:     mapPreStates(t.PreStates),
+			StartedAt:     t.StartedAt,
+			FinishedAt:    t.FinishedAt,
+		}
+		if t.CommittedAt != nil {
+			txn.CommittedAt = *t.CommittedAt
 		}
 		if t.Error != nil {
 			txn.Err = friendlyTxnErr(t.Error.Error())
@@ -252,4 +308,43 @@ func txnEvidence(t kensaapi.TransactionResult) json.RawMessage {
 		"steps":          len(t.Steps),
 	})
 	return b
+}
+
+// mapSteps carries Kensa's per-phase journal across the package boundary.
+func mapSteps(in []kensaapi.StepResult) []RemediationStep {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]RemediationStep, 0, len(in))
+	for _, s := range in {
+		out = append(out, RemediationStep{
+			Index:      s.StepIndex,
+			Mechanism:  s.Mechanism,
+			Detail:     s.Detail,
+			Success:    s.Success,
+			Capturable: s.Capturable,
+			Staged:     s.Staged,
+			Stranded:   s.Stranded,
+		})
+	}
+	return out
+}
+
+// mapPreStates carries the capture across. Data is copied verbatim: its shape
+// is the handler's, not ours, and guessing at it here would break whenever a
+// handler changed its layout.
+func mapPreStates(in []kensaapi.PreState) []RemediationPreState {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]RemediationPreState, 0, len(in))
+	for _, p := range in {
+		out = append(out, RemediationPreState{
+			Index:      p.StepIndex,
+			Mechanism:  p.Mechanism,
+			Capturable: p.Capturable,
+			Data:       p.Data,
+		})
+	}
+	return out
 }

--- a/internal/remediation/execution.go
+++ b/internal/remediation/execution.go
@@ -157,13 +157,23 @@ func (s *Service) RecordExecution(ctx context.Context, id uuid.UUID, ruleID stri
 			if len(ev) == 0 {
 				ev = []byte("{}")
 			}
+			steps := t.Steps
+			if len(steps) == 0 {
+				steps = []byte("[]")
+			}
+			pre := t.PreState
+			if len(pre) == 0 {
+				pre = []byte("[]")
+			}
 			txnID := uuid.Must(uuid.NewV7())
 			if _, err := tx.Exec(ctx, `
 				INSERT INTO remediation_transactions
 					(id, request_id, ordinal, rule_id, kensa_txn_id,
-					 phase_result, evidence, dry_run, applied_at)
-				VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,false,now())`,
-				txnID, id, i, ruleID, t.TxnID.String(), phase, ev); err != nil {
+					 mechanism, phase_result, evidence, steps, pre_state,
+					 dry_run, applied_at)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,false,now())`,
+				txnID, id, i, ruleID, t.TxnID.String(), nullIfEmpty(t.Mechanism),
+				phase, ev, steps, pre); err != nil {
 				return Request{}, fmt.Errorf("remediation: insert journal: %w", err)
 			}
 		}
@@ -351,4 +361,14 @@ func phaseResult(t ExecTxn) string {
 	default:
 		return "skipped"
 	}
+}
+
+// nullIfEmpty keeps mechanism NULL rather than an empty string when a
+// transaction produced no steps, so "we did not record it" stays
+// distinguishable from "it had no mechanism".
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/internal/remediation/service.go
+++ b/internal/remediation/service.go
@@ -271,7 +271,8 @@ func (s *Service) ListRequests(ctx context.Context, f ListFilter) ([]Request, er
 // steps).
 func (s *Service) ListSteps(ctx context.Context, requestID uuid.UUID) ([]Step, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, rule_id, COALESCE(mechanism, ''), phase_result, dry_run, applied_at
+		SELECT id, rule_id, COALESCE(mechanism, ''), phase_result, dry_run,
+		       applied_at, steps, pre_state
 		  FROM remediation_transactions
 		 WHERE request_id = $1
 		 ORDER BY ordinal ASC, created_at ASC`, requestID)
@@ -282,9 +283,15 @@ func (s *Service) ListSteps(ctx context.Context, requestID uuid.UUID) ([]Step, e
 	out := []Step{}
 	for rows.Next() {
 		var st Step
+		var phases []byte
 		if err := rows.Scan(&st.ID, &st.RuleID, &st.Mechanism, &st.PhaseResult,
-			&st.DryRun, &st.AppliedAt); err != nil {
+			&st.DryRun, &st.AppliedAt, &phases, &st.PreState); err != nil {
 			return nil, fmt.Errorf("remediation: scan step: %w", err)
+		}
+		// A journal that will not parse is reported as absent rather than
+		// failing the read: the rest of the request is still worth showing.
+		if len(phases) > 0 {
+			_ = json.Unmarshal(phases, &st.Phases)
 		}
 		out = append(out, st)
 	}

--- a/internal/remediation/types.go
+++ b/internal/remediation/types.go
@@ -18,6 +18,7 @@
 package remediation
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -132,6 +133,26 @@ type Step struct {
 	PhaseResult *string
 	DryRun      bool
 	AppliedAt   *time.Time
+	// Phases is the per-phase Kensa journal for this rule's transaction.
+	// A "step" in this API has always meant one RULE; the Capture, Apply,
+	// Validate and Commit phases an operator wants to see are one level
+	// below it, and this is where they live.
+	Phases []Phase
+	// PreState is the captured pre-change state, verbatim from Kensa. Held
+	// as raw JSON because its shape is the handler's, not ours.
+	PreState json.RawMessage
+}
+
+// Phase is one Capture/Apply/Validate/Commit phase within a rule's
+// transaction.
+type Phase struct {
+	Index      int    `json:"index"`
+	Mechanism  string `json:"mechanism"`
+	Detail     string `json:"detail,omitempty"`
+	Success    bool   `json:"success"`
+	Capturable bool   `json:"capturable"`
+	Staged     bool   `json:"staged"`
+	Stranded   bool   `json:"stranded"`
 }
 
 // ExecTxn is a neutral, kensa-free view of one Kensa remediation transaction
@@ -155,6 +176,17 @@ type ExecTxn struct {
 	// Evidence is the signed evidence envelope (or a summary), stored in the
 	// remediation_transactions.evidence JSONB column.
 	Evidence []byte
+	// Steps is the per-phase journal, serialised, stored in
+	// remediation_transactions.steps. Empty for a transaction that never ran.
+	Steps []byte
+	// PreState is the captured pre-change state, serialised, stored in
+	// remediation_transactions.pre_state. That column has existed since
+	// migration 0037 and was never written until this carried it.
+	PreState []byte
+	// Mechanism is the first step's mechanism, stored in
+	// remediation_transactions.mechanism, another column that existed and was
+	// never populated.
+	Mechanism string
 	// Err is the transaction error string, empty on success.
 	Err string
 	// HostUnchanged mirrors api.TransactionResult.HostUnchanged: true if and

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -1132,9 +1132,12 @@ func (e RemediationRequestStatus) Valid() bool {
 
 // Defines values for RemediationStepPhaseResult.
 const (
-	RemediationStepPhaseResultCommitted  RemediationStepPhaseResult = "committed"
-	RemediationStepPhaseResultRolledBack RemediationStepPhaseResult = "rolled_back"
-	RemediationStepPhaseResultSkipped    RemediationStepPhaseResult = "skipped"
+	RemediationStepPhaseResultCommitted        RemediationStepPhaseResult = "committed"
+	RemediationStepPhaseResultNotApplied       RemediationStepPhaseResult = "not_applied"
+	RemediationStepPhaseResultPartiallyApplied RemediationStepPhaseResult = "partially_applied"
+	RemediationStepPhaseResultRolledBack       RemediationStepPhaseResult = "rolled_back"
+	RemediationStepPhaseResultSkipped          RemediationStepPhaseResult = "skipped"
+	RemediationStepPhaseResultStaged           RemediationStepPhaseResult = "staged"
 )
 
 // Valid indicates whether the value is a known member of the RemediationStepPhaseResult enum.
@@ -1142,9 +1145,15 @@ func (e RemediationStepPhaseResult) Valid() bool {
 	switch e {
 	case RemediationStepPhaseResultCommitted:
 		return true
+	case RemediationStepPhaseResultNotApplied:
+		return true
+	case RemediationStepPhaseResultPartiallyApplied:
+		return true
 	case RemediationStepPhaseResultRolledBack:
 		return true
 	case RemediationStepPhaseResultSkipped:
+		return true
+	case RemediationStepPhaseResultStaged:
 		return true
 	default:
 		return false
@@ -3175,6 +3184,44 @@ type ProjectedLift struct {
 	Stig *float64 `json:"stig,omitempty"`
 }
 
+// RemediationPhase One Capture/Apply/Validate/Commit phase of a rule's transaction.
+type RemediationPhase struct {
+	// Capturable False when this phase's mechanism cannot record pre-state, which is
+	// what makes a rule non-rollbackable.
+	Capturable bool `json:"capturable"`
+
+	// Detail Human-readable account of what this phase did, or why it did not.
+	Detail    *string `json:"detail,omitempty"`
+	Index     int     `json:"index"`
+	Mechanism string  `json:"mechanism"`
+
+	// Staged True when the change was written to the persist layer but the
+	// running host has not converged, so a re-scan still reports the rule
+	// failing until reboot.
+	Staged bool `json:"staged"`
+
+	// Stranded True for a non-capturable phase that succeeded before a later
+	// failure. Rollback does NOT reverse it.
+	Stranded bool `json:"stranded"`
+	Success  bool `json:"success"`
+}
+
+// RemediationPreState One phase's captured pre-change state.
+//
+// `data` is mechanism-specific and is passed through from Kensa without
+// interpretation. OpenWatch has no schema for it and deliberately does
+// not decode it: each capturable handler defines its own layout, so
+// reading it here would couple this contract to Kensa handler internals.
+// Clients should treat it as opaque evidence unless they know the
+// mechanism.
+type RemediationPreState struct {
+	// Capturable False for phases whose mechanism cannot capture pre-state; `data` is then empty.
+	Capturable bool                    `json:"capturable"`
+	Data       *map[string]interface{} `json:"data,omitempty"`
+	Index      int                     `json:"index"`
+	Mechanism  string                  `json:"mechanism"`
+}
+
 // RemediationRequest defines model for RemediationRequest.
 type RemediationRequest struct {
 	HostId openapi_types.UUID `json:"host_id"`
@@ -3223,17 +3270,32 @@ type RemediationReview struct {
 	Note *string `json:"note,omitempty"`
 }
 
-// RemediationStep defines model for RemediationStep.
+// RemediationStep One rule's Kensa transaction. Note that a "step" here is a RULE, not a
+// phase: the Capture/Apply/Validate/Commit phases are in `phases`, one
+// level below.
 type RemediationStep struct {
-	AppliedAt   *time.Time                  `json:"applied_at,omitempty"`
-	DryRun      bool                        `json:"dry_run"`
-	Id          openapi_types.UUID          `json:"id"`
-	Mechanism   *string                     `json:"mechanism,omitempty"`
+	AppliedAt *time.Time         `json:"applied_at,omitempty"`
+	DryRun    bool               `json:"dry_run"`
+	Id        openapi_types.UUID `json:"id"`
+	Mechanism *string            `json:"mechanism,omitempty"`
+
+	// PhaseResult Terminal outcome of the rule's transaction. Widened past
+	// committed/rolled_back/skipped by the v0.7.0 outcome vocabulary.
 	PhaseResult *RemediationStepPhaseResult `json:"phase_result,omitempty"`
-	RuleId      string                      `json:"rule_id"`
+
+	// Phases The per-phase journal Kensa returned, in execution order. `detail`
+	// is the engine's own account of what each phase did, and is the
+	// answer to why a remediation failed.
+	Phases *[]RemediationPhase `json:"phases,omitempty"`
+
+	// PreState The state captured before any change, one entry per phase, in phase
+	// order.
+	PreState *[]RemediationPreState `json:"pre_state,omitempty"`
+	RuleId   string                 `json:"rule_id"`
 }
 
-// RemediationStepPhaseResult defines model for RemediationStep.PhaseResult.
+// RemediationStepPhaseResult Terminal outcome of the rule's transaction. Widened past
+// committed/rolled_back/skipped by the v0.7.0 outcome vocabulary.
 type RemediationStepPhaseResult string
 
 // RemediationStepList defines model for RemediationStepList.

--- a/internal/server/remediation_handlers.go
+++ b/internal/server/remediation_handlers.go
@@ -88,6 +88,33 @@ func toAPIStep(st remediation.Step) api.RemediationStep {
 		m := st.Mechanism
 		out.Mechanism = &m
 	}
+	if len(st.Phases) > 0 {
+		ph := make([]api.RemediationPhase, 0, len(st.Phases))
+		for _, p := range st.Phases {
+			item := api.RemediationPhase{
+				Index:      p.Index,
+				Mechanism:  p.Mechanism,
+				Success:    p.Success,
+				Capturable: p.Capturable,
+				Staged:     p.Staged,
+				Stranded:   p.Stranded,
+			}
+			if p.Detail != "" {
+				d := p.Detail
+				item.Detail = &d
+			}
+			ph = append(ph, item)
+		}
+		out.Phases = &ph
+	}
+	// Passed through without interpretation: the shape belongs to the Kensa
+	// handler that captured it.
+	if len(st.PreState) > 0 {
+		var pre []api.RemediationPreState
+		if err := json.Unmarshal(st.PreState, &pre); err == nil && len(pre) > 0 {
+			out.PreState = &pre
+		}
+	}
 	if st.PhaseResult != nil {
 		pr := api.RemediationStepPhaseResult(*st.PhaseResult)
 		out.PhaseResult = &pr

--- a/internal/worker/remediation_worker.go
+++ b/internal/worker/remediation_worker.go
@@ -447,13 +447,27 @@ func (w *RemediationWorker) emitHMACRejected(ctx context.Context, jobID uuid.UUI
 func mapExecTxns(in []kensa.RemediationTxn) []remediation.ExecTxn {
 	out := make([]remediation.ExecTxn, 0, len(in))
 	for _, t := range in {
-		out = append(out, remediation.ExecTxn{
+		e := remediation.ExecTxn{
 			TxnID:         t.TxnID,
 			Status:        t.Status,
 			Evidence:      t.Evidence,
 			Err:           t.Err,
 			HostUnchanged: t.HostUnchanged,
-		})
+		}
+		// Serialise here rather than threading Kensa types further in:
+		// internal/remediation deliberately does not import internal/kensa.
+		if len(t.Steps) > 0 {
+			if b, err := json.Marshal(t.Steps); err == nil {
+				e.Steps = b
+			}
+			e.Mechanism = t.Steps[0].Mechanism
+		}
+		if len(t.PreStates) > 0 {
+			if b, err := json.Marshal(t.PreStates); err == nil {
+				e.PreState = b
+			}
+		}
+		out = append(out, e)
 	}
 	return out
 }

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-remediation
   title: Remediation governance - request/approve lifecycle, projected lift, and queued single-rule execute/rollback (OpenWatch Core, free)
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 1
 
@@ -180,6 +180,19 @@ spec:
         reachable from staged: the rollback precondition accepts staged as
         well as executed, and the rollback transaction handle resolves from a
         staged journal row as well as a committed one.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-12
+      description: >
+        The per-phase Kensa journal survives the boundary. Mapping a
+        TransactionResult carries every StepResult field an operator needs to
+        understand the outcome, Detail above all, plus the captured PreStates,
+        and the steps endpoint returns them. Before this the journal was
+        reduced to a step COUNT in an evidence summary, so a rolled-back
+        remediation could report only that the host was unchanged while the
+        engine's own account of why sat unread. PreState data is carried
+        verbatim and not decoded: its layout belongs to the Kensa handler that
+        wrote it.
       priority: critical
       references_constraints: [C-09]
     - id: AC-10


### PR DESCRIPTION
First step of the v0.7.1 remediation-visibility work: surface what Kensa
already gives us, and find out precisely where the real limitation is.

## The black box was ours

Kensa returns `TransactionResult.Steps` - one `StepResult` per
Capture/Apply/Validate/Commit phase - and each carries a `Detail` that Kensa's
own documentation describes as *"human-readable per-step output suitable for
logs and UI"*.

We threw it away. `mapTxns` kept five fields, and the evidence summary recorded:

```go
"steps": len(t.Steps),   // the COUNT of steps
```

So a rolled-back remediation could report only "reverted, host unchanged" while
the engine's explanation sat unread.

| Kensa returned | We kept, before |
|---|---|
| `Steps[].Detail` | a number |
| `Steps[].Capturable / Staged / Stranded` | nothing |
| `PreStates[]` (the capture) | nothing |
| `StartedAt / FinishedAt / CommittedAt` | nothing |

`remediation_transactions.pre_state` and `.mechanism` have existed since
migration **0037** and had never been written.

## What changes

Carried end to end: kensa -> worker -> service -> DB -> API. Migration 0055 adds
a `steps` column and documents the two dormant ones. `/remediation/requests/{rid}/steps`
now returns `phases` and `pre_state`, and `phase_result`'s enum catches up with
the six-outcome vocabulary v0.7.0 shipped (it was still
`committed|rolled_back|skipped`).

**Three flags matter more than they look**, because none can be inferred from
the terminal status an operator sees:

- `stranded` - rollback will **not** reverse this step
- `staged` - written to the persist layer, running host has not converged, so a
  re-scan still reports the rule failing
- `capturable` - what makes a rule rollbackable at all

Also worth naming: a "step" in this API has always meant a **rule**. The phases
you actually want to watch are one level below, which is why nothing surfaced
them before. The schema now says so.

## The limitation, which is the point of doing this first

`PreState.Data` is `map[string]interface{}` whose layout is defined by each
capturable handler. Kensa exposes no schema and no display projection for it.

So we can show **that** a phase captured something, and store it verbatim as
evidence, but we cannot render "the prior config line, mode, or unit status"
without either decoding per mechanism in this repo - coupling us to Kensa
handler internals that will rot - or Kensa growing a display-ready form.

That is the concrete case for a `features/KN-...` request, and it is now
backed by shipped code rather than a guess.

## Verification

`api-remediation` 1.2.0 -> 1.3.0, AC-12, with a regression test at the exact
boundary where the loss happened. Mutation-checked: restoring the dropped
assignment fails it with *"the journal is being dropped again"*.

A shape bug was caught before it shipped - `pre_state` is stored as an array
(one entry per phase) but was first declared as an object, so the handler's
unmarshal would have failed silently and it would never have surfaced.

Backend only. Rendering this in the host Remediation tab is the next PR.