### PR TITLE
fix(lens): grade EL rebuilds against the upstream benchmark

### DIFF
--- a/frontend/src/utils/osLabel.ts
+++ b/frontend/src/utils/osLabel.ts
@@ -3,15 +3,24 @@
 // OS display label used by HostsListPage and HostDetailPage. The
 // mapping is intentionally closed; unrecognized families fall through
 // to "Unknown" so a pre-Discovery host or an unsupported distro never
-// gets silently labelled with a confidently-wrong guess.
+// gets silently labeled with a confidently-wrong guess.
 //
 // Spec: frontend-host-list-os C-02 + AC-01..AC-03.
 
+// This is a DISPLAY label, not a benchmark-equivalence claim. The two look
+// alike and are not the same question: the EL rebuilds below print as "RHEL"
+// AND are graded against the RHEL benchmarks, but Fedora prints as itself
+// because it is upstream of RHEL rather than a rebuild and has no EL benchmark.
+// Benchmark equivalence lives in one place, framework.BenchmarkFamily on the
+// backend; do not infer it from this table.
 const KENSA_FAMILY_TO_LABEL: Record<string, string> = {
   rhel: 'RHEL',
   centos: 'RHEL',
   rocky: 'RHEL',
   almalinux: 'RHEL',
+  ol: 'RHEL',
+  oracle: 'RHEL',
+  fedora: 'Fedora',
   ubuntu: 'Ubuntu',
   debian: 'Debian',
   opensuse: 'SUSE',

--- a/frontend/tests/utils/osLabel.test.ts
+++ b/frontend/tests/utils/osLabel.test.ts
@@ -5,7 +5,10 @@
 //   AC-01  test('frontend-host-list-os/AC-01 — RHEL family maps to RHEL (case-insensitive)')
 //   AC-02  test('frontend-host-list-os/AC-02 — ubuntu/debian/suse families map to expected labels')
 //   AC-03  test('frontend-host-list-os/AC-03 — null/undefined/empty/unknown families fall back to Unknown')
+//   AC-08  test('frontend-host-list-os/AC-08 — fedora is named, not Unknown and not RHEL')
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, test } from 'vitest';
 import { osDisplayLabel } from '@/utils/osLabel';
 
@@ -16,6 +19,8 @@ describe('frontend-host-list-os — osDisplayLabel', () => {
     expect(osDisplayLabel('centos')).toBe('RHEL');
     expect(osDisplayLabel('rocky')).toBe('RHEL');
     expect(osDisplayLabel('almalinux')).toBe('RHEL');
+    expect(osDisplayLabel('ol')).toBe('RHEL');
+    expect(osDisplayLabel('oracle')).toBe('RHEL');
     // case folding
     expect(osDisplayLabel('RHEL')).toBe('RHEL');
     expect(osDisplayLabel('Rhel')).toBe('RHEL');
@@ -36,10 +41,30 @@ describe('frontend-host-list-os — osDisplayLabel', () => {
     expect(osDisplayLabel(undefined)).toBe('Unknown');
     expect(osDisplayLabel('')).toBe('Unknown');
     expect(osDisplayLabel('   ')).toBe('Unknown');
-    // Fedora is intentionally excluded (development stream, not enterprise)
-    expect(osDisplayLabel('fedora')).toBe('Unknown');
-    // Other unsupported families
+    // Unsupported families. Fedora moved to AC-08 in spec v1.1.0.
     expect(osDisplayLabel('arch')).toBe('Unknown');
     expect(osDisplayLabel('freebsd')).toBe('Unknown');
+  });
+
+  // @ac AC-08
+  test('frontend-host-list-os/AC-08 — fedora is named, not Unknown and not RHEL', () => {
+    // Not 'Unknown': Discovery knows exactly what this host is, so 'Unknown'
+    // reads as a detection failure that did not happen.
+    expect(osDisplayLabel('fedora')).toBe('Fedora');
+    // Not 'RHEL' either: Fedora is upstream of RHEL, not a rebuild of it, and
+    // folding it into the RHEL bucket would distort the group-by-OS rollup.
+    expect(osDisplayLabel('fedora')).not.toBe('RHEL');
+    expect(osDisplayLabel('FEDORA')).toBe('Fedora');
+  });
+
+  // @ac AC-08
+  test('frontend-host-list-os/AC-08 — the table warns it is not benchmark equivalence', () => {
+    // The display table and framework.BenchmarkFamily agree on the EL rebuilds
+    // and MUST NOT agree on Fedora: it displays as itself and has no EL
+    // benchmark, so grading it against the RHEL 9 STIG would invent coverage.
+    // The comment is what stops the next author copying this map backend-side.
+    const src = readFileSync(resolve(__dirname, '../../src/utils/osLabel.ts'), 'utf8');
+    expect(src).toMatch(/DISPLAY label, not a benchmark-equivalence claim/);
+    expect(src).toMatch(/BenchmarkFamily/);
   });
 });

