### PR TITLE
fix(remediation): stop the plan preview claiming a fix is unverified

### DIFF
--- a/frontend/src/components/hosts/RemediationJournal.tsx
+++ b/frontend/src/components/hosts/RemediationJournal.tsx
@@ -269,18 +269,33 @@ function PlanPreview({ hostId, requestId }: { hostId: string; requestId: string 
       ))}
 
       <PlanSection title="What it will change" items={steps} empty="No apply steps." />
-      <PlanSection title="How it will be checked" items={checks} empty="No validators." />
+
+      {/* Stated from what the engine does, not from Plan.Validators, which the
+          planner leaves nil for every rule. Rendering that field's emptiness
+          printed an empty-validator line beside the button that
+          applies the fix, telling the operator nothing verifies it. Untrue: the rule's own check
+          re-runs after apply and a failure restores the capture. Filed as
+          features/KN-OW-017. */}
+      <div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ow-fg-0)', marginBottom: 6 }}>
+          How it will be checked
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--ow-fg-1)' }}>
+          After applying, this rule&apos;s own check runs again. If it does not pass, the captured
+          state is restored.
+        </div>
+      </div>
+
+      {checks.length > 0 ? (
+        <PlanSection title="Additional validators" items={checks} empty="" />
+      ) : null}
+
       <PlanSection
         title={`How it can be undone (${plan.reversible_steps} of ${steps.length} reversible)`}
         items={undo}
         empty="This fix cannot be rolled back."
+        dedupe
       />
-
-      {plan.estimated_seconds ? (
-        <div style={{ fontSize: 11, color: 'var(--ow-fg-3)' }}>
-          Estimated {Math.round(plan.estimated_seconds)}s.
-        </div>
-      ) : null}
     </div>
   );
 }
@@ -293,26 +308,45 @@ type PlanItem = {
   capturable?: boolean;
 };
 
