### PR TITLE
feat(remediation): show what was on the host before the change

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5969,6 +5969,19 @@ components:
           description: Kensa's own operator-facing notices about this plan.
           type: array
           items: {type: string}
+        before:
+          description: |
+            What Kensa found on the host while planning, one entry per step.
+            Computed live and never stored, because a plan describes the host
+            as it is now.
+          type: array
+          items:
+            type: object
+            required: [index, mechanism]
+            properties:
+              index:     {type: integer}
+              mechanism: {type: string}
+              summary:   {type: string}
         estimated_seconds: {type: number}
         captured_at:       {type: string, format: date-time}
 
@@ -6003,6 +6016,18 @@ components:
         capturable:
           description: False for phases whose mechanism cannot capture pre-state; `data` is then empty.
           type: boolean
+        summary:
+          description: |
+            Kensa's one-line rendering of what was captured, from the handler
+            that captured it.
+
+            Display text, not evidence. It carries no stability guarantee and
+            may change between Kensa releases, which is why the transaction
+            records the Kensa version that produced it. `data` remains the
+            authoritative capture. Elided by construction so no file body
+            appears, and a credential named inside a config line is redacted,
+            but it is not a secret scanner: treat it as operator-visible text.
+          type: string
         data:
           type: object
           additionalProperties: true

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -3921,6 +3921,16 @@ export interface components {
             control_channel_sensitive: boolean;
             /** @description Kensa's own operator-facing notices about this plan. */
             warnings?: string[];
+            /**
+             * @description What Kensa found on the host while planning, one entry per step.
+             *     Computed live and never stored, because a plan describes the host
+             *     as it is now.
+             */
+            before?: {
+                index: number;
+                mechanism: string;
+                summary?: string;
+            }[];
             estimated_seconds?: number;
             /** Format: date-time */
             captured_at?: string;
@@ -3948,6 +3958,18 @@ export interface components {
             mechanism: string;
             /** @description False for phases whose mechanism cannot capture pre-state; `data` is then empty. */
             capturable: boolean;
+            /**
+             * @description Kensa's one-line rendering of what was captured, from the handler
+             *     that captured it.
+             *
+             *     Display text, not evidence. It carries no stability guarantee and
+             *     may change between Kensa releases, which is why the transaction
+             *     records the Kensa version that produced it. `data` remains the
+             *     authoritative capture. Elided by construction so no file body
+             *     appears, and a credential named inside a config line is redacted,
+             *     but it is not a secret scanner: treat it as operator-visible text.
+             */
+            summary?: string;
             data?: {
                 [key: string]: unknown;
             };

--- a/frontend/src/components/hosts/RemediationJournal.tsx
+++ b/frontend/src/components/hosts/RemediationJournal.tsx
@@ -179,6 +179,23 @@ function CapturedState({ entries }: { entries: RemediationPreState[] }) {
                 <span style={{ color: 'var(--ow-fg-3)' }}> (no pre-state, not restorable)</span>
               )}
             </div>
+            {/* Kensa's rendering of what was on the host. Display text, not
+                evidence: the raw capture stays below, behind the disclosure it
+                has always been behind, because the summary is elided by
+                construction and is not a secret scanner. */}
+            {e.summary ? (
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--ow-fg-1)',
+                  fontFamily: 'var(--ow-font-mono)',
+                  marginTop: 2,
+                  wordBreak: 'break-word',
+                }}
+              >
+                before: {e.summary}
+              </div>
+            ) : null}
             {e.capturable && e.data ? (
               <pre
                 style={{
@@ -243,6 +260,7 @@ function PlanPreview({ hostId, requestId }: { hostId: string; requestId: string 
   const checks = plan.checks ?? [];
   const undo = plan.undo ?? [];
   const warnings = plan.warnings ?? [];
+  const before = plan.before ?? [];
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: '4px 2px 12px' }}>
@@ -267,6 +285,29 @@ function PlanPreview({ hostId, requestId }: { hostId: string; requestId: string 
           {w}
         </Callout>
       ))}
+
+      {/* What is there now, before what it becomes. An operator reads the
+          two together: this is the half that was missing until Kensa v0.9.0
+          shipped DescribePreState. */}
+      {before.length > 0 ? (
+        <div>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--ow-fg-0)', marginBottom: 6 }}>
+            What is there now
+          </div>
+          <ul
+            style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}
+          >
+            {before.map((b) => (
+              <li
+                key={b.index}
+                style={{ fontSize: 12, color: 'var(--ow-fg-1)', fontFamily: 'var(--ow-font-mono)' }}
+              >
+                {b.summary ?? b.mechanism}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
 
       <PlanSection title="What it will change" items={steps} empty="No apply steps." />
 

--- a/frontend/tests/components/remediation-journal.test.ts
+++ b/frontend/tests/components/remediation-journal.test.ts
@@ -93,3 +93,36 @@ describe('frontend-remediation-tab AC-09 - pre-state is evidence, not interpreta
     expect(read('src/hooks/useRemediationSteps.ts')).not.toMatch(/—/);
   });
 });
+
+describe('frontend-remediation-tab AC-11 - the capture is shown, still not decoded', () => {
+  const journalSrc = read('src/components/hosts/RemediationJournal.tsx');
+
+  // @ac AC-11
+  test('frontend-remediation-tab/AC-11 - the journal shows what was there before', () => {
+    expect(journalSrc).toMatch(/before: \{e\.summary\}/);
+  });
+
+  // @ac AC-11
+  test('frontend-remediation-tab/AC-11 - the plan shows what is there now', () => {
+    expect(journalSrc).toMatch(/What is there now/);
+    expect(journalSrc).toMatch(/plan\.before/);
+  });
+
+  // @ac AC-11
+  test('frontend-remediation-tab/AC-11 - raw data stays behind its disclosure', () => {
+    // The summary is elided by construction and explicitly not a secret
+    // scanner, so it does not earn the raw capture a promotion out of the
+    // collapsed <details> it has always lived in.
+    expect(journalSrc).toMatch(/<details/);
+    expect(journalSrc).toContain('JSON.stringify(e.data, null, 2)');
+  });
+
+  // @ac AC-11
+  test('frontend-remediation-tab/AC-11 - no mechanism-specific decoding in TypeScript', () => {
+    // A per-mechanism renderer here would drift against 24 private layouts,
+    // one language further from the handlers than a Go one would.
+    for (const key of ['prior_line', 'prior_value', 'immutable_staged', 'find_based']) {
+      expect(journalSrc).not.toContain(key);
+    }
+  });
+});

--- a/internal/kensa/planfunc.go
+++ b/internal/kensa/planfunc.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	kensaapi "github.com/Hanalyx/kensa/api"
+	pkgkensa "github.com/Hanalyx/kensa/pkg/kensa"
 	"github.com/google/uuid"
 )
 
@@ -21,13 +22,15 @@ type PlanFunc func(ctx context.Context, hostID uuid.UUID, ruleID string) (*Remed
 
 // RemediationPlan is the OpenWatch-side view of a kensa Plan.
 //
-// Everything here is already human-readable in the Kensa contract:
-// StepPreview.Summary is documented with the example "Set PermitRootLogin=no
-// in sshd_config.d/00-kensa.conf". The one thing that is not is PreStates,
-// whose Data is mechanism-specific and opaque, so the captured values are
-// deliberately absent until pkg/kensa.DescribePreState lands
-// (features/KN-OW-016). Showing which steps captured something is honest;
-// guessing at what it means is not.
+// Everything here is human-readable in the Kensa contract: StepPreview.Summary
+// is documented with the example "Set PermitRootLogin=no in
+// sshd_config.d/00-kensa.conf", and as of Kensa v0.9.0 the captured pre-state
+// renders through DescribePreState, which closes features/KN-OW-016.
+//
+// The Before summaries are computed live and never stored. A plan describes
+// the host as it is now and is discarded after it is read, so the
+// version-stamping obligation that applies to ingested transactions does not
+// apply here.
 type RemediationPlan struct {
 	PlanID  uuid.UUID
 	RuleID  string
@@ -47,6 +50,17 @@ type RemediationPlan struct {
 	ControlChannelSensitive bool
 	EstimatedSeconds        float64
 	CapturedAt              time.Time
+	// Before is what Kensa found on the host while planning, one entry per
+	// capturable step. This is the "what does it look like now" half of the
+	// preview; the apply-step summaries are the "what will it become" half.
+	Before []PlanCapture
+}
+
+// PlanCapture is one captured pre-state, rendered for display.
+type PlanCapture struct {
+	Index     int
+	Mechanism string
+	Summary   string
 }
 
 // PlanStep is one apply step that would run.
@@ -124,11 +138,16 @@ func mapPlan(p *kensaapi.Plan, ruleID string) *RemediationPlan {
 		})
 	}
 	// How much of this fix is reversible, counted from what Kensa captured
-	// rather than from the rule's own claim about itself.
+	// rather than from the rule's own claim about itself. The same pass
+	// renders each capture, so the preview can say what is there now.
 	for _, ps := range p.PreStates {
 		if ps.Capturable {
 			out.CanUndo++
 		}
+		out.Before = append(out.Before, PlanCapture{
+			Index: ps.StepIndex, Mechanism: ps.Mechanism,
+			Summary: pkgkensa.DescribePreState(ps),
+		})
 	}
 	return out
 }

--- a/internal/kensa/prestate_summary_test.go
+++ b/internal/kensa/prestate_summary_test.go
@@ -1,0 +1,71 @@
+// @spec api-remediation
+//
+//	AC-15  TestKensa_PreStateSummaryIsDerivedNotDecoded
+package kensa
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	kensaapi "github.com/Hanalyx/kensa/api"
+)
+
+// @ac AC-15
+// AC-15: the capture is rendered by Kensa, never decoded here.
+//
+// The whole point of features/KN-OW-016 was that OpenWatch must not read
+// mechanism-specific Data keys. Writing this test proved the argument: with
+// Kensa's own list of key names in hand, guesses at config_set's layout still
+// produced "prior state not captured", because the describer reads different
+// keys than the names suggest. A TypeScript or Go decoder here would have been
+// wrong on day one and would drift silently after.
+func TestKensa_PreStateSummaryIsDerivedNotDecoded(t *testing.T) {
+	t.Run("api-remediation/AC-15", func(t *testing.T) {
+		// Non-capturable steps get a marker, not an empty string, so the UI
+		// can distinguish "this mechanism cannot capture" from "no summary".
+		got := mapPreStates([]kensaapi.PreState{
+			{StepIndex: 0, Mechanism: "service_enabled", Capturable: false},
+		})
+		if len(got) != 1 {
+			t.Fatalf("mapped %d pre-states, want 1", len(got))
+		}
+		if got[0].Summary == "" {
+			t.Error("a non-capturable step must carry a marker, not an empty summary")
+		}
+		if got[0].Capturable {
+			t.Error("capturable must survive the mapping")
+		}
+
+		// Data is carried verbatim alongside the summary. The summary is for
+		// the screen; Data is what an auditor reads and what rollback needs.
+		withData := mapPreStates([]kensaapi.PreState{{
+			StepIndex: 1, Mechanism: "file_permissions", Capturable: true,
+			Data: map[string]any{"path": "/etc/shadow", "mode": "0640"},
+		}})
+		if withData[0].Data["path"] != "/etc/shadow" {
+			t.Error("Data must be carried verbatim, not replaced by the summary")
+		}
+		if withData[0].Summary == "" {
+			t.Error("a capturable step with data should render a summary")
+		}
+
+		// This package must not read mechanism-specific keys to build display
+		// text. Kensa owns that; we would drift against 24 private layouts.
+		src := readSource(t, "remediatefunc.go")
+		for _, forbidden := range []string{`Data["prior_line"]`, `Data["prior_value"]`, `Data["content"]`} {
+			if strings.Contains(src, forbidden) {
+				t.Errorf("this package decodes %s; that belongs to the handler", forbidden)
+			}
+		}
+	})
+}
+
+func readSource(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/kensa/remediatefunc.go
+++ b/internal/kensa/remediatefunc.go
@@ -123,6 +123,20 @@ type RemediationPreState struct {
 	Mechanism  string         `json:"mechanism"`
 	Capturable bool           `json:"capturable"`
 	Data       map[string]any `json:"data,omitempty"`
+	// Summary is Kensa's one-line rendering of Data, from the handler that
+	// captured it. Persisted rather than derived on read because the capture
+	// is rendered in the browser, which cannot call into Kensa.
+	//
+	// Not evidence and not stable: Kensa states plainly that describer output
+	// is not semver-frozen, not parseable, and may change in any release
+	// including a patch. Data stays the authoritative capture. That is why
+	// remediation_transactions.kensa_version exists, so a corrected describer
+	// can be re-run over exactly the rows it affects.
+	//
+	// Elided by construction, not scrubbed: no file body reaches it at any
+	// length, and a credential named inside a config line is redacted. It is
+	// not a secret scanner, so treat it as operator-visible text.
+	Summary string `json:"summary,omitempty"`
 }
 
 // RollbackRunResult is the OpenWatch-side view of a kensa RollbackResult.
@@ -365,6 +379,11 @@ func mapPreStates(in []kensaapi.PreState) []RemediationPreState {
 			Mechanism:  p.Mechanism,
 			Capturable: p.Capturable,
 			Data:       p.Data,
+			// Derived here, at ingest, because the handler registry lives in
+			// this binary and the browser that renders it does not. A
+			// non-capturable step gets a fixed marker rather than an empty
+			// string, so the UI can tell "cannot capture" from "no summary".
+			Summary: pkgkensa.DescribePreState(p),
 		})
 	}
 	return out

