### PR TITLE
feat(fips): report FIPS state from the runtime, and warn on fips140=only

### DIFF
--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -987,7 +987,24 @@ func printVersion(out *os.File) {
 	fmt.Fprintf(out, "openwatch %s\n", version.Version)
 	fmt.Fprintf(out, "  commit:    %s\n", version.Commit)
 	fmt.Fprintf(out, "  built:     %s\n", version.BuildTime)
-	fmt.Fprintf(out, "  fips:      %s\n", version.FIPS)
+	// Runtime truth, not the build flag: a binary can carry -X FIPS=true
+	// without GOFIPS140 and would otherwise advertise a module it does not
+	// have. An auditor reads this off the box, so it has to be measured.
+	fmt.Fprintf(out, "  fips:      %t\n", version.FIPSEnabled())
+	if version.FIPSEnabled() {
+		fmt.Fprintf(out, "  fips_module: %s\n", version.FIPSModule())
+		fmt.Fprintf(out, "  fips_mode:   %s\n", version.FIPSMode())
+		if version.FIPSMode() == "only" {
+			fmt.Fprintf(out, "  WARNING: fips140=only refuses algorithms that "+
+				"golang.org/x/crypto/ssh requires; SSH scanning and remediation "+
+				"will fail against every host. Use fips140=on.\n")
+		}
+	}
+	if version.FIPSClaimMismatch() {
+		fmt.Fprintf(out, "  WARNING: this binary was built with -ldflags FIPS=%s "+
+			"but the runtime reports FIPS %t. The build is misconfigured; do not "+
+			"rely on its FIPS status.\n", version.FIPS, version.FIPSEnabled())
+	}
 	fmt.Fprintf(out, "  goversion: %s\n", runtime.Version())
 	fmt.Fprintf(out, "  os/arch:   %s/%s\n", runtime.GOOS, runtime.GOARCH)
 }

--- a/internal/version/fips.go
+++ b/internal/version/fips.go
@@ -91,7 +91,7 @@ func fips140Setting(godebug string) string {
 }
 
 // FIPSClaimMismatch reports whether the build-time FIPS ldflag disagrees with
-// the runtime. True means the binary was labelled FIPS but has no active
+// the runtime. True means the binary was labeled FIPS but has no active
 // module, or the reverse. Callers surface this loudly: a mislabelled binary is
 // worse than an unlabelled one, because it is trusted.
 func FIPSClaimMismatch() bool {

--- a/internal/version/fips.go
+++ b/internal/version/fips.go
@@ -1,0 +1,99 @@
+// FIPS reporting, sourced from the runtime rather than from a build flag.
+//
+// WHY THIS EXISTS: --version used to print the FIPS ldflag verbatim. That is a
+// claim about how someone intended to build the binary, not a fact about the
+// binary. `go build -ldflags "-X ...version.FIPS=true"` without GOFIPS140 set
+// produces a binary that reports fips=true and contains no FIPS module at all.
+// For a compliance product that is the worst possible failure: an auditor reads
+// the claim off the box and it is false.
+//
+// Everything here is read from the running binary. FIPS is the ldflag, kept as
+// a cross-check: when the two disagree the binary says so instead of choosing
+// the flattering answer.
+package version
+
+import (
+	"crypto/fips140"
+	"os"
+	"runtime/debug"
+	"strings"
+)
+
+// FIPSEnabled reports whether the FIPS 140-3 module is active in this binary,
+// as the crypto runtime sees it. This is the authoritative answer.
+func FIPSEnabled() bool {
+	return fips140.Enabled()
+}
+
+// FIPSModule returns the FIPS module build tag linked into the binary, for
+// example "fips140v1.0", or "" when no module is linked. Read from build info,
+// so it reflects what GOFIPS140 actually selected at link time.
+func FIPSModule() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, s := range bi.Settings {
+		if s.Key != "-tags" {
+			continue
+		}
+		for _, tag := range strings.Split(s.Value, ",") {
+			if strings.HasPrefix(tag, "fips140") {
+				return tag
+			}
+		}
+	}
+	return ""
+}
+
+// FIPSMode returns the active enforcement mode: "off", "on", or "only".
+//
+// The distinction matters operationally, not just cosmetically. In "only" mode
+// the Go crypto runtime refuses every algorithm outside the validated set, and
+// golang.org/x/crypto/ssh cannot complete a handshake because its AES-GCM path
+// uses arbitrary IVs. An OpenWatch reaching for maximum assurance by setting
+// fips140=only loses the ability to scan any host, so the mode has to be
+// visible rather than inferred.
+//
+// A GODEBUG environment setting overrides the value baked in at build time,
+// which is why both are consulted in that order.
+func FIPSMode() string {
+	if m := fips140Setting(os.Getenv("GODEBUG")); m != "" {
+		return m
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range bi.Settings {
+			if s.Key == "DefaultGODEBUG" {
+				if m := fips140Setting(s.Value); m != "" {
+					return m
+				}
+			}
+		}
+	}
+	if FIPSEnabled() {
+		return "on"
+	}
+	return "off"
+}
+
+// fips140Setting extracts the fips140 value from a GODEBUG-style
+// comma-separated list, returning "" when the key is absent. The last
+// occurrence wins, matching the runtime's own precedence.
+func fips140Setting(godebug string) string {
+	out := ""
+	for _, kv := range strings.Split(godebug, ",") {
+		k, v, found := strings.Cut(strings.TrimSpace(kv), "=")
+		if found && k == "fips140" {
+			out = v
+		}
+	}
+	return out
+}
+
+// FIPSClaimMismatch reports whether the build-time FIPS ldflag disagrees with
+// the runtime. True means the binary was labelled FIPS but has no active
+// module, or the reverse. Callers surface this loudly: a mislabelled binary is
+// worse than an unlabelled one, because it is trusted.
+func FIPSClaimMismatch() bool {
+	return (FIPS == "true") != FIPSEnabled()
+}

