### PR TITLE
fix(idempotency): scope the response cache to the caller that created it

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -359,7 +359,7 @@
         "filename": "internal/db/db_gaps_test.go",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
       }
     ],
     "internal/dbbackup/dbbackup_test.go": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T15:40:58Z"
+  "generated_at": "2026-08-12T16:47:21Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- An idempotent request is now cached per caller, and an unauthenticated
+  request is never cached at all. Before this, a stored response was looked up
+  by the `Idempotency-Key` header alone, and the cache answered before the
+  handler ran. So anyone who knew a used key and its exact body was served the
+  stored response, whatever their identity, and no permission check applied.
+  **If two of your clients share an Idempotency-Key, they now each get their own
+  cached response instead of one seeing the other's.** Existing cached entries
+  are dropped on upgrade; a client mid-retry re-executes once, the same as when
+  an entry expires.
+- Skipping the cache for unauthenticated requests also closes two things it was
+  doing quietly. `POST /api/v1/auth/logout` accepts no credentials, is not rate
+  limited, and returned a cacheable 204, so anyone who could reach the port
+  could write rows without limit and nothing ever removed them. And a login or
+  refresh call carrying an `Idempotency-Key` stored its response body, which
+  contains a live access token and refresh token, as readable JSON for 24 hours.
+- The cache identity now includes the method, path and query, not the request
+  body alone. Two different endpoints called with the same key and the same body
+  used to share one entry, so one route could answer with another's stored
+  response. That now returns 409 `idempotency.key_reused` instead.
 - Two diagnostics routes now require a permission. `POST /api/v1/diagnostics:echo`
   requires `system:read` and `POST /api/v1/diagnostics:evaluate-alert` requires
   `policy:read`. Both were reachable without any credentials. Every call to

--- a/internal/db/db_gaps_test.go
+++ b/internal/db/db_gaps_test.go
@@ -11,6 +11,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -158,21 +159,25 @@ func TestSchema_AuditEvents(t *testing.T) {
 }
 
 // @ac AC-06
