### PR TITLE
fix(remediation): stop offering a rollback for a fix that never ran

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/Hanalyx/kensa v0.8.0
+	github.com/Hanalyx/kensa v0.9.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-pdf/fpdf v0.9.0
@@ -43,6 +43,7 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Hanalyx/kensa v0.8.0 h1:H0KOY7F9vDA54fgz9jm3gd7/X/cW8tuXqJ9L7KT3ZtA=
-github.com/Hanalyx/kensa v0.8.0/go.mod h1:RuBtdJNBlr5cCT6O8LjQqwx9gRyR+owlAiwIQrB4TRk=
 github.com/Hanalyx/kensa v0.9.0 h1:nREms9TWDDNMZBwwBxRIlYw73rvdMwkghIaf4WQP49U=
 github.com/Hanalyx/kensa v0.9.0/go.mod h1:RuBtdJNBlr5cCT6O8LjQqwx9gRyR+owlAiwIQrB4TRk=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
@@ -138,8 +136,6 @@ golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
-google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Hanalyx/kensa v0.8.0 h1:H0KOY7F9vDA54fgz9jm3gd7/X/cW8tuXqJ9L7KT3ZtA=
 github.com/Hanalyx/kensa v0.8.0/go.mod h1:RuBtdJNBlr5cCT6O8LjQqwx9gRyR+owlAiwIQrB4TRk=
