### PR TITLE
ci: exclude test fixtures from secret scanning (replaces #750)

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,18 @@
+# GitHub secret scanning, path exclusions.
+# https://docs.github.com/en/code-security/secret-scanning/using-advanced-secret-scanning-and-push-protection-features/excluding-folders-and-files-from-secret-scanning
+#
+# Scope is deliberately narrow: test FIXTURE directories only. These hold keys
+# committed on purpose that keep raising false positives, for example
+# internal/license/testdata/license-privkey-test.pem and
+# internal/policy/testdata/policy-privkey-test.pem. Those are Ed25519 signing
+# test keys. Their real counterparts live in the offline operator vault, and the
+# build rejects an embedded key that equals a testdata key.
+#
+# General source is NOT excluded, and neither is "**/*_test.go", so a real
+# credential committed to a test still gets flagged.
+#
+# Exclusions apply to FUTURE commits only. Alerts already open (all test
+# fixtures, plus an already-rotated and removed MongoDB certificate) have to be
+# dismissed once in the UI as "Used in tests" or "Revoked".
+paths-ignore:
+  - "**/testdata/**"


### PR DESCRIPTION
Replaces PR #750, which cannot be merged as it stands. Close that one in favor of this.

## What the exclusion does

Every open secret-scanning alert on this repo is a committed-on-purpose test fixture: the Ed25519 signing keys under `internal/license/testdata/` and `internal/policy/testdata/`, plus one MongoDB certificate that was rotated and removed. They will keep firing until the path is excluded.

Scope is one path, `**/testdata/**`. General source is not excluded, and neither is `**/*_test.go`, so a real credential committed to a test still gets flagged. A blanket exclusion would have made the check useless.

Exclusions apply to future commits only. The alerts already open have to be dismissed once in the UI as "Used in tests" or "Revoked".

## Why not just merge #750

Two problems, both from age. That branch was cut 2026-07-17, before the compliance-lens work landed.

1. **It reverts unrelated work.** GitHub reports it CONFLICTING/DIRTY. Its diff against main rolls `packaging/version.env` back from 0.7.1 to 0.6.0 and touches 21 other files it has no business changing. Its real contribution was 2 files.
2. **It reintroduces a leaked path.** The comment block named the release captain's vault directory, in a public repository. That is the same path PR #804 is removing from `docs/runbooks/RELEASING.md`. Merging #750 would have put it straight back.

This branch is cut from current `main` and carries the one file, with the vault reference reduced to "the offline operator vault".

The `.gitignore` negation #750 also carried is no longer needed. `git check-ignore -v .github/secret_scanning.yml` reports the file is not ignored under main's current rules.