-// AC-06: idempotency_keys schema includes key (TEXT PK), request_hash,
-// response_status, response_body (JSONB), expires_at.
+// AC-06: idempotency_keys schema includes actor_id (TEXT), key (TEXT),
+// request_hash, response_status, response_body (JSONB) and expires_at. Its
+// primary key is the composite (actor_id, key), not key alone.
+//
+// The primary key is asserted directly. Until 2026-08, this test built a
+// column map and then iterated only over its want map, so it never read the
+// primary key at all and no column set could have failed it. The cache being
+// scoped to one caller rests entirely on that key, so it is checked here as
+// an ordered column list.
+//
+// The pool comes from dbtest, which keys its migrated template on the
+// migration set. A run against an older migration set therefore cannot reuse
+// a database that this migration already touched, which matters because
+// goose only moves forward.
 func TestSchema_IdempotencyKeys(t *testing.T) {
 	t.Run("system-db/AC-06", func(t *testing.T) {
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("Apply: %v", err)
-		}
 
 		rows, err := pool.Query(ctx, `
 			SELECT column_name, data_type
@@ -191,6 +196,7 @@ func TestSchema_IdempotencyKeys(t *testing.T) {
 			cols[name] = dtype
 		}
 		want := map[string]string{
+			"actor_id":        "text",
 			"key":             "text",
 			"request_hash":    "text",
 			"response_status": "integer",
@@ -206,6 +212,35 @@ func TestSchema_IdempotencyKeys(t *testing.T) {
 			if got != wantType {
 				t.Errorf("idempotency_keys.%s type = %q, want %q", name, got, wantType)
 			}
+		}
+
+		pkRows, err := pool.Query(ctx, `
+			SELECT kcu.column_name
+			FROM information_schema.table_constraints tc
+			JOIN information_schema.key_column_usage kcu
+			  ON kcu.constraint_name = tc.constraint_name
+			 AND kcu.table_schema = tc.table_schema
+			WHERE tc.table_name = 'idempotency_keys'
+			  AND tc.constraint_type = 'PRIMARY KEY'
+			ORDER BY kcu.ordinal_position`)
+		if err != nil {
+			t.Fatalf("primary key columns: %v", err)
+		}
+		defer pkRows.Close()
+		var pk []string
+		for pkRows.Next() {
+			var name string
+			if err := pkRows.Scan(&name); err != nil {
+				t.Fatalf("scan primary key column: %v", err)
+			}
+			pk = append(pk, name)
+		}
+		if err := pkRows.Err(); err != nil {
+			t.Fatalf("read primary key columns: %v", err)
+		}
+		wantPK := []string{"actor_id", "key"}
+		if !reflect.DeepEqual(pk, wantPK) {
+			t.Errorf("idempotency_keys primary key = %v, want %v (the cache is scoped to the caller that created the entry)", pk, wantPK)
 		}
 	})
 }

--- a/internal/db/migrations/0058_idempotency_actor_scope.sql
+++ b/internal/db/migrations/0058_idempotency_actor_scope.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- Scope the idempotency cache to the caller who created the entry.
+--
+-- A cache hit answers at internal/idempotency/middleware.go with
+-- replayCached and returns without calling next.ServeHTTP, so the handler
+-- never runs and no authorization check inside it ever executes. The cached
+-- row carried no caller identity: the primary key was the client-supplied
+-- header value alone, one global namespace with a 24 hour life. Any caller
+-- who knew another caller's key and the exact body that produced its hash
+-- was served that caller's stored response. See CP
+-- bugs/OW-012-idempotency-replay-bypasses-authorization.
+--
+-- Moving the permission check above the middleware was considered and is not
+-- enough. It stops an anonymous replay, but caller B, who legitimately holds
+-- the permission, is still served caller A's cached response. The cache key
+-- itself has to carry the actor, which is what this migration adds.
+--
+-- Dropping the existing rows is required, not merely tolerated. ADD COLUMN
+-- with NOT NULL and no default fails on a non-empty table, and there is no
+-- honest actor value to backfill: the rows never recorded who made the call,
+-- so any default would invent one. Dropping them is also correct on its own
+-- terms. This table is a response cache with a 24 hour life, an upgrade
+-- restarts the process anyway, and the worst case is one client re-executing
+-- a retry once. That is the same outcome as the TTL expiring a second
+-- earlier, which the design already accepts.
+DELETE FROM idempotency_keys;
+ALTER TABLE idempotency_keys DROP CONSTRAINT idempotency_keys_pkey;
+ALTER TABLE idempotency_keys ADD COLUMN actor_id TEXT NOT NULL;
+ALTER TABLE idempotency_keys ADD CONSTRAINT idempotency_keys_pkey PRIMARY KEY (actor_id, key);
+
+COMMENT ON COLUMN idempotency_keys.actor_id IS
+    'auth.Identity.ID of the caller that created this entry. Part of the primary key: a replay from a different actor must miss the cache so the handler runs and that caller''s own authorization applies. See CP bugs/OW-012-idempotency-replay-bypasses-authorization.';
+
+-- +goose Down
+-- Same reasoning in reverse. The rows cannot survive the narrower key
+-- collapsing back to a wider one: two actors may hold the same key, and
+-- key alone can only keep one of them.
+DELETE FROM idempotency_keys;
+ALTER TABLE idempotency_keys DROP CONSTRAINT idempotency_keys_pkey;
+ALTER TABLE idempotency_keys DROP COLUMN actor_id;
+ALTER TABLE idempotency_keys ADD CONSTRAINT idempotency_keys_pkey PRIMARY KEY (key);

--- a/internal/idempotency/middleware.go
+++ b/internal/idempotency/middleware.go
@@ -1,7 +1,12 @@
 // Package idempotency provides the middleware that makes mutating HTTP
 // requests safely retryable. A request that arrives with an
-// Idempotency-Key header is cached for 24 hours; replay with the same
-// key + body returns the cached response without re-running the handler.
+// Idempotency-Key header is cached for 24 hours; replay by the same caller
+// with the same key and request returns the cached response without
+// re-running the handler.
+//
+// The cache is scoped to the calling identity. A cache hit skips the
+// handler, so it also skips every authorization check inside it. Only the
+// caller who created an entry can have it replayed.
 //
 // Spec: specs/system/idempotency.spec.yaml
 package idempotency
@@ -18,6 +23,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -39,15 +45,20 @@ var safeMethods = map[string]bool{
 
 // Middleware wraps mutating handlers with the idempotency cache.
 //
-// Behavior (per spec AC-1..AC-9):
+// Behavior (per spec system-idempotency v2.0.0):
 //
 //   - Safe methods (GET/HEAD/OPTIONS) pass through unchanged.
 //   - Missing Idempotency-Key passes through (the handler decides whether
 //     the header is required; the middleware doesn't enforce presence).
-//   - Cache hit (same key + same body hash): returns cached status + body
-//     byte-for-byte. Handler is not invoked.
-//   - Cache hit (same key + different body hash): returns 409 with
-//     error.code = "idempotency.key_reused".
+//   - An anonymous caller passes through, uncached. See the skip below.
+//   - Cache hit (same actor + same key + same request hash): returns the
+//     cached status and a JSON-equal body (JSONB storage normalizes
+//     whitespace). Handler is not invoked.
+//   - Cache hit (same actor + same key + different request hash): returns
+//     409 with error.code = "idempotency.key_reused".
+//   - Same key held by a different actor: a plain miss. The handler runs
+//     under that caller's own authorization and stores under their own
+//     actor. No 409, so the route is not an existence oracle.
 //   - Cache miss: runs handler, captures the response, persists to DB on
 //     2xx. 4xx/5xx are NOT cached (per AC-6 — failures are not pinned).
 func Middleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
@@ -66,6 +77,35 @@ func Middleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 				return
 			}
 
+			// An anonymous caller gets no cache at all. The identity binder
+			// runs before this middleware (internal/server/server.go), so an
+			// empty ID here means nothing was bound, not that binding has yet
+			// to happen. Skipping here rather than lower down skips the
+			// lookup, the 409, the body read and the store in one move.
+			//
+			// Caching an anonymous response is a defect, not a feature:
+			//
+			//   - replayCached writes only status, Content-Type and body. It
+			//     drops every Set-Cookie. Login sets three (session, CSRF,
+			//     refresh), so a replayed login already returned 200 with no
+			//     session cookie: a success the client cannot use.
+			//   - Login and refresh return AccessToken and RefreshToken in the
+			//     body, so caching them writes live credentials as plaintext
+			//     JSONB for 24 hours. The row outlives the token.
+			//   - POST /auth/logout is CSRF-exempt (the /api/v1/auth/ prefix
+			//     in internal/server/csrf.go), is not rate limited (only login
+			//     and mfa:verify are), and answers 204, which caches. Nothing
+			//     reaps expired rows. That is an unauthenticated unbounded
+			//     write into the table, and this skip closes it.
+			//
+			// No anonymous route declares Idempotency-Key in
+			// api/openapi.yaml, so nothing legitimate loses caching here.
+			actor := auth.FromContext(r.Context())
+			if actor.IsAnonymous || actor.ID == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			// Read and hash the body. We have to consume r.Body once; the
 			// handler still needs it, so we restore it before next.ServeHTTP.
 			body, err := io.ReadAll(r.Body)
@@ -76,10 +116,10 @@ func Middleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 			_ = r.Body.Close()
 			r.Body = io.NopCloser(bytes.NewReader(body))
 
-			hash := hashBody(body)
+			hash := hashRequest(r.Method, r.URL.EscapedPath(), r.URL.RawQuery, body)
 
-			// Look up by key. Cache hit logic:
-			cached, found, err := lookup(r.Context(), pool, key)
+			// Look up by (actor, key). Cache hit logic:
+			cached, found, err := lookup(r.Context(), pool, actor.ID, key)
 			if err != nil {
 				slog.WarnContext(r.Context(), "idempotency: lookup failed; bypassing cache",
 					slog.String("error", err.Error()),
@@ -93,7 +133,7 @@ func Middleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 					writeKeyReusedError(w, r.Context())
 					return
 				}
-				// AC-2: cache hit, identical body — return cached response.
+				// AC-2: cache hit, identical request — return cached response.
 				replayCached(w, cached)
 				return
 			}
@@ -104,7 +144,7 @@ func Middleware(pool *pgxpool.Pool) func(http.Handler) http.Handler {
 
 			// Per AC-6: only cache 2xx responses. Errors re-run.
 			if rec.status >= 200 && rec.status < 300 {
-				if err := store(r.Context(), pool, key, hash, rec.status, rec.body.Bytes()); err != nil {
+				if err := store(r.Context(), pool, actor.ID, key, hash, rec.status, rec.body.Bytes()); err != nil {
 					slog.WarnContext(r.Context(), "idempotency: store failed",
 						slog.String("error", err.Error()),
 						slog.String("key", key))
@@ -142,11 +182,31 @@ func (r *recorder) Write(b []byte) (int, error) {
 	return r.ResponseWriter.Write(b)
 }
 
-// hashBody is SHA-256 in hex of the request body. Empty bodies hash to
-// the empty-string SHA-256 (deterministic, comparable across requests).
-func hashBody(body []byte) string {
-	sum := sha256.Sum256(body)
-	return hex.EncodeToString(sum[:])
+// hashRequest is SHA-256 in hex over the canonical string
+// method + "\n" + escaped_path + "\n" + raw_query + "\n" + body, per spec
+// C-07.
+//
+// The body alone is not enough to identify a request. Two different
+// endpoints called with the same key and the same body would share one
+// cache entry, and the second would be answered with the first one's
+// response. An empty body is common on :action routes, so that collision
+// is easy to reach by accident, not only on purpose.
+//
+// The three separators are unambiguous: a method, an escaped path and a
+// raw query cannot contain a newline, and the body comes last. The path is
+// taken escaped for that reason, so a decoded %0A cannot move the boundary.
+// Empty bodies still hash deterministically and stay comparable across
+// requests to the same route.
+func hashRequest(method, escapedPath, rawQuery string, body []byte) string {
+	h := sha256.New()
+	h.Write([]byte(method))
+	h.Write([]byte("\n"))
+	h.Write([]byte(escapedPath))
+	h.Write([]byte("\n"))
+	h.Write([]byte(rawQuery))
+	h.Write([]byte("\n"))
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // cachedRow is one row of idempotency_keys, hydrated into a Go struct.
@@ -159,15 +219,21 @@ type cachedRow struct {
 
 // lookup checks the idempotency_keys table; returns (row, true) on a
 // fresh hit, (zero, false) on miss or expired.
-func lookup(ctx context.Context, pool *pgxpool.Pool, key string) (cachedRow, bool, error) {
+//
+// Scoped to actor: another caller's entry is a plain miss, so the handler
+// runs and that caller's own authorization applies. Deliberately NOT a 409.
+// writeKeyReusedError fires before any authorization runs, so answering 409
+// here would turn the route into an oracle for whether some other caller
+// holds a given key.
+func lookup(ctx context.Context, pool *pgxpool.Pool, actorID, key string) (cachedRow, bool, error) {
 	const q = `
 SELECT key, request_hash, response_status, response_body
 FROM idempotency_keys
-WHERE key = $1 AND expires_at > now()
+WHERE actor_id = $1 AND key = $2 AND expires_at > now()
 `
 	var row cachedRow
 	var body []byte
-	err := pool.QueryRow(ctx, q, key).Scan(&row.Key, &row.RequestHash, &row.ResponseStatus, &body)
+	err := pool.QueryRow(ctx, q, actorID, key).Scan(&row.Key, &row.RequestHash, &row.ResponseStatus, &body)
 	switch {
 	case err == nil:
 		row.ResponseBody = body
@@ -181,11 +247,11 @@ WHERE key = $1 AND expires_at > now()
 
 // store persists a cached response. Best-effort: failures are logged but
 // the request itself already returned to the client.
-func store(ctx context.Context, pool *pgxpool.Pool, key, hash string, status int, body []byte) error {
+func store(ctx context.Context, pool *pgxpool.Pool, actorID, key, hash string, status int, body []byte) error {
 	const q = `
-INSERT INTO idempotency_keys (key, request_hash, response_status, response_body, expires_at)
-VALUES ($1, $2, $3, $4::jsonb, $5)
-ON CONFLICT (key) DO UPDATE
+INSERT INTO idempotency_keys (actor_id, key, request_hash, response_status, response_body, expires_at)
+VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+ON CONFLICT (actor_id, key) DO UPDATE
   SET request_hash    = EXCLUDED.request_hash,
       response_status = EXCLUDED.response_status,
       response_body   = EXCLUDED.response_body,
@@ -194,7 +260,7 @@ ON CONFLICT (key) DO UPDATE
 	if len(body) == 0 {
 		body = []byte("null")
 	}
-	_, err := pool.Exec(ctx, q, key, hash, status, body, time.Now().Add(TTL))
+	_, err := pool.Exec(ctx, q, actorID, key, hash, status, body, time.Now().Add(TTL))
 	return err
 }
 

--- a/internal/idempotency/middleware_test.go
+++ b/internal/idempotency/middleware_test.go
@@ -4,12 +4,23 @@
 //   AC-01  TestIdempotency_FirstWriteRecordsCacheEntry
 //   AC-02  TestIdempotency_ReplaySameKeyAndBodyReturnsCachedResponse
 //   AC-03  TestIdempotency_ReplaySameKeyDifferentBodyReturns409
-//   AC-04  (handler-enforced; tested in API integration tests, not here)
+//   AC-04  TestIdempotency_MissingKeyMiddlewareNoOp
 //   AC-05  TestIdempotency_GetRequestPassesThroughUnchanged
 //   AC-06  TestIdempotency_NonSuccessResponsesNotCached
-//   AC-07  (perf benchmark; tracked in BenchmarkLookup)
+//   AC-07  TestIdempotency_LookupLatencyP99
 //   AC-08  TestIdempotency_ExpiredEntryIsCacheMiss
 //   AC-09  TestIdempotency_ConcurrentRaceProducesOneEffect
+//   AC-10  TestIdempotency_AnonymousCallerNeverTouchesCache
+//   AC-11  TestIdempotency_CrossActorReplayIsPlainMiss
+//   AC-12  TestIdempotency_HashCoversRouteNotOnlyBody
+//   AC-13  TestIdempotency_DenialIsNeverCached
+//   AC-14  TestIdempotency_SameKeyDifferentActorsCoexist
+//
+// The tests below reach the middleware only through Middleware() and
+// auth.SetIdentity, plus raw SQL for seeding and inspection. They never call
+// the unexported store, lookup or hashRequest. The expected request hash is
+// recomputed here from the canonical string in C-07, so the encoding is
+// pinned by an independent implementation rather than by the one under test.
 
 package idempotency
 
@@ -28,6 +39,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Hanalyx/openwatch/internal/auth"
 	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/perftest"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -58,8 +70,34 @@ func freshPool(t *testing.T) *pgxpool.Pool {
 	return pool
 }
 
-// echoHandler is a minimal handler that counts invocations and echoes the
-// request body back as JSON. Used to verify cache hits skip the handler.
+// wantHash recomputes the canonical request hash from C-07:
+// sha256(method + "\n" + escaped_path + "\n" + raw_query + "\n" + body).
+// Written out here on purpose. The middleware's own hashRequest is the code
+// under test, so it cannot be the oracle for its own encoding.
+func wantHash(method, escapedPath, rawQuery, body string) string {
+	sum := sha256.Sum256([]byte(method + "\n" + escapedPath + "\n" + rawQuery + "\n" + body))
+	return hex.EncodeToString(sum[:])
+}
+
+// authed binds an authenticated identity onto the request, the way the
+// identity binder does in production before this middleware runs.
+func authed(r *http.Request, actorID string, role auth.RoleID) *http.Request {
+	return r.WithContext(auth.SetIdentity(r.Context(), auth.Identity{
+		ID:     actorID,
+		RoleID: role,
+	}))
+}
+
+// postAs builds an authenticated POST for the given actor.
+func postAs(actorID, target, body string, key string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set(HeaderName, key)
+	return authed(req, actorID, auth.RoleAdmin)
+}
+
+// echoHandler counts invocations and answers 201 with the calling actor's
+// ID in the body. The actor in the body is what makes a cross-actor replay
+// visible: if B is served A's cached response, B sees A's ID.
 type echoHandler struct {
 	invocations atomic.Int64
 }
@@ -68,9 +106,49 @@ func (h *echoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.invocations.Add(1)
 	body := make([]byte, r.ContentLength)
 	_, _ = r.Body.Read(body)
+	actor := auth.FromContext(r.Context())
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_, _ = w.Write([]byte(`{"echoed":true}`))
+	_, _ = w.Write([]byte(`{"echoed":true,"actor":"` + actor.ID + `"}`))
+}
+
+// storedRow is one inspected idempotency_keys row.
+type storedRow struct {
+	ActorID   string
+	Key       string
+	Hash      string
+	Status    int
+	Body      []byte
+	ExpiresAt time.Time
+}
+
+// readRow reads the row at (actorID, key). ok is false when there is none.
+func readRow(t *testing.T, pool *pgxpool.Pool, actorID, key string) (storedRow, bool) {
+	t.Helper()
+	var row storedRow
+	err := pool.QueryRow(context.Background(),
+		`SELECT actor_id, key, request_hash, response_status, response_body, expires_at
+		 FROM idempotency_keys WHERE actor_id = $1 AND key = $2`,
+		actorID, key).Scan(&row.ActorID, &row.Key, &row.Hash, &row.Status, &row.Body, &row.ExpiresAt)
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return storedRow{}, false
+		}
+		t.Fatalf("read row (%s, %s): %v", actorID, key, err)
+	}
+	return row, true
+}
+
+// countKey counts rows for a key across all actors. Schema-agnostic on
+// purpose: it answers "was anything written for this key at all".
+func countKey(t *testing.T, pool *pgxpool.Pool, key string) int64 {
+	t.Helper()
+	var n int64
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM idempotency_keys WHERE key = $1`, key).Scan(&n); err != nil {
+		t.Fatalf("count rows for key %q: %v", key, err)
+	}
+	return n
 }
 
 // @ac AC-01
@@ -80,8 +158,9 @@ func TestIdempotency_FirstWriteRecordsCacheEntry(t *testing.T) {
 		handler := &echoHandler{}
 		mw := Middleware(pool)(handler)
 
-		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
-		req.Header.Set(HeaderName, "key-001")
+		const body = `{"x":1}`
+		before := time.Now()
+		req := postAs("actor-a", "/test?a=1", body, "key-001")
 		rec := httptest.NewRecorder()
 		mw.ServeHTTP(rec, req)
 
@@ -89,22 +168,24 @@ func TestIdempotency_FirstWriteRecordsCacheEntry(t *testing.T) {
 			t.Errorf("handler invocations = %d, want 1", handler.invocations.Load())
 		}
 
-		// Verify the row landed in idempotency_keys.
-		var key string
-		var hash string
-		var status int
-		err := pool.QueryRow(context.Background(),
-			`SELECT key, request_hash, response_status FROM idempotency_keys WHERE key = $1`,
-			"key-001").Scan(&key, &hash, &status)
-		if err != nil {
-			t.Fatalf("query cache row: %v", err)
+		row, ok := readRow(t, pool, "actor-a", "key-001")
+		if !ok {
+			t.Fatal("no row at (actor-a, key-001)")
 		}
-		expectedHash := sha256.Sum256([]byte(`{"x":1}`))
-		if hash != hex.EncodeToString(expectedHash[:]) {
-			t.Errorf("hash mismatch: got %q, want sha256 of body", hash)
+		if row.ActorID != "actor-a" {
+			t.Errorf("actor_id = %q, want %q", row.ActorID, "actor-a")
 		}
-		if status != http.StatusCreated {
-			t.Errorf("cached status = %d, want 201", status)
+		if want := wantHash("POST", "/test", "a=1", body); row.Hash != want {
+			t.Errorf("request_hash = %q, want %q (sha256 over method, path, query, body)", row.Hash, want)
+		}
+		if row.Status != http.StatusCreated {
+			t.Errorf("cached status = %d, want 201", row.Status)
+		}
+		// TTL is 24h from first-seen (C-04). One minute of slack covers the
+		// gap between the reading of before and the middleware's own clock.
+		wantExpiry := before.Add(TTL)
+		if d := row.ExpiresAt.Sub(wantExpiry); d < -time.Minute || d > time.Minute {
+			t.Errorf("expires_at = %v, want within 1m of %v (now + 24h)", row.ExpiresAt, wantExpiry)
 		}
 	})
 }
@@ -116,20 +197,13 @@ func TestIdempotency_ReplaySameKeyAndBodyReturnsCachedResponse(t *testing.T) {
 		handler := &echoHandler{}
 		mw := Middleware(pool)(handler)
 
-		// First call
-		req1 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
-		req1.Header.Set(HeaderName, "key-replay")
 		rec1 := httptest.NewRecorder()
-		mw.ServeHTTP(rec1, req1)
-
+		mw.ServeHTTP(rec1, postAs("actor-a", "/test", `{"x":1}`, "key-replay"))
 		first := rec1.Body.String()
 		firstStatus := rec1.Code
 
-		// Replay with same key and same body
-		req2 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
-		req2.Header.Set(HeaderName, "key-replay")
 		rec2 := httptest.NewRecorder()
-		mw.ServeHTTP(rec2, req2)
+		mw.ServeHTTP(rec2, postAs("actor-a", "/test", `{"x":1}`, "key-replay"))
 
 		// Handler should have been invoked exactly once (replay hit cache).
 		if handler.invocations.Load() != 1 {
@@ -152,16 +226,11 @@ func TestIdempotency_ReplaySameKeyDifferentBodyReturns409(t *testing.T) {
 		handler := &echoHandler{}
 		mw := Middleware(pool)(handler)
 
-		// First call with body A
-		req1 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
-		req1.Header.Set(HeaderName, "key-conflict")
-		mw.ServeHTTP(httptest.NewRecorder(), req1)
+		mw.ServeHTTP(httptest.NewRecorder(), postAs("actor-a", "/test", `{"x":1}`, "key-conflict"))
 
-		// Replay with same key, different body B
-		req2 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":2}`))
-		req2.Header.Set(HeaderName, "key-conflict")
+		// Same key, same route, different body: a different request hash.
 		rec2 := httptest.NewRecorder()
