### PR TITLE
fix(packaging): refuse to build a release whose tag disagrees with version.env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The tag is the only place a pre-release identity exists on the way in,
+      # and packaging/version.env is the only place it exists on the way out.
+      # Nothing compared them, so tagging v0.7.0-rc.1 and v0.7.0-rc.2 against a
+      # version.env of "0.7.0" produced two byte-different builds sharing one
+      # NEVRA (openwatch-1:0.7.0-1.x86_64). `dnf upgrade` between them reports
+      # "Nothing to do", and `rpm -q` cannot tell them apart, so a tester can
+      # verify an RC they never actually installed. The build scripts already
+      # tilde-encode a pre-release correctly; the suffix simply never reached
+      # them. This gate makes that impossible to repeat.
+      - name: Verify the tag matches packaging/version.env
+        run: bash packaging/check-tag-version.sh
+        env:
+          RELEASE_REF: ${{ github.event.inputs.version || github.ref_name }}
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/packaging/check-tag-version.sh
+++ b/packaging/check-tag-version.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Assert that the release ref being built matches packaging/version.env.
+#
+# WHY THIS EXISTS: the pre-release identity of a build lives in two places and
+# nothing compared them. The tag carries it on the way in (v0.7.0-rc.2) and
+# packaging/version.env carries it on the way out (VERSION="0.7.0-rc.2"), and
+# only the second reaches the package metadata.
+#
+# v0.7.0-rc.1 and v0.7.0-rc.2 were both tagged against a version.env of
+# "0.7.0". The build scripts did nothing wrong: build-rpm.sh tilde-encodes a
+# pre-release correctly, and there is a test asserting it does. The suffix
+# simply never got as far as them. Both RCs therefore shipped as
+#
+#   openwatch-1:0.7.0-1.x86_64
+#
+# byte-different artifacts with one identity. `dnf upgrade` between them prints
+# "Nothing to do" and leaves the host on the older build; `rpm -q` cannot tell
+# them apart. The dangerous case is silent: install rc.1, "upgrade" to rc.2,
+# test, sign off, having verified rc.1 the whole time. Only
+# GET /api/v1/version, which reports the build commit, distinguishes them.
+#
+# Usage: RELEASE_REF=v0.7.0-rc.2 packaging/check-tag-version.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ref="${RELEASE_REF:-}"
+if [ -z "$ref" ]; then
+    echo "check-tag-version: RELEASE_REF is empty; expected a tag such as v0.7.0-rc.2" >&2
+    exit 2
+fi
+
+# shellcheck source=/dev/null
+. "$here/version.env"
+
+# The tag is the semver prefixed with 'v'; version.env holds the bare semver.
+tag_version="${ref#v}"
+
+if [ "$tag_version" = "$VERSION" ]; then
+    echo "check-tag-version: OK — tag $ref matches VERSION=$VERSION"
+    exit 0
+fi
+
+cat >&2 <<EOF
+check-tag-version: REFUSING TO BUILD
+
+  tag                    $ref  (version $tag_version)
+  packaging/version.env  VERSION="$VERSION"
+
+These must be identical. VERSION is what reaches the RPM and DEB metadata, so
+building this tag would publish a package whose version is not the one you
+tagged.
+
+If this is a release candidate, the pre-release suffix belongs in version.env
+too, exactly as the v0.2.0 series did (0.2.0-rc.16, 0.2.0-rc.17, then 0.2.0 at
+GA). Set VERSION="$tag_version", update the README version phrase and the
+newest CHANGELOG heading to match (packaging/tests enforces all three agree),
+then move the tag.
+
+Two pre-releases that share a VERSION produce two different builds with one
+package identity, and dnf or apt will refuse to move between them.
+EOF
+exit 1

--- a/packaging/tests/package_test.go
+++ b/packaging/tests/package_test.go
@@ -907,7 +907,7 @@ func TestPackaging_ReleaseTagMatchesVersionEnv(t *testing.T) {
 				"an artifact")
 		}
 
-		// Behaviour, against the real version.env in the tree.
+		// Behavior, against the real version.env in the tree.
 		version := versionEnvVersion(t)
 		run := func(ref string) error {
 			cmd := exec.Command("bash", script)

--- a/packaging/tests/package_test.go
+++ b/packaging/tests/package_test.go
@@ -866,3 +866,72 @@ func TestPackaging_PreReleaseVersioning(t *testing.T) {
 		}
 	})
 }