+github.com/Hanalyx/kensa v0.9.0 h1:nREms9TWDDNMZBwwBxRIlYw73rvdMwkghIaf4WQP49U=
+github.com/Hanalyx/kensa v0.9.0/go.mod h1:RuBtdJNBlr5cCT6O8LjQqwx9gRyR+owlAiwIQrB4TRk=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
@@ -136,6 +138,8 @@ golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/kensa/remediatefunc.go
+++ b/internal/kensa/remediatefunc.go
@@ -62,6 +62,18 @@ type RemediationTxn struct {
 	// HostUnchanged mirrors api.TransactionResult.HostUnchanged: true if and
 	// only if Kensa can prove the host is in its pre-transaction state.
 	HostUnchanged bool
+	// AlreadyCompliant mirrors api.TransactionResult.AlreadyCompliant: the
+	// rule's check passed BEFORE any apply, so nothing was changed. Kensa
+	// still reports Status=committed, which on its own is indistinguishable
+	// from a real remediation.
+	//
+	// SCOPE, from the field's godoc: this is meaningful on the REMEDIATION
+	// path only. Kensa leaves it false on the check-only entries in
+	// ScanResult.Transactions rather than extending that legacy overload, so
+	// "committed and not AlreadyCompliant" must NEVER be read as "the host was
+	// changed" against a scan result: every passing rule of a read-only check
+	// would satisfy it. mapTxns is called from the remediation path only.
+	AlreadyCompliant bool
 	// Steps is the per-phase journal Kensa returns. Until this existed the
 	// engine's own account of what it did was reduced to a step COUNT, so a
 	// failed remediation could report only "reverted, host unchanged" while
@@ -268,14 +280,15 @@ func mapTxns(in []kensaapi.TransactionResult) []RemediationTxn {
 	out := make([]RemediationTxn, 0, len(in))
 	for _, t := range in {
 		txn := RemediationTxn{
-			TxnID:         t.TransactionID,
-			Status:        string(t.Status),
-			Evidence:      txnEvidence(t),
-			HostUnchanged: t.HostUnchanged,
-			Steps:         mapSteps(t.Steps),
-			PreStates:     mapPreStates(t.PreStates),
-			StartedAt:     t.StartedAt,
-			FinishedAt:    t.FinishedAt,
+			TxnID:            t.TransactionID,
+			Status:           string(t.Status),
+			Evidence:         txnEvidence(t),
+			HostUnchanged:    t.HostUnchanged,
+			AlreadyCompliant: t.AlreadyCompliant,
+			Steps:            mapSteps(t.Steps),
+			PreStates:        mapPreStates(t.PreStates),
+			StartedAt:        t.StartedAt,
+			FinishedAt:       t.FinishedAt,
 		}
 		if t.CommittedAt != nil {
 			txn.CommittedAt = *t.CommittedAt

--- a/internal/kensa/types.go
+++ b/internal/kensa/types.go
@@ -10,7 +10,7 @@ import (
 // KensaModuleVersion is the version pin recorded in the spec's context
 // block. AC-10 source-inspects to verify this matches the corresponding
 // entry in app/go.mod.
-const KensaModuleVersion = "v0.8.0"
+const KensaModuleVersion = "v0.9.0"
 
 // Sentinel errors returned by Executor.Run. Tests use errors.Is for
 // classification; the audit emission path maps each to a typed

--- a/internal/remediation/already_compliant_test.go
+++ b/internal/remediation/already_compliant_test.go
@@ -1,0 +1,89 @@
+// @spec api-remediation
+//
+//	AC-14  TestRemediation_AlreadyCompliantIsNotAChange
+package remediation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// @ac AC-14
+// AC-14: an already-compliant run must not offer a rollback.
+//
+// Kensa reports committed when a rule was already passing, which on its own is
+// indistinguishable from a real fix. Reading that as a change marked the
+// request executed, badged the rule fixed, and offered Roll back for a
+// transaction that mutated nothing and captured no state to restore. Kensa
+// never persisted such a record, so the rollback would act against a capture
+// that does not describe a change.
+func TestRemediation_AlreadyCompliantIsNotAChange(t *testing.T) {
+	t.Run("api-remediation/AC-14", func(t *testing.T) {
+		already := ExecTxn{
+			TxnID:            uuid.Must(uuid.NewV7()),
+			Status:           "committed",
+			AlreadyCompliant: true,
+		}
+		real := ExecTxn{
+			TxnID:  uuid.Must(uuid.NewV7()),
+			Status: "committed",
+		}
+
+		got, known := OutcomeOf(already)
+		if !known {
+			t.Fatal("an already-compliant commit must be a recognised outcome")
+		}
+		if got != StatusNotApplied {
+			t.Errorf("already-compliant maps to %q, want %q; %q keeps the Roll back button",
+				got, StatusNotApplied, got)
+		}
+
+		// The distinction is the whole point: a real commit is still executed.
+		if g, _ := OutcomeOf(real); g != StatusExecuted {
+			t.Errorf("a real commit maps to %q, want %q", g, StatusExecuted)
+		}
+
+		// not_applied is deliberately outside the rollback-eligible set. If
+		// this ever changes, the affordance returns and this test is the only
+		// thing standing between an operator and a rollback of nothing.
+		if StatusNotApplied == StatusExecuted || StatusNotApplied == StatusStaged {
+			t.Error("not_applied must stay distinct from the rollback-eligible statuses")
+		}
+	})
+}
+
+// @ac AC-14
+// AC-14 (companion): the operator is told why, not just that nothing happened.
+func TestRemediation_AlreadyCompliantExplainsItself(t *testing.T) {
+	t.Run("api-remediation/AC-14", func(t *testing.T) {
+		final, reason := rollUpOutcome(context.Background(), []ExecTxn{{
+			TxnID:            uuid.Must(uuid.NewV7()),
+			Status:           "committed",
+			AlreadyCompliant: true,
+		}})
+		if final != StatusNotApplied {
+			t.Fatalf("roll-up produced %q, want %q", final, StatusNotApplied)
+		}
+		// "The engine declined to apply this rule" is true of a refusal and
+		// wrong here: nothing declined, the host was already correct.
+		if strings.Contains(reason, "declined") {
+			t.Errorf("already-compliant reused the refusal wording: %q", reason)
+		}
+		for _, want := range []string{"already satisfied", "nothing to roll back"} {
+			if !strings.Contains(strings.ToLower(reason), want) {
+				t.Errorf("reason %q does not say %q", reason, want)
+			}
+		}
+
+		// A refusal keeps its own sentence.
+		_, refusedReason := rollUpOutcome(context.Background(), []ExecTxn{{
+			TxnID: uuid.Must(uuid.NewV7()), Status: "committed", Refused: true,
+		}})
+		if !strings.Contains(refusedReason, "declined") {
+			t.Errorf("a refusal should still read as a refusal: %q", refusedReason)
+		}
+	})
+}

--- a/internal/remediation/execution.go
+++ b/internal/remediation/execution.go
@@ -283,6 +283,16 @@ func rollUpOutcome(ctx context.Context, txns []ExecTxn) (Status, string) {
 
 	seen := make(map[Status]bool, len(txns))
 	reason := ""
+	// Already-compliant needs its own sentence. It maps to not_applied, which
+	// otherwise reads as "the engine declined" -- true but unhelpful when the
+	// actual news is that the host already satisfied the rule. Without this an
+	// operator sees "Not applied" and cannot tell whether something went wrong.
+	allAlreadyCompliant := true
+	for _, t := range txns {
+		if !t.AlreadyCompliant {
+			allAlreadyCompliant = false
+		}
+	}
 	for _, t := range txns {
 		st, known := OutcomeOf(t)
 		if !known {
@@ -315,7 +325,12 @@ func rollUpOutcome(ctx context.Context, txns []ExecTxn) (Status, string) {
 	}
 
 	if reason == "" {
-		reason = outcomeReason(final)
+		if final == StatusNotApplied && allAlreadyCompliant {
+			reason = "The host already satisfied this rule. Nothing was changed, " +
+				"so there is nothing to roll back."
+		} else {
+			reason = outcomeReason(final)
+		}
 	}
 	return final, reason
 }

--- a/internal/remediation/types.go
+++ b/internal/remediation/types.go
@@ -168,6 +168,13 @@ type ExecTxn struct {
 	// rolled_back | partially_applied | errored | staged. Passed through
 	// verbatim from api.TransactionStatus and mapped by OutcomeOf.
 	Status string
+	// AlreadyCompliant is true when the rule's check passed before any apply,
+	// so Kensa changed nothing. It reports Status=committed regardless, which
+	// is why this must be consulted before treating a commit as a change.
+	//
+	// Only meaningful on the remediation path: Kensa leaves it false on the
+	// check-only transactions inside a scan result.
+	AlreadyCompliant bool
 	// Refused is true when the engine declined to act WITHOUT mutating the
 	// host (Kensa reported Success=false with a detail rather than an error),
 	// e.g. the v0.8.0 duplicate-audit-action guard. Kensa has no distinct
@@ -246,6 +253,20 @@ func OutcomeOf(t ExecTxn) (Status, bool) {
 	// A refusal is not a Kensa status; check it before the status switch.
 	// The engine declined without touching the host.
 	if t.Refused {
+		return StatusNotApplied, true
+	}
+	// Neither is already-compliant, and it is the more dangerous of the two to
+	// miss. Kensa reports committed, so without this the request is marked
+	// executed, the rule is badged as fixed, and the operator is offered a
+	// Roll back for a transaction that mutated nothing and captured no state
+	// to restore. Kensa never persisted such a record, so the rollback would
+	// act against a capture that does not describe a change.
+	//
+	// not_applied is the right outcome rather than a seventh status: the host
+	// is compliant either way, and what an operator can DO about it is
+	// identical to a refusal, which is what the status vocabulary encodes.
+	// The difference is the reason, and rollUpOutcome carries that.
+	if t.AlreadyCompliant && t.Status == kensaCommitted {
 		return StatusNotApplied, true
 	}
 	switch t.Status {

--- a/internal/worker/remediation_worker.go
+++ b/internal/worker/remediation_worker.go
@@ -449,11 +449,12 @@ func mapExecTxns(in []kensa.RemediationTxn) []remediation.ExecTxn {
 	out := make([]remediation.ExecTxn, 0, len(in))
 	for _, t := range in {
 		e := remediation.ExecTxn{
-			TxnID:         t.TxnID,
-			Status:        t.Status,
-			Evidence:      t.Evidence,
-			Err:           t.Err,
-			HostUnchanged: t.HostUnchanged,
+			TxnID:            t.TxnID,
+			Status:           t.Status,
+			Evidence:         t.Evidence,
+			Err:              t.Err,
+			HostUnchanged:    t.HostUnchanged,
+			AlreadyCompliant: t.AlreadyCompliant,
 		}
 		// Serialise here rather than threading Kensa types further in:
 		// internal/remediation deliberately does not import internal/kensa.

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-remediation
   title: Remediation governance - request/approve lifecycle, projected lift, and queued single-rule execute/rollback (OpenWatch Core, free)
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 1
 
@@ -230,5 +230,21 @@ spec:
         carries Kensa's own step, validator and rollback summaries verbatim,
         the count of steps that actually captured pre-state, and the
         control-channel-sensitive flag.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-14
+      description: >
+        An already-compliant run is never reported as a change. Kensa returns
+        Status=committed with AlreadyCompliant=true when the rule's check
+        passed before any apply, and OutcomeOf maps that to not_applied rather
+        than executed. That removes the Roll back affordance, which is the
+        sharp edge: the transaction mutated nothing and captured no state, and
+        Kensa never persisted it, so a rollback would act against a capture
+        describing no change. The reason names the actual news, that the host
+        already satisfied the rule, because "not applied" alone reads as an
+        engine refusal. The field is consulted on the remediation path only:
+        Kensa leaves it false on the check-only transactions inside a scan
+        result, where every passing rule would otherwise look like a real
+        remediation.
       priority: critical
       references_constraints: [C-09]

--- a/specs/system/kensa-executor.spec.yaml
+++ b/specs/system/kensa-executor.spec.yaml
@@ -10,7 +10,7 @@ spec:
     feature: Kensa scan execution bridge
     description: >
       The executor invokes Kensa (Go module github.com/Hanalyx/kensa
-      pinned to v0.8.0) to run a scan against a single host using the
+      pinned to v0.9.0) to run a scan against a single host using the
       FULL rule corpus applicable to the host's detected OS
       capabilities. The Kensa API (`Kensa.Scan(ctx, host, rules,
       opts...)` per kensa-go/api/kensa.go:228) takes a `[]*api.Rule`
@@ -131,7 +131,7 @@ spec:
       type: technical
       enforcement: error
     - id: C-13
-      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.8.0 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
+      description: The production scanFunc MUST compose the scan-only Kensa via api.New with pkg/kensa.NewScanner (kensa v0.9.0 — stateless, concurrency-safe shared) and this package's TransportFactory; no engine, store, or signer is constructed for the scan path. The worker subcommand binds it via WithScanFunc(NewProductionScanFunc(...)). unwiredScanFunc may remain ONLY as the test fallback NewExecutor defaults to before binding, annotated as such
       type: technical
       enforcement: error
     - id: C-14


### PR DESCRIPTION
Closes **KN-OW-015**, shipped in Kensa v0.9.0 as
`TransactionResult.AlreadyCompliant`. This is the live defect of the three.

## What was wrong

A rule that was **already passing** produced `Status=committed`, which on its
own is indistinguishable from a real remediation. So OpenWatch marked the
request executed, badged the rule fixed, and offered the operator a **Roll
back**.

kensa-agent's reading of the severity was sharper than mine, and is why this
went first:

> a green badge that overstates is a reporting bug, but a rollback affordance
> for a transaction that never mutated anything invites an operator to take a
> destructive action against a captured state that does not describe a change

Kensa never persisted such a record, so there was nothing for that rollback to
restore.

## The fix is one mapping

`OutcomeOf` maps `committed && AlreadyCompliant` to `not_applied`.

That is the whole fix on the affordance side, because the vocabulary already
handles `not_applied` correctly: it sits outside `ROLLBACK_ELIGIBLE` and renders
neutral rather than green. **A seventh status would have been the wrong shape** -
the host is compliant either way, and what an operator can *do* is identical to
a refusal, which is what the status encodes. The difference is the reason.

## So the reason carries it

`"No change made. The engine declined to apply this rule"` is true of a refusal
and wrong here: nothing declined, the host was already correct. Already-compliant
gets its own sentence naming that, and that there is nothing to roll back.
A refusal keeps its own wording, and a test asserts the two do not merge.

## The scope warning is carried, not left upstream

The godoc is explicit that the field is meaningful on the **remediation path
only** - Kensa leaves it false on the check-only transactions inside a
`ScanResult` rather than extending that legacy overload. Reading `committed &&
!AlreadyCompliant` as "the host changed" against a scan would be true of every
passing rule.

That warning now sits in our own type comments, where someone reusing `mapTxns`
will meet it.

## Verification

`api-remediation` 1.4.0 -> 1.5.0, AC-14, two tests. Mutation-checked - not
consulting the field produces:

```
already-compliant maps to "executed", want "not_applied";
"executed" keeps the Roll back button
```

The kensa bump to v0.9.0 also tripped the version-pin guard, which failed until
`go.mod`, `types.go` and `kensa-executor.spec.yaml` all agreed. AC-10 doing its
job.

## Not in this PR

`DescribePreState` (KN-OW-016) is the next one - the captured "before" values in
the journal and the plan preview. KN-OW-017 needs no code from us; our corrected
panel behaviour is now written into Kensa's contract.