-		mw.ServeHTTP(rec2, req2)
+		mw.ServeHTTP(rec2, postAs("actor-a", "/test", `{"x":2}`, "key-conflict"))
 
 		if rec2.Code != http.StatusConflict {
 			t.Errorf("status = %d, want 409", rec2.Code)
@@ -169,9 +238,56 @@ func TestIdempotency_ReplaySameKeyDifferentBodyReturns409(t *testing.T) {
 		if !strings.Contains(rec2.Body.String(), "idempotency.key_reused") {
 			t.Errorf("body lacks idempotency.key_reused: %s", rec2.Body.String())
 		}
+		if strings.Contains(rec2.Body.String(), "echoed") {
+			t.Errorf("first response was replayed instead of 409: %s", rec2.Body.String())
+		}
 		// Handler should have run exactly once (the first call).
 		if handler.invocations.Load() != 1 {
 			t.Errorf("handler invocations = %d, want 1", handler.invocations.Load())
+		}
+		// The stored row still carries the first request's hash.
+		row, ok := readRow(t, pool, "actor-a", "key-conflict")
+		if !ok {
+			t.Fatal("no row at (actor-a, key-conflict)")
+		}
+		if want := wantHash("POST", "/test", "", `{"x":1}`); row.Hash != want {
+			t.Errorf("request_hash = %q, want the first request's hash %q", row.Hash, want)
+		}
+	})
+}
+
+// @ac AC-04
+// AC-04: Mutating request without Idempotency-Key passes through the
+// middleware unchanged. The handler is responsible for returning
+// 400 idempotency.key_required. This test verifies the middleware
+// honors that contract by NOT caching, NOT writing rows, and NOT
+// hijacking the response when the header is absent.
+func TestIdempotency_MissingKeyMiddlewareNoOp(t *testing.T) {
+	t.Run("system-idempotency/AC-04", func(t *testing.T) {
+		pool := freshPool(t)
+		handler := &echoHandler{}
+		mw := Middleware(pool)(handler)
+
+		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
+		// No Idempotency-Key header.
+		req = authed(req, "actor-a", auth.RoleAdmin)
+		rec := httptest.NewRecorder()
+		mw.ServeHTTP(rec, req)
+
+		// Handler ran (middleware did not block or transform).
+		if handler.invocations.Load() != 1 {
+			t.Errorf("handler invocations = %d, want 1", handler.invocations.Load())
+		}
+		// Handler's 201 came through unmodified.
+		if rec.Code != http.StatusCreated {
+			t.Errorf("status = %d, want 201 (handler response, not middleware-injected)", rec.Code)
+		}
+		// No row written: the middleware skipped the cache write path.
+		var count int64
+		_ = pool.QueryRow(context.Background(),
+			`SELECT count(*) FROM idempotency_keys`).Scan(&count)
+		if count != 0 {
+			t.Errorf("idempotency_keys row count = %d, want 0 (no header, no cache)", count)
 		}
 	})
 }