+
+// @ac AC-24
+// AC-24: the release ref and packaging/version.env must agree before anything
+// is built.
+//
+// AC-21 already asserts the tilde encoding is present in the build scripts,
+// and it was present and correct throughout the v0.7.0 cycle. It still shipped
+// v0.7.0-rc.1 and v0.7.0-rc.2 as the same package, because both were tagged
+// against VERSION="0.7.0" and the pre-release suffix never reached the code
+// AC-21 guards. A source-inspection test on the encoder cannot see that its
+// input was wrong, so this one runs the gate instead of reading it.
+func TestPackaging_ReleaseTagMatchesVersionEnv(t *testing.T) {
+	t.Run("release-package-build/AC-24", func(t *testing.T) {
+		dir := appDir(t)
+		script := filepath.Join(dir, "packaging", "check-tag-version.sh")
+		if _, err := os.Stat(script); err != nil {
+			t.Fatalf("packaging/check-tag-version.sh is missing: %v", err)
+		}
+
+		// The gate must be wired into the release workflow BEFORE the build,
+		// or it protects nothing.
+		wf, err := os.ReadFile(filepath.Join(dir, ".github", "workflows", "release.yml"))
+		if err != nil {
+			t.Fatalf("read release.yml: %v", err)
+		}
+		flow := string(wf)
+		gateAt := strings.Index(flow, "packaging/check-tag-version.sh")
+		buildAt := strings.Index(flow, "make packages")
+		switch {
+		case gateAt < 0:
+			t.Error("release.yml does not invoke packaging/check-tag-version.sh; " +
+				"the tag and version.env would go uncompared")
+		case buildAt < 0:
+			t.Error("release.yml no longer runs `make packages`; this test's ordering " +
+				"check is stale")
+		case gateAt > buildAt:
+			t.Error("release.yml runs check-tag-version.sh AFTER `make packages`; " +
+				"the gate must precede the build so a mismatched tag never produces " +
+				"an artifact")
+		}
+
+		// Behaviour, against the real version.env in the tree.
+		version := versionEnvVersion(t)
+		run := func(ref string) error {
+			cmd := exec.Command("bash", script)
+			cmd.Env = append(os.Environ(), "RELEASE_REF="+ref)
+			return cmd.Run()
+		}
+		if err := run("v" + version); err != nil {
+			t.Errorf("gate rejected the matching tag v%s: %v", version, err)
+		}
+		for _, bad := range []string{
+			"v" + version + "-rc.2", // the exact v0.7.0 defect
+			"v0.0.1-rc.1",
+			"v99.99.99",
+		} {
+			if err := run(bad); err == nil {
+				t.Errorf("gate ACCEPTED tag %q against VERSION=%q; it must refuse, "+
+					"because VERSION is what reaches the package metadata", bad, version)
+			}
+		}
+		// An empty ref is a misconfigured workflow, not a pass.
+		cmd := exec.Command("bash", script)
+		cmd.Env = append(os.Environ(), "RELEASE_REF=")
+		if err := cmd.Run(); err == nil {
+			t.Error("gate accepted an empty RELEASE_REF; a missing ref must fail loudly")
+		}
+	})
+}

--- a/specs/release/package-build.spec.yaml
+++ b/specs/release/package-build.spec.yaml
@@ -152,6 +152,20 @@ spec:
         not land on the read-only root.
       type: technical
       enforcement: error
+    - id: C-14
+      description: >
+        The release ref MUST equal "v" + packaging/version.env VERSION, verified
+        before any package is built. C-12 governs how a pre-release VERSION is
+        encoded, but presupposes that VERSION carries the suffix at all. In the
+        v0.7.0 cycle it did not: v0.7.0-rc.1 and v0.7.0-rc.2 were tagged against
+        VERSION="0.7.0", so the tilde encoding C-12 requires had nothing to act
+        on and both RCs published as openwatch-1:0.7.0-1.x86_64. The pre-release
+        identity exists in the tag on the way in and in version.env on the way
+        out, and only the second reaches package metadata, so the two MUST be
+        compared rather than assumed to agree. Two builds sharing one NEVRA make
+        "dnf upgrade" a silent no-op.
+      type: technical
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -272,3 +286,17 @@ spec:
         remediation/rollback returned "not wired" while scans worked.
       priority: critical
       references_constraints: [C-13]
+    - id: AC-24
+      description: >-
+        The release ref and packaging/version.env must agree before anything is
+        built. packaging/check-tag-version.sh exits 0 when RELEASE_REF equals
+        "v" + VERSION and non-zero otherwise, and .github/workflows/release.yml
+        invokes it before the package build step. Backstops the v0.7.0 defect
+        where v0.7.0-rc.1 and v0.7.0-rc.2 were both tagged against
+        VERSION="0.7.0": AC-21's tilde encoding was present and correct, but the
+        pre-release suffix never reached it, so both RCs published as
+        openwatch-1:0.7.0-1.x86_64. Two byte-different builds under one identity
+        make "dnf upgrade" a no-op and leave "rpm -q" unable to tell them apart,
+        so an operator can verify one RC believing it is the other.
+      priority: critical
+      references_constraints: [C-12, C-14]


### PR DESCRIPTION
Written 2026-07-30, never opened as a PR. Verified against current `main` before pushing: merges clean, and `go build`, `go vet`, `go test ./packaging/tests` all pass on the merge result.

## The defect this closes

The tag is the only place a pre-release identity exists on the way in. `packaging/version.env` is the only place it exists on the way out. Nothing compares them.

So tagging `v0.7.0-rc.1` and `v0.7.0-rc.2` against a `version.env` of `0.7.0` produced two byte-different builds sharing one NEVRA, `openwatch-1:0.7.0-1.x86_64`. The consequences:

- `dnf upgrade` between two RCs reports "Nothing to do".
- `rpm -q` cannot tell them apart.
- **A tester can sign off on an RC they never actually installed.** That is the one that matters, because Stage 3 of the release runbook depends on a human verifying the candidate on a real box.

Every v0.7.0 RC and the GA build shipped under that same version string. Only `/api/v1/version`'s commit hash distinguished them.

## What changes

`packaging/check-tag-version.sh` compares the release ref against `packaging/version.env` and fails the build when they disagree. `release.yml` runs it before anything is built.

The build scripts already tilde-encode a pre-release correctly. The suffix simply never reached them.

## Files

| File | |
|---|---|
| `packaging/check-tag-version.sh` | new, 63 lines |
| `packaging/tests/package_test.go` | 69 lines of coverage |
| `.github/workflows/release.yml` | the gate |
| `specs/release/package-build.spec.yaml` | the acceptance criteria |