--- a/internal/version/fips_test.go
+++ b/internal/version/fips_test.go
@@ -80,7 +80,7 @@ func TestFIPS_GodebugParsing(t *testing.T) {
 }
 
 // @ac AC-10
-// AC-10: "only" is a recognised mode and is treated as unsafe rather than as
+// AC-10: "only" is a recognized mode and is treated as unsafe rather than as
 // the strictest good option.
 //
 // The empirical basis: a FIPS-built SSH client connecting to a real host

--- a/internal/version/fips_test.go
+++ b/internal/version/fips_test.go
@@ -1,0 +1,106 @@
+// @spec release-fips-build
+//
+//	AC-09  TestFIPS_ReportedFromRuntimeNotBuildFlag
+//	AC-10  TestFIPS_OnlyModeIsFlaggedUnsafe
+package version
+
+import (
+	"crypto/fips140"
+	"strings"
+	"testing"
+)
+
+// @ac AC-09
+// AC-09: the FIPS report is measured, not declared.
+//
+// This test runs under whichever toolchain mode the suite was invoked with, so
+// it asserts the INVARIANT (report agrees with the crypto runtime) rather than
+// a fixed value. `make test` and `GOFIPS140=v1.0.0 go test` therefore both
+// exercise it, and a build that lies is caught either way.
+func TestFIPS_ReportedFromRuntimeNotBuildFlag(t *testing.T) {
+	t.Run("release-fips-build/AC-09", func(t *testing.T) {
+		if FIPSEnabled() != fips140.Enabled() {
+			t.Errorf("FIPSEnabled() = %t, crypto/fips140.Enabled() = %t; the report "+
+				"must mirror the runtime", FIPSEnabled(), fips140.Enabled())
+		}
+
+		// The module tag is present exactly when a module is linked. A build
+		// claiming FIPS with no tag is the mislabelled case this guards.
+		mod := FIPSModule()
+		if FIPSEnabled() && mod == "" {
+			t.Error("FIPS is enabled but FIPSModule() is empty; the linked module " +
+				"tag should be readable from build info")
+		}
+		if mod != "" && !strings.HasPrefix(mod, "fips140") {
+			t.Errorf("FIPSModule() = %q, want a fips140* build tag", mod)
+		}
+
+		// Mode is constrained to the three the runtime defines, and must be
+		// off exactly when FIPS is inactive.
+		switch m := FIPSMode(); m {
+		case "off":
+			if FIPSEnabled() {
+				t.Error(`FIPSMode() = "off" while FIPS is enabled`)
+			}
+		case "on", "only":
+			if !FIPSEnabled() {
+				t.Errorf("FIPSMode() = %q while FIPS is disabled", m)
+			}
+		default:
+			t.Errorf("FIPSMode() = %q, want off, on, or only", m)
+		}
+	})
+}
+
+// @ac AC-09
+// AC-09 (parser): GODEBUG parsing, asserted directly so the precedence rules
+// are pinned without needing to relaunch the process under each setting.
+func TestFIPS_GodebugParsing(t *testing.T) {
+	t.Run("release-fips-build/AC-09", func(t *testing.T) {
+		cases := []struct {
+			godebug string
+			want    string
+		}{
+			{"", ""},
+			{"fips140=on", "on"},
+			{"fips140=only", "only"},
+			{"http2debug=1,fips140=only", "only"},
+			{"fips140=only,http2debug=1", "only"},
+			{" fips140=on , other=2 ", "on"},
+			{"notfips140=only", ""},
+			// Last occurrence wins, matching the runtime.
+			{"fips140=on,fips140=only", "only"},
+		}
+		for _, c := range cases {
+			if got := fips140Setting(c.godebug); got != c.want {
+				t.Errorf("fips140Setting(%q) = %q, want %q", c.godebug, got, c.want)
+			}
+		}
+	})
+}
+
+// @ac AC-10
+// AC-10: "only" is a recognised mode and is treated as unsafe rather than as
+// the strictest good option.
+//
+// The empirical basis: a FIPS-built SSH client connecting to a real host
+// succeeds at fips140=on and fails at fips140=only with "crypto/cipher: use of
+// GCM with arbitrary IVs is not allowed in FIPS 140-only mode". The failure is
+// in golang.org/x/crypto/ssh, not in OpenWatch, so it cannot be fixed here and
+// has to be surfaced. An operator choosing "only" for maximum assurance would
+// otherwise silently lose scanning against every host.
+func TestFIPS_OnlyModeIsFlaggedUnsafe(t *testing.T) {
+	t.Run("release-fips-build/AC-10", func(t *testing.T) {
+		if got := fips140Setting("fips140=only"); got != "only" {
+			t.Fatalf("fips140Setting could not detect only mode, got %q", got)
+		}
+		// C-05 claims the two binaries are functionally identical. That holds
+		// for the diagnostic echo path it names, and does NOT hold across FIPS
+		// modes. This assertion exists so the mode stays distinguishable: the
+		// warning in printVersion depends on telling "only" from "on".
+		if fips140Setting("fips140=on") == fips140Setting("fips140=only") {
+			t.Error("on and only must be distinguishable; the --version warning " +
+				"and the supported-configuration claim both depend on it")
+		}
+	})
+}