@@ -183,25 +299,19 @@ func TestIdempotency_GetRequestPassesThroughUnchanged(t *testing.T) {
 		handler := &echoHandler{}
 		mw := Middleware(pool)(handler)
 
-		// Two GET calls with same Idempotency-Key — both should reach handler.
+		// Two GET calls with same Idempotency-Key: both should reach handler.
 		for i := 0; i < 2; i++ {
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			req.Header.Set(HeaderName, "get-key")
-			mw.ServeHTTP(httptest.NewRecorder(), req)
+			mw.ServeHTTP(httptest.NewRecorder(), authed(req, "actor-a", auth.RoleAdmin))
 		}
 
 		if handler.invocations.Load() != 2 {
 			t.Errorf("handler invocations = %d, want 2 (GET should bypass cache)",
 				handler.invocations.Load())
 		}
-
-		// Verify no row was written.
-		var count int64
-		_ = pool.QueryRow(context.Background(),
-			`SELECT count(*) FROM idempotency_keys WHERE key = $1`,
-			"get-key").Scan(&count)
-		if count != 0 {
-			t.Errorf("cache row count = %d, want 0 (GET should not write)", count)
+		if n := countKey(t, pool, "get-key"); n != 0 {
+			t.Errorf("cache row count = %d, want 0 (GET should not write)", n)
 		}
 	})
 }
@@ -217,93 +327,23 @@ func TestIdempotency_NonSuccessResponsesNotCached(t *testing.T) {
 		})
 		mw := Middleware(pool)(failHandler)
 
-		// Two POSTs with same key — neither should be cached (both 500).
+		// Two POSTs with same key: neither should be cached (both 500).
 		for i := 0; i < 2; i++ {
-			req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
-			req.Header.Set(HeaderName, "fail-key")
-			mw.ServeHTTP(httptest.NewRecorder(), req)
+			mw.ServeHTTP(httptest.NewRecorder(), postAs("actor-a", "/test", `{"x":1}`, "fail-key"))
 		}
 
 		if calls.Load() != 2 {
-			t.Errorf("handler invocations = %d, want 2 (5xx must not be cached)",
-				calls.Load())
+			t.Errorf("handler invocations = %d, want 2 (5xx must not be cached)", calls.Load())
 		}