--- a/internal/framework/benchmark_family_test.go
+++ b/internal/framework/benchmark_family_test.go
@@ -1,0 +1,99 @@
+// @spec system-compliance-lens
+//
+//	AC-12  TestBenchmarkFamily_NormalizesRebuildsOnly
+//	AC-13  TestBenchmarkFamily_BothResolutionPathsConsumeIt
+package framework
+
+import (
+	"strings"
+	"testing"
+)
+
+// @ac AC-12
+// AC-12: an EL rebuild is graded against its upstream, and nothing else is.
+//
+// Found on a live host: an almalinux 9.8 host carried 391 rule results
+// referencing stig_rhel9, and the lens asked for stig_almalinux9, which no rule
+// in the corpus emits. The negative half matters as much as the positive half.
+// Fedora rolls up to the rhel FAMILY in host discovery, so the obvious "just
+// use the discovery rollup" fix would have swept it in and graded a Fedora host
+// against the RHEL 9 STIG, inventing coverage rather than reporting none.
+func TestBenchmarkFamily_NormalizesRebuildsOnly(t *testing.T) {
+	t.Run("system-compliance-lens/AC-12", func(t *testing.T) {
+		rebuilds := map[string]string{
+			"almalinux": "rhel",
+			"centos":    "rhel",
+			"ol":        "rhel",
+			"oracle":    "rhel",
+			"rocky":     "rhel",
+			// Not a rebuild, but must survive the mapping unchanged.
+			"rhel":   "rhel",
+			"ubuntu": "ubuntu",
+			"debian": "debian",
+			// Case and whitespace folded: os_family arrives from Discovery.
+			"AlmaLinux": "rhel",
+			"  Rocky  ": "rhel",
+		}
+		for in, want := range rebuilds {
+			if got := BenchmarkFamily(in); got != want {
+				t.Errorf("BenchmarkFamily(%q) = %q, want %q", in, got, want)
+			}
+		}
+
+		// The deliberate exclusions. If either of these ever returns "rhel",
+		// OpenWatch is grading a host against a benchmark it was never
+		// assessed under, which is worse than offering no lens at all.
+		for _, notEL := range []string{"fedora", "amzn", "amazon", "arch"} {
+			if got := BenchmarkFamily(notEL); got == "rhel" {
+				t.Errorf("BenchmarkFamily(%q) = %q; %q is not an EL rebuild and must not be graded as one", notEL, got, notEL)
+			}
+		}
+		if got := BenchmarkFamily("fedora"); got != "fedora" {
+			t.Errorf("BenchmarkFamily(\"fedora\") = %q, want %q unchanged", got, "fedora")
+		}
+		// An unknown family is returned as-is, so it resolves to a key the
+		// corpus does not emit and no OS-specific lens is offered.
+		if got := BenchmarkFamily("Gentoo"); got != "gentoo" {
+			t.Errorf("BenchmarkFamily(\"Gentoo\") = %q, want %q", got, "gentoo")
+		}
+		if got := BenchmarkFamily(""); got != "" {
+			t.Errorf("BenchmarkFamily(\"\") = %q, want empty", got)
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: the SQL half and the Go half consume the same mapping.
+//
+// This is the actual defect class. The product already knew almalinux was RHEL
+// -- the frontend's osLabel table said so -- while the query did not, so one
+// page labeled a host "RHEL 9.8" and then withheld the RHEL 9 benchmarks from
+// it. Two independent copies of one fact is how that shipped, so the guard is
+// that both paths route through BenchmarkFamily rather than that they happen to
+// agree today.
+func TestBenchmarkFamily_BothResolutionPathsConsumeIt(t *testing.T) {
+	t.Run("system-compliance-lens/AC-13", func(t *testing.T) {
+		sql := OSResolvedMatchSQL("$1", "h.os_family", "h.os_version")
+
+		// The SQL must normalize, not lower-case. A bare lower() is the bug.
+		for _, rebuild := range []string{"almalinux", "centos", "ol", "oracle", "rocky"} {
+			if !strings.Contains(sql, "WHEN '"+rebuild+"' THEN 'rhel'") {
+				t.Errorf("OSResolvedMatchSQL does not map %q to rhel; an EL rebuild would resolve to a key the corpus never emits.\nSQL: %s", rebuild, sql)
+			}
+		}
+		if strings.Contains(sql, "'fedora'") {
+			t.Error("OSResolvedMatchSQL maps fedora; Fedora has no EL benchmark and must not be graded against one")
+		}
+
+		// Generated from the map rather than hand-written, so the two cannot
+		// drift. Deterministic ordering keeps the query text stable.
+		if a, b := benchmarkFamilySQL("x"), benchmarkFamilySQL("x"); a != b {
+			t.Errorf("benchmarkFamilySQL is not deterministic:\n%s\n%s", a, b)
+		}
+		for fam := range benchmarkFamily {
+			if !strings.Contains(sql, "WHEN '"+fam+"'") {
+				t.Errorf("benchmarkFamily has %q but the generated SQL does not; the map and the SQL have drifted", fam)
+			}
+		}
+	})
+}

--- a/internal/framework/framework.go
+++ b/internal/framework/framework.go
@@ -40,6 +40,75 @@ const OSSuffixSQL = `_(rhel|ubuntu)[0-9]+$`
 //	stig_rhel9 -> stig ; cis_ubuntu22 -> cis ; nist_800_53 -> nist_800_53
 func FamilyOf(key string) string { return osSuffix.ReplaceAllString(key, "") }
 
+// benchmarkFamily maps a distro ID onto the upstream distro whose benchmarks
+// the host is graded against. An enterprise-Linux rebuild is graded as its
+// upstream: Kensa runs the RHEL 9 rules on an AlmaLinux 9 host, so that host's
+// STIG lens must resolve to stig_rhel9. Deriving the key from the raw distro id
+// asks for stig_almalinux9, which NO rule in the corpus emits, so the lens
+// silently matches nothing and the picker drops it entirely -- the operator is
+// shown a page with no STIG or CIS option and no hint that either exists.
+//
+// This is a STAND-IN for a fact Kensa computes and does not publish. Kensa
+// resolved the host to an EL platform in order to decide which rules to run;
+// features/KN-OW-018 asks it to say so on the scan result. Delete this map when
+// that lands rather than extending it -- every entry here is a second copy of
+// Kensa's platform gate, and the gate is expected to widen.
+//
+// Two families are absent ON PURPOSE, and neither is an oversight:
+//
+//   - Fedora rolls up to the rhel family in host discovery, but it is upstream
+//     of RHEL rather than a rebuild of it and has no EL benchmark. Grading a
+//     Fedora host against the RHEL 9 STIG would manufacture coverage that does
+//     not exist.
+//   - Amazon Linux is EL-adjacent and untested here. A wrong mapping grades a
+//     host against the wrong benchmark, which is worse than offering no lens.
+//
+// A distro absent from this map keeps its own id, so it resolves to a key the
+// corpus does not emit and no OS-specific lens is offered. That is the honest
+// outcome for a platform nobody has verified.
+var benchmarkFamily = map[string]string{
+	"almalinux": "rhel",
+	"centos":    "rhel",
+	"ol":        "rhel",
+	"oracle":    "rhel",
+	"rocky":     "rhel",
+}
+
+// BenchmarkFamily normalizes a hosts.os_family value to the distro whose corpus
+// keys apply to it. Unknown or empty input is returned lower-cased and
+// unchanged.
+func BenchmarkFamily(osFamily string) string {
+	k := strings.ToLower(strings.TrimSpace(osFamily))
+	if up, ok := benchmarkFamily[k]; ok {
+		return up
+	}
+	return k
+}
+
+// benchmarkFamilySQL renders BenchmarkFamily as a SQL CASE over the given
+// column expression. GENERATED from the same map rather than hand-written, so
+// the SQL and Go paths cannot drift -- the drift they replace is exactly how
+// this bug shipped: the frontend already mapped almalinux to RHEL for display
+// while the query did not, so one page labeled a host "RHEL 9.8" and then
+// withheld the RHEL 9 benchmarks from it.
+//
+// osFamilyExpr must be a fixed literal in code (a bind placeholder or a column
+// reference), never user input; the map keys are compile-time constants.
+func benchmarkFamilySQL(osFamilyExpr string) string {
+	keys := make([]string, 0, len(benchmarkFamily))
+	for k := range benchmarkFamily {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // deterministic SQL, so the query text is stable
+	var b strings.Builder
+	b.WriteString("CASE lower(" + osFamilyExpr + ")")
+	for _, k := range keys {
+		b.WriteString(" WHEN '" + k + "' THEN '" + benchmarkFamily[k] + "'")
+	}
+	b.WriteString(" ELSE lower(" + osFamilyExpr + ") END")
+	return b.String()
+}
+
 // MatchSQL returns a SQL boolean fragment (for a WHERE clause on a table
 // with a framework_refs JSONB column) that is TRUE when:
 //   - the bind parameter is NULL (all-rules, no filter), OR
@@ -82,11 +151,16 @@ func MatchSQL(paramRef string) string {
 // famRef, osFamilyExpr, osVersionExpr are SQL expressions (a bind placeholder
 // like "$2", or a column reference like "eff.fam"/"hh.os_family"); they must be
 // fixed literals in code, never user input. The OS token mirrors the corpus key
-// suffix: lower(os_family) concatenated with the major version
+// suffix: the BENCHMARK family concatenated with the major version
 // (split_part(os_version,'.',1)) — e.g. rhel+9 = rhel9, ubuntu+22 = ubuntu22.
+//
+// The family goes through benchmarkFamilySQL rather than a bare lower(), so an
+// EL rebuild resolves to its upstream: an almalinux 9.8 host asks for stig_rhel9
+// (391 of its rules carry that ref) instead of stig_almalinux9 (which no rule
+// carries). See benchmarkFamily for why that mapping is a stand-in.
 func OSResolvedMatchSQL(famRef, osFamilyExpr, osVersionExpr string) string {
 	return `(` + famRef + `::text IS NULL
-			OR framework_refs ? (` + famRef + ` || '_' || lower(` + osFamilyExpr + `) || split_part(` + osVersionExpr + `, '.', 1))
+			OR framework_refs ? (` + famRef + ` || '_' || ` + benchmarkFamilySQL(osFamilyExpr) + ` || split_part(` + osVersionExpr + `, '.', 1))
 			OR framework_refs ? ` + famRef + `)`
 }
 

--- a/internal/server/host_compliance_lens_handler.go
+++ b/internal/server/host_compliance_lens_handler.go
@@ -411,9 +411,16 @@ var osPinnedSegment = regexp.MustCompile(`^([a-z]+)(\d+)$`)
 //
 //   - ids with no OS-pinned segment are OS-neutral -> always true
 //   - an undiscovered host (empty family) cannot be judged -> true
-//   - otherwise the pinned family must equal the host family, and the
-//     pinned digits must equal the host's major version (or the
+//   - otherwise the pinned family must equal the host's BENCHMARK family, and
+//     the pinned digits must equal the host's major version (or the
 //     major+minor concatenation, covering ubuntu2404 vs "24.04")
+//
+// The host family is normalized through framework.BenchmarkFamily so an EL
+// rebuild is judged against its upstream. Comparing the raw distro id rejected
+// stig_rhel9 for an almalinux host, and because this function decides which
+// lenses are OFFERED, the effect was not an empty STIG score but no STIG option
+// at all -- a page that looks complete while withholding two thirds of the
+// host's compliance signal.
 func frameworkCompatibleWithOS(frameworkID, osFamily, osVersion string) bool {
 	pinFamily, pinVersion := "", ""
 	for _, seg := range strings.Split(strings.ToLower(frameworkID), "_") {
@@ -429,7 +436,7 @@ func frameworkCompatibleWithOS(frameworkID, osFamily, osVersion string) bool {
 	if osFamily == "" {
 		return true // host OS unknown; cannot judge, do not hide
 	}
-	if pinFamily != strings.ToLower(osFamily) {
+	if pinFamily != framework.BenchmarkFamily(osFamily) {
 		return false
 	}
 	if osVersion == "" {

--- a/internal/server/lens_rebuild_os_test.go
+++ b/internal/server/lens_rebuild_os_test.go
@@ -1,0 +1,54 @@
+// @spec system-compliance-lens
+//
+//	AC-13  TestFrameworkCompatibleWithOS_RebuildsOfferedFedoraNot
+package server
+
+import "testing"
+
+// @ac AC-13
+// AC-13, the lens-offer half: an EL rebuild must be OFFERED the upstream's
+// benchmarks, and a non-rebuild must not be.
+//
+// This function is why the live defect looked benign. It decides which lenses
+// appear in the picker, so comparing the raw distro id did not produce a STIG
+// score of zero on an AlmaLinux host -- it produced a page with no STIG option
+// at all, next to 391 rule results carrying stig_rhel9. Nothing on screen said
+// anything was missing.
+func TestFrameworkCompatibleWithOS_RebuildsOfferedFedoraNot(t *testing.T) {
+	t.Run("system-compliance-lens/AC-13", func(t *testing.T) {
+		cases := []struct {
+			frameworkID, osFamily, osVersion string
+			want                             bool
+			why                              string
+		}{
+			// The live host. Kensa ran the EL 9 rules on it and its results
+			// carry stig_rhel9, so the STIG lens must be reachable.
+			{"stig_rhel9", "almalinux", "9.8", true, "AlmaLinux 9 is graded as EL 9"},
+			{"cis_rhel9", "almalinux", "9.8", true, "same for CIS"},
+			{"stig_rhel9", "rocky", "9.5", true, "Rocky 9 is graded as EL 9"},
+			{"stig_rhel9", "centos", "9", true, "CentOS Stream 9 is EL 9"},
+			{"stig_rhel9", "ol", "9.4", true, "Oracle Linux 9 is EL 9"},
+
+			// Unchanged behavior, so the fix did not widen anything else.
+			{"stig_rhel9", "rhel", "9.6", true, "the case that already worked"},
+			{"stig_rhel10", "almalinux", "9.8", false, "major version still has to match"},
+			{"cis_ubuntu2404", "ubuntu", "24.04", true, "major+minor concatenation"},
+			{"nist_800_53", "almalinux", "9.8", true, "OS-neutral lens is always offered"},
+			{"stig_rhel9", "", "", true, "undiscovered host cannot be judged"},
+
+			// The exclusion that keeps this honest. Fedora rolls up to the
+			// rhel family in Discovery, so a rollup-based fix would have made
+			// this true and graded a Fedora host against the RHEL 9 STIG.
+			{"stig_rhel9", "fedora", "41", false, "Fedora is upstream of RHEL, not a rebuild, and has no EL benchmark"},
+			{"cis_rhel9", "fedora", "41", false, "same for CIS"},
+			{"stig_rhel9", "arch", "1", false, "unknown distro gets no OS-specific lens"},
+		}
+		for _, c := range cases {
+			got := frameworkCompatibleWithOS(c.frameworkID, c.osFamily, c.osVersion)
+			if got != c.want {
+				t.Errorf("frameworkCompatibleWithOS(%q, %q, %q) = %v, want %v (%s)",
+					c.frameworkID, c.osFamily, c.osVersion, got, c.want, c.why)
+			}
+		}
+	})
+}

--- a/specs/frontend/host-list-os.spec.yaml
+++ b/specs/frontend/host-list-os.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: frontend-host-list-os
   title: Host list OS column — sourced from real os_family (no hostname heuristic)
-  version: "1.0.0"
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -20,18 +20,40 @@ spec:
 
       Mapping table (Kensa families → display label):
 
-        rhel, centos, rocky, almalinux  ->  'RHEL'
-        ubuntu                          ->  'Ubuntu'
-        debian                          ->  'Debian'
-        opensuse, sles                  ->  'SUSE'
-        anything else (incl. null)      ->  'Unknown'
+        rhel, centos, rocky, almalinux, ol, oracle  ->  'RHEL'
+        fedora                                      ->  'Fedora'
+        ubuntu                                      ->  'Ubuntu'
+        debian                                      ->  'Debian'
+        opensuse, sles                              ->  'SUSE'
+        anything else (incl. null)                  ->  'Unknown'
 
-      The mapping is intentionally narrow. Fedora is excluded from the
-      'RHEL' bucket because Fedora is a development stream, not an
-      enterprise-tracked target; lumping it in would distort the
-      group-by-OS rollup that the prototype's filterbar drives. New
-      families MUST be added explicitly — the default branch returns
-      'Unknown', not a silent best-effort guess.
+      The mapping is intentionally narrow. New families MUST be added
+      explicitly — the default branch returns 'Unknown', not a silent
+      best-effort guess.
+
+      v1.1.0 (2026-08-04) makes two changes, both about not lying to the
+      operator.
+
+      Fedora now gets its OWN label rather than 'Unknown'. v1.0.0 excluded
+      it from the 'RHEL' bucket for a sound reason (it is a development
+      stream, not an enterprise-tracked target, and lumping it in would
+      distort the group-by-OS rollup) but then let it fall through to
+      'Unknown', which reads as "OpenWatch could not determine this host's
+      OS" when in fact Discovery determined it exactly. 'Fedora' keeps it
+      out of the RHEL rollup, which was the actual requirement, while
+      saying what the host is.
+
+      Oracle Linux (ol, oracle) joins the RHEL bucket. It is an enterprise
+      Linux rebuild in the same class as Rocky and AlmaLinux, and its
+      absence was an omission rather than a decision.
+
+      IMPORTANT — this table is a DISPLAY mapping and MUST NOT be read as
+      a benchmark-equivalence claim. The two coincide for the EL rebuilds
+      and diverge for Fedora: Fedora displays as itself AND has no EL
+      benchmark, so it is deliberately absent from framework.BenchmarkFamily
+      on the backend. Grading a Fedora host against the RHEL 9 STIG would
+      manufacture coverage that does not exist. Benchmark equivalence has
+      exactly one home (framework.BenchmarkFamily) and it is not this file.
 
     related_specs:
       - api-hosts
@@ -74,7 +96,7 @@ spec:
 
   acceptance_criteria:
     - id: AC-01
-      description: 'osDisplayLabel("rhel"), osDisplayLabel("centos"), osDisplayLabel("rocky"), osDisplayLabel("almalinux") each return "RHEL". Case folding: osDisplayLabel("RHEL") and osDisplayLabel("Rhel") also return "RHEL"'
+      description: 'osDisplayLabel("rhel"), osDisplayLabel("centos"), osDisplayLabel("rocky"), osDisplayLabel("almalinux"), osDisplayLabel("ol"), osDisplayLabel("oracle") each return "RHEL". Case folding: osDisplayLabel("RHEL") and osDisplayLabel("Rhel") also return "RHEL"'
       priority: critical
       references_constraints: [C-02]
     - id: AC-02
@@ -82,7 +104,7 @@ spec:
       priority: critical
       references_constraints: [C-02]
     - id: AC-03
-      description: 'osDisplayLabel(null), osDisplayLabel(undefined), osDisplayLabel(""), osDisplayLabel("fedora"), osDisplayLabel("arch") all return "Unknown". The mapping is closed; unrecognized families MUST NOT pass through unchanged'
+      description: 'osDisplayLabel(null), osDisplayLabel(undefined), osDisplayLabel(""), osDisplayLabel("arch") all return "Unknown". The mapping is closed; unrecognized families MUST NOT pass through unchanged. NOTE: fedora moved OUT of this AC in v1.1.0 and is asserted by AC-08'
       priority: critical
       references_constraints: [C-02]
     - id: AC-04
@@ -101,3 +123,7 @@ spec:
       description: 'Source inspection: HostsListPage.tsx declares an OS_COLOR_FALLBACK constant referenced by OSChip via the "?? OS_COLOR_FALLBACK" lookup pattern. Proves the neutral-fallback wiring is in place — OS_COLOR is typed Record<string, string> (open map) and the bracket access is guarded against the unmapped/undefined case'
       priority: high
       references_constraints: [C-03]
+    - id: AC-08
+      description: 'osDisplayLabel("fedora") returns "Fedora", NOT "Unknown" and NOT "RHEL". A Fedora host is identified as Fedora (Discovery knows what it is, so "Unknown" would be a lie) and is kept out of the RHEL rollup (it is not an enterprise-tracked target). Source inspection of frontend/src/utils/osLabel.ts: the file MUST carry a comment stating the table is a display mapping and NOT a benchmark-equivalence claim, so the next author does not copy fedora into framework.BenchmarkFamily on the backend'
+      priority: critical
+      references_constraints: [C-02]

--- a/specs/system/compliance-lens.spec.yaml
+++ b/specs/system/compliance-lens.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-compliance-lens
   title: Default compliance lens — org-wide framework projection
-  version: "1.4.0"
+  version: "1.5.0"
   status: approved
   tier: 2
 
@@ -111,6 +111,29 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-07
+      description: >
+        OS-resolution MUST normalize an enterprise-Linux REBUILD to the upstream
+        distro whose corpus keys apply to it, in exactly one place
+        (framework.BenchmarkFamily), used by BOTH the SQL match
+        (OSResolvedMatchSQL) and the lens-offer filter
+        (frameworkCompatibleWithOS). Rationale: the corpus authors OS keys for
+        rhel and ubuntu only, so deriving the key from the raw distro id asks an
+        almalinux 9 host for stig_almalinux9, which no rule emits. Because
+        frameworkCompatibleWithOS decides which lenses are OFFERED, the failure
+        is not an empty score but an ABSENT lens: the operator sees a coherent
+        page with no STIG or CIS option and no indication that either exists.
+        Fedora and Amazon Linux MUST NOT be normalized -- Fedora is upstream of
+        RHEL rather than a rebuild and has no EL benchmark, and grading against
+        a benchmark the host was never assessed under manufactures coverage. A
+        distro absent from the map keeps its own id and is offered no
+        OS-specific lens, which is the honest outcome for an unverified
+        platform. This normalization is a STAND-IN for a fact Kensa computes and
+        does not publish (features/KN-OW-018) and MUST be deleted, not extended,
+        when that lands.
+      type: technical
+      enforcement: error
+
   acceptance_criteria:
     - id: AC-01
       description: ComplianceConfig defaults DefaultFramework to "" (All rules); Validate accepts empty and a short lowercase family token and rejects an over-long or invalid-character value. SetCompliance persists and LoadCompliance round-trips the value; a fresh store with no row returns the empty (All rules) default.
@@ -193,3 +216,25 @@ spec:
         default and no group/host target, both revert to all-rules.
       priority: high
       references_constraints: [C-06]
+    - id: AC-12
+      description: >
+        BenchmarkFamily normalizes the EL rebuilds and ONLY those:
+        almalinux/centos/ol/oracle/rocky -> "rhel"; rhel -> "rhel";
+        ubuntu -> "ubuntu"; case and surrounding whitespace folded. Fedora
+        MUST return "fedora" (NOT "rhel") and amzn MUST return "amzn", so
+        neither is graded against an EL benchmark. An unknown family is
+        returned lower-cased and unchanged rather than guessed at.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-13
+      description: >
+        Both OS-resolution paths consume BenchmarkFamily, verified so the SQL
+        and Go halves cannot drift apart: OSResolvedMatchSQL emits a CASE
+        mapping the rebuild families to their upstream (not a bare lower()),
+        and frameworkCompatibleWithOS("stig_rhel9", "almalinux", "9.8") is
+        TRUE while frameworkCompatibleWithOS("stig_rhel9", "fedora", "41") is
+        FALSE. The negative case is the load-bearing one: it proves the fix
+        widened resolution to rebuilds WITHOUT silently widening it to every
+        distro that rolls up to the rhel family in discovery.
+      priority: critical
+      references_constraints: [C-07]


### PR DESCRIPTION
A Rocky, AlmaLinux, Oracle Linux or CentOS host is offered **no STIG or CIS lens at all**.

Confirmed on a live host rather than from source. `owas-rock09` (almalinux 9.8) had 769 rule results stored, **391 of them carrying a `stig_rhel9` ref**, and the lens picker showed only "All rules" and "NIST 800-53".

| | `owas-tst02` (rhel 9.6) | `owas-rock09` (almalinux 9.8) |
|---|---|---|
| Lenses offered | All rules · CIS RHEL 9 · NIST 800-53 · STIG RHEL 9 | All rules · NIST 800-53 |
| STIG | 88.3%, 401 rules | **not offered** |
| CIS | 79.2%, 313 rules | **not offered** |

## Cause

Two paths derived the lens key from the raw distro id:

- `OSResolvedMatchSQL` built `<family>_<lower(os_family)><major>`, asking for `stig_almalinux9`. No rule in the corpus emits that; Kensa authors OS keys for `rhel8/9/10` and `ubuntu22/24` only.
- `frameworkCompatibleWithOS` rejected `stig_rhel9` because the pinned family `rhel` did not equal the host family `almalinux`.

The second is why this was invisible rather than merely wrong. It decides which lenses are **offered**, so the symptom was not a zero score but an absent lens: a page that looks complete while withholding two thirds of the host's compliance signal, with nothing on screen to say so.

**The product already had the right mapping, in the wrong layer.** `osLabel.ts` mapped `almalinux → RHEL` for display, so the header read "RHEL 9.8" while the query asked for `almalinux`.

## Fix

Two independent copies of one fact is how this shipped, so: one `framework.BenchmarkFamily` consumed by both paths, with the SQL `CASE` **generated** from the Go map rather than hand-mirrored. AC-13 asserts both paths consume it, not that they happen to agree today.

**Fedora and Amazon Linux are deliberately excluded.** Fedora rolls up to the `rhel` family in Discovery, so the obvious rollup-based fix would have swept it in and graded a Fedora host against the RHEL 9 STIG, manufacturing coverage rather than reporting none. A distro absent from the map keeps its own id and is offered no OS-specific lens. The negative cases carry the AC.

`osLabel` also gains `fedora` as its own label instead of falling through to "Unknown" (which read as a detection failure that had not happened), plus `ol`/`oracle` in the RHEL display bucket. The table now carries a comment that it is a display mapping and **not** a benchmark-equivalence claim, since copying it backend-side is exactly what would reintroduce this.

## Why nothing caught it

Every host fixture in the tree sets `os_family` to `rhel` or `ubuntu`.

## Upstream

The normalization is a **stand-in** for a fact Kensa computes and discards: it resolved the host to an EL platform in order to decide which rules to run, and does not publish what it resolved to. Filed as `features/KN-OW-018`. Delete this map when that lands rather than extending it, since every entry is a second copy of Kensa's platform gate and the gate is expected to widen.

Worth noting the stored data cannot answer it either: `framework_refs` is a property of the *rule*, so an AlmaLinux host and a RHEL host come back carrying the same five STIG keys, including two Ubuntu ones.

## Verification

- `system-compliance-lens` 1.4.0 → 1.5.0 (C-07, AC-12, AC-13); `frontend-host-list-os` 1.0.0 → 1.1.0 (AC-08)
- 118/118 specs at 100% annotation coverage; Go tests and 387 frontend tests pass; gofmt clean
- **Mutation-checked all three guards**: reverting the SQL to `lower()`, adding fedora to the map, and reverting the lens comparison each fail loudly
- Verified live after the fix: the same host now reports **STIG RHEL 9 at 41.4% over 391 rules** and **CIS RHEL 9 at 49.2% over 303**, and the Compliance tab regained its failing-count badge

## Blast radius

Every Rocky, AlmaLinux, Oracle Linux and CentOS Stream host. Those platforms are named in the CMMC Sprint scope, and drift detection is computed from the compliance score that was coming back empty.