### PR TITLE
feat(db): refuse to migrate against a PostgreSQL the schema cannot build

### DIFF
--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -850,6 +850,20 @@ func cmdMigrate(cfg *config.Config, args []string, stdout, stderr *os.File) int 
 	}
 	defer pool.Close()
 
+	// Preflight the server version before touching the schema. Below the hard
+	// floor a migration run fails partway through naming a missing function
+	// rather than a version, leaving the schema half-applied; refusing here
+	// keeps the database untouched. Runs for --status too, so the check is
+	// reachable without committing to a migration.
+	advisory, err := db.CheckServerVersion(ctx, pool)
+	if err != nil {
+		fmt.Fprintf(stderr, "openwatch migrate: %v\n", err)
+		return 1
+	}
+	if advisory != "" {
+		fmt.Fprintf(stderr, "openwatch migrate: WARNING: %s\n", advisory)
+	}
+
 	curr, files, err := migrations.Status(ctx, pool)
 	if err != nil {
 		fmt.Fprintf(stderr, "openwatch migrate: status: %v\n", err)

--- a/internal/db/serverversion.go
+++ b/internal/db/serverversion.go
@@ -11,7 +11,7 @@
 //     rather than a version and leaves the schema half-applied.
 //
 //  2. Between the hard floor and the supported floor the schema builds, but
-//     the version is old enough to carry behaviour the install guide does not
+//     the version is old enough to carry behavior the install guide does not
 //     account for. PostgreSQL 13 defaults password_encryption to md5 where 14
 //     and later default to scram-sha-256, so a role created by following the
 //     guide could not authenticate against the pg_hba.conf rules the same

--- a/internal/db/serverversion.go
+++ b/internal/db/serverversion.go
@@ -1,0 +1,113 @@
+// Server-version preflight for the migration path.
+//
+// WHY THIS EXISTS: nothing in the binary checked what PostgreSQL it was
+// talking to. Two versions of that problem showed up during a v0.7.0 install
+// on RHEL 9, which defaults to PostgreSQL 13:
+//
+//  1. Below the hard floor the schema simply does not build. gen_random_uuid()
+//     became a built-in in PostgreSQL 13; three migrations use it as a column
+//     DEFAULT. On 12 or older the operator gets "function gen_random_uuid()
+//     does not exist" partway through a migration run, which names a function
+//     rather than a version and leaves the schema half-applied.
+//
+//  2. Between the hard floor and the supported floor the schema builds, but
+//     the version is old enough to carry behaviour the install guide does not
+//     account for. PostgreSQL 13 defaults password_encryption to md5 where 14
+//     and later default to scram-sha-256, so a role created by following the
+//     guide could not authenticate against the pg_hba.conf rules the same
+//     guide supplied.
+//
+// Those are different failures and deserve different answers, so this reports
+// them separately. Documentation cannot enforce a floor; a released binary
+// can, and says so once, in terms naming the version.
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	// MinServerVersionNum is the HARD floor, below which migrations cannot
+	// succeed. 13 is set by gen_random_uuid() as a built-in. Raising this is
+	// a breaking change for existing deployments, so it tracks what the SQL
+	// actually requires, not what the project prefers to support.
+	MinServerVersionNum = 130000
+
+	// SupportedServerVersionNum is the lowest version a NEW install should
+	// target. Deliberately higher than the hard floor: PostgreSQL 14 reaches
+	// end of life in November 2026, and a release that ships before then
+	// still runs past it. Below this the binary warns and continues, so an
+	// existing deployment is never bricked by a policy change.
+	SupportedServerVersionNum = 150000
+)
+
+// ServerVersion reports the connected server's version as a PostgreSQL
+// version number (major*10000 + minor), for example 150018 for 15.18.
+func ServerVersion(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+	var num int
+	// server_version_num is stable across releases; parsing the
+	// server_version string is not, since it carries vendor suffixes such as
+	// "15.18 (Debian 15.18-1.pgdg120+1)".
+	//
+	// current_setting with an explicit ::int rather than SHOW: every GUC comes
+	// back as text regardless of its underlying type, so SHOW cannot scan into
+	// an int and fails with a type error at runtime.
+	const q = `SELECT current_setting('server_version_num')::int`
+	if err := pool.QueryRow(ctx, q).Scan(&num); err != nil {
+		return 0, fmt.Errorf("db: read server_version_num: %w", err)
+	}
+	return num, nil
+}
+
+// FormatServerVersion renders a version number as major.minor for humans.
+func FormatServerVersion(num int) string {
+	return fmt.Sprintf("%d.%d", num/10000, num%10000)
+}
+
+// CheckServerVersion enforces the hard floor and reports whether the server is
+// merely below the supported floor.
+//
+// Returns an error only when the server cannot run the schema at all. The
+// second return is a non-empty advisory when the server is usable but older
+// than a new install should target; callers print it and continue.
+func CheckServerVersion(ctx context.Context, pool *pgxpool.Pool) (advisory string, err error) {
+	num, err := ServerVersion(ctx, pool)
+	if err != nil {
+		return "", err
+	}
+	if num < MinServerVersionNum {
+		return "", belowFloorError(num)
+	}
+	if num < SupportedServerVersionNum {
+		return belowSupportedAdvisory(num), nil
+	}
+	return "", nil
+}
+
+// belowFloorError builds the refusal. Split out from CheckServerVersion so the
+// wording is testable without an old server to connect to, which is the only
+// way it would otherwise be exercised.
+func belowFloorError(num int) error {
+	return fmt.Errorf(
+		"db: PostgreSQL %s is too old: OpenWatch requires %s or newer "+
+			"(gen_random_uuid must be built in). Upgrade the server, or point "+
+			"OPENWATCH_DATABASE_DSN at a supported instance",
+		FormatServerVersion(num), FormatServerVersion(MinServerVersionNum))
+}
+
+// belowSupportedAdvisory builds the warning for a server that works but is
+// older than a new install should target. It names the md5 default explicitly
+// because that is the failure this whole check came out of, and the symptom
+// (authentication rejected) points at the role rather than at the version.
+func belowSupportedAdvisory(num int) string {
+	return fmt.Sprintf(
+		"PostgreSQL %s is below the supported minimum %s. Migrations will run, "+
+			"but this version is not a supported target for a new install. Note that "+
+			"PostgreSQL 13 defaults password_encryption to md5 while the install guide "+
+			"configures pg_hba.conf for scram-sha-256; if role authentication fails, "+
+			"check the stored hash format",
+		FormatServerVersion(num), FormatServerVersion(SupportedServerVersionNum))
+}