-	})
-}
-
-// @ac AC-08
-func TestIdempotency_ExpiredEntryIsCacheMiss(t *testing.T) {
-	t.Run("system-idempotency/AC-08", func(t *testing.T) {
-		pool := freshPool(t)
-		handler := &echoHandler{}
-		mw := Middleware(pool)(handler)
-
-		// Directly insert a row with expires_at in the past.
-		expectedHash := sha256.Sum256([]byte(`{"x":1}`))
-		_, err := pool.Exec(context.Background(),
-			`INSERT INTO idempotency_keys (key, request_hash, response_status, response_body, expires_at)
-			 VALUES ($1, $2, $3, $4::jsonb, $5)`,
-			"expired-key", hex.EncodeToString(expectedHash[:]), 201, `{"stale":true}`,
-			time.Now().Add(-1*time.Hour))
-		if err != nil {
-			t.Fatalf("seed expired row: %v", err)
-		}
-
-		// Replay — should treat as miss, invoke handler, and overwrite.
-		req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
-		req.Header.Set(HeaderName, "expired-key")
-		rec := httptest.NewRecorder()
-		mw.ServeHTTP(rec, req)
-
-		if handler.invocations.Load() != 1 {
-			t.Errorf("handler invocations = %d, want 1 (expired entry must be miss)",
-				handler.invocations.Load())
-		}
-		if strings.Contains(rec.Body.String(), "stale") {
-			t.Error("response body included stale cached content")
-		}
-	})
-}
-
-// @ac AC-04
-// AC-04: Mutating request without Idempotency-Key passes through the
-// middleware unchanged — the handler is responsible for returning
-// 400 idempotency.key_required. This test verifies the middleware
-// honors that contract by NOT caching, NOT writing rows, and NOT
-// hijacking the response when the header is absent.
-func TestIdempotency_MissingKeyMiddlewareNoOp(t *testing.T) {
-	t.Run("system-idempotency/AC-04", func(t *testing.T) {
-		pool := freshPool(t)
-		handler := &echoHandler{}
-		mw := Middleware(pool)(handler)
-
-		req := httptest.NewRequest(http.MethodPost, "/test",
-			strings.NewReader(`{"x":1}`))
-		// No Idempotency-Key header.
-		rec := httptest.NewRecorder()
-		mw.ServeHTTP(rec, req)
-
-		// Handler ran (middleware did not block or transform).
-		if handler.invocations.Load() != 1 {
-			t.Errorf("handler invocations = %d, want 1", handler.invocations.Load())
-		}
-		// Handler's 201 came through unmodified.
-		if rec.Code != http.StatusCreated {
-			t.Errorf("status = %d, want 201 (handler response, not middleware-injected)", rec.Code)
-		}
-		// No row written — middleware skipped the cache write path entirely.
-		var count int64
-		_ = pool.QueryRow(context.Background(),
-			`SELECT count(*) FROM idempotency_keys`).Scan(&count)
-		if count != 0 {
-			t.Errorf("idempotency_keys row count = %d, want 0 (no header → no cache)", count)
+		if n := countKey(t, pool, "fail-key"); n != 0 {
+			t.Errorf("cache row count = %d, want 0 (5xx must not be stored)", n)
 		}
 	})
 }
 
 // @ac AC-07
 // AC-07: Cache lookup latency p99 < 5ms against local DB. Populates one
-// row, then measures the hot path (key match → cached body returned).
+// row, then measures the hot path (key match, cached body returned).
 func TestIdempotency_LookupLatencyP99(t *testing.T) {
 	t.Run("system-idempotency/AC-07", func(t *testing.T) {
 		pool := freshPool(t)
@@ -311,19 +351,14 @@ func TestIdempotency_LookupLatencyP99(t *testing.T) {
 		mw := Middleware(pool)(handler)
 
 		// Populate one cached row (key=perf-key, body={"x":1}).
-		seed := httptest.NewRequest(http.MethodPost, "/test",
-			strings.NewReader(`{"x":1}`))
-		seed.Header.Set(HeaderName, "perf-key")
-		mw.ServeHTTP(httptest.NewRecorder(), seed)
+		mw.ServeHTTP(httptest.NewRecorder(), postAs("actor-a", "/test", `{"x":1}`, "perf-key"))
 
-		// Now measure replays — these should be cache hits, no handler call.
+		// Now measure replays. These should be cache hits, no handler call.
 		baseline := handler.invocations.Load()
 		const n = 200
 		durs := make([]time.Duration, n)
 		for i := 0; i < n; i++ {
-			req := httptest.NewRequest(http.MethodPost, "/test",
-				strings.NewReader(`{"x":1}`))
-			req.Header.Set(HeaderName, "perf-key")
+			req := postAs("actor-a", "/test", `{"x":1}`, "perf-key")
 			start := time.Now()
 			mw.ServeHTTP(httptest.NewRecorder(), req)
 			durs[i] = time.Since(start)
@@ -332,7 +367,7 @@ func TestIdempotency_LookupLatencyP99(t *testing.T) {
 			t.Errorf("handler ran during replay loop: %d extra calls",
 				handler.invocations.Load()-baseline)
 		}
-		// Sort + pick p99.
+		// Sort, then pick p99.
 		for i := 1; i < n; i++ {
 			v := durs[i]
 			j := i - 1
@@ -347,6 +382,48 @@ func TestIdempotency_LookupLatencyP99(t *testing.T) {
 			perftest.Budgetf(t, "Cache lookup p99 = %v, want < 5ms", p99)
 		}
 		t.Logf("Cache lookup p99 = %v over %d replays", p99, n)
+	})
+}
+
+// @ac AC-08
+func TestIdempotency_ExpiredEntryIsCacheMiss(t *testing.T) {
+	t.Run("system-idempotency/AC-08", func(t *testing.T) {
+		pool := freshPool(t)
+		handler := &echoHandler{}
+		mw := Middleware(pool)(handler)
+
+		// Seed a row for this actor and key that expired an hour ago.
+		_, err := pool.Exec(context.Background(),
+			`INSERT INTO idempotency_keys (actor_id, key, request_hash, response_status, response_body, expires_at)
+			 VALUES ($1, $2, $3, $4, $5::jsonb, $6)`,
+			"actor-a", "expired-key", wantHash("POST", "/test", "", `{"x":1}`),
+			201, `{"stale":true}`, time.Now().Add(-1*time.Hour))
+		if err != nil {
+			t.Fatalf("seed expired row: %v", err)
+		}
+
+		// Replay: should be a miss, so the handler runs and overwrites.
+		rec := httptest.NewRecorder()
+		mw.ServeHTTP(rec, postAs("actor-a", "/test", `{"x":1}`, "expired-key"))
+
+		if handler.invocations.Load() != 1 {
+			t.Errorf("handler invocations = %d, want 1 (expired entry must be miss)",
+				handler.invocations.Load())
+		}
+		if strings.Contains(rec.Body.String(), "stale") {
+			t.Error("response body included stale cached content")
+		}
+		// The row for that same actor and key was overwritten, not duplicated.
+		if n := countKey(t, pool, "expired-key"); n != 1 {
+			t.Errorf("rows for expired-key = %d, want 1 (overwrite, not insert)", n)
+		}
+		row, ok := readRow(t, pool, "actor-a", "expired-key")
+		if !ok {
+			t.Fatal("no row at (actor-a, expired-key) after the miss")
+		}
+		if row.ExpiresAt.Before(time.Now()) {
+			t.Errorf("expires_at = %v, want a future time after the overwrite", row.ExpiresAt)
+		}
 	})
 }
 
@@ -366,21 +443,16 @@ func TestIdempotency_ConcurrentRaceProducesOneEffect(t *testing.T) {
 				req := httptest.NewRequest(http.MethodPost, "/test",
 					bytes.NewReader([]byte(`{"x":1}`)))
 				req.Header.Set(HeaderName, "race-key")
-				mw.ServeHTTP(httptest.NewRecorder(), req)
+				mw.ServeHTTP(httptest.NewRecorder(), authed(req, "actor-a", auth.RoleAdmin))
 			}()
 		}
 		wg.Wait()
 
 		// The race COULD produce up to n invocations if no DB serialization,
-		// but at least the spec invariant is: cached row exists, all callers
-		// see consistent responses. We assert <= n invocations and exactly
-		// 1 cached row.
-		var count int64
-		_ = pool.QueryRow(context.Background(),
-			`SELECT count(*) FROM idempotency_keys WHERE key = $1`,
-			"race-key").Scan(&count)
-		if count != 1 {
-			t.Errorf("cached rows for race-key = %d, want 1", count)
+		// but the spec invariant is: one cached row, consistent responses.
+		// We assert <= n invocations and exactly 1 cached row.
+		if got := countKey(t, pool, "race-key"); got != 1 {
+			t.Errorf("cached rows for race-key = %d, want 1", got)
 		}
 		// Best effort: handler invoked at least once, at most n times.
 		// (Without distributed locking, the first-write-wins race is allowed.)
@@ -388,5 +460,345 @@ func TestIdempotency_ConcurrentRaceProducesOneEffect(t *testing.T) {
 		if got < 1 || got > n {
 			t.Errorf("handler invocations = %d, want in [1, %d]", got, n)
 		}
+	})
+}
+
+// @ac AC-10
+// AC-10: an anonymous caller does not touch the cache in either direction.
+//
+// Two assertions, and the second one is the load-bearing half. A test that
+// only checks "nothing was written" passes against code that skips the
+// write but still replays, which is the exact shape of the defect this
+// clause exists to stop. So part two seeds a row whose hash matches the
+// anonymous request and proves it is not served back.
+func TestIdempotency_AnonymousCallerNeverTouchesCache(t *testing.T) {
+	t.Run("system-idempotency/AC-10", func(t *testing.T) {
+		pool := freshPool(t)
+		handler := &echoHandler{}
+		mw := Middleware(pool)(handler)
+
+		// Part one: an anonymous request writes nothing. No identity is set
+		// on the context, so auth.FromContext reports anonymous.
+		anon1 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
+		anon1.Header.Set(HeaderName, "anon-key")
+		rec1 := httptest.NewRecorder()
+		mw.ServeHTTP(rec1, anon1)
+
+		if handler.invocations.Load() != 1 {
+			t.Errorf("handler invocations = %d, want 1 (anonymous request must reach the handler)",
+				handler.invocations.Load())
+		}
+		if rec1.Code != http.StatusCreated {
+			t.Errorf("status = %d, want 201 (handler response)", rec1.Code)
+		}
+		if n := countKey(t, pool, "anon-key"); n != 0 {
+			t.Errorf("rows for anon-key = %d, want 0 (anonymous traffic must not be stored)", n)
+		}
+
+		// Part two: a matching row already exists, and the anonymous caller
+		// must still not be served from it.
+		const seededBody = `{"cached":"for-actor-a"}`
+		seedExpiry := time.Now().Add(TTL)
+		_, err := pool.Exec(context.Background(),
+			`INSERT INTO idempotency_keys (actor_id, key, request_hash, response_status, response_body, expires_at)
+			 VALUES ($1, $2, $3, $4, $5::jsonb, $6)`,
+			"actor-a", "shared-key", wantHash("POST", "/test", "", `{"x":1}`),
+			200, seededBody, seedExpiry)
+		if err != nil {
+			t.Fatalf("seed row at (actor-a, shared-key): %v", err)
+		}
+
+		anon2 := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"x":1}`))
+		anon2.Header.Set(HeaderName, "shared-key")
+		rec2 := httptest.NewRecorder()
+		mw.ServeHTTP(rec2, anon2)
+
+		if handler.invocations.Load() != 2 {
+			t.Errorf("handler invocations = %d, want 2 (the seeded row must not short-circuit the handler)",
+				handler.invocations.Load())
+		}
+		if rec2.Code != http.StatusCreated {
+			t.Errorf("status = %d, want 201 (handler response, not the seeded 200)", rec2.Code)
+		}
+		if strings.Contains(rec2.Body.String(), "for-actor-a") {
+			t.Errorf("anonymous caller was served actor-a's cached body: %s", rec2.Body.String())
+		}
+		if rec2.Code == http.StatusConflict {
+			t.Error("anonymous caller got 409; the middleware must not consult the cache at all")
+		}
+
+		// The seeded row is untouched: same hash, status, body and expiry.
+		row, ok := readRow(t, pool, "actor-a", "shared-key")
+		if !ok {
+			t.Fatal("seeded row at (actor-a, shared-key) is gone")
+		}
+		if row.Status != 200 {
+			t.Errorf("seeded response_status = %d, want 200 (unchanged)", row.Status)
+		}
+		jsonEqual(t, row.Body, []byte(seededBody))
+		if d := row.ExpiresAt.Sub(seedExpiry); d < -time.Second || d > time.Second {
+			t.Errorf("seeded expires_at = %v, want unchanged %v", row.ExpiresAt, seedExpiry)
+		}
+		if n := countKey(t, pool, "shared-key"); n != 1 {
+			t.Errorf("rows for shared-key = %d, want 1 (the anonymous call must add none)", n)
+		}
+	})
+}
+
+// @ac AC-11
+// AC-11: a cross-actor replay is a plain miss, not a 409.
+//
+// The order of the assertions matters. B's own response is checked before
+// any row inspection, so code that serves B actor A's cached response fails
+// on the behavior rather than on a schema detail.
+func TestIdempotency_CrossActorReplayIsPlainMiss(t *testing.T) {
+	t.Run("system-idempotency/AC-11", func(t *testing.T) {
+		pool := freshPool(t)
+		handler := &echoHandler{}
+		mw := Middleware(pool)(handler)
+
+		// Actor A caches a response at (actor-a, K).
+		recA := httptest.NewRecorder()
+		mw.ServeHTTP(recA, postAs("actor-a", "/test", `{"x":1}`, "shared-key"))
+		if !strings.Contains(recA.Body.String(), `"actor":"actor-a"`) {
+			t.Fatalf("setup: A's response = %s, want A's own", recA.Body.String())
+		}
+		beforeA, ok := readRow(t, pool, "actor-a", "shared-key")
+		if !ok {
+			t.Fatal("setup: no row at (actor-a, shared-key)")
+		}
+
+		// Actor B sends the same key, method, path and body.
+		recB := httptest.NewRecorder()
+		mw.ServeHTTP(recB, postAs("actor-b", "/test", `{"x":1}`, "shared-key"))
+
+		// B ran the handler, so B's own authorization applied.
+		if recB.Code == http.StatusConflict {
+			t.Errorf("B got 409; a key held by another actor must read as a plain miss, "+
+				"never as an existence oracle: %s", recB.Body.String())
+		}
+		if recB.Code != http.StatusCreated {
+			t.Errorf("B status = %d, want 201 (B's own handler response)", recB.Code)
+		}
+		if !strings.Contains(recB.Body.String(), `"actor":"actor-b"`) {
+			t.Errorf("B was served %s, want B's own response. A cached response from "+
+				"another actor was replayed, skipping B's authorization", recB.Body.String())
+		}
+		if handler.invocations.Load() != 2 {
+			t.Errorf("handler invocations = %d, want 2 (B must run the handler)",
+				handler.invocations.Load())
+		}
+
+		// A row now exists at (actor-b, K), and A's row is unchanged.
+		rowB, ok := readRow(t, pool, "actor-b", "shared-key")
+		if !ok {
+			t.Fatal("no row at (actor-b, shared-key)")
+		}
+		if !strings.Contains(string(rowB.Body), "actor-b") {
+			t.Errorf("row at (actor-b, shared-key) holds %q, want B's own response", rowB.Body)
+		}
+
+		afterA, ok := readRow(t, pool, "actor-a", "shared-key")
+		if !ok {
+			t.Fatal("A's row disappeared after B's call")
+		}
+		if afterA.Hash != beforeA.Hash {
+			t.Errorf("A's request_hash changed: %q -> %q", beforeA.Hash, afterA.Hash)
+		}
+		if afterA.Status != beforeA.Status {
+			t.Errorf("A's response_status changed: %d -> %d", beforeA.Status, afterA.Status)
+		}
+		jsonEqual(t, afterA.Body, beforeA.Body)
+		// An unchanged expiry proves B's call did not refresh A's TTL.
+		if d := afterA.ExpiresAt.Sub(beforeA.ExpiresAt); d < -time.Second || d > time.Second {
+			t.Errorf("A's expires_at changed: %v -> %v", beforeA.ExpiresAt, afterA.ExpiresAt)
+		}
+		if n := countKey(t, pool, "shared-key"); n != 2 {
+			t.Errorf("rows for shared-key = %d, want 2 (one per actor)", n)
+		}
+	})
+}
+
+// @ac AC-12
+// AC-12: the hash covers the route, not only the body. Same actor, same key
+// and same body on a different path, method or query is a different request,
+// so it must be 409 rather than a replay of the first response.
+func TestIdempotency_HashCoversRouteNotOnlyBody(t *testing.T) {
+	t.Run("system-idempotency/AC-12", func(t *testing.T) {
+		const body = `{"x":1}`
+		cases := []struct {
+			name   string
+			key    string
+			method string
+			target string
+		}{
+			{"different path", "route-key-path", http.MethodPost, "/other"},
+			{"different method", "route-key-method", http.MethodPut, "/test"},
+			{"different query", "route-key-query", http.MethodPost, "/test?a=2"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				pool := freshPool(t)
+				handler := &echoHandler{}
+				mw := Middleware(pool)(handler)
+
+				// First call: POST /test?a=1 with body B.
+				mw.ServeHTTP(httptest.NewRecorder(),
+					postAs("actor-a", "/test?a=1", body, tc.key))
+
+				// Second call: same key, same body, one route element changed.
+				req := httptest.NewRequest(tc.method, tc.target, strings.NewReader(body))
+				req.Header.Set(HeaderName, tc.key)
+				rec := httptest.NewRecorder()
+				mw.ServeHTTP(rec, authed(req, "actor-a", auth.RoleAdmin))
+
+				if rec.Code != http.StatusConflict {
+					t.Errorf("status = %d, want 409 (the route is part of the hash)", rec.Code)
+				}
+				if !strings.Contains(rec.Body.String(), "idempotency.key_reused") {
+					t.Errorf("body lacks idempotency.key_reused: %s", rec.Body.String())
+				}
+				if strings.Contains(rec.Body.String(), "echoed") {
+					t.Errorf("the first route's response was replayed: %s", rec.Body.String())
+				}
+				if handler.invocations.Load() != 1 {
+					t.Errorf("handler invocations = %d, want 1 (only the first call)",
+						handler.invocations.Load())
+				}
+			})
+		}
+	})
+}
+
+// @ac AC-13
+// AC-13: a denial is never cached. A cached denial would pin a 401 or a 403
+// to a key for 24 hours, so granting the permission would change nothing
+// until the entry expired.
+func TestIdempotency_DenialIsNeverCached(t *testing.T) {
+	t.Run("system-idempotency/AC-13", func(t *testing.T) {
+		// A route that needs host:write. Viewer lacks it, admin holds it.
+		guarded := func(calls *atomic.Int64) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if !auth.FromContext(r.Context()).HasPermission(auth.HostWrite) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"error":{"code":"rbac.forbidden"}}`))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"granted":true}`))
+			})
+		}
+
+		t.Run("403 then grant", func(t *testing.T) {
+			pool := freshPool(t)
+			var calls atomic.Int64
+			mw := Middleware(pool)(guarded(&calls))
+
+			// Actor B lacks host:write.
+			denied := httptest.NewRequest(http.MethodPost, "/hosts", strings.NewReader(`{"x":1}`))
+			denied.Header.Set(HeaderName, "denied-key")
+			rec1 := httptest.NewRecorder()
+			mw.ServeHTTP(rec1, authed(denied, "actor-b", auth.RoleViewer))
+
+			if rec1.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403 (setup: viewer must lack host:write)", rec1.Code)
+			}
+			if n := countKey(t, pool, "denied-key"); n != 0 {
+				t.Errorf("rows for denied-key = %d, want 0 (a denial must not be cached)", n)
+			}
+
+			// Same actor, same key, now holding the permission.
+			granted := httptest.NewRequest(http.MethodPost, "/hosts", strings.NewReader(`{"x":1}`))
+			granted.Header.Set(HeaderName, "denied-key")
+			rec2 := httptest.NewRecorder()
+			mw.ServeHTTP(rec2, authed(granted, "actor-b", auth.RoleAdmin))
+
+			if rec2.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 (the grant must take effect, not a replayed denial)",
+					rec2.Code)
+			}
+			if strings.Contains(rec2.Body.String(), "rbac.forbidden") {
+				t.Errorf("the denial was replayed after the grant: %s", rec2.Body.String())
+			}
+			if calls.Load() != 2 {
+				t.Errorf("handler invocations = %d, want 2 (both calls must reach the handler)",
+					calls.Load())
+			}
+		})
+
+		t.Run("401 is not cached", func(t *testing.T) {
+			pool := freshPool(t)
+			var calls atomic.Int64
+			unauthorized := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"code":"auth.session_invalid"}}`))
+			})
+			mw := Middleware(pool)(unauthorized)
+
+			for i := 0; i < 2; i++ {
+				mw.ServeHTTP(httptest.NewRecorder(),
+					postAs("actor-b", "/hosts", `{"x":1}`, "unauth-key"))
+			}
+			if calls.Load() != 2 {
+				t.Errorf("handler invocations = %d, want 2 (a 401 must not be cached)", calls.Load())
+			}
+			if n := countKey(t, pool, "unauth-key"); n != 0 {
+				t.Errorf("rows for unauth-key = %d, want 0 (a 401 must not be stored)", n)
+			}
+		})
+	})
+}
+
+// @ac AC-14
+// AC-14: the primary key is the composite (actor_id, key). Two rows with the
+// same key and different actor_id coexist. The assertion is that BOTH rows
+// survive, not merely that the second insert returned no error: a key-only
+// primary key with an upsert would also return no error while destroying the
+// first row.
+func TestIdempotency_SameKeyDifferentActorsCoexist(t *testing.T) {
+	t.Run("system-idempotency/AC-14", func(t *testing.T) {
+		pool := freshPool(t)
+		ctx := context.Background()
+		const insert = `INSERT INTO idempotency_keys
+			(actor_id, key, request_hash, response_status, response_body, expires_at)
+			VALUES ($1, $2, $3, $4, $5::jsonb, $6)`
+
+		if _, err := pool.Exec(ctx, insert,
+			"actor-a", "same-key", "hash-a", 201, `{"owner":"a"}`,
+			time.Now().Add(TTL)); err != nil {
+			t.Fatalf("insert row for actor-a: %v", err)
+		}
+		if _, err := pool.Exec(ctx, insert,
+			"actor-b", "same-key", "hash-b", 200, `{"owner":"b"}`,
+			time.Now().Add(TTL)); err != nil {
+			t.Fatalf("insert row for actor-b: %v", err)
+		}
+
+		if n := countKey(t, pool, "same-key"); n != 2 {
+			t.Errorf("rows for same-key = %d, want 2 (both actors keep their own row)", n)
+		}
+
+		rowA, ok := readRow(t, pool, "actor-a", "same-key")
+		if !ok {
+			t.Fatal("actor-a's row is gone; the second insert overwrote it")
+		}
+		if rowA.Hash != "hash-a" || rowA.Status != 201 {
+			t.Errorf("actor-a's row = (%q, %d), want (hash-a, 201) unchanged", rowA.Hash, rowA.Status)
+		}
+		jsonEqual(t, rowA.Body, []byte(`{"owner":"a"}`))
+
+		rowB, ok := readRow(t, pool, "actor-b", "same-key")
+		if !ok {
+			t.Fatal("actor-b's row is missing")
+		}
+		if rowB.Hash != "hash-b" || rowB.Status != 200 {
+			t.Errorf("actor-b's row = (%q, %d), want (hash-b, 200)", rowB.Hash, rowB.Status)
+		}
+		jsonEqual(t, rowB.Body, []byte(`{"owner":"b"}`))
 	})
 }