--- a/specs/release/fips-build.spec.yaml
+++ b/specs/release/fips-build.spec.yaml
@@ -43,7 +43,13 @@ spec:
       type: security
       enforcement: error
     - id: C-02
-      description: make build-fips MUST inject FIPS=true via -ldflags so the binary reports fips=true at --version
+      description: >
+        make build-fips MUST inject FIPS=true via -ldflags, and --version MUST
+        report the RUNTIME state (crypto/fips140.Enabled) rather than that flag.
+        The flag is retained only as a cross-check: -ldflags alone, without
+        GOFIPS140 set, produces a binary carrying no FIPS module that would
+        otherwise advertise one. When flag and runtime disagree --version MUST
+        say so.
       type: technical
       enforcement: error
     - id: C-03
@@ -95,3 +101,26 @@ spec:
     - id: AC-08
       description: The two binaries report the same Version, Commit, and BuildTime when built from the same source tree at the same time.
       priority: medium
+    - id: AC-09
+      description: >
+        --version reports FIPS from the runtime, not from the ldflag.
+        FIPSEnabled mirrors crypto/fips140.Enabled; FIPSModule returns the
+        linked module tag (for example "fips140v1.0") and empty on a non-FIPS
+        build; FIPSMode returns off, on, or only, with a GODEBUG environment
+        setting taking precedence over the DefaultGODEBUG baked in at link
+        time. FIPSClaimMismatch is true when the ldflag and the runtime
+        disagree, which is the case a mislabelled build produces.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-10
+      description: >
+        fips140=only is called out as operationally unsafe. In that mode the Go
+        crypto runtime refuses algorithms golang.org/x/crypto/ssh requires and
+        every SSH handshake fails with "use of GCM with arbitrary IVs is not
+        allowed in FIPS 140-only mode", so scanning and remediation stop
+        working against every host. The FIPS binary is therefore NOT
+        functionally identical across modes (see C-05, which covers the
+        diagnostic echo path only), and --version MUST warn when it detects
+        mode "only". The supported FIPS configuration is fips140=on, which is
+        what GOFIPS140 bakes in as DefaultGODEBUG.
+      priority: critical


### PR DESCRIPTION
Written 2026-07-30, never opened as a PR. Verified against current `main` before pushing: merges clean, and `go build`, `go vet`, `go test ./cmd/openwatch ./internal/version` all pass on the merge result.

## The problem

`openwatch version` prints `fips:` straight from `version.FIPS`, a string set by an `-ldflags` build flag. Nothing measures the runtime. A binary built with `-X FIPS=true` and no `GOFIPS140` advertises a FIPS module it does not have, and an auditor reads that line off the box as a fact about the host.

## What changes

`fips:` now reports `version.FIPSEnabled()`, measured from the runtime. When FIPS is on, the command also prints the module version and the mode.

Two warnings are added:

- **`fips140=only`.** Only-mode refuses algorithms that `golang.org/x/crypto/ssh` requires. Every SSH handshake fails, so scanning and remediation die against every host, and the operator sees connection failures rather than a crypto policy. The command now says to use `fips140=on`.
- **Claim mismatch.** `FIPSClaimMismatch()` compares the build-time `FIPS` ldflag against the measured runtime state and says the build is misconfigured when they disagree.

## Files

| File | |
|---|---|
| `internal/version/fips.go` | new, 99 lines |
| `internal/version/fips_test.go` | new, 106 lines |
| `cmd/openwatch/main.go` | the version output |
| `specs/release/fips-build.spec.yaml` | the acceptance criteria |
