### PR TITLE
feat(remediation): preview the fix before it runs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2207,6 +2207,57 @@ paths:
             application/json:
               schema: {$ref: '#/components/schemas/ErrorEnvelope'}
 
+  /api/v1/remediation/requests/{rid}/plan:
+    get:
+      operationId: getRemediationPlan
+      summary: Preview what a remediation would do, without changing the host
+      description: |
+        Asks Kensa to plan the request's rule against its host: the apply steps
+        that would run, the validators that would check them, and how each
+        would be reversed. Read-only. Kensa captures pre-state during planning
+        but does not apply anything.
+
+        This reaches the host over SSH, so it is a live call and fails the way
+        a scan does when the host is unreachable. It is not cached: a plan
+        describes the host as it is now, and a stale preview is worse than none.
+
+        Free core, like the single-rule fix it previews. RBAC:
+        remediation:read. Spec api-remediation.
+      x-required-permission: remediation:read
+      parameters:
+        - name: rid
+          in: path
+          required: true
+          schema: {type: string, format: uuid}
+      responses:
+        '200':
+          description: The plan
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/RemediationPlan'}
+        '404':
+          description: Remediation request not found
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '403':
+          description: Caller lacks remediation:read permission
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '502':
+          description: |
+            The host could not be planned against (unreachable, auth, or sudo).
+            The body names which.
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+        '503':
+          description: Planning is unavailable because the Kensa rule corpus is not loaded
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/ErrorEnvelope'}
+
   /api/v1/remediation/requests/{rid}:approve:
     post:
       operationId: approveRemediation
@@ -5871,6 +5922,68 @@ components:
             order.
           type: array
           items: {$ref: '#/components/schemas/RemediationPreState'}
+
+    RemediationPlan:
+      description: |
+        What remediating one rule on one host would do. Produced by Kensa
+        without mutating the host.
+      type: object
+      required: [rule_id, steps, checks, undo, transactional, control_channel_sensitive, reversible_steps]
+      properties:
+        plan_id: {type: string, format: uuid}
+        rule_id: {type: string}
+        steps:
+          description: The apply steps that would run, in order.
+          type: array
+          items: {$ref: '#/components/schemas/RemediationPlanStep'}
+        checks:
+          description: The validators that would run after apply.
+          type: array
+          items:
+            type: object
+            required: [name]
+            properties:
+              name:    {type: string}
+              summary: {type: string}
+        undo:
+          description: |
+            How each applied step would be reversed. Rollback runs this in
+            reverse order.
+          type: array
+          items: {$ref: '#/components/schemas/RemediationPlanStep'}
+        reversible_steps:
+          description: |
+            How many steps Kensa actually captured pre-state for, counted from
+            the capture rather than from the rule's own claim about itself.
+          type: integer
+        transactional:
+          description: False when the steps are not all-or-nothing.
+          type: boolean
+        control_channel_sensitive:
+          description: |
+            True when a step touches SSH, networking, PAM or firewall state.
+            Kensa arms a deadman timer before applying such a transaction, so
+            a fix that could lock you out reverts itself if you lose contact.
+          type: boolean
+        warnings:
+          description: Kensa's own operator-facing notices about this plan.
+          type: array
+          items: {type: string}
+        estimated_seconds: {type: number}
+        captured_at:       {type: string, format: date-time}
+
+    RemediationPlanStep:
+      type: object
+      required: [index, mechanism]
+      properties:
+        index:     {type: integer}
+        mechanism: {type: string}
+        summary:
+          description: Kensa's human-readable description of the action.
+          type: string
+        capturable:
+          description: False when this step cannot be reversed.
+          type: boolean
 
     RemediationPreState:
       description: |

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -617,7 +617,8 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	// a durable SQLite store for rollback pre-state — derive a path from the
 	// kensa store env (dev default under the working dir).
 	remExecutor := scanExecutor