--- a/internal/server/api/server.gen.go
+++ b/internal/server/api/server.gen.go
@@ -3209,6 +3209,14 @@ type RemediationPhase struct {
 // RemediationPlan What remediating one rule on one host would do. Produced by Kensa
 // without mutating the host.
 type RemediationPlan struct {
+	// Before What Kensa found on the host while planning, one entry per step.
+	// Computed live and never stored, because a plan describes the host
+	// as it is now.
+	Before *[]struct {
+		Index     int     `json:"index"`
+		Mechanism string  `json:"mechanism"`
+		Summary   *string `json:"summary,omitempty"`
+	} `json:"before,omitempty"`
 	CapturedAt *time.Time `json:"captured_at,omitempty"`
 
 	// Checks The validators that would run after apply.
@@ -3268,6 +3276,17 @@ type RemediationPreState struct {
 	Data       *map[string]interface{} `json:"data,omitempty"`
 	Index      int                     `json:"index"`
 	Mechanism  string                  `json:"mechanism"`
+
+	// Summary Kensa's one-line rendering of what was captured, from the handler
+	// that captured it.
+	//
+	// Display text, not evidence. It carries no stability guarantee and
+	// may change between Kensa releases, which is why the transaction
+	// records the Kensa version that produced it. `data` remains the
+	// authoritative capture. Elided by construction so no file body
+	// appears, and a credential named inside a config line is redacted,
+	// but it is not a secret scanner: treat it as operator-visible text.
+	Summary *string `json:"summary,omitempty"`
 }
 
 // RemediationRequest defines model for RemediationRequest.

--- a/internal/server/remediation_handlers.go
+++ b/internal/server/remediation_handlers.go
@@ -548,6 +548,26 @@ func toAPIPlan(p *kensa.RemediationPlan) api.RemediationPlan {
 	for _, u := range p.Undo {
 		out.Undo = append(out.Undo, planStep(u.Index, u.Mechanism, u.Summary, nil))
 	}
+	if len(p.Before) > 0 {
+		before := make([]struct {
+			Index     int     `json:"index"`
+			Mechanism string  `json:"mechanism"`
+			Summary   *string `json:"summary,omitempty"`
+		}, 0, len(p.Before))
+		for _, b := range p.Before {
+			item := struct {
+				Index     int     `json:"index"`
+				Mechanism string  `json:"mechanism"`
+				Summary   *string `json:"summary,omitempty"`
+			}{Index: b.Index, Mechanism: b.Mechanism}
+			if b.Summary != "" {
+				sum := b.Summary
+				item.Summary = &sum
+			}
+			before = append(before, item)
+		}
+		out.Before = &before
+	}
 	for _, c := range p.Checks {
 		item := struct {
 			Name    string  `json:"name"`

--- a/specs/api/remediation.spec.yaml
+++ b/specs/api/remediation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: api-remediation
   title: Remediation governance - request/approve lifecycle, projected lift, and queued single-rule execute/rollback (OpenWatch Core, free)
-  version: "1.5.0"
+  version: "1.6.0"
   status: approved
   tier: 1
 
@@ -246,5 +246,18 @@ spec:
         Kensa leaves it false on the check-only transactions inside a scan
         result, where every passing rule would otherwise look like a real
         remediation.
+      priority: critical
+      references_constraints: [C-09]
+    - id: AC-15
+      description: >
+        The captured pre-state is rendered, and rendered as display text rather
+        than as evidence. The summary comes from Kensa's DescribePreState,
+        derived at ingest because the browser cannot call into the handler
+        registry, and persisted alongside the Kensa version that produced it so
+        a corrected describer can be re-run over exactly the rows it affects.
+        Raw Data is still returned verbatim and is still the authoritative
+        capture. Plan previews compute the same summaries live and never store
+        them, because a plan describes the host as it is now. OpenWatch decodes
+        no Data key itself, in Go or in TypeScript.
       priority: critical
       references_constraints: [C-09]

--- a/specs/frontend/remediation-tab.spec.yaml
+++ b/specs/frontend/remediation-tab.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-remediation-tab
   title: Host detail Remediation tab + per-rule request/apply affordance
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -149,5 +149,16 @@ spec:
         one fails. A planning failure states that nothing was changed on the
         host, because the operator's first question on seeing an error next to
         a fix button is whether it half-ran.
+      priority: critical
+      references_constraints: [C-04]
+    - id: AC-11
+      description: >
+        The journal shows what was on the host before the change, and the plan
+        preview shows what is there now, both from Kensa's own rendering. The
+        raw capture stays behind the disclosure it has always been behind
+        rather than being promoted alongside the summary, because the summary
+        is elided by construction and is explicitly not a secret scanner. A
+        non-capturable step still renders its distinction, so "cannot capture"
+        never reads as "nothing found".
       priority: critical
       references_constraints: [C-04]


### PR DESCRIPTION
Closes **KN-OW-016**, shipped in Kensa v0.9.0 as `pkg/kensa.DescribePreState`.

This answers the half of the founder's original question that was never ours to
fix:

> We can't see what was captured, what will be applied.

The journal renders `before: ...` per captured step. The plan preview gains
**"What is there now"** above what it will become, so an operator reads the two
together.

## Derived at ingest, and why that needs the version column

The browser renders the capture and cannot call into the handler registry, so
the summary is computed in the worker and persisted. That is exactly why 0056
added `kensa_version`: Kensa states plainly that describer output is **not**
semver-frozen, not parseable, and may change in any release including a patch.
A corrected describer can then be re-run over the rows it affects rather than
over all history.

Plan previews compute the same summaries **live and never store them**, since a
plan describes the host as it is now.

## Raw `Data` keeps its disclosure

The summary is elided by construction, and Kensa is explicit it is **not a
secret scanner**. So it earns no promotion: raw `Data` stays verbatim, behind
the collapsed `<details>` it has always been behind. A test asserts that.

## Writing the test proved the argument

With Kensa's own list of Data key names in front of me, my guesses at
`config_set`'s layout still produced:

```
config_set | PASS_MAX_DAYS, prior state not captured
```

The describer reads different keys than their names suggest. A decoder in
OpenWatch would have been wrong on **day one** and drifted silently after. Both
suites now assert this package and the component decode no mechanism-specific
key.

## Verified against shipped describers, not the design

Probed the real function before wiring it, which is what kensa-agent's own
correction-3 episode argued for:

```
mount_option_set | /mnt/share, //srv/s /mnt/share cifs password=<redacted>,uid=0 0 0
file_permissions | /etc/shadow, 0640 root:root
service_enabled  | no pre-state (mechanism is not capturable)
```

The credential inside the mount line is redacted while `uid=0` survives, and a
non-capturable step returns a marker rather than an empty string - so "cannot
capture" never renders as "nothing found".

## Their guidance inverted, and I followed the new one

Correction 3 said prefer the generic fallback when a describer might not
summarise safely. With `prestate.Line` shipped, the **describer** is now the
better-protected path for config lines, because it inspects inside the value
where the fallback only checks the Data key. We use the describer.

Their guarantee 4 remains an honest limit rather than a promise: `prestate.Field`
still does not check the Data key, unreachable in today's describer set but
pinned by nothing. Our disclosure decision stays a decision.

## Verification

`api-remediation` 1.5.0 -> 1.6.0 (AC-15), `frontend-remediation-tab` 1.4.0 ->
1.5.0 (AC-11). Mutation-checked.