--- a/internal/server/rbac_coverage_test.go
+++ b/internal/server/rbac_coverage_test.go
@@ -704,28 +704,34 @@ func TestRBACCoverage_EchoRequiresSystemRead(t *testing.T) {
 			t.Fatalf("viewer :echo status = %d, want 200; body=%s", code, body)
 		}
 
-		// THE ANONYMOUS REPLAY CASE IS DELIBERATELY NOT ASSERTED HERE.
-		// See bugs/OW-012.
+		// 5. The anonymous replay. This assertion was withdrawn when AC-24 was
+		// written, because it could not hold: internal/idempotency answered a
+		// cache hit before the handler ran, so the auth.EnforcePermission above
+		// never executed and the stored 200 was served to anyone holding the
+		// key. That was bugs/OW-012, and it is now fixed.
 		//
-		// Replaying the key cached at step 4 with no credentials returns that
-		// stored 200, not a 401. I measured it on this branch and coder4
-		// measured it independently, so it is filed rather than overlooked. No
-		// in-handler check can change it: internal/idempotency/middleware.go
-		// answers a cache hit with replayCached and returns before calling the
-		// handler, so the auth.EnforcePermission at the top of
-		// PostDiagnosticsEcho never runs. The cache key is the Idempotency-Key
-		// alone and idempotency_keys has no actor column, so the fix needs a
-		// migration and a middleware change, not a handler change.
+		// The middleware no longer runs at all for an anonymous caller, so the
+		// key cached at step 4 is not even looked up. The request reaches the
+		// handler and the permission check answers it.
 		//
