### PR TITLE
docs(release): v0.7.1, the release that makes remediation legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.1] Eyrie (2026-08-04)
+
+Remediation stops being a black box. v0.7.0 could tell you a fix had been
+reverted and nothing more; this release shows what the engine did, what it
+found on the host first, and what a fix will do before you approve it.
+
+### Added
+
+- **See what a fix will do before approving it.** Expanding a remediation
+  request that has not run shows the plan: the steps that would be applied, how
+  the result will be checked, and how each step can be undone, in the engine's
+  own words rather than a restatement of the rule. It is planned against the
+  host at that moment and nothing is changed. A fix that touches SSH,
+  networking, PAM or firewall state says so, and says that the change reverts
+  itself if the host stops answering, which is what stops a hardening fix from
+  locking you out of the host you are hardening.
+- **See what happened, phase by phase.** An executed request now shows the
+  Capture, Apply, Validate and Commit phases with the engine's account of each.
+  When a fix fails you get the reason instead of only "reverted, host
+  unchanged". Three consequences are stated in words because none can be read
+  off the status: a step that rollback will not reverse, a change written but
+  not live until reboot, and a step that cannot be rolled back at all.
+- **See what was on the host before the change.** Each captured step shows a
+  one-line summary of the state that was recorded before anything was applied,
+  and the plan preview shows the same for the current host. The full captured
+  state is still available and is still what an auditor should read; the
+  summary is for the screen and is not a substitute for it.
+
+### Fixed
+
+- **A rule that was already compliant no longer looks like a fix that ran, and
+  no longer offers to roll back.** When a rule already passed, the engine
+  reported the same result as a successful remediation, so OpenWatch marked the
+  request executed, showed it as fixed, and offered a Roll back for a change
+  that never happened and captured nothing to restore. Such a request now
+  reports that no change was made, explains that the host already satisfied the
+  rule, and offers no rollback.
+- The plan preview no longer reports that a fix has no validators. Every rule
+  showed that, and it was wrong: the rule's own check re-runs after a fix is
+  applied and the captured state is restored if it does not pass. The preview
+  now says so.
+
+### Changed
+
+- **Kensa 0.9.0.** Brings the engine-side surfaces this release is built on.
+  Compliance verdicts are unchanged from 0.8.0, so fleet scores do not move on
+  upgrade.
+
 ## [0.7.0] Eyrie (2026-07-30)
 
 Enforcement and integrity. Authorization and licensing are now guaranteed by the

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenWatch is the compliance operating system for teams managing Linux infrastruc
 > Python/FastAPI implementation was archived out of the repo on 2026-06-05). The
 > Go tree lives at the **repo root**: Go 1.26 backend (`cmd/`, `internal/`),
 > React 19 + TanStack frontend (`frontend/`), PostgreSQL-only. The current
-> version is `0.7.0`, on the general-availability line that opened with `0.2.0`.
+> version is `0.7.1`, on the general-availability line that opened with `0.2.0`.
 
 ![OpenWatch Host Management: a fleet of RHEL and Ubuntu hosts with per-host compliance scores against the 769-rule Kensa corpus](docs/images/host-management.png)
 

--- a/docs/guides/API_GUIDE.md
+++ b/docs/guides/API_GUIDE.md
@@ -1,6 +1,6 @@
 # API guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 Most operators use the web UI for daily work: managing hosts, viewing fleet
 health, reading compliance state, and triaging alerts. This guide is for

--- a/docs/guides/BACKUP_RECOVERY.md
+++ b/docs/guides/BACKUP_RECOVERY.md
@@ -1,6 +1,6 @@
 # Backup and recovery
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers backup, restore, and disaster recovery for an OpenWatch
 deployment. OpenWatch is a single Go binary (`/usr/bin/openwatch`) that serves

--- a/docs/guides/COMPLIANCE_CONTROLS.md
+++ b/docs/guides/COMPLIANCE_CONTROLS.md
@@ -1,6 +1,6 @@
 # Compliance control mapping
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This document maps OpenWatch's security controls to industry frameworks, providing evidence for compliance audits.
 

--- a/docs/guides/DATABASE_MIGRATIONS.md
+++ b/docs/guides/DATABASE_MIGRATIONS.md
@@ -1,6 +1,6 @@
 # Database migration guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers how OpenWatch's PostgreSQL schema is versioned, how migrations
 are applied in production, and how to add a new migration. OpenWatch is a single

