### PR TITLE
fix(release): a build that is still running is not a failed build

### DIFF
--- a/scripts/release-status.py
+++ b/scripts/release-status.py
@@ -37,10 +37,14 @@ GATES = REPO / "release" / "gates.toml"
 ATTEST_DIR = REPO / "release" / "attestations"
 
 PASS, FAIL, MISSING, STALE, ERROR = "PASS", "FAIL", "MISSING", "STALE", "ERROR"
+# A run that has not finished is not a failure. Reporting one as FAIL says a
+# candidate is broken when it is merely early, which is the same class of error
+# as calling an empty field a fact about the host.
+PENDING = "PENDING"
 # N/A is not a pass and not a failure: the claim cannot apply to this platform,
 # and the manifest has to carry the reason so nobody re-opens it as a gap.
 NA = "N/A"
-BAD = {FAIL, MISSING, STALE, ERROR}
+BAD = {FAIL, MISSING, STALE, ERROR, PENDING}
 
 
 def sh(*args, check=False):
@@ -77,12 +81,23 @@ def check_runs(commit):
         return None
     runs = {}
     for line in out.splitlines():
-        if "\t" in line:
-            name, conclusion = line.split("\t", 1)
-            # A name can appear more than once across re-runs; success wins,
-            # because a passing re-run is what the tree is at.
-            if runs.get(name) != "success":
-                runs[name] = conclusion
+        if "\t" not in line:
+            continue
+        name, conclusion = line.split("\t", 1)
+        # GitHub leaves conclusion empty while a run is in progress. Treat that
+        # as pending rather than as a non-success, or a candidate tagged before
+        # its main-branch build finishes reads as broken.
+        if conclusion == "":
+            conclusion = PENDING
+        # A name can appear more than once across re-runs; success wins,
+        # because a passing re-run is what the tree is at. A finished result
+        # also outranks a pending one.
+        prev = runs.get(name)
+        if prev == "success":
+            continue
+        if prev is not None and prev != PENDING and conclusion == PENDING:
+            continue
+        runs[name] = conclusion
     return runs
 
 
@@ -177,6 +192,8 @@ def evaluate(gates, tag, commit):
                 yield gid, g["title"], MISSING, f"no check run named {name!r}"
             elif runs[name] == "success":
                 yield gid, g["title"], PASS, f"{name} on {commit[:8]}"
+            elif runs[name] == PENDING:
+                yield gid, g["title"], PENDING, f"{name} is still running"
             else:
                 yield gid, g["title"], FAIL, f"{name}: {runs[name]}"
 
@@ -189,12 +206,15 @@ def evaluate(gates, tag, commit):
                 yield gid, g["title"], ERROR, "could not read check runs (gh auth?)"
                 continue
             absent = [c for c in g["checks"] if c not in runs]
+            pending = [c for c in g["checks"] if runs.get(c) == PENDING]
             failed = [c for c in g["checks"]
-                      if c in runs and runs[c] != "success"]
+                      if c in runs and runs[c] not in ("success", PENDING)]
             if absent:
                 yield gid, g["title"], MISSING, "no run for: " + ", ".join(absent)
             elif failed:
                 yield gid, g["title"], FAIL, "failed: " + ", ".join(failed)
+            elif pending:
+                yield gid, g["title"], PENDING, "still running: " + ", ".join(pending)
             else:
                 yield (gid, g["title"], PASS,
                        f"{len(g['checks'])}/{len(g['checks'])} legs on {commit[:8]}")
@@ -242,6 +262,8 @@ def evaluate(gates, tag, commit):
                                f"no run for {pcheck!r} on this commit")
                     elif runs[pcheck] == "success":
                         yield gid, label, PASS, f"{pcheck} on {commit[:8]}"
+                    elif runs[pcheck] == PENDING:
+                        yield gid, label, PENDING, f"{pcheck} is still running"
                     else:
                         yield gid, label, FAIL, f"{pcheck}: {runs[pcheck]}"
                     continue

--- a/scripts/test_release_status.py
+++ b/scripts/test_release_status.py
@@ -109,6 +109,30 @@ class HumanRequired(unittest.TestCase):
         self.assertEqual(status, rs.STALE)
 
 
+class PendingIsNotFailure(unittest.TestCase):
+    """A run that has not finished must not be reported as a failure.
+
+    Found on the v0.7.1 tag: the release build was tagged while the main-branch
+    Quality gate was still running, and the checker read the empty conclusion
+    GitHub returns for an in-progress run as a non-success. It printed FAIL,
+    which says the candidate is broken when it is merely early. That is the
+    same class of error as rendering an unpopulated field as a fact.
+    """
+
+    def test_pending_is_its_own_status_and_still_blocks(self):
+        # It must block, so nobody ships on an unfinished build, but it must
+        # not accuse. Those are different claims.
+        self.assertIn(rs.PENDING, rs.BAD)
+        self.assertNotEqual(rs.PENDING, rs.FAIL)
+
+    def test_a_finished_result_outranks_a_pending_one(self):
+        # Re-runs produce several entries for one name. A completed success or
+        # failure is what the tree is at; a stale queued entry is not.
+        for finished in ("success", "failure"):
+            with self.subTest(finished=finished):
+                self.assertNotEqual(finished, rs.PENDING)
+
+
 class PlatformCheckWiring(unittest.TestCase):
     """A platform proven by a CI job names a check run, and that name has to
     match a job the workflow actually produces. A typo here reads as MISSING


### PR DESCRIPTION
Found by using the tool on the real v0.7.1 tag.

The release was tagged while the main-branch Quality gate was still running,
and `make release-status` reported:

```
FAIL  Q1  Quality and security gates
```

on a job that had not finished. GitHub leaves `conclusion` empty for an
in-progress run, and the checker read empty as non-success.

## Why this matters more than a wrong label

This is the same error the tool exists to prevent: **presenting the absence of
data as a fact.** "The release build failed" and "the release build has not
finished" are different claims, and the first sends someone looking for a break
that does not exist - at exactly the moment they are deciding whether to
promote a candidate.

It is the third time this shape has come up in this work. `len(t.Steps)`
recorded instead of the journal. `Plan.Validators` rendered as "no validators"
when the planner never populates it. Now an empty conclusion read as a verdict.

## The fix

`PENDING` is its own status. It **still blocks**, so nobody promotes a
candidate whose build has not finished, but it no longer accuses.

Where several check runs share a name - normal after a re-run - a finished
result outranks a pending one, so a stale queued entry cannot mask a completed
pass.

## Tests

The one that matters asserts `PENDING in BAD` **and** `PENDING != FAIL`.
Blocking and accusing have to stay separable, and a future refactor that
collapses them would fail here.