-		// An earlier draft of AC-24 required a 401 here. It was withdrawn
-		// because it is unsatisfiable where it was written, not because the
-		// concern was wrong. A disabled assertion left in place would be worse
-		// than none: dead code reads as coverage, and this gap is exactly the
-		// kind that a reader assumes some test somewhere already holds.
-		//
-		// OW-012 also covers the wider case this route cannot show: nothing
-		// ties a cached row to its creator, so one AUTHENTICATED caller can
-		// replay another's stored response by reusing their key.
+		// Re-enabling this here rather than only in the idempotency package is
+		// deliberate. system-idempotency AC-10 pins the middleware behavior;
+		// this pins the property an operator actually cares about, that a
+		// cached success is never handed to a caller who was never authorized,
+		// through the route where it was first measured.
+		// The key and body MUST match step 4 exactly. A different key is not a
+		// replay at all, it is a fresh anonymous call, and this assertion then
+		// passes against a completely broken cache. That is not hypothetical:
+		// the first version of this step reused a stale key name and survived
+		// three separate mutations of the guard it was supposed to be pinning.
+		code, body = post("ac24-ok-key", "ac24-replay", "authorized", false)
+		if code != http.StatusUnauthorized {
+			t.Errorf("anonymous replay of a used Idempotency-Key: status = %d, want 401. "+
+				"A stored success must not be handed to a caller who was never authorized; body=%s", code, body)
+		}
+		if !strings.Contains(body, "auth.required") {
+			t.Errorf("anonymous replay body lacks auth.required: %s", body)
+		}
 	})
 }
 

--- a/specs/system/db.spec.yaml
+++ b/specs/system/db.spec.yaml
@@ -1,7 +1,10 @@
 spec:
   id: system-db
   title: PostgreSQL pool and audit queries
-  version: "1.0.0"
+  # Version 1.1.0 (was 1.0.0). Minor, because only AC-06 changed and it
+  # describes one table's column set. The idempotency_keys primary key becomes
+  # the composite (actor_id, key). No other AC in this file is affected.
+  version: "1.1.0"
   status: approved
   tier: 2
 
@@ -70,7 +73,12 @@ spec:
       priority: critical
       references_constraints: [C-03]
     - id: AC-06
-      description: idempotency_keys schema includes key (TEXT PK), request_hash, response_status, response_body (JSONB), expires_at.
+      description: >
+        idempotency_keys schema includes actor_id (TEXT NOT NULL), key (TEXT
+        NOT NULL), request_hash, response_status, response_body (JSONB) and
+        expires_at. Its primary key is the composite (actor_id, key), not key
+        alone, so the cache is scoped to the caller that created the entry.
+        See system-idempotency C-09.
       priority: critical
     - id: AC-07
       description: InsertAuditEvent persists row with supplied parameters and returns same row with occurred_at populated.

--- a/specs/system/idempotency.spec.yaml
+++ b/specs/system/idempotency.spec.yaml
@@ -1,7 +1,13 @@
 spec:
   id: system-idempotency
   title: Idempotency middleware
-  version: "1.0.0"
+  # Version 2.0.0 (was 1.0.0). Major, because the cache key changed shape and
+  # two published acceptance criteria changed meaning. The key was `key`; it is
+  # now `(actor_id, key)`. The request hash covered the body alone; it now
+  # covers method, path, query and body. AC-01 and AC-03 assert different
+  # things than they did, and an anonymous caller no longer touches the cache
+  # at all. A consumer written against 1.0.0 is wrong against this file.
+  version: "2.0.0"
   status: approved
   tier: 2
 
@@ -9,23 +15,34 @@ spec:
     system: openwatch
     feature: Idempotency replay caching
     description: >
-      Caches the full response (status + body) for mutating requests
-      arriving with an Idempotency-Key header. Replay within 24h returns
-      the cached response byte-identically without re-running the handler.
-      Same key + different body = 409 idempotency.key_reused.
+      Caches the full response (status + body) for mutating requests that
+      arrive with an Idempotency-Key header from an authenticated caller.
+      The cache entry belongs to the caller who created it. Replay within
+      24h by that same caller returns the cached response without
+      re-running the handler. Same caller, same key, different request
+      returns 409 idempotency.key_reused. A different caller gets a plain
+      cache miss, so their own authorization runs.
+
+      An anonymous caller does not use this cache in either direction.
+      Nothing is looked up for them and nothing is stored for them.
 
   objective:
     summary: >
-      Make POST/PUT/PATCH/DELETE safely retryable. A client that times
-      out and replays must see exactly-one effect plus the same response.
+      Make POST/PUT/PATCH/DELETE safely retryable by the caller that made
+      the original call. A client that times out and replays must see
+      exactly-one effect plus the same response. No caller may be served
+      a response produced under another caller's authorization.
     scope:
       includes:
-        - Body-hash + key cache key
+        - Cache key of (actor_id, Idempotency-Key)
+        - Request hash over method, path, query and body
         - 24h TTL persisted in PostgreSQL
         - 2xx caching only
+        - Pass-through for anonymous callers
       excludes:
         - Distributed locking
         - Client-side replay logic
+        - Any caching of anonymous traffic
 
   constraints:
     - id: C-01
@@ -37,7 +54,11 @@ spec:
       type: technical
       enforcement: error
     - id: C-03
-      description: Key + body-hash MUST be the cache key (replay with same body returns cached; different body returns 409)
+      description: >
+        The cache key MUST be the pair (actor_id, Idempotency-Key). An entry
+        is a hit only when both match and the row has not expired. A hit whose
+        stored request_hash differs from the current request hash MUST return
+        409 idempotency.key_reused.
       type: technical
       enforcement: error
     - id: C-04
@@ -46,37 +67,86 @@ spec:
       enforcement: error
     - id: C-05
       description: >
-        Cache hit MUST short-circuit the handler entirely — no audit, no
-        DB write, no downstream call. Returned body MUST be
+        Cache hit MUST short-circuit the handler entirely, with no audit, no
+        DB write and no downstream call. The returned body MUST be
         semantically-equivalent JSON to the cached value (whitespace
         normalization by JSONB storage is acceptable).
       type: technical
       enforcement: error
     - id: C-06
-      description: Captured body MUST be persisted only on 2xx responses
+      description: >
+        Captured body MUST be persisted only on 2xx responses. A denial
+        therefore never becomes a replayable entry, so a 401 or a 403 MUST
+        NOT be written to the cache.
       type: technical
       enforcement: error
     - id: C-07
-      description: Body hash MUST be SHA-256
+      description: >
+        The request hash MUST be SHA-256 over the canonical string
+        method + "\n" + escaped_path + "\n" + raw_query + "\n" + body.
+        The path is the URL path with no scheme, host or fragment. The three
+        separators are unambiguous because a method, an escaped path and a
+        raw query cannot contain a newline, and the body comes last. The body
+        alone is not enough: two different endpoints called with the same key
+        and the same body would otherwise share one entry, and an empty body
+        is common on action routes.
+      type: security
+      enforcement: error
+    - id: C-08
+      description: >
+        The middleware MUST be a pure pass-through when the bound identity is
+        anonymous. It MUST NOT read the body, look up an entry, return 409, or
+        store a response. The check belongs immediately after the empty-key
+        check and before the body read. This closes an unauthenticated write
+        primitive, since anonymous routes such as POST /auth/logout are
+        CSRF-exempt and unthrottled and nothing reaps rows. It also keeps live
+        credentials out of the cache, since the login and refresh responses
+        carry access and refresh tokens in the body and the cache stores
+        plaintext JSONB for 24 hours.
+      type: security
+      enforcement: error
+    - id: C-09
+      description: >
+        The stored row MUST carry actor_id TEXT NOT NULL, taken from the bound
+        identity's ID. The table's primary key MUST be the composite
+        (actor_id, key), so two callers can hold the same key at the same time.
+        The lookup MUST filter on actor_id and key together.
+      type: security
+      enforcement: error
+    - id: C-10
+      description: >
+        A key held by a different actor MUST read as a plain cache miss. It
+        MUST NOT return 409 and MUST NOT read the other actor's row. A 409
+        would be an existence oracle across tenants, because the key-reused
+        response is written before any authorization runs.
       type: security
       enforcement: error
 
   acceptance_criteria:
     - id: AC-01