-function PlanSection({ title, items, empty }: { title: string; items: PlanItem[]; empty: string }) {
+function PlanSection({
+  title,
+  items,
+  empty,
+  dedupe,
+}: {
+  title: string;
+  items: PlanItem[];
+  empty: string;
+  // dedupe collapses consecutive identical lines. Kensa builds each rollback
+  // summary from the mechanism alone, so a rule with two steps of the same
+  // mechanism produces the same sentence twice: two lines carrying one fact.
+  dedupe?: boolean;
+}) {
+  const shown = dedupe
+    ? items.filter((it, i) => i === 0 || it.summary !== items[i - 1]?.summary)
+    : items;
   return (
     <div>
       <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ow-fg-0)', marginBottom: 6 }}>
         {title}
       </div>
-      {items.length === 0 ? (
+      {shown.length === 0 ? (
         <div style={{ fontSize: 12, color: 'var(--ow-fg-3)' }}>{empty}</div>
       ) : (
         <ol
           style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 6 }}
         >
-          {items.map((it, i) => (
+          {shown.map((it, i) => (
             <li key={`${it.mechanism ?? it.name ?? i}-${i}`} style={{ fontSize: 12 }}>
               {/* Kensa's own words. If a handler gave no summary we show the
                   mechanism rather than inventing a description of it. */}
               <span style={{ color: 'var(--ow-fg-1)' }}>
                 {it.summary ?? it.mechanism ?? it.name}
               </span>
-              {it.summary && (it.mechanism || it.name) ? (
+              {/* Only when the summary does not already name it. Kensa's
+                  summaries lead with the mechanism, so this tag was repeating
+                  the first word of the sentence beside it. */}
+              {it.summary && it.mechanism && !it.summary.includes(it.mechanism) ? (
                 <span
                   style={{
                     color: 'var(--ow-fg-3)',
@@ -321,7 +355,7 @@ function PlanSection({ title, items, empty }: { title: string; items: PlanItem[]
                     marginLeft: 8,
                   }}
                 >
-                  {it.mechanism ?? it.name}
+                  {it.mechanism}
                 </span>
               ) : null}
               {it.capturable === false ? (

--- a/frontend/tests/components/remediation-plan.test.ts
+++ b/frontend/tests/components/remediation-plan.test.ts
@@ -13,6 +13,38 @@ const hooks = read('src/hooks/useRemediationSteps.ts');
 
 describe('frontend-remediation-tab AC-10 - preview before the fix runs', () => {
   // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - never claims a fix is unverified', () => {
+    // Plan.Validators is hardcoded nil in Kensa's planner, so rendering its
+    // emptiness printed "No validators" for EVERY rule, next to the button
+    // that applies the fix. That is false: the rule's own check re-runs after
+    // apply and a failure restores the capture. Filed as KN-OW-017.
+    expect(journal).not.toMatch(/No validators/);
+    expect(journal).toMatch(/own check runs again/i);
+    expect(journal).toMatch(/captured\s*\n?\s*state is restored|captured state is restored/i);
+    // Any real validators Kensa starts returning are shown as an addition,
+    // not as the answer to whether the fix is checked at all.
+    expect(journal).toMatch(/Additional validators/);
+    expect(journal).toMatch(/checks\.length > 0/);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - does not present a placeholder as an estimate', () => {
+    // EstimatedDuration is len(steps) * 2s in the planner: a constant, not a
+    // measurement. Rendering it as "Estimated 4s." implied precision that
+    // does not exist.
+    expect(journal).not.toMatch(/Estimated \{/);
+    expect(journal).not.toMatch(/estimated_seconds/);
+  });
+
+  // @ac AC-10
+  test('frontend-remediation-tab/AC-10 - identical rollback lines collapse', () => {
+    // Kensa builds each rollback summary from the mechanism alone, so a rule
+    // with two steps of one mechanism yields the same sentence twice.
+    expect(journal).toMatch(/dedupe/);
+    expect(journal).toMatch(/it\.summary !== items\[i - 1\]\?\.summary/);
+  });
+
+  // @ac AC-10
   test('frontend-remediation-tab/AC-10 - an unexecuted request shows the plan, not an empty panel', () => {
     // The old behaviour was a bare "No transaction yet". Deciding whether to
     // approve a fix needs what it WILL do, not only what it did.


### PR DESCRIPTION
Three defects found by looking at the shipped panel on a real host. The worst
is one I introduced by promising a section the data cannot fill.

## "No validators" was false, and would have said it forever

`api.Plan.Validators` is documented as *"describes the post-apply validators
that would run"*. Kensa's planner sets it unconditionally:

```go
// internal/engine/plan.go
Validators:              nil,
```

So the "How it will be checked" section reported that the rule had no
validators - for **every rule, always** - directly beside the button that
applies the fix.

It is not merely empty, it is **untrue**. Kensa's validate phase re-runs the
rule's own check and restores the capture when it fails. The panel told
operators nothing verifies a fix, on the one screen whose entire purpose is to
be trusted before a host is changed.

It now states what the engine actually does. If Kensa ever populates the field,
those render under "Additional validators" - an addition, not the answer to
whether the fix is checked at all.

Filed upstream as `features/KN-OW-017`: either populate the field or stop
promising it.

## "Estimated 4s" was a constant

```go
EstimatedDuration: time.Duration(len(txn.Steps)) * 2 * time.Second
```

Two steps times two seconds. Rendering it implied a measurement. Removed - a
wrong number is worse than no number here.

## Duplicate rollback lines

Kensa builds each rollback summary from the mechanism alone, so a rule with two
steps of one mechanism showed the same sentence twice. Consecutive identical
lines now collapse, and the mechanism tag is suppressed when the summary already
names it, which it always does.

## Verification

All three pinned by tests. The validators fix is mutation-checked: restoring the
old wording fails it. `frontend-remediation-tab` stays at 100%.

One thing worth noting about the test: it asserts the component never renders an
empty-validator claim, which initially failed against my own **code comment**
quoting the old string. Reworded the comment so the assertion tests the UI
rather than the commentary.

## Why this shape of bug keeps appearing

This is the same defect as the one fixed in #791, from the other side. There,
OpenWatch recorded `len(t.Steps)` and discarded the journal, so a failure could
only say "reverted, host unchanged". Here, a nil field with an affirmative doc
comment got rendered as a fact about the host. Both times a declared surface
silently carried nothing, and the consumer presented that emptiness as truth.