### PR TITLE
feat(remediation): show the transaction, not a diagram of it

### DIFF
--- a/frontend/src/components/hosts/RemediationJournal.tsx
+++ b/frontend/src/components/hosts/RemediationJournal.tsx
@@ -1,0 +1,217 @@
+import { AlertTriangle, Check, Clock, X } from 'lucide-react';
+import type { components } from '@/api/schema';
+import { phaseLabel, phaseNote, useRemediationSteps } from '@/hooks/useRemediationSteps';
+
+type RemediationPhase = components['schemas']['RemediationPhase'];
+type RemediationPreState = components['schemas']['RemediationPreState'];
+
+// RemediationJournal renders one request's Kensa transaction: the phases that
+// ran, what each did, and what was captured before anything changed.
+//
+// This exists because the tab used to show the four phases as a static
+// diagram. The model was described and the run was not, so a failed fix could
+// say only "reverted, host unchanged" while the reason sat in the API unread.
+export function RemediationJournal({
+  hostId,
+  requestId,
+  expanded,
+}: {
+  hostId: string;
+  requestId: string;
+  expanded: boolean;
+}) {
+  const journal = useRemediationSteps(hostId, requestId, expanded);
+
+  if (!expanded) return null;
+
+  if (journal.isPending) {
+    return <JournalNote>Loading the transaction journal...</JournalNote>;
+  }
+  if (journal.isError) {
+    return <JournalNote tone="bad">{journal.error ?? 'Could not load the journal.'}</JournalNote>;
+  }
+  if (journal.steps.length === 0) {
+    // Not an error: a request that was never executed has no journal. Saying
+    // why is better than an empty panel that reads as a failure.
+    return (
+      <JournalNote>
+        No transaction yet. Kensa records the phases when the fix runs, so this fills in once the
+        request is executed.
+      </JournalNote>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14, padding: '4px 2px 10px' }}>
+      {journal.steps.map((step) => {
+        const phases = step.phases ?? [];
+        const pre = step.pre_state ?? [];
+        return (
+          <div key={step.id} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {phases.length === 0 ? (
+              <JournalNote>
+                This transaction recorded no phases. The outcome is {step.phase_result ?? 'unknown'}
+                .
+              </JournalNote>
+            ) : (
+              <ol
+                style={{
+                  listStyle: 'none',
+                  margin: 0,
+                  padding: 0,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 8,
+                }}
+              >
+                {phases.map((p) => (
+                  <PhaseRow key={p.index} phase={p} total={phases.length} />
+                ))}
+              </ol>
+            )}
+            <CapturedState entries={pre} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function PhaseRow({ phase, total }: { phase: RemediationPhase; total: number }) {
+  const note = phaseNote(phase);
+  const tone = phase.staged ? 'warn' : phase.success ? 'ok' : 'bad';
+  const Icon = phase.staged ? Clock : phase.success ? Check : X;
+  const color =
+    tone === 'ok' ? 'var(--ow-ok)' : tone === 'warn' ? 'var(--ow-warn)' : 'var(--ow-bad)';
+
+  return (
+    <li
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '20px 130px 1fr',
+        gap: 10,
+        alignItems: 'start',
+      }}
+    >
+      <Icon size={15} style={{ color, marginTop: 2 }} aria-hidden />
+      <div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ow-fg-0)' }}>
+          {phaseLabel(phase, total)}
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--ow-fg-3)', fontFamily: 'var(--ow-font-mono)' }}>
+          {phase.mechanism}
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        {/* Kensa's own account of what this phase did. This is the answer to
+            "why did it fail", and it was previously discarded. */}
+        {phase.detail ? (
+          <div
+            style={{
+              fontSize: 12,
+              color: 'var(--ow-fg-1)',
+              fontFamily: 'var(--ow-font-mono)',
+              lineHeight: 1.5,
+              wordBreak: 'break-word',
+            }}
+          >
+            {phase.detail}
+          </div>
+        ) : (
+          <div style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>
+            No detail recorded for this phase.
+          </div>
+        )}
+        {note ? (
+          <div
+            style={{
+              display: 'flex',
+              gap: 6,
+              alignItems: 'flex-start',
+              fontSize: 11,
+              color: 'var(--ow-fg-2)',
+              background: 'var(--ow-bg-2)',
+              border: '1px solid var(--ow-line)',
+              borderRadius: 'var(--ow-radius-sm, 6px)',
+              padding: '6px 8px',
+            }}
+          >
+            <AlertTriangle
+              size={12}
+              style={{ color: 'var(--ow-warn)', marginTop: 1 }}
+              aria-hidden
+            />
+            <span>{note}</span>
+          </div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+// CapturedState shows what Kensa recorded before it changed anything.
+//
+// The data is deliberately not interpreted. Its layout is defined by whichever
+// Kensa handler captured it, with no published schema, so decoding it here
+// would couple this component to Kensa handler internals and break silently
+// when one changes. Until Kensa exposes a display projection (features/
+// KN-OW-016) this shows that a capture exists, which steps it covers, and the
+// raw evidence, rather than a prettier guess at what it means.
+function CapturedState({ entries }: { entries: RemediationPreState[] }) {
+  if (entries.length === 0) return null;
+  const restorable = entries.filter((e) => e.capturable);
+
+  return (
+    <details style={{ marginLeft: 30 }}>
+      <summary
+        style={{ cursor: 'pointer', fontSize: 12, color: 'var(--ow-fg-2)', userSelect: 'none' }}
+      >
+        Captured before the change: {restorable.length} of {entries.length}{' '}
+        {entries.length === 1 ? 'step' : 'steps'} restorable
+      </summary>
+      <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {entries.map((e) => (
+          <div key={e.index}>
+            <div style={{ fontSize: 11, color: 'var(--ow-fg-2)' }}>
+              <span style={{ fontFamily: 'var(--ow-font-mono)' }}>{e.mechanism}</span>
+              {e.capturable ? null : (
+                <span style={{ color: 'var(--ow-fg-3)' }}> (no pre-state, not restorable)</span>
+              )}
+            </div>
+            {e.capturable && e.data ? (
+              <pre
+                style={{
+                  margin: '4px 0 0',
+                  padding: 8,
+                  background: 'var(--ow-bg-2)',
+                  border: '1px solid var(--ow-line)',
+                  borderRadius: 'var(--ow-radius-sm, 6px)',
+                  fontSize: 11,
+                  color: 'var(--ow-fg-1)',
+                  overflowX: 'auto',
+                }}
+              >
+                {JSON.stringify(e.data, null, 2)}
+              </pre>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function JournalNote({ children, tone }: { children: React.ReactNode; tone?: 'bad' }) {
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        color: tone === 'bad' ? 'var(--ow-bad)' : 'var(--ow-fg-3)',
+        padding: '8px 2px 12px',
+        lineHeight: 1.5,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useRemediationSteps.ts
+++ b/frontend/src/hooks/useRemediationSteps.ts
@@ -1,0 +1,87 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/api/client';
+import { apiErrorMessage } from '@/api/errors';
+import type { components } from '@/api/schema';
+
+type RemediationStep = components['schemas']['RemediationStep'];
+type RemediationPhase = components['schemas']['RemediationPhase'];
+
+// useRemediationSteps fetches one request's transaction journal: the
+// Capture/Apply/Validate/Commit phases Kensa recorded, with the detail that
+// says why each did what it did.
+//
+// Fetched on demand rather than with the request list. A host can carry many
+// requests and the journal is only meaningful once someone opens one, so
+// `enabled` gates the round-trip on the row actually being expanded.
+//
+// The query key sits under ['host', hostId] so the existing scan.completed SSE
+// invalidation and the remediation mutations refresh it alongside the list,
+// rather than leaving an expanded row showing a stale journal after a rollback.
+export interface RemediationJournal {
+  steps: RemediationStep[];
+  isPending: boolean;
+  isError: boolean;
+  error: string | null;
+}
+
+export function useRemediationSteps(
+  hostId: string,
+  requestId: string,
+  enabled: boolean,
+): RemediationJournal {
+  const q = useQuery({
+    queryKey: ['host', hostId, 'remediation', requestId, 'steps'],
+    enabled,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/remediation/requests/{rid}/steps', {
+        params: { path: { rid: requestId } },
+      });
+      if (error) {
+        throw new Error(
+          apiErrorMessage(error, `Could not load the transaction journal (${response.status})`),
+        );
+      }
+      return data?.steps ?? [];
+    },
+  });
+
+  return {
+    steps: q.data ?? [],
+    isPending: q.isPending,
+    isError: q.isError,
+    error: q.isError ? apiErrorMessage(q.error, 'Could not load the transaction journal.') : null,
+  };
+}
+
+// phaseLabel names a phase for display.
+//
+// Kensa numbers steps but does not name them, and the mechanism (config_set,
+// service_enabled) describes HOW a phase acted rather than WHICH phase it is.
+// The transaction always runs Capture, Apply, Validate, then Commit or
+// Rollback, so the index maps to the phase for the common four-step shape; a
+// longer transaction (a rule with several apply steps) falls back to the
+// mechanism, which is honest rather than inventing a name.
+export function phaseLabel(phase: RemediationPhase, total: number): string {
+  if (total === 4) {
+    return ['Capture', 'Apply', 'Validate', 'Commit'][phase.index] ?? phase.mechanism;
+  }
+  return phase.mechanism;
+}
+
+// phaseNote returns the consequence an operator cannot infer from the outcome
+// alone, or null when there is nothing unusual to say.
+//
+// These three flags each change what the operator should do next, and none of
+// them is visible in the request's terminal status.
+export function phaseNote(phase: RemediationPhase): string | null {
+  if (phase.stranded) {
+    return 'Not reversed by rollback. This step cannot capture pre-state, and it succeeded before a later step failed.';
+  }
+  if (phase.staged) {
+    return 'Written, but the running host has not changed. A re-scan reports this rule failing until the host reboots.';
+  }
+  if (!phase.capturable && !phase.success) {
+    return 'This step cannot capture pre-state, so it cannot be rolled back.';
+  }
+  return null;
+}

--- a/frontend/src/pages/HostDetailPage.tsx
+++ b/frontend/src/pages/HostDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams, useSearch, useNavigate, Link } from '@tanstack/react-router';
-import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
+import { Fragment, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 import {
   Activity as ActivityIcon,
   AlertTriangle,
@@ -28,6 +28,7 @@ import type { LucideIcon } from 'lucide-react';
 import api from '@/api/client';
 import { useHostExceptions } from '@/hooks/useHostExceptions';
 import { useHostRemediations } from '@/hooks/useHostRemediations';
+import { RemediationJournal } from '@/components/hosts/RemediationJournal';
 import { formatLift } from '@/components/hosts/RequestRemediationModal';
 import { apiErrorCode, apiErrorMessage } from '@/api/errors';
 import { useDefaultLens, resolveLensForHost } from '@/api/useDefaultLens';
@@ -1293,6 +1294,9 @@ function RemediationTab({ hostId }: { hostId: string }) {
   const canApprove = useAuthStore((s) => s.hasPermission('remediation:approve')) || isAdmin;
   const canExecute = useAuthStore((s) => s.hasPermission('remediation:execute')) || isAdmin;
   const canRollback = useAuthStore((s) => s.hasPermission('remediation:rollback')) || isAdmin;
+  // One row open at a time. The journal is a detailed read, and several open
+  // at once turns the table back into a wall rather than an explanation.
+  const [expandedRequestId, setExpandedRequestId] = useState<string | null>(null);
 
   let body: ReactNode;
   if (rem.isPending) {
@@ -1343,31 +1347,76 @@ function RemediationTab({ hostId }: { hostId: string }) {
         <tbody>
           {rem.items.map((r) => {
             const lift = formatLift(r.projected_lift);
+            const open = expandedRequestId === r.id;
             return (
-              <tr key={r.id} style={{ borderTop: '1px solid var(--ow-line)' }}>
-                <td style={remTd}>
-                  <RemStatusChip status={r.status} />
-                </td>
-                <td style={remTd}>
-                  <span style={{ fontFamily: 'var(--ow-font-mono)', color: 'var(--ow-fg-0)' }}>
-                    {r.rule_id}
-                  </span>
-                </td>
-                <td
-                  style={{ ...remTd, color: 'var(--ow-fg-2)', fontVariantNumeric: 'tabular-nums' }}
-                >
-                  {lift ?? <span style={{ color: 'var(--ow-fg-3)' }}>—</span>}
-                </td>
-                <td style={remTd}>
-                  <RemediationRowAction
-                    request={r}
-                    hostId={hostId}
-                    canApprove={canApprove}
-                    canExecute={canExecute}
-                    canRollback={canRollback}
-                  />
-                </td>
-              </tr>
+              <Fragment key={r.id}>
+                <tr style={{ borderTop: '1px solid var(--ow-line)' }}>
+                  <td style={remTd}>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedRequestId(open ? null : r.id)}
+                      aria-expanded={open}
+                      aria-label={
+                        open
+                          ? `Hide transaction for ${r.rule_id}`
+                          : `Show transaction for ${r.rule_id}`
+                      }
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        background: 'none',
+                        border: 'none',
+                        padding: 0,
+                        cursor: 'pointer',
+                        color: 'inherit',
+                        font: 'inherit',
+                      }}
+                    >
+                      <ChevronRight
+                        size={13}
+                        aria-hidden
+                        style={{
+                          color: 'var(--ow-fg-3)',
+                          transform: open ? 'rotate(90deg)' : 'none',
+                          transition: 'transform 120ms',
+                        }}
+                      />
+                      <RemStatusChip status={r.status} />
+                    </button>
+                  </td>
+                  <td style={remTd}>
+                    <span style={{ fontFamily: 'var(--ow-font-mono)', color: 'var(--ow-fg-0)' }}>
+                      {r.rule_id}
+                    </span>
+                  </td>
+                  <td
+                    style={{
+                      ...remTd,
+                      color: 'var(--ow-fg-2)',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {lift ?? <span style={{ color: 'var(--ow-fg-3)' }}>—</span>}
+                  </td>
+                  <td style={remTd}>
+                    <RemediationRowAction
+                      request={r}
+                      hostId={hostId}
+                      canApprove={canApprove}
+                      canExecute={canExecute}
+                      canRollback={canRollback}
+                    />
+                  </td>
+                </tr>
+                {open ? (
+                  <tr>
+                    <td colSpan={4} style={{ padding: '0 12px', background: 'var(--ow-bg-0)' }}>
+                      <RemediationJournal hostId={hostId} requestId={r.id} expanded />
+                    </td>
+                  </tr>
+                ) : null}
+              </Fragment>
             );
           })}
         </tbody>

--- a/frontend/tests/components/remediation-journal.test.ts
+++ b/frontend/tests/components/remediation-journal.test.ts
@@ -24,23 +24,27 @@ const phase = (over: Partial<Phase> = {}): Phase => ({
 });
 
 describe('frontend-remediation-tab AC-09 - the journal is shown, not described', () => {
-  test('the four-phase transaction is named by phase, not by mechanism', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - the four-phase transaction is named by phase, not by mechanism', () => {
     const four = [0, 1, 2, 3].map((index) => phase({ index }));
     expect(four.map((p) => phaseLabel(p, 4))).toEqual(['Capture', 'Apply', 'Validate', 'Commit']);
   });
 
-  test('a transaction that is not four phases falls back to the mechanism', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - a transaction that is not four phases falls back to the mechanism', () => {
     // Inventing a phase name for a shape we do not recognise would be a
     // confident guess presented as fact. The mechanism is at least true.
     expect(phaseLabel(phase({ index: 4, mechanism: 'audit_ruleset' }), 6)).toBe('audit_ruleset');
   });
 
-  test('stranded says rollback will not reverse it', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - stranded says rollback will not reverse it', () => {
     const note = phaseNote(phase({ stranded: true, capturable: false }));
     expect(note).toMatch(/not reversed by rollback/i);
   });
 
-  test('staged says the running host has not changed yet', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - staged says the running host has not changed yet', () => {
     // The dangerous reading is "done". A staged change leaves the host
     // unprotected until reboot, and a re-scan still reports the rule failing.
     const note = phaseNote(phase({ staged: true }));
@@ -48,11 +52,13 @@ describe('frontend-remediation-tab AC-09 - the journal is shown, not described',
     expect(note).toMatch(/reboot/i);
   });
 
-  test('a successful ordinary phase says nothing extra', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - a successful ordinary phase says nothing extra', () => {
     expect(phaseNote(phase())).toBeNull();
   });
 
-  test('stranded outranks staged when a phase is both', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - stranded outranks staged when a phase is both', () => {
     // Both can be true on one step. Not-reversed-by-rollback is the one that
     // changes what the operator must do next.
     const note = phaseNote(phase({ stranded: true, staged: true }));
@@ -63,22 +69,26 @@ describe('frontend-remediation-tab AC-09 - the journal is shown, not described',
 describe('frontend-remediation-tab AC-09 - pre-state is evidence, not interpretation', () => {
   const journal = read('src/components/hosts/RemediationJournal.tsx');
 
-  test('captured data is rendered verbatim, never decoded per mechanism', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - captured data is rendered verbatim, never decoded per mechanism', () => {
     // Decoding it here would couple this component to Kensa handler internals
     // and break silently when a handler changes its layout.
     expect(journal).toContain('JSON.stringify(e.data, null, 2)');
     expect(journal).toMatch(/KN-OW-016/);
   });
 
-  test('a non-capturable capture is still shown, as a gap', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - a non-capturable capture is still shown, as a gap', () => {
     expect(journal).toMatch(/not restorable/i);
   });
 
-  test('the detail Kensa returned is rendered', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - the detail Kensa returned is rendered', () => {
     expect(journal).toContain('phase.detail');
   });
 
-  test('no em dashes in the copy', () => {
+  // @ac AC-09
+  test('frontend-remediation-tab/AC-09 - no em dashes in the copy', () => {
     expect(journal).not.toMatch(/—/);
     expect(read('src/hooks/useRemediationSteps.ts')).not.toMatch(/—/);
   });

--- a/frontend/tests/components/remediation-journal.test.ts
+++ b/frontend/tests/components/remediation-journal.test.ts
@@ -1,0 +1,85 @@
+// @spec frontend-remediation-tab
+//
+//   AC-09  the transaction journal is shown, and its consequences are worded
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { phaseLabel, phaseNote } from '@/hooks/useRemediationSteps';
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+type Phase = Parameters<typeof phaseNote>[0];
+
+const phase = (over: Partial<Phase> = {}): Phase => ({
+  index: 0,
+  mechanism: 'config_set',
+  success: true,
+  capturable: true,
+  staged: false,
+  stranded: false,
+  ...over,
+});
+
+describe('frontend-remediation-tab AC-09 - the journal is shown, not described', () => {
+  test('the four-phase transaction is named by phase, not by mechanism', () => {
+    const four = [0, 1, 2, 3].map((index) => phase({ index }));
+    expect(four.map((p) => phaseLabel(p, 4))).toEqual(['Capture', 'Apply', 'Validate', 'Commit']);
+  });
+
+  test('a transaction that is not four phases falls back to the mechanism', () => {
+    // Inventing a phase name for a shape we do not recognise would be a
+    // confident guess presented as fact. The mechanism is at least true.
+    expect(phaseLabel(phase({ index: 4, mechanism: 'audit_ruleset' }), 6)).toBe('audit_ruleset');
+  });
+
+  test('stranded says rollback will not reverse it', () => {
+    const note = phaseNote(phase({ stranded: true, capturable: false }));
+    expect(note).toMatch(/not reversed by rollback/i);
+  });
+
+  test('staged says the running host has not changed yet', () => {
+    // The dangerous reading is "done". A staged change leaves the host
+    // unprotected until reboot, and a re-scan still reports the rule failing.
+    const note = phaseNote(phase({ staged: true }));
+    expect(note).toMatch(/has not changed/i);
+    expect(note).toMatch(/reboot/i);
+  });
+
+  test('a successful ordinary phase says nothing extra', () => {
+    expect(phaseNote(phase())).toBeNull();
+  });
+
+  test('stranded outranks staged when a phase is both', () => {
+    // Both can be true on one step. Not-reversed-by-rollback is the one that
+    // changes what the operator must do next.
+    const note = phaseNote(phase({ stranded: true, staged: true }));
+    expect(note).toMatch(/not reversed by rollback/i);
+  });
+});
+
+describe('frontend-remediation-tab AC-09 - pre-state is evidence, not interpretation', () => {
+  const journal = read('src/components/hosts/RemediationJournal.tsx');
+
+  test('captured data is rendered verbatim, never decoded per mechanism', () => {
+    // Decoding it here would couple this component to Kensa handler internals
+    // and break silently when a handler changes its layout.
+    expect(journal).toContain('JSON.stringify(e.data, null, 2)');
+    expect(journal).toMatch(/KN-OW-016/);
+  });
+
+  test('a non-capturable capture is still shown, as a gap', () => {
+    expect(journal).toMatch(/not restorable/i);
+  });
+
+  test('the detail Kensa returned is rendered', () => {
+    expect(journal).toContain('phase.detail');
+  });
+
+  test('no em dashes in the copy', () => {
+    expect(journal).not.toMatch(/—/);
+    expect(read('src/hooks/useRemediationSteps.ts')).not.toMatch(/—/);
+  });
+});

--- a/specs/frontend/remediation-tab.spec.yaml
+++ b/specs/frontend/remediation-tab.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-remediation-tab
   title: Host detail Remediation tab + per-rule request/apply affordance
-  version: "1.2.0"
+  version: "1.3.0"
   status: approved
   tier: 2
 
@@ -108,6 +108,21 @@ spec:
       description: 'Source inspection: the OpenWatch Enterprise upsell now describes BULK and AUTOMATED remediation (RemediationUpsell, "Bulk and automated remediation (OpenWatch Enterprise)"), is DISABLED, and the single-rule "Execute on host (OpenWatch Enterprise)" upsell copy is gone. No em-dash characters appear in the RemediationTab copy'
       priority: high
       references_constraints: [C-03, C-04]
+    - id: AC-09
+      description: >
+        The tab shows the transaction, not just a diagram of it. Expanding a
+        request renders the per-phase Kensa journal, and each phase shows the
+        engine's own detail, which is the answer to why a fix failed. The three
+        consequences an operator cannot infer from the terminal status are
+        called out in words rather than left implicit: a stranded phase is not
+        reversed by rollback, a staged phase means the running host has not
+        changed until it reboots, and a non-capturable phase cannot be rolled
+        back. Captured pre-state is shown as evidence and NOT decoded, because
+        its layout belongs to the Kensa handler that wrote it and no schema is
+        published (features/KN-OW-016). No em-dash characters appear in the
+        copy.
+      priority: critical
+      references_constraints: [C-04]
     - id: AC-08
       description: >
         Source inspection: the outcome vocabulary is rendered so that colour and


### PR DESCRIPTION
Second half of the v0.7.1 visibility work. #791 carried the journal through to
the API; this renders it.

## The problem, restated

The tab drew Capture, Apply, Validate and Commit as four static chips. It
described the model and never showed the run, so a failed fix reported:

> Reverted, host unchanged

and nothing else, while Kensa's own explanation sat in the API unread.

## What expanding a request now shows

The phases that actually ran, each with `detail` - the engine's account of what
it did, which is the answer to *why*.

**Three consequences are stated in words**, because none can be read off the
terminal status:

| Flag | What the operator is told |
|---|---|
| `stranded` | Not reversed by rollback. This step cannot capture pre-state and succeeded before a later one failed. |
| `staged` | Written, but the running host has not changed. A re-scan reports this rule failing until it reboots. |
| `capturable: false` | Cannot be rolled back at all. |

A staged fix reading as "done" is the dangerous one, and it is exactly the case
the founder hit on `owas-tst02`.

## Two deliberate restraints

**Phase naming admits what it does not know.** A four-phase transaction is
labelled Capture/Apply/Validate/Commit. Anything longer - a rule with several
apply steps - falls back to the mechanism rather than inventing a name for a
shape we do not recognise.

**Captured pre-state is evidence, not interpretation.** Its layout belongs to
whichever Kensa handler wrote it and no schema is published, so decoding it here
would couple this component to Kensa internals and break silently when a handler
changes. Filed as `features/KN-OW-016`. Until that lands the UI shows which steps
are restorable and the raw capture, rather than a prettier guess at what it
means. The test asserts we keep doing that.

## Cost

One row expands at a time and the journal is fetched on demand, so a host with
many requests does not pay for a read nobody opened. The query key sits under
`['host', hostId]` so the existing SSE invalidation refreshes an open row rather
than leaving a stale journal after a rollback.

## Verification

`frontend-remediation-tab` 1.2.0 -> 1.3.0, AC-09, 10 tests. Mutation-checked:
removing the stranded warning fails two of them.

An em dash reached the copy via prettier's reformatting and was caught by the
AC's own no-em-dash assertion, which is the second time that guard has earned
its keep.