-      description: POST with Idempotency-Key K and body B writes idempotency_keys row with key=K, request_hash=sha256(B), expires_at=now()+24h.
+      description: >
+        Authenticated actor A sends POST to path P with Idempotency-Key K and
+        body B. A row is written with actor_id = A's identity ID, key = K,
+        request_hash = sha256("POST\n" + P + "\n" + query + "\n" + B), and
+        expires_at = now() + 24h.
       priority: critical
-      references_constraints: [C-01, C-03, C-04, C-07]
+      references_constraints: [C-01, C-03, C-04, C-07, C-09]
     - id: AC-02
       description: >
-        Replay with same K and same B returns the cached response_status
-        and a semantically-equivalent response_body (JSON-equal); handler
-        NOT invoked. (Byte-for-byte equality is not asserted because
-        PostgreSQL's JSONB storage normalizes whitespace; the user-
-        observable effect is identical.)
+        Actor A replays the same key, method, path, query and body. The
+        response carries the cached response_status and a
+        semantically-equivalent response_body (JSON-equal), and the handler is
+        NOT invoked. Byte-for-byte equality is not asserted because
+        PostgreSQL's JSONB storage normalizes whitespace, and the
+        user-observable effect is identical.
       priority: critical
       references_constraints: [C-05]
     - id: AC-03
-      description: Replay with same K and different B returns 409 with error.code = "idempotency.key_reused".
+      description: >
+        Actor A replays the same key K with a different request hash, produced
+        by changing the body. The response is 409 with
+        error.code = "idempotency.key_reused" and the first response is not
+        replayed.
       priority: critical
       references_constraints: [C-03]
     - id: AC-04
@@ -94,8 +164,56 @@ spec:
       description: Cache lookup latency p99 < 5ms against local DB.
       priority: medium
     - id: AC-08
-      description: Expired cache entry (now() > expires_at) is treated as cache miss; handler runs and overwrites.
+      description: Expired cache entry (now() > expires_at) is treated as cache miss; handler runs and overwrites the row for that same actor and key.
       priority: high
+      references_constraints: [C-03, C-09]
     - id: AC-09
-      description: Two concurrent requests with same Key + body race cleanly; one runs handler+caches, the other reads cached (no duplicate side effects).
+      description: >
+        Two concurrent requests from the SAME actor with the same key and the
+        same request hash race cleanly. One runs the handler and caches, the
+        other reads the cached row, and there are no duplicate side effects.
       priority: high
+      references_constraints: [C-09]
+    - id: AC-10
+      description: >
+        An anonymous caller does not touch the cache in either direction. Two
+        assertions. First, an anonymous request carrying Idempotency-Key K runs
+        the handler and writes no idempotency_keys row for K. Second, with a
+        row already seeded at (some actor, K) whose request_hash matches, the
+        anonymous request is still not served from cache. The handler runs and
+        the seeded row is unchanged.
+      priority: critical
+      references_constraints: [C-08]
+    - id: AC-11
+      description: >
+        A cross-actor replay is a plain miss, not a 409. Actor A caches a
+        response at (A, K). Actor B sends the same key, method, path and body.
+        B's request runs the handler, so B's own authorization applies. The
+        status is not 409, the response is the one produced for B, a row now
+        exists at (B, K), and A's row is unchanged.
+      priority: critical
+      references_constraints: [C-09, C-10]
+    - id: AC-12
+      description: >
+        The hash covers the route, not only the body. Actor A calls path P1
+        with key K and body B, then calls path P2 with the same key K and the
+        same body B. The second call returns 409
+        error.code = "idempotency.key_reused" and does not replay the P1
+        response. The same holds when only the method changes.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-13
+      description: >
+        A denial is never cached. Actor B lacks the permission the route
+        requires and calls it with key K, receiving 403. No row exists at
+        (B, K). After B is granted the permission, the same key runs the
+        handler rather than replaying the denial. The same holds for a 401.
+      priority: critical
+      references_constraints: [C-06, C-08]
+    - id: AC-14
+      description: >
+        The primary key is the composite (actor_id, key). Two rows with the
+        same key and different actor_id coexist, and writing one does not
+        overwrite or conflict with the other.
+      priority: critical
+      references_constraints: [C-09]


### PR DESCRIPTION
A cache hit was answered before the handler ran, and the lookup was keyed on the `Idempotency-Key` header alone. So anyone who knew a used key and its exact body was served the stored response, whatever their identity, and no authorization ran.

Closes `bugs/OW-012`. Two agents reproduced it independently before any code changed.

## Why the previous PR could not fix this

`fix(rbac)` (#814) added a permission check to `POST /diagnostics:echo`. That check never runs on a replay: `internal/idempotency/middleware.go` answers a cache hit with `replayCached` and returns without calling the handler.

That is why the assertion for it was withdrawn from `system-rbac` AC-24 and left in place as a comment naming this bug, described as **unsatisfiable where it was written, not wrong**. It is re-enabled in this PR, and it is the acceptance test for the change.

## Three parts

### An anonymous caller skips the middleware entirely

Placed before the body is even read, so it bypasses the lookup, the 409, the read and the store together.

This is the strongest single change, and it closes two things nobody had filed:

- **`POST /api/v1/auth/logout` was an unauthenticated unbounded write primitive.** It is CSRF-exempt (the whole `/api/v1/auth/` prefix is), unthrottled (the limiter covers login and mfa:verify only), and answers 204, which caches. Nothing reaps rows. `DISK_FULL.md` already tells operators to check that table without saying why it grows.
- **Login and refresh stored live credentials at rest.** Both return `AccessToken` and `RefreshToken` in the body, written as readable JSON for 24 hours. The refresh token's 7-day window outlives the row.

**Nothing is lost by skipping it.** No anonymous route declares `Idempotency-Key`, the SPA mints a fresh UUID per call, and `replayCached` writes only status, Content-Type and body, dropping every `Set-Cookie`. A cached login replay already answered 200 with no session cookie. Caching anonymous responses was a defect, not a feature.

### The cache is keyed `(actor_id, key)`

A caller replaying another's key is a plain **MISS**, not a 409. The handler runs and their own authorization answers, and a row lands at their own `(actor, key)`.

A 409 would have made the route a cross-tenant existence oracle, because the key-reused path fires before any authorization. **That oracle was real, and it is now proven rather than inferred.** Pre-fix, an unauthenticated caller who guessed a key received a 409 with the handler never running.

### The hash covers the route, not the body alone

`sha256(method + "\n" + escaped_path + "\n" + raw_query + "\n" + body)`

Two endpoints called with the same key and the same body used to share one entry, and empty bodies are common on `:action` routes. Actor scoping does not fix that.

**Escaped rather than decoded is deliberate:** a client-supplied `%0A` in a decoded path could move a separator boundary and forge a collision. The canonical string is pinned byte-for-byte in `system-idempotency` C-07, because "the hash covers method and path" is not implementable without an encoding.

## A spec clause that had never been enforced

`system-db` AC-06 has claimed `key (TEXT PK)` since it was written. **It never asserted any primary key.** The test built a column map from `information_schema` and then looped over its own `want` map, so extra columns passed silently and the key was never read. The schema could have had any primary key at all and the test would have stayed green.

It now asserts the ordered primary key, and that assertion was **watched failing** on the pre-fix schema:

    db_gaps_test.go:243: idempotency_keys primary key = [key], want [actor_id key]

It also moved to `dbtest.Pool`. Goose is forward-only, so once migration `0058` lands in the base DSN database, a pre-fix run through `testDSN` sees the **fixed** schema and the assertion passes exactly when it must fail. A mutation check that cannot fail is worse than none, because it produces evidence.

## Verification

| Check | Result |
|---|---|
| `go test ./...` | 59 packages, 0 failures |
| `specter coverage --strictness annotation` | 118 specs 100%. `system-idempotency` 14/14, `system-db` 13/13 |
| `go test -race` on both packages | clean |
| `go build`, `go vet`, `gofmt -l` | clean |
| `check-doc-style.py` | clean |

DB tests ran against isolated `_test` namespaces, never a live database.

**Every security assertion is mutation-checked.** The re-enabled AC-24 replay assertion passes on the fix and fails when the scoping is removed, returning the stored 200 with the authorized caller's body.

Worth recording: the first version of that re-enabled assertion **was vacuous**. It replayed a key that had never been cached, so it passed against three separate mutations of the guard it was meant to pin. It was caught by not accepting a passing mutation, and the test now carries a comment explaining why the key must match.

## Migration

`0058` drops every existing row. `ADD COLUMN ... NOT NULL` with no default requires a non-empty table to be cleared, and it is correct regardless: this is a response cache with a 24 hour life, an upgrade restarts the process, and the worst case is one client re-executing a retry once, identical to an entry expiring.

Up and Down were round-tripped by hand over a non-empty legacy table, which no test covers.

## Filed rather than fixed here

- **`bugs/OW-013`** nothing reaps expired rows. The anonymous skip closes the unauthenticated half; any authenticated caller can still grow the table without limit.
- **`bugs/OW-014`** a replay drops every response header, including `Set-Cookie` and any security header. Not live today, a trap for the next mutating route.
- **`bugs/OW-016`** five sibling schema tests carry the same forward-only-goose hazard that was removed from AC-06. They are green, and green is not evidence they would go red.

## Spec versions

`system-idempotency` 1.0.0 to 2.0.0, major because the cache key changed shape and AC-01 and AC-03 changed meaning. `system-db` 1.0.0 to 1.1.0, AC-06 only.