--- a/docs/guides/ENVIRONMENT_REFERENCE.md
+++ b/docs/guides/ENVIRONMENT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Configuration and environment reference
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This document is the field reference for how you configure the OpenWatch
 binary: the TOML file, the environment-variable overrides, and the on-disk paths

--- a/docs/guides/HOSTS_AND_REMEDIATION.md
+++ b/docs/guides/HOSTS_AND_REMEDIATION.md
@@ -1,6 +1,6 @@
 # Host management and remediation
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers adding and managing hosts, organizing them into groups,
 understanding server intelligence data, and using automated remediation to fix
@@ -243,12 +243,40 @@ After starting a remediation, track its progress on the host detail page
 under the **Remediation** tab.
 
 
-The progress view shows:
+Each request is one rule on one host. Expanding a row shows either what the
+fix will do, or what it did.
 
-- **Job status**: pending, running, completed, failed, partial, cancelled
-- **Progress percentage**: how many rules have been processed
-- **Per-rule results**: which fixes succeeded, failed, or were skipped
-- **Execution log**: timestamps and details for each step
+**Before it runs.** Expanding an approved request plans the fix against the
+host and shows the result without changing anything:
+
+- **What is there now**: the state the engine found on the host.
+- **What it will change**: the steps that would be applied.
+- **How it will be checked**: after applying, the rule's own check runs again,
+  and the captured state is restored if it does not pass.
+- **How it can be undone**, including how many steps can be reversed. That
+  count comes from what was actually captured, not from what the rule claims.
+
+A fix that touches SSH, networking, PAM or firewall state is called out. The
+engine arms a timer before applying such a change, so it reverts by itself if
+the host stops answering.
+
+Planning contacts the host, so it fails the way a scan does if the host is
+unreachable. When that happens the panel says nothing was changed.
+
+**After it runs.** Expanding an executed request shows the transaction the
+engine performed, phase by phase, with its own account of each:
+
+- **Capture**, **Apply**, **Validate**, **Commit** or **Rollback**, each with
+  the detail the engine recorded. When a fix fails, this is where the reason
+  is.
+- **Before**: a one-line summary of the state captured for each step, with the
+  full captured state available beneath it. The summary is for reading; the
+  full capture is the evidence.
+
+Three things are called out in words, because none can be inferred from the
+status alone: a step that rollback will not reverse, a change that was written
+but is not live until the host reboots, and a step that cannot be rolled back
+at all.
 
 ---
 
@@ -256,6 +284,12 @@ The progress view shows:
 
 Pre-state snapshots are captured automatically before any remediation changes.
 If a remediation causes problems, you can roll back to the pre-change state.
+
+Not every request offers a rollback, and the absence of the control is
+meaningful. A request that reports no change was made because the host already
+satisfied the rule has nothing to restore, so no rollback is offered. Steps
+whose mechanism cannot capture pre-state are named in the transaction view for
+the same reason.
 
 ### From the UI
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -1,6 +1,6 @@
 # OpenWatch install guide (native packages)
 
-**Last updated:** 2026-07-31 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-31 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide takes an administrator from a fresh Linux host to a running,
 logged-in OpenWatch. Install the packages and run `openwatch setup`, which does

--- a/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
+++ b/docs/guides/LINUX_DISTRIBUTION_SUPPORT.md
@@ -7,7 +7,7 @@
 > evidence, which distributions work for (1) running the OpenWatch server and
 > (2) being added as a managed/scanned host.
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 **Last verified:** 2026-07-28 against Kensa rule corpus **v0.8.0** (769 rules in the corpus).
 Per-OS counts below are read from each rule's `platforms:` declarations in the

--- a/docs/guides/MONITORING_SETUP.md
+++ b/docs/guides/MONITORING_SETUP.md
@@ -1,6 +1,6 @@
 # OpenWatch monitoring and operations guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide describes how you monitor a running OpenWatch deployment and how you
 respond to common operational incidents. OpenWatch ships as a single Go binary

--- a/docs/guides/PRODUCTION_DEPLOYMENT.md
+++ b/docs/guides/PRODUCTION_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Production deployment guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers running OpenWatch in production: a single Go binary that serves
 the REST API and the embedded React UI over HTTPS, backed by PostgreSQL, managed

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 Go from a freshly installed package to your first host under automatic
 compliance monitoring. This guide assumes OpenWatch is already installed and