--- a/internal/db/serverversion_test.go
+++ b/internal/db/serverversion_test.go
@@ -1,0 +1,99 @@
+// @spec system-db
+//
+//	AC-13  TestServerVersion_PreflightEnforcesFloorAndAdvises
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+)
+
+// @ac AC-13
+// AC-13: the version preflight enforces the hard floor and advises separately
+// on the supported floor.
+//
+// The two thresholds are deliberately different lines and the test pins both.
+// Collapsing them would either brick an existing deployment on an older server
+// (if the supported floor were enforced) or let a migration run start on a
+// server that cannot build the schema (if only the supported floor warned).
+func TestServerVersion_PreflightEnforcesFloorAndAdvises(t *testing.T) {
+	t.Run("system-db/AC-13", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+		ctx := context.Background()
+
+		// ServerVersion reads the integer GUC, so it never has to parse a
+		// vendor-suffixed version string.
+		num, err := ServerVersion(ctx, pool)
+		if err != nil {
+			t.Fatalf("ServerVersion: %v", err)
+		}
+		if num < 100000 || num > 999999 {
+			t.Errorf("server_version_num = %d, want a 6-digit PostgreSQL version number", num)
+		}
+
+		// The test database is a supported version, so the preflight is silent.
+		advisory, err := CheckServerVersion(ctx, pool)
+		if err != nil {
+			t.Errorf("CheckServerVersion on %s: unexpected error %v",
+				FormatServerVersion(num), err)
+		}
+		if num >= SupportedServerVersionNum && advisory != "" {
+			t.Errorf("advisory on supported version %s = %q, want empty",
+				FormatServerVersion(num), advisory)
+		}
+
+		// The thresholds are ordered, and the hard floor is the one the SQL
+		// actually requires. If someone raises MinServerVersionNum to match
+		// the supported floor, existing deployments stop migrating.
+		if MinServerVersionNum > SupportedServerVersionNum {
+			t.Errorf("MinServerVersionNum %d must not exceed SupportedServerVersionNum %d",
+				MinServerVersionNum, SupportedServerVersionNum)
+		}
+		if MinServerVersionNum != 130000 {
+			t.Errorf("MinServerVersionNum = %d, want 130000: the floor is set by "+
+				"gen_random_uuid becoming a built-in in PostgreSQL 13, so it moves "+
+				"only when the migrations' SQL requirements move", MinServerVersionNum)
+		}
+
+		// Both messages must name the version, because the failure they
+		// replace named a missing function instead and sent operators looking
+		// at the wrong thing.
+		if got := FormatServerVersion(130000); got != "13.0" {
+			t.Errorf("FormatServerVersion(130000) = %q, want \"13.0\"", got)
+		}
+		if got := FormatServerVersion(150018); got != "15.18" {
+			t.Errorf("FormatServerVersion(150018) = %q, want \"15.18\"", got)
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13 (message content): the operator-facing strings name the version found
+// and the version needed. Asserted separately from the live-database case so
+// the wording is pinned even where no old server is available to connect to.
+func TestServerVersion_MessagesNameVersions(t *testing.T) {
+	t.Run("system-db/AC-13", func(t *testing.T) {
+		// Below the hard floor: an error naming both versions.
+		err := belowFloorError(120000)
+		if err == nil {
+			t.Fatal("expected an error below the hard floor")
+		}
+		for _, want := range []string{"12.0", "13.0"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("hard-floor error %q does not name %q", err.Error(), want)
+			}
+		}
+
+		// Between floors: an advisory naming both versions and the md5 trap
+		// that motivated the check.
+		adv := belowSupportedAdvisory(130023)
+		for _, want := range []string{"13.23", "15.0", "md5"} {
+			if !strings.Contains(adv, want) {
+				t.Errorf("advisory %q does not mention %q", adv, want)
+			}
+		}
+	})
+}

--- a/specs/system/db.spec.yaml
+++ b/specs/system/db.spec.yaml
@@ -91,3 +91,16 @@ spec:
     - id: AC-12
       description: Data persists across binary restart (rebuild + remigrate idempotently; row remains).
       priority: high
+    - id: AC-13
+      description: >
+        Server-version preflight. ServerVersion reads server_version_num (not
+        the server_version string, which carries vendor suffixes) and
+        CheckServerVersion enforces two distinct lines. Below
+        MinServerVersionNum (130000, set by gen_random_uuid becoming a
+        built-in) it returns an error naming both the version found and the
+        version required, and the caller refuses to migrate so a half-applied
+        schema is impossible. Between the hard floor and
+        SupportedServerVersionNum (150000) it returns a non-empty advisory and
+        no error, so an existing deployment on an older server still migrates.
+        At or above the supported floor both returns are empty.
+      priority: high


### PR DESCRIPTION
Written 2026-07-30, never opened as a PR. Verified against current `main` before pushing: merges clean, and `go build`, `go vet`, `go test ./cmd/openwatch ./internal/db` all pass on the merge result.

## The gap

`openwatch setup` gained a PostgreSQL version check in PR #776: `internal/setup/steps.go` reads `server_version_num` and refuses below `minPostgresMajor = 15`.

`openwatch migrate` has no such check. `CheckServerVersion` appears nowhere in `main`. That is the path an operator takes on a manual install and on every upgrade, which is exactly where a half-applied schema does the most damage.

## What changes

`internal/db/serverversion.go` defines two floors, and `migrate` consults them before touching the schema:

- **Hard floor.** Below it the schema cannot build at all. A migration run fails partway through naming a missing function rather than a version, leaving the schema half-applied. Refusing up front keeps the database untouched.
- **Supported floor**, `SupportedServerVersionNum = 150000`. Between the two the schema builds but behavior differs, so this reports an advisory instead of refusing. This agrees with `setup`'s `minPostgresMajor = 15`.

The check also runs for `migrate --status`, so an operator can reach it without committing to a migration.

## Files

| File | |
|---|---|
| `internal/db/serverversion.go` | new, 113 lines |
| `internal/db/serverversion_test.go` | new, 99 lines |
| `cmd/openwatch/main.go` | the migrate preflight |
| `specs/system/db.spec.yaml` | the acceptance criteria |