-	if remFn, rbFn, remErr := kensa.NewProductionRemediateFunc(bootCtx, kensa.RemediateFuncDeps{
+	var remediationPlanFn kensa.PlanFunc
+	if remFn, rbFn, planFn, remErr := kensa.NewProductionRemediateFunc(bootCtx, kensa.RemediateFuncDeps{
 		Pool:        pool,
 		Credentials: credSvc,
 		RulesDir:    scanRulesDir,
@@ -638,6 +639,7 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 			slog.String("error", remErr.Error()))
 	} else {
 		remExecutor = remExecutor.WithRemediateFunc(remFn, rbFn)
+		remediationPlanFn = planFn
 	}
 	remediationWorker := worker.NewRemediationWorker(worker.RemediationConfig{
 		Pool:       pool,
@@ -718,6 +720,7 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 		WithVariableCatalog(varCatalog).
 		WithExceptions(exceptionSvc).
 		WithRemediation(remediationSvc).
+		WithRemediationPlan(remediationPlanFn).
 		WithGroups(group.NewService(pool)).
 		WithReports(reportSvc).
 		WithReportSchedules(reportScheduleSvc).

--- a/cmd/openwatch/worker.go
+++ b/cmd/openwatch/worker.go
@@ -207,7 +207,9 @@ func cmdWorker(cfg *config.Config, args []string, stdout, stderr *os.File) int {
 	// remediate share one per-host inFlight guard. The apply-enabled Kensa
 	// needs a durable SQLite store for rollback pre-state.
 	remExecutor := executor
-	remFn, rbFn, remErr := kensa.NewProductionRemediateFunc(bootCtx, kensa.RemediateFuncDeps{
+	// The worker never serves the plan preview: that is a synchronous API
+	// read, so the closure is discarded here.
+	remFn, rbFn, _, remErr := kensa.NewProductionRemediateFunc(bootCtx, kensa.RemediateFuncDeps{
 		Pool:        pool,
 		Credentials: credSvc,
 		RulesDir:    rulesDir,

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1400,6 +1400,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/remediation/requests/{rid}/plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Preview what a remediation would do, without changing the host
+         * @description Asks Kensa to plan the request's rule against its host: the apply steps
+         *     that would run, the validators that would check them, and how each
+         *     would be reversed. Read-only. Kensa captures pre-state during planning
+         *     but does not apply anything.
+         *
+         *     This reaches the host over SSH, so it is a live call and fails the way
+         *     a scan does when the host is unreachable. It is not cached: a plan
+         *     describes the host as it is now, and a stale preview is worse than none.
+         *
+         *     Free core, like the single-rule fix it previews. RBAC:
+         *     remediation:read. Spec api-remediation.
+         */
+        get: operations["getRemediationPlan"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/remediation/requests/{rid}:approve": {
         parameters: {
             query?: never;
@@ -3855,6 +3885,53 @@ export interface components {
              *     order.
              */
             pre_state?: components["schemas"]["RemediationPreState"][];
+        };
+        /**
+         * @description What remediating one rule on one host would do. Produced by Kensa
+         *     without mutating the host.
+         */
+        RemediationPlan: {
+            /** Format: uuid */
+            plan_id?: string;
+            rule_id: string;
+            /** @description The apply steps that would run, in order. */
+            steps: components["schemas"]["RemediationPlanStep"][];
+            /** @description The validators that would run after apply. */
+            checks: {
+                name: string;
+                summary?: string;
+            }[];
+            /**
+             * @description How each applied step would be reversed. Rollback runs this in
+             *     reverse order.
+             */
+            undo: components["schemas"]["RemediationPlanStep"][];
+            /**
+             * @description How many steps Kensa actually captured pre-state for, counted from
+             *     the capture rather than from the rule's own claim about itself.
+             */
+            reversible_steps: number;
+            /** @description False when the steps are not all-or-nothing. */
+            transactional: boolean;
+            /**
+             * @description True when a step touches SSH, networking, PAM or firewall state.
+             *     Kensa arms a deadman timer before applying such a transaction, so
+             *     a fix that could lock you out reverts itself if you lose contact.
+             */
+            control_channel_sensitive: boolean;
+            /** @description Kensa's own operator-facing notices about this plan. */
+            warnings?: string[];
+            estimated_seconds?: number;
+            /** Format: date-time */
+            captured_at?: string;
+        };
+        RemediationPlanStep: {
+            index: number;
+            mechanism: string;
+            /** @description Kensa's human-readable description of the action. */
+            summary?: string;
+            /** @description False when this step cannot be reversed. */
+            capturable?: boolean;
         };
         /**
          * @description One phase's captured pre-change state.
@@ -7720,6 +7797,67 @@ export interface operations {
             };
             /** @description Remediation request not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    getRemediationPlan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                rid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The plan */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RemediationPlan"];
+                };
+            };
+            /** @description Caller lacks remediation:read permission */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Remediation request not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /**
+             * @description The host could not be planned against (unreachable, auth, or sudo).
+             *     The body names which.
+             */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Planning is unavailable because the Kensa rule corpus is not loaded */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/components/hosts/RemediationJournal.tsx
+++ b/frontend/src/components/hosts/RemediationJournal.tsx
@@ -1,6 +1,11 @@
 import { AlertTriangle, Check, Clock, X } from 'lucide-react';
 import type { components } from '@/api/schema';
-import { phaseLabel, phaseNote, useRemediationSteps } from '@/hooks/useRemediationSteps';
+import {
+  phaseLabel,
+  phaseNote,
+  useRemediationPlan,
+  useRemediationSteps,
+} from '@/hooks/useRemediationSteps';
 
 type RemediationPhase = components['schemas']['RemediationPhase'];
 type RemediationPreState = components['schemas']['RemediationPreState'];
@@ -31,14 +36,10 @@ export function RemediationJournal({
     return <JournalNote tone="bad">{journal.error ?? 'Could not load the journal.'}</JournalNote>;
   }
   if (journal.steps.length === 0) {
-    // Not an error: a request that was never executed has no journal. Saying
-    // why is better than an empty panel that reads as a failure.
-    return (
-      <JournalNote>
-        No transaction yet. Kensa records the phases when the fix runs, so this fills in once the
-        request is executed.
-      </JournalNote>
-    );
+    // Nothing has run yet, so show what WOULD run. This is the half of the
+    // question the journal cannot answer: an operator deciding whether to
+    // approve a fix needs to know what it will do, not only what it did.
+    return <PlanPreview hostId={hostId} requestId={requestId} />;
   }
 
   return (
@@ -212,6 +213,149 @@ function JournalNote({ children, tone }: { children: React.ReactNode; tone?: 'ba
       }}
     >
       {children}
+    </div>
+  );
+}
+
+// PlanPreview shows what a fix would do, before it does it.
+//
+// Shown in place of the journal when a request has not executed. Kensa plans
+// the rule against the live host and reports the apply steps, the validators
+// and the rollback, all read-only. Every string here is Kensa's own: the
+// summaries are handler-authored, so this describes the actual mechanism
+// rather than a generic restatement of the rule title.
+function PlanPreview({ hostId, requestId }: { hostId: string; requestId: string }) {
+  const { plan, isPending, isError, error } = useRemediationPlan(hostId, requestId, true);
+
+  if (isPending) return <JournalNote>Planning against the host...</JournalNote>;
+  if (isError) {
+    // Planning reaches the host, so a failure here is about the host, not the
+    // fix. Say so, and do not imply the fix itself is broken.
+    return (
+      <JournalNote tone="bad">
+        {error ?? 'Could not plan this fix.'} Nothing was changed on the host.
+      </JournalNote>
+    );
+  }
+  if (!plan) return <JournalNote>No plan available.</JournalNote>;
+
+  const steps = plan.steps ?? [];
+  const checks = plan.checks ?? [];
+  const undo = plan.undo ?? [];
+  const warnings = plan.warnings ?? [];
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: '4px 2px 12px' }}>
+      <div style={{ fontSize: 12, color: 'var(--ow-fg-2)' }}>
+        Nothing has run yet. This is what would happen, planned against the host now.
+      </div>
+
+      {plan.control_channel_sensitive ? (
+        <Callout tone="warn">
+          This fix touches SSH, networking, PAM or firewall state. Kensa arms a timer before
+          applying it, so the change reverts by itself if the host stops answering. That is what
+          stops a hardening fix from locking you out of the host you are hardening.
+        </Callout>
+      ) : null}
+      {plan.transactional === false ? (
+        <Callout tone="warn">
+          This rule is not all-or-nothing. If a later step fails, earlier ones stay applied.
+        </Callout>
+      ) : null}
+      {warnings.map((w) => (
+        <Callout key={w} tone="warn">
+          {w}
+        </Callout>
+      ))}
+
+      <PlanSection title="What it will change" items={steps} empty="No apply steps." />
+      <PlanSection title="How it will be checked" items={checks} empty="No validators." />
+      <PlanSection
+        title={`How it can be undone (${plan.reversible_steps} of ${steps.length} reversible)`}
+        items={undo}
+        empty="This fix cannot be rolled back."
+      />
+
+      {plan.estimated_seconds ? (
+        <div style={{ fontSize: 11, color: 'var(--ow-fg-3)' }}>
+          Estimated {Math.round(plan.estimated_seconds)}s.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type PlanItem = {
+  index?: number;
+  mechanism?: string;
+  name?: string;
+  summary?: string;
+  capturable?: boolean;
+};
+
+function PlanSection({ title, items, empty }: { title: string; items: PlanItem[]; empty: string }) {
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ow-fg-0)', marginBottom: 6 }}>
+        {title}
+      </div>
+      {items.length === 0 ? (
+        <div style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>{empty}</div>
+      ) : (
+        <ol
+          style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 6 }}
+        >
+          {items.map((it, i) => (
+            <li key={`${it.mechanism ?? it.name ?? i}-${i}`} style={{ fontSize: 12 }}>
+              {/* Kensa's own words. If a handler gave no summary we show the
+                  mechanism rather than inventing a description of it. */}
+              <span style={{ color: 'var(--ow-fg-1)' }}>
+                {it.summary ?? it.mechanism ?? it.name}
+              </span>
+              {it.summary && (it.mechanism || it.name) ? (
+                <span
+                  style={{
+                    color: 'var(--ow-fg-3)',
+                    fontFamily: 'var(--ow-font-mono)',
+                    fontSize: 11,
+                    marginLeft: 8,
+                  }}
+                >
+                  {it.mechanism ?? it.name}
+                </span>
+              ) : null}
+              {it.capturable === false ? (
+                <span style={{ color: 'var(--ow-warn)', fontSize: 11, marginLeft: 8 }}>
+                  not reversible
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function Callout({ children, tone }: { children: React.ReactNode; tone: 'warn' }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 8,
+        alignItems: 'flex-start',
+        fontSize: 12,
+        lineHeight: 1.5,
+        color: 'var(--ow-fg-1)',
+        background: 'var(--ow-bg-2)',
+        border: '1px solid var(--ow-line)',
+        borderLeft: `3px solid var(--ow-${tone})`,
+        borderRadius: 'var(--ow-radius-sm, 6px)',
+        padding: '8px 10px',
+      }}
+    >
+      <AlertTriangle size={13} style={{ color: `var(--ow-${tone})`, marginTop: 2 }} aria-hidden />
+      <span>{children}</span>
     </div>
   );
 }

--- a/frontend/src/hooks/useRemediationSteps.ts
+++ b/frontend/src/hooks/useRemediationSteps.ts
@@ -85,3 +85,48 @@ export function phaseNote(phase: RemediationPhase): string | null {
   }
   return null;
 }
+
+// useRemediationPlan previews what a fix would do, before it does it.
+//
+// Fetched only when a row is expanded AND has no transaction yet, because
+// planning reaches the host over SSH: it is a live call, not a cached read. A
+// remembered plan would describe a host that has since moved on, which is the
+// same staleness Kensa's PlanStaleError exists to prevent on the execute side.
+//
+// Deliberately no retry. A failed plan means the host could not be reached or
+// authenticated, and hammering it on a schedule helps nobody.
+export interface RemediationPlanView {
+  plan: components['schemas']['RemediationPlan'] | null;
+  isPending: boolean;
+  isError: boolean;
+  error: string | null;
+}
+
+export function useRemediationPlan(
+  hostId: string,
+  requestId: string,
+  enabled: boolean,
+): RemediationPlanView {
+  const q = useQuery({
+    queryKey: ['host', hostId, 'remediation', requestId, 'plan'],
+    enabled,
+    retry: false,
+    staleTime: 0,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/remediation/requests/{rid}/plan', {
+        params: { path: { rid: requestId } },
+      });
+      if (error) {
+        throw new Error(apiErrorMessage(error, `Could not plan this fix (${response.status})`));
+      }
+      return data ?? null;
+    },
+  });
+
+  return {
+    plan: q.data ?? null,
+    isPending: q.isPending,
+    isError: q.isError,
+    error: q.isError ? apiErrorMessage(q.error, 'Could not plan this fix.') : null,
+  };
+}

--- a/frontend/tests/components/remediation-plan.test.ts
+++ b/frontend/tests/components/remediation-plan.test.ts
@@ -1,0 +1,66 @@
+// @spec frontend-remediation-tab
+//
+//   AC-10  a request that has not run shows what the fix would do
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+const journal = read('src/components/hosts/RemediationJournal.tsx');
+const hooks = read('src/hooks/useRemediationSteps.ts');
+
+describe('frontend-remediation-tab AC-10 - preview before the fix runs', () => {
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - an unexecuted request shows the plan, not an empty panel', () => {
+    // The old behaviour was a bare "No transaction yet". Deciding whether to
+    // approve a fix needs what it WILL do, not only what it did.
+    expect(journal).toContain('<PlanPreview');
+    expect(journal).toMatch(/What it will change/);
+    expect(journal).toMatch(/How it will be checked/);
+    expect(journal).toMatch(/How it can be undone/);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - control-channel risk is stated as a consequence', () => {
+    // Naming the flag tells an operator nothing. What matters is that the
+    // change undoes itself if the host stops answering, which is the
+    // difference between a risky fix and one that can strand you.
+    expect(journal).toMatch(/reverts by itself if the host stops answering/i);
+    expect(journal).not.toMatch(/control_channel_sensitive is true/i);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - a non-transactional rule warns that earlier steps stay applied', () => {
+    expect(journal).toMatch(/earlier ones stay applied/i);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - a planning failure says nothing was changed', () => {
+    // First question on seeing an error next to a Fix button is whether it
+    // half-ran. Answer it without being asked.
+    expect(journal).toMatch(/Nothing was changed on the host/i);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - the plan is live, never cached or retried', () => {
+    // A remembered plan describes a host that has since moved on, and
+    // retrying a failed plan hammers a host that is already not answering.
+    expect(hooks).toMatch(/staleTime:\s*0/);
+    expect(hooks).toMatch(/retry:\s*false/);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - Kensa summaries are shown verbatim, not restated', () => {
+    // Falls back to the mechanism when a handler gave no summary rather than
+    // inventing a description of it.
+    expect(journal).toContain('it.summary ?? it.mechanism ?? it.name');
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - no em dashes in the copy', () => {
+    expect(journal).not.toMatch(/—/);
+    expect(hooks).not.toMatch(/—/);
+  });
+});

--- a/internal/db/migrations/0056_remediation_kensa_version.sql
+++ b/internal/db/migrations/0056_remediation_kensa_version.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Stamp each recorded transaction with the Kensa version that produced it.
+--
+-- Needed before the pre-state summary lands, not after. Kensa's describer
+-- output carries NO stability guarantee: it is not semver-frozen, not
+-- parseable, and may change in any release including a patch. OpenWatch will
+-- persist those summaries at ingest, so a release that CORRECTS a describer
+-- leaves stale and possibly wrong strings in this table with nothing marking
+-- them stale. A summary that was wrong and got fixed upstream is worse than
+-- one that was never there.
+--
+-- With the version recorded, a re-backfill after a Kensa bump targets only the
+-- rows a describer change actually affected. Without it the only options are
+-- re-running over all history or silently keeping stale text. Agreed with
+-- kensa-agent on features/KN-OW-016; cheap now, a migration later.
+ALTER TABLE remediation_transactions
+    ADD COLUMN IF NOT EXISTS kensa_version TEXT;
+
+COMMENT ON COLUMN remediation_transactions.kensa_version IS
+    'Kensa version that produced this transaction. Scopes a re-backfill of derived display strings, whose output is explicitly not stable across releases.';
+
+-- +goose Down
+ALTER TABLE remediation_transactions DROP COLUMN IF EXISTS kensa_version;

--- a/internal/kensa/planfunc.go
+++ b/internal/kensa/planfunc.go
@@ -1,0 +1,134 @@
+package kensa
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	kensaapi "github.com/Hanalyx/kensa/api"
+	"github.com/google/uuid"
+)
+
+// PlanFunc previews what remediating one rule on one host would do, without
+// changing anything.
+//
+// This is the half of the operator's question that the transaction journal
+// cannot answer. The journal explains a fix after it ran; a plan explains one
+// before it does. Kensa's Plan connects to the host, captures pre-state and
+// returns the apply steps, the validators and the rollback plan, all read-only.
+type PlanFunc func(ctx context.Context, hostID uuid.UUID, ruleID string) (*RemediationPlan, FailureReason, error)
+
+// RemediationPlan is the OpenWatch-side view of a kensa Plan.
+//
+// Everything here is already human-readable in the Kensa contract:
+// StepPreview.Summary is documented with the example "Set PermitRootLogin=no
+// in sshd_config.d/00-kensa.conf". The one thing that is not is PreStates,
+// whose Data is mechanism-specific and opaque, so the captured values are
+// deliberately absent until pkg/kensa.DescribePreState lands
+// (features/KN-OW-016). Showing which steps captured something is honest;
+// guessing at what it means is not.
+type RemediationPlan struct {
+	PlanID  uuid.UUID
+	RuleID  string
+	Steps   []PlanStep
+	Checks  []PlanCheck
+	Undo    []PlanUndo
+	CanUndo int
+	// Warnings are Kensa's own operator-facing notices, e.g. that the rule is
+	// transactional:false and therefore cannot be rolled back as a unit.
+	Warnings []string
+	// Transactional is false when the rule's steps are not all-or-nothing.
+	Transactional bool
+	// ControlChannelSensitive is true when a step touches SSH, networking, PAM
+	// or firewall state. Kensa arms a deadman timer before applying such a
+	// transaction, which is the difference between a risky fix and one that
+	// can lock the operator out of the host they are fixing.
+	ControlChannelSensitive bool
+	EstimatedSeconds        float64
+	CapturedAt              time.Time
+}
+
+// PlanStep is one apply step that would run.
+type PlanStep struct {
+	Index      int
+	Mechanism  string
+	Summary    string
+	Capturable bool
+}
+
+// PlanCheck is one validator that would run after apply.
+type PlanCheck struct {
+	Name    string
+	Summary string
+}
+
+// PlanUndo is how one apply step would be reversed.
+type PlanUndo struct {
+	Index     int
+	Mechanism string
+	Summary   string
+}
+
+// planService is the slice of kensa's surface the plan closure consumes.
+type planService interface {
+	Plan(ctx context.Context, host kensaapi.HostConfig, rule *kensaapi.Rule) (*kensaapi.Plan, error)
+}
+
+func makePlan(deps RemediateFuncDeps, corpus *corpusCache, svc planService) PlanFunc {
+	return func(ctx context.Context, hostID uuid.UUID, ruleID string) (*RemediationPlan, FailureReason, error) {
+		target, err := loadScanHost(ctx, deps.Pool, hostID)
+		if err != nil {
+			return nil, ReasonKensaError, err
+		}
+		rule := findRule(corpus.current(ctx, deps.Variables), ruleID)
+		if rule == nil {
+			return nil, ReasonKensaError, fmt.Errorf("kensa: rule %q not in corpus", ruleID)
+		}
+		p, err := svc.Plan(ctx, target.hostConfig(hostID), rule)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, "", err
+			}
+			// Planning reaches the host over SSH, so it fails the same ways a
+			// scan does: unreachable, auth, sudo. Reuse that classification
+			// rather than reporting every failure as an engine fault.
+			return nil, classifyScanError(err), err
+		}
+		return mapPlan(p, ruleID), "", nil
+	}
+}
+
+func mapPlan(p *kensaapi.Plan, ruleID string) *RemediationPlan {
+	out := &RemediationPlan{
+		PlanID:                  p.ID,
+		RuleID:                  ruleID,
+		Warnings:                p.Warnings,
+		Transactional:           p.Transactional,
+		ControlChannelSensitive: p.ControlChannelSensitive,
+		EstimatedSeconds:        p.EstimatedDuration.Seconds(),
+		CapturedAt:              p.CreatedAt,
+	}
+	for _, s := range p.ApplySteps {
+		out.Steps = append(out.Steps, PlanStep{
+			Index: s.Index, Mechanism: s.Mechanism,
+			Summary: s.Summary, Capturable: s.Capturable,
+		})
+	}
+	for _, v := range p.Validators {
+		out.Checks = append(out.Checks, PlanCheck{Name: v.Name, Summary: v.Summary})
+	}
+	for _, r := range p.RollbackPlan {
+		out.Undo = append(out.Undo, PlanUndo{
+			Index: r.Index, Mechanism: r.Mechanism, Summary: r.Summary,
+		})
+	}
+	// How much of this fix is reversible, counted from what Kensa captured
+	// rather than from the rule's own claim about itself.
+	for _, ps := range p.PreStates {
+		if ps.Capturable {
+			out.CanUndo++
+		}
+	}
+	return out
+}

--- a/internal/kensa/remediatefunc.go
+++ b/internal/kensa/remediatefunc.go
@@ -147,11 +147,18 @@ type RemediateFuncDeps struct {
 
 // NewProductionRemediateFunc loads the rule corpus and composes the full Kensa
 // service over our credential-resolved, APPLY-enabled TransportFactory,
-// returning the remediate + rollback closures the worker binds.
-func NewProductionRemediateFunc(ctx context.Context, deps RemediateFuncDeps) (RemediateFunc, RollbackFunc, error) {
+// returning the remediate + rollback closures the worker binds and the plan
+// closure the API serves.
+//
+// The plan closure shares this composition rather than getting its own. It is
+// read-only, so it does not need the apply-enabled transport, but capture reads
+// root-owned state and therefore needs the same credential resolution and sudo
+// policy. One composition with three closures beats two services that must be
+// kept in agreement about how to reach a host.
+func NewProductionRemediateFunc(ctx context.Context, deps RemediateFuncDeps) (RemediateFunc, RollbackFunc, PlanFunc, error) {
 	rules, err := pkgkensa.LoadRules(deps.RulesDir, nil, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("kensa: load rule corpus: %w", err)
+		return nil, nil, nil, fmt.Errorf("kensa: load rule corpus: %w", err)
 	}
 	corpus := &corpusCache{rules: rules, dir: deps.RulesDir}
 	factory := &TransportFactory{
@@ -166,9 +173,10 @@ func NewProductionRemediateFunc(ctx context.Context, deps RemediateFuncDeps) (Re
 	}
 	svc, err := pkgkensa.DefaultWithTransportFactory(ctx, deps.StorePath, factory)
 	if err != nil {
-		return nil, nil, fmt.Errorf("kensa: compose remediation service: %w", err)
+		return nil, nil, nil, fmt.Errorf("kensa: compose remediation service: %w", err)
 	}
-	return makeRemediate(deps, corpus, svc), makeRollback(deps, svc), nil
+	return makeRemediate(deps, corpus, svc), makeRollback(deps, svc),
+		makePlan(deps, corpus, svc), nil
 }
 
 func makeRemediate(deps RemediateFuncDeps, corpus *corpusCache, svc remediateService) RemediateFunc {

--- a/internal/remediation/execution.go
+++ b/internal/remediation/execution.go
@@ -170,10 +170,10 @@ func (s *Service) RecordExecution(ctx context.Context, id uuid.UUID, ruleID stri
 				INSERT INTO remediation_transactions
 					(id, request_id, ordinal, rule_id, kensa_txn_id,
 					 mechanism, phase_result, evidence, steps, pre_state,
-					 dry_run, applied_at)
-				VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,false,now())`,
+					 kensa_version, dry_run, applied_at)
+				VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,$11,false,now())`,
 				txnID, id, i, ruleID, t.TxnID.String(), nullIfEmpty(t.Mechanism),
-				phase, ev, steps, pre); err != nil {
+				phase, ev, steps, pre, nullIfEmpty(t.KensaVersion)); err != nil {
 				return Request{}, fmt.Errorf("remediation: insert journal: %w", err)
 			}
 		}

--- a/internal/remediation/types.go
+++ b/internal/remediation/types.go
@@ -187,6 +187,12 @@ type ExecTxn struct {
 	// remediation_transactions.mechanism, another column that existed and was
 	// never populated.
 	Mechanism string
+	// KensaVersion is the engine version that produced this transaction.
+	// Recorded so a re-backfill of derived display strings can be scoped to
+	// the rows a describer change affected: Kensa states plainly that
+	// describer output is not stable across releases, so persisted summaries
+	// go stale silently without it. See features/KN-OW-016.
+	KensaVersion string
 	// Err is the transaction error string, empty on success.
 	Err string
 	// HostUnchanged mirrors api.TransactionResult.HostUnchanged: true if and

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -3206,6 +3206,54 @@ type RemediationPhase struct {
 	Success  bool `json:"success"`
 }
 
+// RemediationPlan What remediating one rule on one host would do. Produced by Kensa
+// without mutating the host.
+type RemediationPlan struct {
+	CapturedAt *time.Time `json:"captured_at,omitempty"`
+
+	// Checks The validators that would run after apply.
+	Checks []struct {
+		Name    string  `json:"name"`
+		Summary *string `json:"summary,omitempty"`
+	} `json:"checks"`
+
+	// ControlChannelSensitive True when a step touches SSH, networking, PAM or firewall state.
+	// Kensa arms a deadman timer before applying such a transaction, so
+	// a fix that could lock you out reverts itself if you lose contact.
+	ControlChannelSensitive bool                `json:"control_channel_sensitive"`
+	EstimatedSeconds        *float32            `json:"estimated_seconds,omitempty"`
+	PlanId                  *openapi_types.UUID `json:"plan_id,omitempty"`
+
+	// ReversibleSteps How many steps Kensa actually captured pre-state for, counted from
+	// the capture rather than from the rule's own claim about itself.
+	ReversibleSteps int    `json:"reversible_steps"`
+	RuleId          string `json:"rule_id"`
+
+	// Steps The apply steps that would run, in order.
+	Steps []RemediationPlanStep `json:"steps"`
+
+	// Transactional False when the steps are not all-or-nothing.
+	Transactional bool `json:"transactional"`
+
+	// Undo How each applied step would be reversed. Rollback runs this in
+	// reverse order.
+	Undo []RemediationPlanStep `json:"undo"`
+
+	// Warnings Kensa's own operator-facing notices about this plan.
+	Warnings *[]string `json:"warnings,omitempty"`
+}
+
+// RemediationPlanStep defines model for RemediationPlanStep.
+type RemediationPlanStep struct {
+	// Capturable False when this step cannot be reversed.
+	Capturable *bool  `json:"capturable,omitempty"`
+	Index      int    `json:"index"`
+	Mechanism  string `json:"mechanism"`
+
+	// Summary Kensa's human-readable description of the action.
+	Summary *string `json:"summary,omitempty"`
+}
+
 // RemediationPreState One phase's captured pre-change state.
 //
 // `data` is mechanism-specific and is passed through from Kensa without
@@ -4584,6 +4632,9 @@ type ServerInterface interface {
 	// Get a remediation request
 	// (GET /api/v1/remediation/requests/{rid})
 	GetRemediationRequest(w http.ResponseWriter, r *http.Request, rid openapi_types.UUID)
+	// Preview what a remediation would do, without changing the host
+	// (GET /api/v1/remediation/requests/{rid}/plan)
+	GetRemediationPlan(w http.ResponseWriter, r *http.Request, rid openapi_types.UUID)
 	// List a remediation request's transaction journal (steps)
 	// (GET /api/v1/remediation/requests/{rid}/steps)
 	ListRemediationSteps(w http.ResponseWriter, r *http.Request, rid openapi_types.UUID)
@@ -5355,6 +5406,12 @@ func (_ Unimplemented) RequestRemediation(w http.ResponseWriter, r *http.Request
 // Get a remediation request
 // (GET /api/v1/remediation/requests/{rid})
 func (_ Unimplemented) GetRemediationRequest(w http.ResponseWriter, r *http.Request, rid openapi_types.UUID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Preview what a remediation would do, without changing the host
+// (GET /api/v1/remediation/requests/{rid}/plan)
+func (_ Unimplemented) GetRemediationPlan(w http.ResponseWriter, r *http.Request, rid openapi_types.UUID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -8917,6 +8974,32 @@ func (siw *ServerInterfaceWrapper) GetRemediationRequest(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
+// GetRemediationPlan operation middleware
+func (siw *ServerInterfaceWrapper) GetRemediationPlan(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "rid" -------------
+	var rid openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "rid", chi.URLParam(r, "rid"), &rid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "rid", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetRemediationPlan(w, r, rid)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // ListRemediationSteps operation middleware
 func (siw *ServerInterfaceWrapper) ListRemediationSteps(w http.ResponseWriter, r *http.Request) {
 
@@ -10542,6 +10625,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/remediation/requests/{rid}", wrapper.GetRemediationRequest)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/remediation/requests/{rid}/plan", wrapper.GetRemediationPlan)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/v1/remediation/requests/{rid}/steps", wrapper.ListRemediationSteps)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -98,6 +98,11 @@ type handlers struct {
 	// projected lift). Set via (*Server).WithRemediation; nil makes the
 	// remediation endpoints 503. Spec api-remediation.
 	remediationSvc *remediation.Service
+	// remediationPlan previews what a fix would do, without changing the host.
+	// Nil when the Kensa rule corpus is unavailable, which makes the plan
+	// endpoint 503 rather than pretending the preview is empty. Spec
+	// api-remediation.
+	remediationPlan kensa.PlanFunc
 
 	// Host group service (sites + OS categories). Set via
 	// (*Server).WithGroups; nil makes the group endpoints 503.

--- a/internal/server/plan_handler_test.go
+++ b/internal/server/plan_handler_test.go
@@ -1,0 +1,81 @@
+// @spec api-remediation
+//
+//	AC-13  TestRemediationPlan_FailsHonestly
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// @ac AC-13
+// AC-13: the plan endpoint fails honestly rather than emptily.
+//
+// The two failure modes matter more than the success path. A missing rule
+// corpus must not render as a plan with no steps: an operator reads that as
+// "this fix does nothing" and approves it. And a host that cannot be reached
+// must say so, because planning touches the host and its failures belong to
+// the host, not to the fix.
+func TestRemediationPlan_FailsHonestly(t *testing.T) {
+	t.Run("api-remediation/AC-13", func(t *testing.T) {
+		b, err := os.ReadFile("remediation_handlers.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := string(b)
+
+		i := strings.Index(src, "func (h *handlers) GetRemediationPlan")
+		if i < 0 {
+			t.Fatal("GetRemediationPlan has moved; this check is stale")
+		}
+		body := src[i:]
+		if end := strings.Index(body, "\n// planFailureMessage"); end > 0 {
+			body = body[:end]
+		}
+
+		// A missing corpus is 503, never a 200 with an empty plan.
+		if !strings.Contains(body, "h.remediationPlan == nil") ||
+			!strings.Contains(body, "StatusServiceUnavailable") {
+			t.Error("an absent plan closure must return 503, not an empty plan")
+		}
+		// The host's failure is reported as the host's.
+		if !strings.Contains(body, "StatusBadGateway") ||
+			!strings.Contains(body, "planFailureMessage") {
+			t.Error("a planning failure must return 502 naming the cause")
+		}
+		// Permission gate, same as the rest of the remediation surface.
+		if !strings.Contains(body, "auth.RemediationRead") {
+			t.Error("the plan endpoint must enforce remediation:read")
+		}
+		// Uncached by construction: no store, no memo, no TTL in the handler.
+		for _, bad := range []string{"cache", "memo", "ttl"} {
+			if strings.Contains(strings.ToLower(body), bad) {
+				t.Errorf("the plan must be live; found %q in the handler", bad)
+			}
+		}
+
+		// Every reason branch has to produce operator-actionable text, not an
+		// enum name echoed back.
+		msg := src[strings.Index(src, "func planFailureMessage"):]
+		if end := strings.Index(msg, "\nfunc "); end > 0 {
+			msg = msg[:end]
+		}
+		// One plain explanation per reason Kensa actually reports. There is no
+		// ReasonUnreachable constant, so an unreachable host lands in the
+		// default branch carrying the wrapped error, which names it.
+		for _, want := range []string{
+			"not trusted",            // ReasonHostKeyUnknown
+			"could not be decrypted", // ReasonCredentialDecryptionFailed
+			"already running",        // ReasonHostBusy
+			"timed out",              // ReasonTimeout
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("planFailureMessage lacks a plain explanation for %q", want)
+			}
+		}
+		if !strings.Contains(msg, "could not plan against the host: ") {
+			t.Error("the default branch must carry the underlying error, not swallow it")
+		}
+	})
+}

--- a/internal/server/remediation_handlers.go
+++ b/internal/server/remediation_handlers.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/Hanalyx/openwatch/internal/kensa"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -27,6 +26,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/audit"
 	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/host"
+	"github.com/Hanalyx/openwatch/internal/kensa"
 	"github.com/Hanalyx/openwatch/internal/queue"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/server/api"

--- a/internal/server/remediation_handlers.go
+++ b/internal/server/remediation_handlers.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/Hanalyx/openwatch/internal/kensa"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -462,4 +463,126 @@ func (h *handlers) emitRemediationActQueued(ctx context.Context, r *http.Request
 		ResourceID:   rq.ID.String(),
 		Detail:       detail,
 	})
+}
+
+// GetRemediationPlan previews what a request's fix would do, without changing
+// the host.
+//
+// Live and uncached on purpose. A plan describes the host as it is now, and a
+// remembered preview is worse than none: it would show an operator a state the
+// host has since left, which is exactly the mistake Kensa's PlanStaleError
+// exists to prevent on the execute side.
+func (h *handlers) GetRemediationPlan(w http.ResponseWriter, r *http.Request, rid openapitypes.UUID) {
+	if denied := auth.EnforcePermission(w, r, auth.RemediationRead); denied {
+		return
+	}
+	if !h.remediationSvcReady(w) {
+		return
+	}
+	ctx := r.Context()
+	req, err := h.remediationSvc.Get(ctx, uuid.UUID(rid))
+	if mapRemediationErr(w, err) {
+		return
+	}
+	if h.remediationPlan == nil {
+		// Not an empty plan. An empty preview reads as "this fix does
+		// nothing", which is a different and much worse claim than "we cannot
+		// tell you yet".
+		writeError(w, http.StatusServiceUnavailable, "remediation.plan_unavailable", "server",
+			"planning needs the Kensa rule corpus, which is not loaded on this deployment", false)
+		return
+	}
+
+	plan, reason, planErr := h.remediationPlan(ctx, req.HostID, req.RuleID)
+	if planErr != nil {
+		// Planning reaches the host, so its failures are the host's, not the
+		// server's. Name which one rather than returning a bare 502.
+		writeError(w, http.StatusBadGateway, "remediation.plan_failed", "server",
+			planFailureMessage(reason, planErr), true)
+		return
+	}
+	writeJSON(w, http.StatusOK, toAPIPlan(plan))
+}
+
+// planFailureMessage turns a Kensa failure reason into something an operator
+// can act on. The reasons are the same ones a scan reports, because planning
+// takes the same path to the host.
+func planFailureMessage(reason kensa.FailureReason, err error) string {
+	switch reason {
+	case kensa.ReasonHostKeyUnknown:
+		return "the host's SSH key is not trusted yet, so planning could not connect"
+	case kensa.ReasonCredentialDecryptionFailed:
+		return "the stored credential for this host could not be decrypted"
+	case kensa.ReasonHostBusy:
+		return "the host is already running a scan or remediation; try again shortly"
+	case kensa.ReasonTimeout:
+		return "planning timed out reaching the host, so its current state is unknown"
+	default:
+		// Includes ReasonKensaError. Planning reads root-owned state over
+		// SSH, so an unreachable host, a refused login and a refused sudo all
+		// land here; the wrapped error carries which.
+		return "could not plan against the host: " + err.Error()
+	}
+}
+
+func toAPIPlan(p *kensa.RemediationPlan) api.RemediationPlan {
+	out := api.RemediationPlan{
+		RuleId:                  p.RuleID,
+		Transactional:           p.Transactional,
+		ControlChannelSensitive: p.ControlChannelSensitive,
+		ReversibleSteps:         p.CanUndo,
+		Steps:                   []api.RemediationPlanStep{},
+		Undo:                    []api.RemediationPlanStep{},
+		Checks: []struct {
+			Name    string  `json:"name"`
+			Summary *string `json:"summary,omitempty"`
+		}{},
+	}
+	if p.PlanID != uuid.Nil {
+		id := openapitypes.UUID(p.PlanID)
+		out.PlanId = &id
+	}
+	for _, s := range p.Steps {
+		out.Steps = append(out.Steps, planStep(s.Index, s.Mechanism, s.Summary, &s.Capturable))
+	}
+	for _, u := range p.Undo {
+		out.Undo = append(out.Undo, planStep(u.Index, u.Mechanism, u.Summary, nil))
+	}
+	for _, c := range p.Checks {
+		item := struct {
+			Name    string  `json:"name"`
+			Summary *string `json:"summary,omitempty"`
+		}{Name: c.Name}
+		if c.Summary != "" {
+			sum := c.Summary
+			item.Summary = &sum
+		}
+		out.Checks = append(out.Checks, item)
+	}
+	if len(p.Warnings) > 0 {
+		wrn := p.Warnings
+		out.Warnings = &wrn
+	}
+	if p.EstimatedSeconds > 0 {
+		est := float32(p.EstimatedSeconds)
+		out.EstimatedSeconds = &est
+	}
+	if !p.CapturedAt.IsZero() {
+		at := p.CapturedAt
+		out.CapturedAt = &at
+	}
+	return out
+}
+
+func planStep(index int, mechanism, summary string, capturable *bool) api.RemediationPlanStep {
+	step := api.RemediationPlanStep{Index: index, Mechanism: mechanism}
+	if summary != "" {
+		s := summary
+		step.Summary = &s
+	}
+	if capturable != nil {
+		c := *capturable
+		step.Capturable = &c
+	}
+	return step
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -150,6 +150,15 @@ func (s *Server) WithRemediation(rm *remediation.Service) *Server {
 	return s
 }
 
+// WithRemediationPlan threads the read-only plan closure into the API handlers
+// so a request can be previewed before it is approved. Nil leaves the endpoint
+// 503, which is the honest answer when the rule corpus is missing: an empty
+// preview would read as "this fix does nothing". Spec api-remediation.
+func (s *Server) WithRemediationPlan(p kensa.PlanFunc) *Server {
+	s.handlers.remediationPlan = p
+	return s
+}
+
 // WithGroups threads the host group service (sites + OS categories)
 // into the API handlers so /api/v1/groups and its sub-routes are
 // routable. Nil makes the group endpoints 503. Spec api-groups.

--- a/internal/worker/remediation_worker.go
+++ b/internal/worker/remediation_worker.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Hanalyx/openwatch/internal/version"
 	"log/slog"
 	"time"
 
@@ -42,6 +41,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/queue"
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/transactionlog"
+	"github.com/Hanalyx/openwatch/internal/version"
 )
 
 // RemediationWorker processes "remediation" queue jobs. One per process,

--- a/internal/worker/remediation_worker.go
+++ b/internal/worker/remediation_worker.go
@@ -29,6 +29,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/Hanalyx/openwatch/internal/version"
 	"log/slog"
 	"time"
 
@@ -467,6 +468,7 @@ func mapExecTxns(in []kensa.RemediationTxn) []remediation.ExecTxn {
 				e.PreState = b
 			}
 		}
+		e.KensaVersion = version.Kensa()
 		out = append(out, e)
 	}
 	return out

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-remediation
   title: Remediation governance - request/approve lifecycle, projected lift, and queued single-rule execute/rollback (OpenWatch Core, free)
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 1
 
@@ -216,5 +216,19 @@ spec:
         never to a success-shaped outcome). This is the guard that the Kensa
         v0.8.0 staged status defeated: a default branch absorbed a new
         terminal state and reported a mutated host as unchanged.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-13
+      description: >
+        The plan endpoint previews a fix without changing the host, and fails
+        honestly. It is live and uncached, because a remembered plan describes
+        a host that has since moved on. When the rule corpus is absent it
+        returns 503 rather than an empty plan, since an empty preview reads as
+        "this fix does nothing", which is a different and worse claim than "we
+        cannot tell you yet". When the host cannot be planned against it
+        returns 502 naming the cause rather than a bare failure. The response
+        carries Kensa's own step, validator and rollback summaries verbatim,
+        the count of steps that actually captured pre-state, and the
+        control-channel-sensitive flag.
       priority: critical
       references_constraints: [C-09]

--- a/specs/frontend/remediation-tab.spec.yaml
+++ b/specs/frontend/remediation-tab.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-remediation-tab
   title: Host detail Remediation tab + per-rule request/apply affordance
-  version: "1.3.0"
+  version: "1.4.0"
   status: approved
   tier: 2
 
@@ -136,5 +136,18 @@ spec:
         it as a failure would train operators to distrust the safety net.
         not_applied likewise renders neutral. partially_applied renders
         critical, because that host needs a human.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-10
+      description: >
+        A request that has not executed shows what the fix WOULD do instead of
+        an empty panel: the apply steps, the validators, and how it can be
+        undone, in Kensa's own words. A control-channel-sensitive plan is
+        called out in terms of the consequence, that the change reverts itself
+        if the host stops answering, rather than by naming the flag. A
+        non-transactional rule warns that earlier steps stay applied if a later
+        one fails. A planning failure states that nothing was changed on the
+        host, because the operator's first question on seeing an error next to
+        a fix button is whether it half-ran.
       priority: critical
       references_constraints: [C-04]


### PR DESCRIPTION
Answers the half of the operator's question the journal cannot: **what will this
fix do, before it does it.** An approved-but-unexecuted request showed "No
transaction yet" and nothing else.

## It needs nothing from Kensa

Worth stating up front, because I said the opposite earlier in the thread and
was wrong. `Plan` is implemented in v0.8.0 (`internal/engine/plan.go`, with its
own tests), and every string in the preview is already human-readable in the
contract:

| Field | What it gives the operator |
|---|---|
| `ApplySteps[].Summary` | handler-authored, e.g. *"Set PermitRootLogin=no in sshd_config.d/00-kensa.conf"* |
| `Validators[].Summary` | how the fix will be checked |
| `RollbackPlan[]` | how each step would be reversed |
| `Warnings[]` | Kensa's own operator-facing notices |
| `ControlChannelSensitive` | touches SSH/networking/PAM/firewall; deadman armed |
| `EstimatedDuration`, `Transactional` | cost and all-or-nothing |

Only the captured **values** wait on `KN-OW-016`, and they are deliberately
absent rather than guessed at. (`Plan.Preview()` *is* a stub, so we read the
struct fields instead of calling it.)

## Two failure modes, designed before the success path

**A missing rule corpus returns 503, never a 200 with an empty plan.** An
operator reads an empty preview as "this fix does nothing" and approves it.
That is a different and much worse claim than "we cannot tell you yet."

**A host that cannot be planned against returns 502 naming the cause,** and the
UI says *nothing was changed on the host*. The first question on seeing an error
beside a Fix button is whether it half-ran; answer it without being asked.

The plan is **live and uncached**, and never retried. A remembered plan
describes a host that has since moved on - the staleness `PlanStaleError` exists
to prevent on the execute side - and retrying hammers a host already not
answering.

## Risk stated as consequence, not as flag names

> This fix touches SSH, networking, PAM or firewall state. Kensa arms a timer
> before applying it, so the change reverts by itself if the host stops
> answering. That is what stops a hardening fix from locking you out of the host
> you are hardening.

A test asserts the copy says that and does **not** say "control_channel_sensitive
is true".

## Also lands the version column (0056)

Folded in as agreed. Kensa states plainly that describer output carries **no
stability guarantee** - not semver-frozen, may change in a patch. Once we
persist pre-state summaries, a release that *corrects* a describer leaves stale
and possibly wrong text in our database with nothing marking it stale. Recording
`kensa_version` per transaction scopes a re-backfill to the rows a describer
change actually affected. Cheap now, a migration later.

## Verification

`api-remediation` 1.3.0 -> 1.4.0 (AC-13), `frontend-remediation-tab` 1.3.0 ->
1.4.0 (AC-10), both at 100% coverage, both mutation-checked - softening the
control-channel copy to "completes normally" fails the frontend test.

While writing the handler test I asserted a `planFailureMessage` branch for an
unreachable host that does not exist: there is no `ReasonUnreachable` constant,
so unreachable lands in the default branch carrying the wrapped error. The test
now asserts the branches Kensa actually reports, plus that the default branch
does not swallow the underlying error.