--- a/docs/guides/SCALING_GUIDE.md
+++ b/docs/guides/SCALING_GUIDE.md
@@ -1,6 +1,6 @@
 # Scaling guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers how OpenWatch behaves as you add hosts, run more scans, and
 push more concurrent API traffic, and what you can tune today. It describes the

--- a/docs/guides/SCANNING_AND_COMPLIANCE.md
+++ b/docs/guides/SCANNING_AND_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Scanning and compliance
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers how OpenWatch performs compliance scanning, how to read
 results and posture scores, and how to use drift detection, alerts, and

--- a/docs/guides/SECRET_ROTATION.md
+++ b/docs/guides/SECRET_ROTATION.md
@@ -1,6 +1,6 @@
 # Secret rotation procedures
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide describes how to rotate each secret used by OpenWatch on the current
 single-binary stack: one `/usr/bin/openwatch` process that serves the REST API

--- a/docs/guides/SECURITY_HARDENING.md
+++ b/docs/guides/SECURITY_HARDENING.md
@@ -1,6 +1,6 @@
 # OpenWatch security hardening guide
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 **Audience:** System administrators, security engineers, compliance officers
 
 This guide covers the security controls you operate when you deploy OpenWatch

--- a/docs/guides/UPGRADE_PROCEDURE.md
+++ b/docs/guides/UPGRADE_PROCEDURE.md
@@ -1,6 +1,6 @@
 # Upgrade procedure
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide covers upgrading an OpenWatch deployment to a newer version. OpenWatch
 ships as a single Go binary (`/usr/bin/openwatch`) that serves both the REST API

--- a/docs/guides/USER_ROLES.md
+++ b/docs/guides/USER_ROLES.md
@@ -1,6 +1,6 @@
 # User roles and permissions
 
-**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.0 (Eyrie)
+**Last updated:** 2026-07-30 · **Applies to:** OpenWatch v0.7.1 (Eyrie)
 
 This guide describes the role-based access control (RBAC) system in the Go-era
 OpenWatch. It covers the five built-in roles, the permissions they grant, and how

--- a/packaging/version.env
+++ b/packaging/version.env
@@ -2,5 +2,5 @@
 #
 # The Go binary's ldflags read this file via the Makefile; build scripts
 # in packaging/{rpm,deb}/ source it for spec macros.
-VERSION="0.7.0"
+VERSION="0.7.1"
 CODENAME="Eyrie"


### PR DESCRIPTION
Cuts **v0.7.1**: version bump, release notes, and the guide those notes
describe.

## What the release is

v0.7.0 shipped remediation as a black box. A failed fix reported "reverted,
host unchanged" and nothing else, and the founder's first question on seeing it
was the right one:

> We can't see what was captured, what will be applied.

Both halves are now answered. The journal shows the engine's account of each
Capture/Apply/Validate/Commit phase, the plan shows what a fix will do before
it is approved, and both show what was on the host first.

It also fixes the sharpest thing v0.7.0 got wrong: **a rule that was already
compliant reported the same result as a successful remediation**, so OpenWatch
marked it fixed and offered a Roll back for a change that never happened and
captured nothing to restore.

## Version consistency

`packaging/version.env`, the README status line, and the newest CHANGELOG
heading all move to `0.7.1` together - the packaging suite fails the build
otherwise. Codename stays `Eyrie`, which is series-wide.

## The changelog is written for someone deciding whether to upgrade

It leads with what an operator can now see, names the rollback defect plainly
rather than dressing it as an improvement, and states that **Kensa 0.9.0
carries no verdict changes** so fleet scores do not move. The 0.8.0 bump did
move them, and people will ask.

## One guide needed content, not a stamp

`HOSTS_AND_REMEDIATION.md`'s progress section described **job statuses and a
percentage complete** - bulk language that never matched the per-rule model -
and did not mention the plan or the transaction view at all. It now describes
what an operator sees on each side of running a fix.

Its rollback section also now says that a **missing rollback control is
meaningful**, not a bug: a request that changed nothing has nothing to restore.

The other sixteen guides are restamped only. **Their "Last updated" dates are
deliberately untouched** - bumping a date on a document nobody reread is
metadata that lies.

## Gates

`packaging/...` suite passes (three-version agreement, changelog dating), and
all 18 guides are doc-style clean.

## Not in this PR

The tag. `make release-status` will still report the four human gates - a fleet
scan, staged remediation, scan variables, and the release captain signature -
because nothing here touches what only a person can attest.