### PR TITLE
feat(retention): delete expired rows on a schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- OpenWatch deletes expired rows from three tables on a schedule:
+  `idempotency_keys` after 24 hours, `sso_auth_states` after 1 hour, and
+  `auth_mfa_otp_uses` after 24 hours. Nothing removed them before, so on a
+  long-running install these tables can be large. **The first sweep after you
+  upgrade may delete a big backlog.** It runs in bounded batches, oldest rows
+  first, so it does not hold a long lock. Deleting rows frees space for
+  PostgreSQL to reuse but does not return it to the filesystem. **If you
+  upgraded to reclaim disk, run `VACUUM FULL` or `pg_repack` on those tables
+  after the first sweep.** `VACUUM FULL` takes an exclusive lock.
+- A used one-time MFA code is now rejected for 24 hours rather than
+  indefinitely. **Nothing to do.** OpenWatch accepts a TOTP code only within 90
+  seconds of its own time step, so this does not change which codes it accepts.
 - A license carrying a feature id this build does not recognize now stays valid
   and enables the features it does recognize. It used to be rejected outright,
   so a license issued against a newer feature list disabled an entitled install

--- a/cmd/openwatch/main.go
+++ b/cmd/openwatch/main.go
@@ -57,6 +57,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/remediation"
 	"github.com/Hanalyx/openwatch/internal/report"
 	"github.com/Hanalyx/openwatch/internal/reportschedule"
+	"github.com/Hanalyx/openwatch/internal/retention"
 	"github.com/Hanalyx/openwatch/internal/scanresult"
 	compsched "github.com/Hanalyx/openwatch/internal/scheduler"
 	"github.com/Hanalyx/openwatch/internal/secretkey"
@@ -658,6 +659,16 @@ func cmdServe(cfg *config.Config, _ []string, stdout, stderr *os.File) int {
 	// snapshots and raises a re-nag-safe in-app notification for accounts
 	// within the configured warn window (or expired). Boot pass + daily tick.
 	accountpolicy.New(pool, govProjector, cfgStore).Run(ctx, 0)
+
+	// Data retention: one registry of per-table policies, one sweeper
+	// that walks it. Boot pass plus a six-hourly tick. This is the one
+	// scheduled job whose absence is invisible, since nothing 503s and
+	// no page goes blank; the only symptom is a disk that fills months
+	// later. Two purge functions already shipped naming a caller that
+	// did not exist, so the wiring is guarded by a source-inspection
+	// test rather than by memory.
+	// Spec system-retention-sweeper C-04, system-daemon-orchestration C-10.
+	retention.NewSweeper(pool, audit.Emit).Run(ctx, 0)
 
 	// Remediation governance: request/approve/reject + projected lift (free
 	// core), AND the queued single-rule execute/rollback (Tier A free core).

--- a/cmd/openwatch/source_test.go
+++ b/cmd/openwatch/source_test.go
@@ -11,6 +11,7 @@
 //   AC-09  TestCmdServe_IntelligenceSchedulerWired
 //   AC-10  TestCmdServe_MaintenancePauseWarnLog
 //   AC-11  TestCmdServe_AllServerBuildersWired
+//   AC-12  TestCmdServe_RetentionSweeperWired
 //
 // These tests are source-inspection — they read cmd/openwatch/main.go
 // and the Slice B package directories and assert structural invariants.
@@ -20,6 +21,7 @@
 package main
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -339,6 +341,136 @@ func TestCmdServe_AllServerBuildersWired(t *testing.T) {
 			if !regexp.MustCompile(`\b` + b + `\(`).MatchString(main) {
 				t.Errorf("server builder %s is defined but never called in main.go — its handler field stays nil and the guarded endpoints 503 in production (the alerts-service gap)", b)
 			}
+		}
+	})
+}
+
+// cmdServeBody parses main.go and returns the body of cmdServe. The
+// retention guard has to be scoped to that function: constructing the
+// sweeper anywhere else in the file, or in a helper nothing calls, is the
+// same dead code this spec exists to prevent.
+func cmdServeBody(t *testing.T) (*ast.BlockStmt, *token.FileSet) {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filepath.Join(filepath.Dir(file), "main.go"), nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if ok && fn.Recv == nil && fn.Name.Name == "cmdServe" {
+			return fn.Body, fset
+		}
+	}
+	t.Fatal("main.go has no top-level cmdServe function")
+	return nil, nil
+}
+
+// pkgCall reports whether n is a call to pkg.name(...).
+func pkgCall(n ast.Node, pkg, name string) bool {
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != name {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == pkg
+}
+
+// @ac AC-12
+// AC-12: cmdServe constructs the retention sweeper AND starts it with a
+// Run call taking ctx, on the pattern of exceptionSvc.Run(ctx, 0) and
+// accountpolicy.New(...).Run(ctx, 0).
+//
+// This is an AST check, not a text match, because the failure it guards
+// is precise. internal/sso PurgeExpiredStates and internal/identity
+// PurgeStaleOTPs were each written, tested and left with no caller for
+// months. A sweeper that is constructed and never started reproduces
+// that exactly, so "constructed" alone must not pass. The check follows
+// the value: either the constructor is chained straight into .Run, or it
+// is bound to a name and that name is what gets run.
+//
+// system-retention-sweeper AC-10 asserts the other half, that the sweep
+// walks the registry instead of a hard-coded table list.
+func TestCmdServe_RetentionSweeperWired(t *testing.T) {
+	t.Run("system-daemon-orchestration/AC-12", func(t *testing.T) {
+		body, fset := cmdServeBody(t)
+
+		// Pass 1: find retention.NewSweeper( and record how its result is
+		// bound. sweeperVars holds the names it was assigned to;
+		// a chained retention.NewSweeper(...).Run(ctx) is accepted too.
+		sweeperVars := map[string]bool{}
+		construct := token.NoPos
+
+		ast.Inspect(body, func(n ast.Node) bool {
+			if pkgCall(n, "retention", "NewSweeper") {
+				construct = n.(*ast.CallExpr).Lparen
+			}
+			// name := retention.NewSweeper(...) or name = ...
+			var lhs, rhs []ast.Expr
+			switch s := n.(type) {
+			case *ast.AssignStmt:
+				lhs, rhs = s.Lhs, s.Rhs
+			default:
+				return true
+			}
+			for i, r := range rhs {
+				if !pkgCall(r, "retention", "NewSweeper") || i >= len(lhs) {
+					continue
+				}
+				if id, ok := lhs[i].(*ast.Ident); ok && id.Name != "_" {
+					sweeperVars[id.Name] = true
+				}
+			}
+			return true
+		})
+
+		if !construct.IsValid() {
+			t.Fatal("cmdServe never calls retention.NewSweeper( — the retention sweeper is not wired, so no table is ever swept in production. This is the defect system-retention-sweeper was written for (see bugs/OW-013)")
+		}
+
+		// Pass 2: find the Run call that starts it.
+		ranAt := token.NoPos
+		ast.Inspect(body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Run" {
+				return true
+			}
+			// The receiver is either the constructor call itself
+			// (chained) or a name bound to it.
+			switch recv := sel.X.(type) {
+			case *ast.CallExpr:
+				if !pkgCall(recv, "retention", "NewSweeper") {
+					return true
+				}
+			case *ast.Ident:
+				if !sweeperVars[recv.Name] {
+					return true
+				}
+			default:
+				return true
+			}
+			// First argument must be ctx.
+			if len(call.Args) == 0 {
+				return true
+			}
+			if id, ok := call.Args[0].(*ast.Ident); !ok || id.Name != "ctx" {
+				return true
+			}
+			ranAt = call.Lparen
+			return true
+		})
+
+		if !ranAt.IsValid() {
+			t.Errorf("cmdServe constructs the retention sweeper at %s but never starts it with a Run call taking ctx. A sweeper that is built and not run deletes nothing, which is the state this spec corrects, not a partial fix of it", fset.Position(construct))
 		}
 	})
 }

--- a/internal/identity/mfa.go
+++ b/internal/identity/mfa.go
@@ -30,10 +30,14 @@ const TOTPIssuer = "OpenWatch"
 // requires ≥80 bits; NIST SP 800-63B requires ≥128. Spec C-09 sets 160.
 const TOTPSecretBytes = 20 // 160 bits
 
-// OTPReplayWindow is how long a used OTP value remains in the replay-
-// prevention table. Set to twice the validation window (±1 step = 90s
-// validation, so 180s replay protection covers the boundary).
-const OTPReplayWindow = 180 * time.Second
+// The replay window used to be a constant here, OTPReplayWindow = 180s.
+// It is gone. How long a used OTP is rejected is how long its row in
+// auth_mfa_otp_uses survives, and that is now the Grace on the
+// auth_mfa_otp_uses entry in internal/retention's registry. One number,
+// in one place. A constant here would be a second source of truth that
+// drifts from the sweeper that actually does the deleting.
+//
+// Spec: specs/system/retention-sweeper.spec.yaml C-10.
 
 // SetEphemeralMFAKey installs a random key. Tests and dev mode only.
 // Wrapper over secretkey.SetEphemeral.
@@ -85,16 +89,22 @@ func EnrollMFA(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, userna
 
 // VerifyMFA validates an OTP against the user's enrolled secret. Returns:
 //   - ErrMFANotEnrolled if no secret exists for the user
-//   - ErrOTPReplayed if the same OTP was used within OTPReplayWindow
+//   - ErrOTPReplayed if the same OTP was used inside the replay window
 //   - ErrMFAInvalidOTP if the OTP is outside the ±1 step window
 //   - nil on success
 //
-// Replay protection: each successful verify stores (user_id, otp) in
-// auth_mfa_otp_uses for OTPReplayWindow seconds. A second use within
-// that window fails — even if the OTP is still inside the ±1 step
-// validation window.
+// Replay protection: each successful verify inserts (user_id, otp) into
+// auth_mfa_otp_uses with ON CONFLICT DO NOTHING, so the check is purely
+// whether the row is there. A second use fails even if the OTP is still
+// inside the ±1 step validation window.
 //
-// Spec AC-15, AC-16, C-10.
+// The window is therefore the row's lifetime, and the row's lifetime is
+// set by one place: the auth_mfa_otp_uses Grace in internal/retention's
+// registry. Shortening that Grace shortens replay rejection. Its floor
+// is the TOTP acceptance window, 90 seconds.
+//
+// Spec system-auth-identity AC-15, AC-16, C-10.
+// Spec system-retention-sweeper C-10.
 func VerifyMFA(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, otpValue string) error {
 	dek, err := secretkey.Active()
 	if err != nil {
@@ -152,13 +162,9 @@ func VerifyMFA(ctx context.Context, pool *pgxpool.Pool, userID uuid.UUID, otpVal
 	return nil
 }
 
-// PurgeStaleOTPs deletes OTP-use rows older than OTPReplayWindow. Called
-// by a cron tick.
-func PurgeStaleOTPs(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
-	tag, err := pool.Exec(ctx,
-		`DELETE FROM auth_mfa_otp_uses WHERE used_at < now() - interval '180 seconds'`)
-	if err != nil {
-		return 0, fmt.Errorf("identity: purge otps: %w", err)
-	}
-	return tag.RowsAffected(), nil
-}
+// PurgeStaleOTPs used to live here. It deleted at 180 seconds, it said
+// "Called by a cron tick", and no cron tick called it. Rows were kept
+// forever, which made replay rejection accidentally unlimited, so
+// wiring the function up as written would have narrowed protection
+// rather than added it. internal/retention deletes this table now, on
+// the registry's grace.

--- a/internal/retention/policy.go
+++ b/internal/retention/policy.go
@@ -1,0 +1,303 @@
+// Package retention holds one registry of retention policies and one
+// sweeper that walks it. Every table the migrations create carries
+// exactly one entry, and every entry carries a reason.
+//
+// Why the registry enumerates tables rather than columns. An earlier
+// survey of this schema keyed on expires_at and missed auth_mfa_otp_uses
+// entirely, because that table keys on used_at. Enumerating tables and
+// demanding an explicit decision for each one is the only version that
+// cannot miss a table.
+//
+// Why the registry exists at all. OpenWatch shipped two purge functions
+// and no sweeper. internal/sso/store.go PurgeExpiredStates said "Called
+// by a periodic sweeper" and had no caller. internal/identity/mfa.go
+// PurgeStaleOTPs said "Called by a cron tick" and had no caller.
+// Different authors, two months apart, same outcome. Both are deleted
+// now, and their tables are swept from here.
+//
+// Spec: specs/system/retention-sweeper.spec.yaml.
+package retention
+
+import "time"
+
+// State is the retention decision recorded for one table. Every table in
+// the schema carries exactly one of these, and every entry carries a
+// reason. Silence is not a state.
+type State string
+
+const (
+	// StateSwept means the sweeper deletes rows past the grace.
+	StateSwept State = "swept"
+
+	// StateNever means rows are kept forever, on purpose. The reason
+	// records why, so a later reader does not "fix" it.
+	StateNever State = "never"
+
+	// StateDeferred means a sweep is wanted but blocked on named work.
+	// The reason names the work, and the entry carries the TTL column,
+	// the grace and any Keep predicate the promotion will use, so
+	// promoting is a one-word state change rather than a fresh design.
+	StateDeferred State = "deferred"
+
+	// StateUndecided means nobody has ruled on this table. It carries no
+	// TTL column and no grace, because naming either would assert a
+	// decision that was never taken.
+	//
+	// This is not the same as deferred. Deferred says "here is the
+	// policy, here is what blocks it". Undecided says "nobody has
+	// looked". Collapsing the two would make an unreviewed table read
+	// like a reviewed one, which is the defect this registry exists to
+	// prevent, one level up.
+	StateUndecided State = "undecided"
+)
+
+// Policy is one table's retention decision.
+//
+// TTLColumn and Grace describe the delete: rows whose TTLColumn is older
+// than Grace are eligible. Keep is an optional SQL predicate naming rows
+// that survive regardless of age; the sweeper negates it in the WHERE
+// clause.
+type Policy struct {
+	// Table is the table name as the migrations create it.
+	Table string
+
+	// TTLColumn is the timestamp column that decides a row's age.
+	TTLColumn string
+
+	// Grace is how long past TTLColumn a row survives.
+	Grace time.Duration
+
+	// State is the retention decision: swept, never, deferred, or
+	// undecided.
+	State State
+
+	// Keep is an optional SQL predicate. A row matching it survives
+	// past its grace.
+	Keep string
+
+	// Reason says why this table has the state it has. Never empty.
+	Reason string
+}
+
+// Eligible reports whether the sweeper deletes from this table.
+func (p Policy) Eligible() bool { return p.State == StateSwept }
+
+// registry is the single source of truth. One entry per table created in
+// the Up section of internal/db/migrations/*.sql. A new table without an
+// entry here fails CI (spec AC-02).
+//
+// Ordered swept, never, deferred, undecided, so the three tables that
+// actually lose rows are readable off the top of the list.
+var registry = []Policy{
+	// ---- swept ----------------------------------------------------
+	{
+		Table:     "idempotency_keys",
+		TTLColumn: "expires_at",
+		Grace:     24 * time.Hour,
+		State:     StateSwept,
+		Reason: "Replay lookup already filters on expires_at > now(), so a row " +
+			"past its expiry is unreadable before it is swept. The 24h grace " +
+			"keeps a recently expired key around long enough to debug a " +
+			"duplicate-submit report against it.",
+	},
+	{
+		Table:     "sso_auth_states",
+		TTLColumn: "expires_at",
+		Grace:     time.Hour,
+		State:     StateSwept,
+		Reason: "An auth state is single-use and is rejected once expired, so " +
+			"the sweep only reclaims abandoned logins. The callback consumes " +
+			"the row it matches (internal/sso/store.go consumeAuthState); this " +
+			"sweep collects the states nobody ever came back for.",
+	},
+	{
+		Table: "auth_mfa_otp_uses",
+		// Note the column. This table has no expires_at, and keying a
+		// retention survey on expires_at is what missed it before.
+		TTLColumn: "used_at",
+		Grace:     24 * time.Hour,
+		State:     StateSwept,
+		Reason: "This Grace IS the OTP replay-rejection window, not a capacity " +
+			"setting. identity.VerifyMFA rejects a replay by inserting " +
+			"(user_id, otp) with ON CONFLICT DO NOTHING, so a used OTP is " +
+			"rejected exactly as long as its row survives. Deleting the row " +
+			"makes the OTP replayable again. The floor is the TOTP acceptance " +
+			"window, 90 seconds (period 30s, skew 1, three steps); 24h is far " +
+			"above it. Do not lower this without reading spec C-10.",
+	},
+
+	// ---- never ----------------------------------------------------
+	{
+		Table:  "api_tokens",
+		State:  StateNever,
+		Reason: reasonAPITokens,
+	},
+	{
+		Table:  "compliance_exceptions",
+		State:  StateNever,
+		Reason: reasonComplianceExceptions,
+	},
+
+	// ---- deferred: decided, blocked on named work ------------------
+	//
+	// The Grace on these two is a placeholder, and each Reason says so.
+	// The label has to travel with the data: anything rendering the
+	// registry for an operator reads Grace, not this comment, and a
+	// consumer showing an invented number as a fact is the defect this
+	// registry exists to remove. The TTLColumn and the Keep predicate
+	// are not placeholders. Those are settled.
+	{
+		Table:     "sessions",
+		TTLColumn: "absolute_expires_at",
+		Grace:     30 * 24 * time.Hour,
+		State:     StateDeferred,
+		Reason: "Blocked on a migration: it needs a non-partial index on " +
+			"absolute_expires_at. The predicate must use absolute_expires_at, " +
+			"because expires_at slides forward on every request and would " +
+			"never settle. The only index today is idx_sessions_expires_at, " +
+			"which is partial (WHERE revoked_at IS NULL) and on the wrong " +
+			"column, so a sweep is a sequential scan over live session " +
+			"history. Deleting session history is not reversible. " +
+			"The 30 day grace is a placeholder to satisfy the registry's " +
+			"shape rule, not a retention decision. Choose the real window at " +
+			"promotion.",
+	},
+	{
+		Table:     "refresh_tokens",
+		TTLColumn: "expires_at",
+		Grace:     30 * 24 * time.Hour,
+		State:     StateDeferred,
+		// Carried now, not at promotion. A reuse_detected_at row is the
+		// only durable artifact of a detected token theft, and the
+		// criterion that proves Keep works is tested before the
+		// promotion rather than with it (spec AC-09).
+		Keep: "reuse_detected_at IS NOT NULL",
+		Reason: "Blocked on a migration: there is no index on expires_at at " +
+			"all, so a sweep today is a sequential scan. The delete must be " +
+			"oldest-first because rotated_to_id references this same table " +
+			"with NO ACTION, and a newest-first batch violates it. A row with " +
+			"reuse_detected_at set is the only durable record of a detected " +
+			"token theft, so the Keep predicate above must survive promotion. " +
+			"The 30 day grace is a placeholder to satisfy the registry's " +
+			"shape rule, not a retention decision. Choose the real window at " +
+			"promotion.",
+	},
+
+	// ---- undecided: nobody has ruled on these ----------------------
+	//
+	// Every entry below carries the same stock reason. That is
+	// deliberate. The value of an undecided entry is that a new table
+	// cannot be added without someone picking a state; the prose is not
+	// doing the work, and 39 hand-written variations would only invite
+	// the reader to mistake description for a decision.
+	//
+	// These are pinned by name, not by count (C-13). A count ratchet
+	// would let a promotion pay for a newly added undecided table while
+	// the total held steady. With names pinned, adding one means editing
+	// a reviewed list.
+	//
+	// Two things worth knowing before anyone rules on them, recorded
+	// here rather than in 39 separate Reason strings:
+	//
+	// Growing without bound, and this is the first place in the
+	// codebase that says so: audit_events, job_queue, notifications,
+	// host_monitoring_history (one row per host per probe, the fastest
+	// of them), host_intelligence_events, posture_snapshots (one row
+	// per host per framework per day), transactions, policy_history,
+	// alerts, scan_runs, scan_results, scan_evidence,
+	// remediation_requests, remediation_transactions, report_snapshots
+	// and report_faces.
+	//
+	// Three of those cannot be swept per table even after a decision.
+	// scan_results references scan_runs, hosts and scan_evidence with
+	// RESTRICT, so any sweep there has to delete in dependency order.
+	// scan_evidence is content-addressed and shared, so removing a body
+	// is reference counting rather than age. host_intelligence_events
+	// and transactions reference hosts with RESTRICT, so those rows
+	// outlive the host they describe.
+	//
+	// The rest hold current state rather than history. Their row count
+	// tracks the number of live objects, so they grow with the fleet and
+	// not with time, and age is the wrong key for all of them.
+	{Table: "audit_events", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "job_queue", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "notifications", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_monitoring_history", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_intelligence_events", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "posture_snapshots", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "transactions", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "policy_history", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "alerts", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "scan_runs", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "scan_results", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "scan_evidence", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "remediation_requests", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "remediation_transactions", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "report_snapshots", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "report_faces", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "users", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "roles", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "user_roles", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "groups", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "group_members", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "hosts", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "credentials", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "system_config", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "auth_policy", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "license_clock_watermark", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "notification_channels", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "report_schedules", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "sso_providers", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "sso_identities", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "ssh_known_hosts", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "auth_mfa_secrets", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_connection_profile", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_liveness", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_backoff_state", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_compliance_schedule", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_intelligence_state", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_system_info", State: StateUndecided, Reason: reasonUndecided},
+	{Table: "host_rule_state", State: StateUndecided, Reason: reasonUndecided},
+}
+
+// reasonUndecided is shared by every table nobody has ruled on. The
+// entry's value is that a new table cannot be added without picking a
+// state; the prose is not doing the work.
+const reasonUndecided = "No retention decision has been taken for this table. See bugs/OW-013."
+
+// reasonAPITokens and reasonComplianceExceptions are held apart from the
+// table above only because they are long. Both record a decision that a
+// later reader would otherwise be tempted to reverse.
+const (
+	reasonAPITokens = "Kept forever on purpose. The operator UI lists expired " +
+		"tokens deliberately: internal/apitoken/apitoken.go filters neither " +
+		"expires_at nor revoked_at. expires_at is nullable, and NULL means the " +
+		"token never expires, so an age-based sweep has nothing to key on for " +
+		"those rows. The row is also a forensic record, carrying created_by, " +
+		"last_used_at and revoked_at, which is exactly what an investigator " +
+		"needs after a token is abused."
+
+	reasonComplianceExceptions = "Kept forever on purpose. Expiry here is " +
+		"already a status transition rather than a deletion, run by " +
+		"exception.Service.Run, and the table's partial unique index depends " +
+		"on expired rows persisting. This table is the model this registry " +
+		"follows, not a defect it corrects."
+)
+
+// Registry returns the retention policies, one per table. The slice is a
+// copy, so a caller cannot mutate the registry.
+func Registry() []Policy {
+	out := make([]Policy, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// Lookup returns the policy for one table.
+func Lookup(table string) (Policy, bool) {
+	for _, p := range registry {
+		if p.Table == table {
+			return p, true
+		}
+	}
+	return Policy{}, false
+}

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -1,0 +1,1857 @@
+// @spec system-retention-sweeper
+//
+// AC traceability (this file):
+//   AC-01  TestRegistryEntriesAreWellFormed
+//   AC-01  TestSweptTTLColumnsAreNotNull
+//   AC-02  TestRegistryCoversEveryMigratedTable
+//   AC-03  TestSweptEntriesAreExactlyTheThree
+//   AC-04  TestNeverTablesSurviveASweep
+//   AC-05  TestDeferredTablesSurviveASweep
+//   AC-06  TestSweepDeletesPastGraceOnly
+//   AC-07  TestSweepIsBatchedAndOldestFirst
+//   AC-08  TestTickDeadlineIsShorterThanInterval
+//   AC-08  TestCanceledSweepLeavesRowsInPlace
+//   AC-09  TestKeepPredicateIsHonored
+//   AC-10  TestSweeperIsReachableFromMain
+//   AC-11  TestNoSecondSweeperInTheTree
+//   AC-12  TestOrphanedPurgeFunctionsAreResolved
+//   AC-13  TestOTPReplayWindowComesFromTheRegistry
+//   AC-14  TestSweepLogsPerTableAndEmitsNoAudit
+//   AC-15  TestOneBadTableDoesNotEndThePass
+//   AC-16  TestUndecidedTablesArePinnedAndUntouched
+//
+// Four of these are structural rather than behavioral, and that is the
+// point of the spec. A unit test of a purge function that production
+// never calls is exactly the state this package replaces: the tree held
+// two exported purge functions with zero callers for months. AC-02,
+// AC-10 and AC-11 are the ones that make a repeat of that fail CI.
+
+package retention
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/correlation"
+	"github.com/Hanalyx/openwatch/internal/db/dbtest"
+	"github.com/Hanalyx/openwatch/internal/identity"
+)
+
+// ---------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------
+
+// repoRoot is the tree root, two levels above internal/retention.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+// goSourceFiles returns every non-test .go file in the tree, as paths
+// relative to the root. Vendor, node_modules and the frontend are
+// skipped because none of them holds Go the server builds.
+func goSourceFiles(t *testing.T, root string) []string {
+	t.Helper()
+	skip := map[string]bool{".git": true, "vendor": true, "node_modules": true, "frontend": true}
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skip[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(out)
+	if len(out) < 100 {
+		t.Fatalf("found only %d Go source files under %s, the walk is broken and every scan below would pass vacuously", len(out), root)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------
+// Migration parsing (AC-02)
+// ---------------------------------------------------------------------
+
+var (
+	createTableRe = regexp.MustCompile(`(?im)^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+	dropTableRe   = regexp.MustCompile(`(?im)^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+	renameTableRe = regexp.MustCompile(`(?im)^\s*ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?\s+RENAME\s+TO\s+"?([A-Za-z_][A-Za-z0-9_]*)"?`)
+)
+
+// migratedTables returns the tables the migrations leave behind, mapped
+// to the file that created each one.
+//
+// Only the Up section of each file is read. The Down sections are full of
+// DROP TABLE statements for tables that very much exist, so parsing a
+// whole file would report an empty schema.
+//
+// The parse follows renames and drops inside Up sections too, because a
+// table created in one migration and renamed in a later one must be
+// demanded under its final name and not its first one.
+//
+// No part of this reads a column name. That is deliberate: an earlier
+// survey of this schema keyed on expires_at, missed auth_mfa_otp_uses
+// (which keys on used_at), and reported the schema as covered.
+func migratedTables(t *testing.T) map[string]string {
+	t.Helper()
+	dir := filepath.Join(repoRoot(t), "internal", "db", "migrations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		t.Fatal("no .sql migrations found, the AC-02 guard would pass vacuously")
+	}
+
+	live := map[string]string{}
+	for _, name := range files {
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		src := string(b)
+
+		// Both markers must be present. A migration written in some other
+		// format would otherwise have its tables silently skipped, which
+		// is the same silence this spec exists to remove.
+		up := strings.Index(src, "-- +goose Up")
+		down := strings.Index(src, "-- +goose Down")
+		if up < 0 || down < 0 {
+			t.Fatalf("%s has no goose Up/Down markers, so this guard cannot tell schema from rollback", name)
+		}
+		if down < up {
+			t.Fatalf("%s has its Down marker before its Up marker", name)
+		}
+		section := src[up:down]
+
+		for _, m := range createTableRe.FindAllStringSubmatch(section, -1) {
+			live[m[1]] = name
+		}
+		for _, m := range renameTableRe.FindAllStringSubmatch(section, -1) {
+			delete(live, m[1])
+			live[m[2]] = name
+		}
+		for _, m := range dropTableRe.FindAllStringSubmatch(section, -1) {
+			delete(live, m[1])
+		}
+	}
+
+	// Floor check. If the regex above ever stops matching, every
+	// "table has no entry" assertion below would pass on an empty set.
+	if len(live) < 40 {
+		t.Fatalf("parsed only %d tables out of %d migrations, the CREATE TABLE parser is broken", len(live), len(files))
+	}
+	return live
+}
+
+// ---------------------------------------------------------------------
+// Database helpers
+// ---------------------------------------------------------------------
+
+// sweptAndSeedableTables are every table these tests write to. Truncated
+// before each database test so one test cannot see another's rows.
+var sweptAndSeedableTables = []string{
+	"idempotency_keys",
+	"sso_auth_states",
+	"auth_mfa_otp_uses",
+	"api_tokens",
+	"compliance_exceptions",
+	"sessions",
+	"refresh_tokens",
+	"auth_mfa_secrets",
+	"sso_providers",
+	"hosts",
+	"users",
+}
+
+// freshPool returns this package's isolated database with the tables
+// these tests own emptied.
+func freshPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool := dbtest.Pool(t)
+	_, err := pool.Exec(context.Background(),
+		"TRUNCATE "+strings.Join(sweptAndSeedableTables, ", ")+" RESTART IDENTITY CASCADE")
+	if err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	return pool
+}
+
+func seedUser(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	name := "ret-" + id.String()[:8]
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO users (id, username, email, password_hash)
+		 VALUES ($1, $2, $3, 'x')`,
+		id, name, name+"@example.test")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func seedHost(t *testing.T, pool *pgxpool.Pool, owner uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO hosts (id, hostname, ip_address, created_by)
+		 VALUES ($1, $2, '192.0.2.10', $3)`,
+		id, "ret-"+id.String()[:8]+".example.test", owner)
+	if err != nil {
+		t.Fatalf("seed host: %v", err)
+	}
+	return id
+}
+
+func seedSSOProvider(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO sso_providers (id, name, issuer, client_id, client_secret_enc)
+		 VALUES ($1, $2, 'https://idp.example.test', 'cid', '\x00'::bytea)`,
+		id, "ret-"+id.String()[:8])
+	if err != nil {
+		t.Fatalf("seed sso provider: %v", err)
+	}
+	return id
+}
+
+// fixtures holds the rows other rows point at.
+type fixtures struct {
+	user     uuid.UUID
+	host     uuid.UUID
+	provider uuid.UUID
+}
+
+func seedFixtures(t *testing.T, pool *pgxpool.Pool) fixtures {
+	t.Helper()
+	u := seedUser(t, pool)
+	return fixtures{user: u, host: seedHost(t, pool, u), provider: seedSSOProvider(t, pool)}
+}
+
+// seedRow inserts one row into the policy's table with its TTL column set
+// to ts, and returns the row's identity as a WHERE clause plus argument.
+//
+// The TTL column name comes from the policy, never from a literal in this
+// test. That is what exercises auth_mfa_otp_uses on used_at without any
+// test here having to know that it has no expires_at.
+func seedRow(t *testing.T, pool *pgxpool.Pool, fx fixtures, p Policy, ts time.Time) (idWhere string, idArg any) {
+	t.Helper()
+	if p.TTLColumn == "" {
+		t.Fatalf("policy for %s has no TTL column, cannot seed an aged row", p.Table)
+	}
+
+	var cols []string
+	var vals []any
+	switch p.Table {
+	case "idempotency_keys":
+		key := uuid.NewString()
+		cols = []string{"key", "request_hash", "response_status", "response_body", "actor_id"}
+		vals = []any{key, "h", 200, []byte(`{}`), "actor"}
+		idWhere, idArg = "key = $1", key
+	case "sso_auth_states":
+		state := uuid.NewString()
+		cols = []string{"state", "provider_id", "nonce", "code_verifier"}
+		vals = []any{state, fx.provider, "n", "v"}
+		idWhere, idArg = "state = $1", state
+	case "auth_mfa_otp_uses":
+		code := uuid.NewString()[:6]
+		cols = []string{"user_id", "otp"}
+		vals = []any{fx.user, code}
+		idWhere, idArg = "otp = $1", code
+	case "api_tokens":
+		id := uuid.New()
+		cols = []string{"id", "name", "token_hash", "prefix", "role_id", "created_by"}
+		vals = []any{id, "t-" + id.String()[:8], []byte(id.String()), id.String()[:8], "admin", fx.user}
+		idWhere, idArg = "id = $1", id
+	case "compliance_exceptions":
+		id := uuid.New()
+		cols = []string{"id", "host_id", "rule_id", "reason", "requested_by"}
+		vals = []any{id, fx.host, "rule-1", "because", fx.user}
+		idWhere, idArg = "id = $1", id
+	case "sessions":
+		id := uuid.New()
+		// Both timestamps are NOT NULL and either one could be the TTL
+		// column, so both are seeded. Seeding only the column the policy
+		// happens to name would turn a wrong-column entry into a seed
+		// error instead of the assertion failure it should be.
+		cols = []string{"id", "user_id", "token_hash", "expires_at", "absolute_expires_at"}
+		vals = []any{id, fx.user, []byte(id.String()), ts, ts}
+		idWhere, idArg = "id = $1", id
+	case "refresh_tokens":
+		id := uuid.New()
+		cols = []string{"id", "user_id", "token_hash"}
+		vals = []any{id, fx.user, []byte(id.String())}
+		idWhere, idArg = "id = $1", id
+	default:
+		t.Fatalf("no seed recipe for table %s, add one rather than skipping the table", p.Table)
+	}
+
+	// The TTL column may already be in the recipe, because some tables
+	// have a NOT NULL timestamp that is not the column the policy keys
+	// on. Overwrite rather than append: listing a column twice is a SQL
+	// error, and that error would fire before any assertion an entry
+	// naming the wrong column was supposed to trip.
+	ttlSeeded := false
+	for i, c := range cols {
+		if c == p.TTLColumn {
+			vals[i] = ts
+			ttlSeeded = true
+			break
+		}
+	}
+	if !ttlSeeded {
+		cols = append(cols, p.TTLColumn)
+		vals = append(vals, ts)
+	}
+
+	placeholders := make([]string, len(cols))
+	for i := range cols {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+	}
+	stmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+		p.Table, strings.Join(cols, ", "), strings.Join(placeholders, ", "))
+	if _, err := pool.Exec(context.Background(), stmt, vals...); err != nil {
+		t.Fatalf("seed %s: %v", p.Table, err)
+	}
+	return idWhere, idArg
+}
+
+func rowExists(t *testing.T, pool *pgxpool.Pool, table, where string, arg any) bool {
+	t.Helper()
+	var n int
+	err := pool.QueryRow(context.Background(),
+		fmt.Sprintf("SELECT count(*) FROM %s WHERE %s", table, where), arg).Scan(&n)
+	if err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n > 0
+}
+
+func countRows(t *testing.T, pool *pgxpool.Pool, table string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), "SELECT count(*) FROM "+table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// swept returns the swept policies from the real registry.
+func swept() []Policy {
+	var out []Policy
+	for _, p := range Registry() {
+		if p.State == StateSwept {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------
+// Statement counting (AC-07)
+// ---------------------------------------------------------------------
+
+// stmtCounter is a pgx QueryTracer that counts executions per SQL text.
+// AC-07 asks how many statements one pass issued, and inferring that from
+// a row count would only prove the drain, not the batching.
+type stmtCounter struct {
+	mu sync.Mutex
+	n  map[string]int
+}
+
+func (c *stmtCounter) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.n == nil {
+		c.n = map[string]int{}
+	}
+	c.n[data.SQL]++
+	return ctx
+}
+
+func (c *stmtCounter) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+func (c *stmtCounter) count(sql string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n[sql]
+}
+
+// tracedPool opens a second pool against the same database as base, with
+// a tracer attached.
+func tracedPool(t *testing.T, base *pgxpool.Pool) (*pgxpool.Pool, *stmtCounter) {
+	t.Helper()
+	counter := &stmtCounter{}
+	cfg := base.Config().Copy()
+	cfg.ConnConfig.Tracer = counter
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("traced pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool, counter
+}
+
+// failIfCalled is the audit emit function the sweeper must never call.
+func failIfCalled(t *testing.T) EmitFunc {
+	return func(_ context.Context, code audit.Code, _ audit.Event) {
+		t.Errorf("the sweeper emitted audit event %q. Retention must not audit its own deletes: audit_events is itself a growing table with no retention decision, so a per-tick event trades one unbounded table for another (spec C-12)", code)
+	}
+}
+
+// ---------------------------------------------------------------------
+// AC-01: registry entries are well formed
+// ---------------------------------------------------------------------
+
+// @ac AC-01
+// AC-01: every entry has a table, a reason, and a legal state. Swept and
+// deferred entries carry a TTL column and a positive grace; never entries
+// carry neither. No table appears twice.
+//
+// The reason is not decoration. An entry with no reason is a decision
+// nobody can audit, which is how api_tokens and compliance_exceptions
+// would eventually get "fixed" by a reader who assumed the omission was
+// an oversight.
+func TestRegistryEntriesAreWellFormed(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-01", func(t *testing.T) {
+		reg := Registry()
+		if len(reg) == 0 {
+			t.Fatal("the registry is empty")
+		}
+
+		seen := map[string]int{}
+		for _, p := range reg {
+			seen[p.Table]++
+			if p.Table == "" {
+				t.Error("an entry has an empty Table")
+				continue
+			}
+			if strings.TrimSpace(p.Reason) == "" {
+				t.Errorf("%s has an empty Reason. Every entry needs one, including swept ones", p.Table)
+			}
+			switch p.State {
+			case StateSwept, StateDeferred:
+				if p.TTLColumn == "" {
+					t.Errorf("%s is %s but has no TTLColumn", p.Table, p.State)
+				}
+				if p.Grace <= 0 {
+					t.Errorf("%s is %s but its Grace is %v, which must be greater than zero", p.Table, p.State, p.Grace)
+				}
+			case StateNever, StateUndecided:
+				if p.TTLColumn != "" {
+					t.Errorf("%s is %s but carries TTLColumn %q. Neither state ages anything", p.Table, p.State, p.TTLColumn)
+				}
+				if p.Grace != 0 {
+					t.Errorf("%s is %s but carries Grace %v. Recording a grace nothing applies would make an unused field read as intent", p.Table, p.State, p.Grace)
+				}
+			default:
+				t.Errorf("%s has state %q, which is not swept, never, deferred or undecided", p.Table, p.State)
+			}
+		}
+
+		for table, n := range seen {
+			if n > 1 {
+				t.Errorf("%s appears %d times in the registry. One table, one decision", table, n)
+			}
+		}
+	})
+}
+
+// @ac AC-01
+// AC-01, schema half: every swept or deferred entry names a TTL column
+// the migrations declare NOT NULL.
+//
+// This reads the schema rather than the registry, so a well-formed entry
+// naming a nullable column still fails. The delete compares that column
+// against a past bound, and a NULL satisfies no comparison, so a nullable
+// TTL column would make a table read as swept while every row whose
+// column is NULL stayed forever. All five entries naming a column are
+// fine today. The point is that the sixth is caught by CI.
+func TestSweptTTLColumnsAreNotNull(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-01", func(t *testing.T) {
+		pool := dbtest.Pool(t)
+
+		checked := 0
+		for _, p := range Registry() {
+			if p.State != StateSwept && p.State != StateDeferred {
+				continue
+			}
+			if p.TTLColumn == "" {
+				continue // Already reported by the well-formed half.
+			}
+			var nullable string
+			err := pool.QueryRow(context.Background(),
+				`SELECT is_nullable FROM information_schema.columns
+				 WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+				p.Table, p.TTLColumn).Scan(&nullable)
+			if err != nil {
+				t.Errorf("%s.%s: cannot read the column from the migrated schema: %v. Either the column does not exist or the entry names it wrong", p.Table, p.TTLColumn, err)
+				continue
+			}
+			if nullable != "NO" {
+				t.Errorf("%s is %s on %s, but the migrations declare that column nullable. A NULL satisfies no comparison, so every row with a NULL there would survive the sweep forever while the table reads as covered", p.Table, p.State, p.TTLColumn)
+			}
+			checked++
+		}
+		if checked == 0 {
+			t.Fatal("no swept or deferred entry named a TTL column, so this guard checked nothing")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-02: the registry covers the schema, both directions
+// ---------------------------------------------------------------------
+
+// @ac AC-02
+// AC-02: every table the migrations create has exactly one entry, and
+// every entry names a table the migrations create.
+//
+// This is the guard that makes a forgotten table fail CI instead of
+// growing forever in silence. It enumerates tables and demands an
+// explicit decision for each. It never reads a column name, because the
+// survey that keyed on expires_at is the one that missed
+// auth_mfa_otp_uses.
+//
+// goose_db_version is goose's own bookkeeping table. No migration file
+// declares it, so it is correctly absent from both sides here, and adding
+// an entry for it would fail the second direction.
+func TestRegistryCoversEveryMigratedTable(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-02", func(t *testing.T) {
+		tables := migratedTables(t)
+
+		entries := map[string]int{}
+		for _, p := range Registry() {
+			entries[p.Table]++
+		}
+
+		var missing []string
+		for table := range tables {
+			if entries[table] == 0 {
+				missing = append(missing, fmt.Sprintf("%s (created in %s)", table, tables[table]))
+			}
+		}
+		sort.Strings(missing)
+		for _, m := range missing {
+			t.Errorf("table %s has no retention entry. Add one to internal/retention/policy.go saying swept, never or deferred, with a reason. Silence is not a decision", m)
+		}
+
+		var unknown []string
+		for table := range entries {
+			if _, ok := tables[table]; !ok {
+				unknown = append(unknown, table)
+			}
+		}
+		sort.Strings(unknown)
+		for _, u := range unknown {
+			t.Errorf("registry entry %q names a table no migration creates. Either the table was renamed or dropped and the entry is stale, or the name is a typo", u)
+		}
+
+		if len(missing) == 0 && len(unknown) == 0 && len(Registry()) != len(tables) {
+			t.Errorf("registry has %d entries for %d tables with no name mismatch, so a table is entered twice", len(Registry()), len(tables))
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-03: the three swept entries, field by field
+// ---------------------------------------------------------------------
+
+// @ac AC-03
+// AC-03: the swept set is exactly idempotency_keys (expires_at, 24h),
+// sso_auth_states (expires_at, 1h) and auth_mfa_otp_uses (used_at, 24h).
+//
+// Asserted field by field so a silent edit of a grace or a TTL column
+// fails here rather than in production. The auth_mfa_otp_uses row pins
+// used_at on purpose: that table has no expires_at, and assuming it did
+// is the mistake this spec was written around.
+func TestSweptEntriesAreExactlyTheThree(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-03", func(t *testing.T) {
+		want := map[string]Policy{
+			"idempotency_keys":  {Table: "idempotency_keys", TTLColumn: "expires_at", Grace: 24 * time.Hour},
+			"sso_auth_states":   {Table: "sso_auth_states", TTLColumn: "expires_at", Grace: time.Hour},
+			"auth_mfa_otp_uses": {Table: "auth_mfa_otp_uses", TTLColumn: "used_at", Grace: 24 * time.Hour},
+		}
+
+		got := map[string]Policy{}
+		for _, p := range swept() {
+			got[p.Table] = p
+		}
+
+		for table, w := range want {
+			g, ok := got[table]
+			if !ok {
+				t.Errorf("%s is not swept. C-07 fixes the swept set at these three tables", table)
+				continue
+			}
+			if g.TTLColumn != w.TTLColumn {
+				t.Errorf("%s TTLColumn = %q, want %q", table, g.TTLColumn, w.TTLColumn)
+			}
+			if g.Grace != w.Grace {
+				t.Errorf("%s Grace = %v, want %v", table, g.Grace, w.Grace)
+			}
+		}
+		for table := range got {
+			if _, ok := want[table]; !ok {
+				t.Errorf("%s is swept but is not one of the three tables C-07 allows. A new swept table needs a spec bump, not just an edit", table)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-04 and AC-05: never and deferred tables survive
+// ---------------------------------------------------------------------
+
+// @ac AC-04
+// AC-04: api_tokens and compliance_exceptions are never, and a sweep
+// leaves an ancient row in each of them alone.
+func TestNeverTablesSurviveASweep(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-04", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+		ancient := time.Now().Add(-365 * 24 * time.Hour)
+
+		type seeded struct {
+			table string
+			where string
+			arg   any
+		}
+		var rows []seeded
+		for _, table := range []string{"api_tokens", "compliance_exceptions"} {
+			p, ok := Lookup(table)
+			if !ok {
+				t.Fatalf("%s has no registry entry", table)
+			}
+			if p.State != StateNever {
+				t.Errorf("%s state = %q, want never", table, p.State)
+			}
+			if strings.TrimSpace(p.Reason) == "" {
+				t.Errorf("%s is never with no reason. The reason is what stops a later reader from sweeping it", table)
+			}
+			// Seed on expires_at directly: a never entry carries no TTL
+			// column, so the aged row is built from the schema instead.
+			seedPolicy := p
+			seedPolicy.TTLColumn = "expires_at"
+			where, arg := seedRow(t, pool, fx, seedPolicy, ancient)
+			rows = append(rows, seeded{table, where, arg})
+		}
+
+		// Reported, not fatal. A sweep that errors part way through can
+		// still have deleted from a table it had no business touching,
+		// and that is the assertion this test exists for.
+		if err := NewSweeper(pool, failIfCalled(t)).Sweep(context.Background()); err != nil {
+			t.Errorf("sweep: %v", err)
+		}
+
+		for _, r := range rows {
+			if !rowExists(t, pool, r.table, r.where, r.arg) {
+				t.Errorf("a %s row expired a year ago was deleted by the sweep. That table is recorded never on purpose", r.table)
+			}
+		}
+	})
+}
+
+// @ac AC-05
+// AC-05: sessions and refresh_tokens are deferred, each says what work it
+// is blocked on, and a sweep leaves an aged row in each alone.
+//
+// Deferred is a state the registry expresses, not silence. Neither may be
+// promoted without its migration, and deleting live session history is
+// not reversible.
+func TestDeferredTablesSurviveASweep(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-05", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+		ancient := time.Now().Add(-365 * 24 * time.Hour)
+
+		type seeded struct {
+			table string
+			where string
+			arg   any
+		}
+		var rows []seeded
+		for _, table := range []string{"sessions", "refresh_tokens"} {
+			p, ok := Lookup(table)
+			if !ok {
+				t.Fatalf("%s has no registry entry", table)
+			}
+			if p.State != StateDeferred {
+				t.Errorf("%s state = %q, want deferred", table, p.State)
+			}
+			if strings.TrimSpace(p.Reason) == "" {
+				t.Errorf("%s is deferred with no reason. The reason has to name the work it is blocked on", table)
+			}
+			where, arg := seedRow(t, pool, fx, p, ancient)
+			rows = append(rows, seeded{table, where, arg})
+		}
+
+		// The parameters a promotion would use, not only the state.
+		// Nothing else checks these, so a wrong column or a missing
+		// safety predicate would stay green until the day someone flips
+		// the state to swept, which is the worst day to find out.
+		sess, _ := Lookup("sessions")
+		if sess.TTLColumn != "absolute_expires_at" {
+			t.Errorf("sessions TTLColumn = %q, want absolute_expires_at. expires_at slides forward on every request (internal/identity/sessions.go:245 extends it by the inactivity window), so an entry pointed there would delete the sessions of users who are merely idle rather than sessions that are finished", sess.TTLColumn)
+		}
+		const wantKeep = "reuse_detected_at IS NOT NULL"
+		if rt, _ := Lookup("refresh_tokens"); rt.Keep != wantKeep {
+			t.Errorf("refresh_tokens Keep = %q, want %q, carried now while the entry is still deferred. A row with reuse_detected_at set is the only durable artifact of a detected token theft, and adding the predicate at promotion time is one review away from being forgotten", rt.Keep, wantKeep)
+		}
+
+		if err := NewSweeper(pool, failIfCalled(t)).Sweep(context.Background()); err != nil {
+			t.Errorf("sweep: %v", err)
+		}
+
+		for _, r := range rows {
+			if !rowExists(t, pool, r.table, r.where, r.arg) {
+				t.Errorf("an aged %s row was deleted. That table is deferred, and its sweep is blocked on a migration that has not landed", r.table)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-06: a sweep deletes past the grace and nothing else
+// ---------------------------------------------------------------------
+
+// @ac AC-06
+// AC-06: for every swept entry, a row inside the grace survives and a row
+// past it goes. Both rows are seeded through the policy's own TTL column,
+// so auth_mfa_otp_uses is exercised on used_at without this test naming
+// that column.
+func TestSweepDeletesPastGraceOnly(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-06", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+
+		policies := swept()
+		if len(policies) == 0 {
+			t.Fatal("no swept entries, this test would pass vacuously")
+		}
+
+		type pair struct {
+			p                  Policy
+			freshW, staleW     string
+			freshArg, staleArg any
+		}
+		var pairs []pair
+		for _, p := range policies {
+			// Half a grace old: inside. A grace plus an hour: past.
+			fw, fa := seedRow(t, pool, fx, p, time.Now().Add(-p.Grace/2))
+			sw, sa := seedRow(t, pool, fx, p, time.Now().Add(-p.Grace-time.Hour))
+			pairs = append(pairs, pair{p, fw, sw, fa, sa})
+		}
+
+		if err := NewSweeper(pool, failIfCalled(t)).Sweep(context.Background()); err != nil {
+			t.Fatalf("sweep: %v", err)
+		}
+
+		for _, pr := range pairs {
+			if !rowExists(t, pool, pr.p.Table, pr.freshW, pr.freshArg) {
+				t.Errorf("%s: a row only half a grace old was deleted. The sweep is deleting inside the grace, and for auth_mfa_otp_uses that would reopen an OTP replay hole", pr.p.Table)
+			}
+			if rowExists(t, pool, pr.p.Table, pr.staleW, pr.staleArg) {
+				t.Errorf("%s: a row past its %v grace on %s survived the sweep", pr.p.Table, pr.p.Grace, pr.p.TTLColumn)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-07: batched and oldest first
+// ---------------------------------------------------------------------
+
+// @ac AC-07
+// AC-07: with batch size N and 2N+1 eligible rows, one pass removes all
+// 2N+1 and issues more than one statement, and the statement carries
+// ORDER BY the TTL column ascending and a LIMIT.
+//
+// The statement count is observed through a pgx tracer rather than
+// inferred from the row count, so the batching is measured and not
+// assumed. Oldest first is a correctness requirement: refresh_tokens
+// carries a self-referencing rotated_to_id with NO ACTION, and a
+// newest-first batch breaks it the moment that entry is promoted.
+func TestSweepIsBatchedAndOldestFirst(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-07", func(t *testing.T) {
+		base := freshPool(t)
+		pool, counter := tracedPool(t, base)
+		fx := seedFixtures(t, base)
+
+		policies := swept()
+		if len(policies) == 0 {
+			t.Fatal("no swept entries, this test would pass vacuously")
+		}
+		p := policies[0]
+
+		const n = 3
+		const eligible = 2*n + 1
+		for i := 0; i < eligible; i++ {
+			// Staggered ages, all past the grace, so ordering is
+			// observable rather than a tie.
+			seedRow(t, base, fx, p, time.Now().Add(-p.Grace-time.Duration(i+1)*time.Hour))
+		}
+
+		sw := NewSweeper(pool, failIfCalled(t)).WithBatchSize(n)
+
+		stmt := sw.DeleteStatement(p)
+		if !strings.Contains(stmt, "ORDER BY "+p.TTLColumn+" ASC") {
+			t.Errorf("the delete for %s has no ORDER BY %s ASC. Got: %s", p.Table, p.TTLColumn, stmt)
+		}
+		if !strings.Contains(stmt, "LIMIT") {
+			t.Errorf("the delete for %s has no LIMIT, so a batch is unbounded. Got: %s", p.Table, stmt)
+		}
+
+		if err := sw.Sweep(context.Background()); err != nil {
+			t.Fatalf("sweep: %v", err)
+		}
+
+		if left := countRows(t, base, p.Table); left != 0 {
+			t.Errorf("%d of %d eligible %s rows survived one pass. The sweep must repeat until a batch comes back short", left, eligible, p.Table)
+		}
+		if got := counter.count(stmt); got < 2 {
+			t.Errorf("one pass issued %d delete statements for %d rows at batch size %d. It must batch, not delete the backlog in a single unbounded statement", got, eligible, n)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-08: a tick cannot outrun its interval
+// ---------------------------------------------------------------------
+
+// @ac AC-08
+// AC-08: the per-tick deadline is strictly shorter than the tick
+// interval, read off the sweeper rather than timed. cron.Scheduler passes
+// no deadline of its own, so a pass that ran long would overlap the next
+// tick and two sweeps would fight over the same rows.
+func TestTickDeadlineIsShorterThanInterval(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-08", func(t *testing.T) {
+		for _, interval := range []time.Duration{time.Minute, time.Hour, DefaultInterval} {
+			sw := NewSweeper(nil, nil).WithInterval(interval)
+			if sw.Interval() != interval {
+				t.Fatalf("Interval() = %v, want %v", sw.Interval(), interval)
+			}
+			d := sw.Deadline()
+			if d <= 0 {
+				t.Errorf("deadline at interval %v is %v, so a tick has no time bound at all", interval, d)
+			}
+			if d >= interval {
+				t.Errorf("deadline %v is not shorter than the %v interval, so a slow pass can overlap the next tick", d, interval)
+			}
+		}
+	})
+}
+
+// @ac AC-08
+// AC-08, second half: a sweep whose context is already canceled returns
+// promptly, does not panic, and leaves every row in place.
+func TestCanceledSweepLeavesRowsInPlace(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-08", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+
+		policies := swept()
+		if len(policies) == 0 {
+			t.Fatal("no swept entries, this test would pass vacuously")
+		}
+		before := map[string]int{}
+		for _, p := range policies {
+			seedRow(t, pool, fx, p, time.Now().Add(-p.Grace-time.Hour))
+			before[p.Table] = countRows(t, pool, p.Table)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		done := make(chan error, 1)
+		go func() { done <- NewSweeper(pool, failIfCalled(t)).Sweep(ctx) }()
+
+		select {
+		case <-done:
+			// Returning at all is the assertion. The error value is not
+			// pinned: a canceled sweep may report the cancellation or
+			// report nothing done.
+		case <-time.After(10 * time.Second):
+			t.Fatal("a sweep on an already-canceled context did not return within 10 seconds")
+		}
+
+		for _, p := range policies {
+			if got := countRows(t, pool, p.Table); got != before[p.Table] {
+				t.Errorf("%s went from %d rows to %d on a canceled sweep. A canceled pass must delete nothing", p.Table, before[p.Table], got)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-09: a Keep predicate is honored
+// ---------------------------------------------------------------------
+
+// @ac AC-09
+// AC-09: with a Keep predicate, a past-grace row matching Keep survives
+// and a past-grace row that does not match is deleted.
+//
+// Tested on refresh_tokens through a test registry, before that entry is
+// promoted to swept rather than with it. A row with reuse_detected_at set
+// is the only durable artifact of a detected token theft, so the
+// promotion is only safe if this already works.
+func TestKeepPredicateIsHonored(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-09", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+
+		base, ok := Lookup("refresh_tokens")
+		if !ok {
+			t.Fatal("refresh_tokens has no registry entry")
+		}
+		if base.Keep == "" {
+			t.Fatalf("refresh_tokens carries no Keep predicate. C-09 requires %q so a detected token theft is not swept away at promotion", "reuse_detected_at IS NOT NULL")
+		}
+
+		aged := time.Now().Add(-base.Grace - time.Hour)
+		keepW, keepArg := seedRow(t, pool, fx, base, aged)
+		goW, goArg := seedRow(t, pool, fx, base, aged)
+
+		// Make one row match Keep.
+		if _, err := pool.Exec(context.Background(),
+			"UPDATE refresh_tokens SET reuse_detected_at = now() WHERE "+keepW, keepArg); err != nil {
+			t.Fatalf("mark reuse: %v", err)
+		}
+
+		// A test registry promoting the entry to swept, Keep intact.
+		promoted := base
+		promoted.State = StateSwept
+		sw := NewSweeper(pool, failIfCalled(t)).WithPolicies([]Policy{promoted})
+
+		if !strings.Contains(sw.DeleteStatement(promoted), promoted.Keep) {
+			t.Errorf("the generated delete does not mention the Keep predicate %q at all: %s", promoted.Keep, sw.DeleteStatement(promoted))
+		}
+		if err := sw.Sweep(context.Background()); err != nil {
+			t.Fatalf("sweep: %v", err)
+		}
+
+		if !rowExists(t, pool, "refresh_tokens", keepW, keepArg) {
+			t.Errorf("a past-grace row matching Keep (%s) was deleted. That row is the only durable record of a detected token theft", promoted.Keep)
+		}
+		if rowExists(t, pool, "refresh_tokens", goW, goArg) {
+			t.Error("a past-grace row not matching Keep survived, so the Keep negation is swallowing everything and the sweep deletes nothing")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-10: the wiring guard
+// ---------------------------------------------------------------------
+
+// @ac AC-10
+// AC-10: main.go reaches the sweeper, and the sweep walks the registry
+// rather than a hard-coded list of tables.
+//
+// This is the criterion the two dead purge functions would have failed.
+// internal/sso PurgeExpiredStates and internal/identity PurgeStaleOTPs
+// were each written, reviewed and left with no caller for months, because
+// nothing in this repo enforced that code is reachable from main. A
+// sweeper that exists and is never started is the same defect wearing a
+// spec.
+//
+// The second half matters just as much. If the sweep named its tables
+// inline, a new swept entry in the registry would do nothing until
+// someone remembered to edit the sweep too, and the registry would drift
+// back into documentation.
+//
+// system-daemon-orchestration AC-12 asserts the main.go half again from
+// the other side, as an AST check over cmdServe.
+func TestSweeperIsReachableFromMain(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-10", func(t *testing.T) {
+		root := repoRoot(t)
+
+		mainPath := filepath.Join(root, "cmd", "openwatch", "main.go")
+		b, err := os.ReadFile(mainPath)
+		if err != nil {
+			t.Fatalf("read main.go: %v", err)
+		}
+		main := string(b)
+		if !strings.Contains(main, "retention.NewSweeper(") {
+			t.Error("cmd/openwatch/main.go never calls retention.NewSweeper(. Nothing sweeps any table in production, which is the state this spec exists to end")
+		} else if !sweeperIsStarted(main) {
+			// Constructed and not started is the failure worth naming.
+			// Both dead purge functions compiled, passed review and did
+			// nothing, so "the code exists" proves nothing here. A bare
+			// search for .Run(ctx would match any of the other services
+			// main.go starts, so the value has to be followed.
+			t.Error("cmd/openwatch/main.go constructs retention.NewSweeper( but never starts that value with a Run call taking ctx. A sweeper that is built and not run deletes nothing")
+		}
+
+		// Second half: the sweep ranges over the registry.
+		pkgDir := filepath.Join(root, "internal", "retention")
+		fset := token.NewFileSet()
+		pkgs, err := parser.ParseDir(fset, pkgDir, func(fi fs.FileInfo) bool {
+			return !strings.HasSuffix(fi.Name(), "_test.go")
+		}, 0)
+		if err != nil {
+			t.Fatalf("parse internal/retention: %v", err)
+		}
+
+		// The range has to be inside the code a tick actually reaches.
+		// Asking only whether the package contains such a range anywhere
+		// is not enough: Lookup ranges over the registry too, so that
+		// version stays green while the sweep itself walks a hard-coded
+		// list. Start at the function handed to cron.New and follow the
+		// calls from there.
+		funcs := map[string]*ast.FuncDecl{}
+		tick := ""
+		for _, pkg := range pkgs {
+			for _, f := range pkg.Files {
+				for _, d := range f.Decls {
+					if fn, ok := d.(*ast.FuncDecl); ok {
+						funcs[fn.Name.Name] = fn
+					}
+				}
+				ast.Inspect(f, func(n ast.Node) bool {
+					if !pkgCallExpr(n, "cron", "New") {
+						return true
+					}
+					args := n.(*ast.CallExpr).Args
+					if len(args) >= 2 {
+						tick = calleeName(args[1])
+					}
+					return true
+				})
+			}
+		}
+		if tick == "" {
+			t.Fatal("internal/retention never calls cron.New with a tick function, so the sweep is not on a scheduler at all")
+		}
+		if _, ok := funcs[tick]; !ok {
+			t.Fatalf("the tick function %q handed to cron.New is not declared in internal/retention, so this guard cannot follow it", tick)
+		}
+
+		reached := map[string]bool{}
+		var walk func(name string)
+		walk = func(name string) {
+			fn, ok := funcs[name]
+			if !ok || reached[name] {
+				return
+			}
+			reached[name] = true
+			ast.Inspect(fn, func(n ast.Node) bool {
+				if call, ok := n.(*ast.CallExpr); ok {
+					if callee := calleeName(call.Fun); callee != "" {
+						walk(callee)
+					}
+				}
+				return true
+			})
+		}
+		walk(tick)
+
+		rangesOverRegistry := false
+		for name := range reached {
+			ast.Inspect(funcs[name], func(n ast.Node) bool {
+				if rng, ok := n.(*ast.RangeStmt); ok && usesRegistry(rng.X) {
+					rangesOverRegistry = true
+				}
+				return true
+			})
+		}
+		if !rangesOverRegistry {
+			t.Errorf("nothing reachable from the cron tick %q iterates the registry (reached: %s). The sweep must walk the registry, so a newly swept entry runs with no change at the call site. A hard-coded table list turns the registry back into documentation", tick, strings.Join(sortedKeys(reached), ", "))
+		}
+	})
+}
+
+// pkgCallExpr reports whether n is a call to pkg.name(...).
+func pkgCallExpr(n ast.Node, pkg, name string) bool {
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != name {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == pkg
+}
+
+// calleeName is the bare function name an expression refers to, for both
+// a package-level call and a method value such as s.sweepWithDeadline.
+func calleeName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return v.Sel.Name
+	}
+	return ""
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sweeperIsStarted reports whether main.go runs the value that
+// retention.NewSweeper returned, either chained straight into Run or
+// bound to a name and that name run.
+//
+// system-daemon-orchestration AC-12 makes the same check over the AST,
+// scoped to cmdServe. This one is text, matching the house style of the
+// other wiring guards, and the two are meant to overlap: a wiring defect
+// this important should fail twice.
+func sweeperIsStarted(main string) bool {
+	if regexp.MustCompile(`retention\.NewSweeper\([^\n]*\)\s*\.\s*Run\(ctx\b`).MatchString(main) {
+		return true
+	}
+	bind := regexp.MustCompile(`(\w+)\s*:?=\s*retention\.NewSweeper\(`).FindStringSubmatch(main)
+	if bind == nil || bind[1] == "_" {
+		return false
+	}
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(bind[1]) + `\s*\.\s*Run\(ctx\b`).MatchString(main)
+}
+
+// usesRegistry reports whether expr reads the package registry, as the
+// bare identifier, as a Registry() call, or through the sweeper's own
+// registry accessor.
+func usesRegistry(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "registry" || e.Name == "Registry"
+	case *ast.CallExpr:
+		return usesRegistry(e.Fun)
+	case *ast.SelectorExpr:
+		return e.Sel.Name == "registry" || e.Sel.Name == "Registry"
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------
+// AC-11: no second sweeper
+// ---------------------------------------------------------------------
+
+// pastBoundPattern is the WHERE shape of an age-based bulk delete: the
+// given column compared against a past bound. now() covers the literal
+// form and now() minus an interval; a bound parameter covers a cutoff
+// computed in Go. A delete keyed on an identifier does not match.
+func pastBoundPattern(column string) string {
+	return `(?is)\b` + regexp.QuoteMeta(column) + `\s*<\s*(now\(\)|current_timestamp|\$\d)`
+}
+
+// literalText is a string literal's contents with its quotes or
+// backticks removed. The delimiters have to go before fragments are
+// joined, or a statement split mid-token ("DELETE FROM sso_auth_" +
+// "states ...") would still not match once folded.
+func literalText(lit *ast.BasicLit) string {
+	s := lit.Value
+	if len(s) >= 2 {
+		if q := s[0]; q == '`' || q == '"' {
+			s = s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// foldStringConcat joins a + concatenation of string literals into the
+// value it builds. Reports false if any operand is not a literal or
+// another such concatenation, because a fragment joined to a variable
+// cannot be read off the source at all.
+func foldStringConcat(e ast.Expr) (string, bool) {
+	switch v := e.(type) {
+	case *ast.ParenExpr:
+		return foldStringConcat(v.X)
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return "", false
+		}
+		return literalText(v), true
+	case *ast.BinaryExpr:
+		if v.Op != token.ADD {
+			return "", false
+		}
+		left, ok := foldStringConcat(v.X)
+		if !ok {
+			return "", false
+		}
+		right, ok := foldStringConcat(v.Y)
+		if !ok {
+			return "", false
+		}
+		return left + right, true
+	}
+	return "", false
+}
+
+// @ac AC-11
+// AC-11: outside internal/retention and outside test files, no Go source
+// runs an age-based bulk DELETE from a swept table.
+//
+// Such a delete anywhere else is a private retention policy the registry
+// does not know about, and that is how this codebase reached two purge
+// functions and no sweeper. There are five cron.New call sites in the
+// tree, each a package owning its own scheduled work. Retention does not
+// join them.
+//
+// The shape is what matters, not the table name. The SSO single-use
+// consume (internal/sso/store.go consumeAuthState) deletes by state = $1
+// and checks expiry in Go afterward, so it is not retention and does not
+// match. It must keep working.
+//
+// Only string literals are scanned. A comment describing a delete is not
+// a delete, and flagging prose would push people into writing SQL that
+// reads worse to get past a test.
+func TestNoSecondSweeperInTheTree(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-11", func(t *testing.T) {
+		policies := swept()
+		if len(policies) == 0 {
+			t.Fatal("no swept entries, so this scan has nothing to look for and would pass vacuously")
+		}
+
+		root := repoRoot(t)
+		fset := token.NewFileSet()
+
+		for _, rel := range goSourceFiles(t, root) {
+			if strings.HasPrefix(rel, "internal/retention/") {
+				continue
+			}
+			f, err := parser.ParseFile(fset, filepath.Join(root, rel), nil, 0)
+			if err != nil {
+				// Generated files and build-tagged files still parse;
+				// a real parse failure is worth reporting, not skipping.
+				t.Errorf("parse %s: %v", rel, err)
+				continue
+			}
+			check := func(sql string, pos token.Pos) {
+				for _, p := range policies {
+					deleteRe := regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+` + regexp.QuoteMeta(p.Table) + `\b(.*)`)
+					m := deleteRe.FindStringSubmatch(sql)
+					if m == nil {
+						continue
+					}
+					ageRe := regexp.MustCompile(pastBoundPattern(p.TTLColumn))
+					if !ageRe.MatchString(m[1]) {
+						continue
+					}
+					t.Errorf("%s:%d runs an age-based bulk DELETE from %s on %s. That is a second retention policy the registry does not know about. Move it into internal/retention or delete it (spec C-03)",
+						rel, fset.Position(pos).Line, p.Table, p.TTLColumn)
+				}
+			}
+
+			ast.Inspect(f, func(n ast.Node) bool {
+				// A SQL string split across a + concatenation reaches the
+				// AST as a BinaryExpr over separate literals. Matching one
+				// literal at a time sees "DELETE FROM x " and "WHERE ttl <
+				// now()" as two harmless fragments and misses the delete
+				// they build. Wrapping a long statement with + is ordinary
+				// Go and this repo does it constantly, so fold first.
+				if bin, ok := n.(*ast.BinaryExpr); ok && bin.Op == token.ADD {
+					if joined, ok := foldStringConcat(bin); ok {
+						check(joined, bin.Pos())
+						// Consumed. Descending would re-report each
+						// fragment against the same finding.
+						return false
+					}
+					// Not an all-literal concatenation, so fall through
+					// and let the literals inside it be checked singly.
+					return true
+				}
+				if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+					check(literalText(lit), lit.Pos())
+				}
+				return true
+			})
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-12: the orphaned purges are resolved
+// ---------------------------------------------------------------------
+
+// orphanedPurges are the two functions that were exported, tested and
+// never called. Each must now be gone or called from internal/retention.
+var orphanedPurges = map[string]string{
+	"PurgeExpiredStates": "internal/sso/store.go",
+	"PurgeStaleOTPs":     "internal/identity/mfa.go",
+}
+
+// falseCallerRe matches a doc comment claiming a scheduled caller.
+var falseCallerRe = regexp.MustCompile(`(?is)called\s+by\s+a\s+(periodic\s+sweeper|cron\s+tick|scheduler|sweeper)`)
+
+// @ac AC-12
+// AC-12: neither orphaned purge is left sitting beside the new sweeper,
+// and no surviving function in those two files claims a scheduled caller
+// it does not have.
+//
+// Identifiers are read from the AST, not from the file text, so prose
+// that names a deleted function in a comment is not mistaken for a live
+// reference to it.
+//
+// The doc-comment half is scoped to comments attached to a declaration.
+// That is where the original defect lived: each function's own doc
+// comment asserted a caller, which is why both read as live for months. A
+// free-standing comment recording that a function used to exist claims
+// nothing about live code and is how a deletion should be documented.
+func TestOrphanedPurgeFunctionsAreResolved(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-12", func(t *testing.T) {
+		root := repoRoot(t)
+		fset := token.NewFileSet()
+
+		// Where each name is used as a real identifier.
+		uses := map[string][]string{}
+		for _, rel := range goSourceFiles(t, root) {
+			f, err := parser.ParseFile(fset, filepath.Join(root, rel), nil, parser.ParseComments)
+			if err != nil {
+				t.Errorf("parse %s: %v", rel, err)
+				continue
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				id, ok := n.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				if _, watched := orphanedPurges[id.Name]; watched {
+					uses[id.Name] = append(uses[id.Name], rel)
+				}
+				return true
+			})
+		}
+
+		referencedFromRetention := map[string]bool{}
+		for name, files := range uses {
+			for _, rel := range files {
+				if strings.HasPrefix(rel, "internal/retention/") {
+					referencedFromRetention[name] = true
+				}
+			}
+		}
+
+		for name := range orphanedPurges {
+			files := uses[name]
+			if len(files) == 0 {
+				continue // Deleted from the tree. Resolved.
+			}
+			if !referencedFromRetention[name] {
+				sort.Strings(files)
+				t.Errorf("%s still exists (%s) and nothing in internal/retention calls it. It must be called from the sweeper or deleted. An exported purge with no caller is the defect this spec corrects, and golangci-lint does not report it",
+					name, strings.Join(files, ", "))
+			}
+		}
+
+		// Doc comments in the two original homes must not claim a
+		// scheduled caller that does not exist.
+		for name, rel := range orphanedPurges {
+			path := filepath.Join(root, rel)
+			f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse %s: %v", rel, err)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				var doc *ast.CommentGroup
+				var decl string
+				switch d := n.(type) {
+				case *ast.FuncDecl:
+					doc, decl = d.Doc, d.Name.Name
+				case *ast.GenDecl:
+					doc, decl = d.Doc, "a declaration"
+				default:
+					return true
+				}
+				if doc == nil || !falseCallerRe.MatchString(doc.Text()) {
+					return true
+				}
+				if referencedFromRetention[decl] {
+					return true
+				}
+				t.Errorf("%s:%d the doc comment on %s claims a scheduled caller, and internal/retention does not call it. That exact claim is why %s read as live for months",
+					rel, fset.Position(doc.Pos()).Line, decl, name)
+				return true
+			})
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-13: the OTP replay window
+// ---------------------------------------------------------------------
+
+// totpAcceptanceWindow is the TOTP window VerifyMFA accepts: period 30s
+// with skew 1, so three steps. The replay grace can never be shorter,
+// because a used OTP is rejected only for as long as its row survives.
+const totpAcceptanceWindow = 90 * time.Second
+
+// @ac AC-13
+// AC-13: the OTP replay window comes from the registry and never drops
+// below the TOTP acceptance window.
+//
+// This is a security parameter, not a capacity setting. VerifyMFA rejects
+// a replay by inserting (user_id, otp) with ON CONFLICT DO NOTHING and
+// checking whether the insert took. The check is existence-based, so
+// deleting the row makes that OTP live again.
+//
+// The functional half is the one that bites. A future change that narrows
+// the grace passes both static assertions if it also edits the constant,
+// but it cannot pass a real verify, sweep, verify sequence.
+//
+// This is why "just call the purge function that already exists" was the
+// wrong fix for OW-013. PurgeStaleOTPs deleted at 180 seconds and had no
+// caller, so replay rejection was accidentally unlimited. Wiring it up as
+// written would have narrowed protection from unlimited to 180 seconds.
+func TestOTPReplayWindowComesFromTheRegistry(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-13", func(t *testing.T) {
+		p, ok := Lookup("auth_mfa_otp_uses")
+		if !ok {
+			t.Fatal("auth_mfa_otp_uses has no registry entry")
+		}
+		if p.Grace < totpAcceptanceWindow {
+			t.Errorf("the auth_mfa_otp_uses grace is %v, below the %v TOTP acceptance window. An OTP would become replayable while it is still valid", p.Grace, totpAcceptanceWindow)
+		}
+
+		// Any surviving OTPReplayWindow constant must equal the grace.
+		// Deleting it is also fine: the registry is the single source of
+		// truth, and two numbers that must agree eventually will not.
+		if w, found := otpReplayWindowConstant(t); found && w != p.Grace {
+			t.Errorf("identity.OTPReplayWindow is %v but the registry grace is %v. Two places state the replay window and they disagree, so one of them is lying to whoever reads it next", w, p.Grace)
+		}
+
+		// Functional: verify once, sweep, verify again.
+		pool := freshPool(t)
+		if err := identity.SetEphemeralMFAKey(); err != nil {
+			t.Fatalf("ephemeral mfa key: %v", err)
+		}
+		userID := seedUser(t, pool)
+		ctx := context.Background()
+
+		uri, err := identity.EnrollMFA(ctx, pool, userID, "ret-otp-user")
+		if err != nil {
+			t.Fatalf("EnrollMFA: %v", err)
+		}
+		u, err := url.Parse(uri)
+		if err != nil {
+			t.Fatalf("parse provisioning uri: %v", err)
+		}
+		secret := u.Query().Get("secret")
+		if secret == "" {
+			t.Fatal("provisioning uri carries no secret")
+		}
+		code, err := totp.GenerateCodeCustom(secret, time.Now().UTC(), totp.ValidateOpts{
+			Period: 30, Skew: 1, Digits: otp.DigitsSix, Algorithm: otp.AlgorithmSHA1,
+		})
+		if err != nil {
+			t.Fatalf("generate otp: %v", err)
+		}
+
+		if err := identity.VerifyMFA(ctx, pool, userID, code); err != nil {
+			t.Fatalf("first VerifyMFA: %v", err)
+		}
+		if n := countRows(t, pool, "auth_mfa_otp_uses"); n != 1 {
+			t.Fatalf("auth_mfa_otp_uses has %d rows after one verify, want 1", n)
+		}
+
+		// Age the row by the full TOTP acceptance window before sweeping.
+		//
+		// Without this the row is zero seconds old and any positive grace
+		// spares it, so the two assertions below would hold no matter how
+		// far the grace was narrowed. Aged 90 seconds, they state the
+		// security property directly and without reading the registry: a
+		// used OTP must still be rejected for as long as that same OTP is
+		// still valid, whatever the grace happens to say.
+		if _, err := pool.Exec(ctx,
+			`UPDATE auth_mfa_otp_uses SET used_at = now() - make_interval(secs => $1)`,
+			totpAcceptanceWindow.Seconds()); err != nil {
+			t.Fatalf("age the otp row: %v", err)
+		}
+
+		if err := NewSweeper(pool, failIfCalled(t)).Sweep(ctx); err != nil {
+			t.Fatalf("sweep: %v", err)
+		}
+
+		if n := countRows(t, pool, "auth_mfa_otp_uses"); n != 1 {
+			t.Errorf("the sweep deleted an OTP row used %v ago (%d rows left), while that OTP is still inside its own validation window. The registry grace is %v", totpAcceptanceWindow, n, p.Grace)
+		}
+		if err := identity.VerifyMFA(ctx, pool, userID, code); err != identity.ErrOTPReplayed {
+			t.Errorf("after a full sweep, replaying the same OTP returned %v, want ErrOTPReplayed. The sweep reopened a replay hole, and system-auth-identity AC-16 no longer holds", err)
+		}
+	})
+}
+
+// otpReplayWindowConstant reads identity.OTPReplayWindow out of the
+// source if it still exists. Reflection cannot see an untyped duration
+// constant that the package may have deleted, and referring to it
+// directly would stop this package compiling once it is gone.
+func otpReplayWindowConstant(t *testing.T) (time.Duration, bool) {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "internal", "identity", "mfa.go")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read mfa.go: %v", err)
+	}
+	m := regexp.MustCompile(`OTPReplayWindow\s*=\s*([0-9]+)\s*\*\s*time\.(Second|Minute|Hour)`).FindStringSubmatch(string(b))
+	if m == nil {
+		return 0, false
+	}
+	var n time.Duration
+	if _, err := fmt.Sscanf(m[1], "%d", &n); err != nil {
+		t.Fatalf("parse OTPReplayWindow: %v", err)
+	}
+	switch m[2] {
+	case "Second":
+		return n * time.Second, true
+	case "Minute":
+		return n * time.Minute, true
+	default:
+		return n * time.Hour, true
+	}
+}
+
+// ---------------------------------------------------------------------
+// AC-14: a tick reports what it did
+// ---------------------------------------------------------------------
+
+// captureHandler collects slog records so a test can read them back,
+// along with the correlation id each one was logged under. The id lives
+// on the context rather than on the record, so it has to be pulled out
+// here or it is gone by the time the test reads the record.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []capturedRecord
+}
+
+type capturedRecord struct {
+	rec           slog.Record
+	correlationID string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(ctx context.Context, r slog.Record) error {
+	id, _ := correlation.From(ctx)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, capturedRecord{rec: r.Clone(), correlationID: id})
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// attrs flattens one record's attributes.
+func attrsOf(r slog.Record) map[string]slog.Value {
+	out := map[string]slog.Value{}
+	r.Attrs(func(a slog.Attr) bool {
+		out[a.Key] = a.Value
+		return true
+	})
+	return out
+}
+
+// @ac AC-14
+// AC-14: a pass that deletes rows logs one record per swept table naming
+// the table and the deleted count, and emits no audit event.
+//
+// The audit half is asserted by passing an emit function that fails the
+// test if it is called. audit_events is itself a growing table with no
+// retention decision yet, so auditing retention would trade one unbounded
+// table for another. Routine expiry is also not an actor's action.
+func TestSweepLogsPerTableAndEmitsNoAudit(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-14", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+
+		policies := swept()
+		if len(policies) == 0 {
+			t.Fatal("no swept entries, this test would pass vacuously")
+		}
+		for _, p := range policies {
+			seedRow(t, pool, fx, p, time.Now().Add(-p.Grace-time.Hour))
+		}
+
+		capture := &captureHandler{}
+		prev := slog.Default()
+		slog.SetDefault(slog.New(capture))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+
+		// Sweep under a cron correlation id, the way cron.Scheduler
+		// calls the tick. Without it the records would carry no id and
+		// the operator could not tie a pass together.
+		tickID := correlation.Generate(correlation.PrefixCron)
+		ctx := correlation.Set(context.Background(), tickID)
+		if err := NewSweeper(pool, failIfCalled(t)).Sweep(ctx); err != nil {
+			t.Fatalf("sweep: %v", err)
+		}
+
+		capture.mu.Lock()
+		records := append([]capturedRecord(nil), capture.records...)
+		capture.mu.Unlock()
+
+		if !strings.HasPrefix(tickID, "cron-") {
+			t.Fatalf("correlation.Generate(PrefixCron) produced %q, which is not a cron- id, so this assertion would not mean what it says", tickID)
+		}
+
+		for _, p := range policies {
+			found := false
+			for _, r := range records {
+				a := attrsOf(r.rec)
+				table, hasTable := a["table"]
+				if !hasTable || table.String() != p.Table {
+					continue
+				}
+				deleted, hasDeleted := a["deleted"]
+				if !hasDeleted {
+					t.Errorf("the log record for %s names the table but carries no deleted count. An operator cannot tell a working sweep from a no-op", p.Table)
+					continue
+				}
+				if deleted.Int64() != 1 {
+					t.Errorf("the log record for %s reports %d rows deleted, want 1", p.Table, deleted.Int64())
+				}
+				if r.correlationID != tickID {
+					t.Errorf("the log record for %s carries correlation id %q, want the tick's %q. Records that do not share the tick's id cannot be read back as one pass", p.Table, r.correlationID, tickID)
+				}
+				found = true
+			}
+			if !found {
+				t.Errorf("no log record names table %s. Each tick must report one record per swept table", p.Table)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-15: one bad table does not end the pass
+// ---------------------------------------------------------------------
+
+// @ac AC-15
+// AC-15: with a first swept entry naming a table that does not exist, the
+// pass still drains the remaining swept tables and returns an error
+// naming the one that failed.
+//
+// A pass that stopped on the first error would let one broken entry hide
+// every table behind it, and the growth would be silent again.
+func TestOneBadTableDoesNotEndThePass(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-15", func(t *testing.T) {
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+
+		kept, ok := Lookup("idempotency_keys")
+		if !ok {
+			t.Fatal("idempotency_keys has no registry entry")
+		}
+		where, arg := seedRow(t, pool, fx, kept, time.Now().Add(-kept.Grace-time.Hour))
+
+		const missing = "table_that_does_not_exist"
+		bad := Policy{
+			Table:     missing,
+			TTLColumn: "expires_at",
+			Grace:     time.Hour,
+			State:     StateSwept,
+			Reason:    "test fixture",
+		}
+
+		err := NewSweeper(pool, failIfCalled(t)).
+			WithPolicies([]Policy{bad, kept}).
+			Sweep(context.Background())
+
+		if err == nil {
+			t.Fatalf("a pass over a table that does not exist returned no error. The failure would be invisible")
+		}
+		if !strings.Contains(err.Error(), missing) {
+			t.Errorf("the error does not name the failing table. Got: %v", err)
+		}
+		if rowExists(t, pool, kept.Table, where, arg) {
+			t.Errorf("the pass stopped at the broken entry: an eligible %s row behind it survived. One bad table must not hide every table after it", kept.Table)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// AC-16: the undecided set is pinned by name
+// ---------------------------------------------------------------------
+
+// undecidedTables is the thirty-nine tables that carry no retention
+// decision yet, pinned by name rather than counted.
+//
+// A count would let a promotion pay for a new undecided table and hold
+// the total, so a table could arrive undecided and stay that way without
+// a reviewer ever seeing it. Pinning the names means adding an undecided
+// table edits this list, and promoting one edits it too. That is a
+// record of the decision, not friction.
+var undecidedTables = []string{
+	"alerts",
+	"audit_events",
+	"auth_mfa_secrets",
+	"auth_policy",
+	"credentials",
+	"group_members",
+	"groups",
+	"host_backoff_state",
+	"host_compliance_schedule",
+	"host_connection_profile",
+	"host_intelligence_events",
+	"host_intelligence_state",
+	"host_liveness",
+	"host_monitoring_history",
+	"host_rule_state",
+	"host_system_info",
+	"hosts",
+	"job_queue",
+	"license_clock_watermark",
+	"notification_channels",
+	"notifications",
+	"policy_history",
+	"posture_snapshots",
+	"remediation_requests",
+	"remediation_transactions",
+	"report_faces",
+	"report_schedules",
+	"report_snapshots",
+	"roles",
+	"scan_evidence",
+	"scan_results",
+	"scan_runs",
+	"ssh_known_hosts",
+	"sso_identities",
+	"sso_providers",
+	"system_config",
+	"transactions",
+	"user_roles",
+	"users",
+}
+
+// @ac AC-16
+// AC-16: the undecided set is exactly that list, and a row in an
+// undecided table survives a sweep however old it is.
+//
+// Why the survival half is here, stated carefully, because the obvious
+// version of the reasoning is wrong today.
+//
+// The worry is a sweep filter written as "not never and not deferred",
+// which would take in all thirty-nine undecided tables. Sweeper.Eligible
+// is written positively (State == StateSwept) so this does not happen,
+// and neither AC-04 nor AC-05 would notice if it did: each looks only at
+// the two tables it names.
+//
+// But writing that filter today does not delete anything. An undecided
+// entry carries no TTLColumn, so the sweep builds a WHERE clause with
+// nothing on its left, Postgres rejects the statement, and the pass ends
+// in an error. Every test that runs a sweep goes red, on the error
+// rather than on a deleted row. Verified: with the filter flipped, the
+// only assertion that fires anywhere is the sweep error, and no row is
+// removed from a never, deferred or undecided table.
+//
+// So the crash, not this assertion, is what currently stops that bug.
+// That protection is an accident of AC-01 and it disappears the moment
+// anyone gives an undecided entry a TTL column for documentation
+// reasons. This assertion is what still holds afterward. Confirmed by
+// mutating both at once, the filter and a TTL column on hosts, which
+// makes it fail on its own:
+//
+//	a five-year-old hosts row was deleted
+//
+// Do not delete this as redundant on the strength of the filter mutation
+// alone. That mutation goes red either way.
+func TestUndecidedTablesArePinnedAndUntouched(t *testing.T) {
+	t.Run("system-retention-sweeper/AC-16", func(t *testing.T) {
+		want := map[string]bool{}
+		for _, table := range undecidedTables {
+			want[table] = true
+		}
+		if len(want) != len(undecidedTables) {
+			t.Fatalf("the pinned list has %d names but only %d are distinct", len(undecidedTables), len(want))
+		}
+
+		got := map[string]bool{}
+		for _, p := range Registry() {
+			if p.State != StateUndecided {
+				continue
+			}
+			got[p.Table] = true
+			if strings.TrimSpace(p.Reason) == "" {
+				t.Errorf("%s is undecided with no reason. The reason has to name the state of the decision and point at bugs/OW-013", p.Table)
+			} else if !strings.Contains(p.Reason, "OW-013") {
+				t.Errorf("%s is undecided but its reason does not point at bugs/OW-013, so a reader has nowhere to go to find out where the decision stands", p.Table)
+			}
+		}
+
+		for table := range want {
+			if !got[table] {
+				t.Errorf("%s is pinned as undecided but the registry no longer says so. If it was promoted, take it out of the pinned list in the same change so the promotion is visible in review", table)
+			}
+		}
+		for table := range got {
+			if !want[table] {
+				t.Errorf("%s is undecided in the registry but is not in the pinned list. A new table arriving with no retention decision has to be added here deliberately, not counted", table)
+			}
+		}
+
+		// A sweep must not touch an undecided table, whatever its age.
+		pool := freshPool(t)
+		fx := seedFixtures(t, pool)
+		if !want["hosts"] {
+			t.Fatal("this test seeds hosts as its undecided sample and hosts is no longer undecided")
+		}
+		if _, err := pool.Exec(context.Background(),
+			"UPDATE hosts SET created_at = now() - interval '5 years' WHERE id = $1", fx.host); err != nil {
+			t.Fatalf("age the host row: %v", err)
+		}
+
+		if err := NewSweeper(pool, failIfCalled(t)).Sweep(context.Background()); err != nil {
+			t.Errorf("sweep: %v", err)
+		}
+		if !rowExists(t, pool, "hosts", "id = $1", fx.host) {
+			t.Error("a five-year-old hosts row was deleted. hosts is undecided, which means no retention decision has been taken for it, so a sweep must leave it alone. A filter written as \"not never and not deferred\" would do exactly this")
+		}
+	})
+}

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -57,6 +57,7 @@ import (
 	"github.com/Hanalyx/openwatch/internal/correlation"
 	"github.com/Hanalyx/openwatch/internal/db/dbtest"
 	"github.com/Hanalyx/openwatch/internal/identity"
+	"github.com/Hanalyx/openwatch/internal/secretkey"
 )
 
 // ---------------------------------------------------------------------
@@ -1469,8 +1470,8 @@ func TestOTPReplayWindowComesFromTheRegistry(t *testing.T) {
 
 		// Functional: verify once, sweep, verify again.
 		pool := freshPool(t)
-		if err := identity.SetEphemeralMFAKey(); err != nil {
-			t.Fatalf("ephemeral mfa key: %v", err)
+		if err := secretkey.SetEphemeral(); err != nil {
+			t.Fatalf("SetEphemeral: %v", err)
 		}
 		userID := seedUser(t, pool)
 		ctx := context.Background()

--- a/internal/retention/sweeper.go
+++ b/internal/retention/sweeper.go
@@ -1,0 +1,212 @@
+// The sweeper: one cron tick that walks the registry and deletes what
+// the registry says to delete. It is the only scheduled deletion path
+// for any table in the registry (spec C-03). A single-use consume, a
+// user-initiated delete, and a scheduled status transition such as the
+// compliance-exception expiry flip are all outside that rule.
+//
+// Spec: specs/system/retention-sweeper.spec.yaml (C-03, C-05, C-06,
+// C-12).
+package retention
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/Hanalyx/openwatch/internal/cron"
+)
+
+// DefaultInterval is the gap between sweeps. Retention is not urgent
+// work: the shortest grace in the registry is an hour, and nothing in
+// the product reads a row the sweep is about to remove.
+const DefaultInterval = 6 * time.Hour
+
+// DefaultBatchSize is how many rows one statement removes. Small enough
+// that a batch holds row locks briefly, large enough that a backlog
+// drains in a sane number of round trips.
+const DefaultBatchSize = 1000
+
+// EmitFunc is the audit-emission shape (matches audit.Emit). The sweeper
+// takes one and never calls it. See Sweep.
+type EmitFunc func(ctx context.Context, code audit.Code, ev audit.Event)
+
+// Sweeper deletes rows past their grace for every swept entry in the
+// registry. Construct with NewSweeper and start with Run.
+type Sweeper struct {
+	pool *pgxpool.Pool
+	emit EmitFunc
+
+	// policies overrides the package registry. nil means the real one.
+	// Tests inject a registry here; production never sets it.
+	policies []Policy
+
+	batchSize int
+	interval  time.Duration
+}
+
+// NewSweeper wires the sweeper. emit is audit.Emit in production, and is
+// deliberately never called (spec C-12).
+func NewSweeper(pool *pgxpool.Pool, emit EmitFunc) *Sweeper {
+	return &Sweeper{
+		pool:      pool,
+		emit:      emit,
+		batchSize: DefaultBatchSize,
+		interval:  DefaultInterval,
+	}
+}
+
+// WithBatchSize sets the rows-per-statement bound. Values below one are
+// ignored, because a zero batch would loop forever.
+func (s *Sweeper) WithBatchSize(n int) *Sweeper {
+	if n > 0 {
+		s.batchSize = n
+	}
+	return s
+}
+
+// WithInterval sets the tick interval, which also sets the per-tick
+// deadline. Values below one are ignored.
+func (s *Sweeper) WithInterval(d time.Duration) *Sweeper {
+	if d > 0 {
+		s.interval = d
+	}
+	return s
+}
+
+// WithPolicies replaces the registry this sweeper walks. For tests only:
+// production reads the package registry, which is what makes a newly
+// swept entry run without a change at the call site.
+func (s *Sweeper) WithPolicies(p []Policy) *Sweeper {
+	s.policies = p
+	return s
+}
+
+// Interval is the gap between ticks.
+func (s *Sweeper) Interval() time.Duration { return s.interval }
+
+// Deadline is the per-tick context deadline. Strictly shorter than the
+// interval, so a slow pass cannot overlap the next tick. cron.Scheduler
+// sets no deadline of its own, so the sweeper sets this one.
+func (s *Sweeper) Deadline() time.Duration { return s.interval / 2 }
+
+// registry returns the policies this sweeper walks.
+func (s *Sweeper) registry() []Policy {
+	if s.policies != nil {
+		return s.policies
+	}
+	return Registry()
+}
+
+// Run starts the sweep on a cron tick with one immediate pass, mirroring
+// exception.Run and posture.Run. interval of zero keeps the configured
+// one. Returns the scheduler so a caller can Stop it.
+func (s *Sweeper) Run(ctx context.Context, interval time.Duration) *cron.Scheduler {
+	s.WithInterval(interval)
+	if err := s.sweepWithDeadline(ctx); err != nil {
+		slog.WarnContext(ctx, "retention boot sweep failed", slog.String("err", err.Error()))
+	}
+	sched := cron.New(s.interval, s.sweepWithDeadline)
+	sched.Start(ctx)
+	return sched
+}
+
+// sweepWithDeadline runs one pass under the per-tick deadline. This is
+// the TickFunc cron calls.
+func (s *Sweeper) sweepWithDeadline(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, s.Deadline())
+	defer cancel()
+	return s.Sweep(ctx)
+}
+
+// Sweep runs one pass over the registry. A failure on one table does not
+// stop the remaining tables: the error is collected, the pass finishes,
+// and the returned error names every table that failed (spec C-12).
+//
+// No audit event is emitted here, for either the pass or a single
+// delete. Routine expiry is not an actor's action, which is the durable
+// reason and holds whatever anyone later decides about audit_events. The
+// second reason is narrower but true today: audit_events grows without
+// bound, so auditing retention would trade one unbounded table for
+// another. s.emit is held so this note sits exactly where someone would
+// otherwise add the call.
+func (s *Sweeper) Sweep(ctx context.Context) error {
+	_ = s.emit // Deliberately unused. See the note above and spec C-12.
+
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("retention: sweep not started: %w", err)
+	}
+
+	var errs []error
+	for _, p := range s.registry() {
+		if !p.Eligible() {
+			continue
+		}
+		deleted, err := s.sweepTable(ctx, p)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("retention: sweep %s: %w", p.Table, err))
+			slog.WarnContext(ctx, "retention sweep failed",
+				slog.String("table", p.Table),
+				slog.String("err", err.Error()))
+			if ctx.Err() != nil {
+				// Out of time or canceled. The remaining tables wait
+				// for the next tick rather than each logging the same
+				// context error.
+				break
+			}
+			continue
+		}
+		slog.InfoContext(ctx, "retention sweep",
+			slog.String("table", p.Table),
+			slog.Int64("deleted", deleted))
+	}
+	return errors.Join(errs...)
+}
+
+// sweepTable drains one table in batches, oldest row first, until a
+// batch comes back short.
+func (s *Sweeper) sweepTable(ctx context.Context, p Policy) (int64, error) {
+	stmt := s.DeleteStatement(p)
+	cutoff := time.Now().Add(-p.Grace)
+
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		tag, err := s.pool.Exec(ctx, stmt, cutoff, s.batchSize)
+		if err != nil {
+			return total, err
+		}
+		total += tag.RowsAffected()
+		if tag.RowsAffected() < int64(s.batchSize) {
+			return total, nil
+		}
+	}
+}
+
+// DeleteStatement builds the batched delete for one policy. $1 is the
+// cutoff timestamp, $2 the batch size.
+//
+// Postgres DELETE takes neither ORDER BY nor LIMIT, so the ordering and
+// the bound live in a ctid subselect. Oldest-first is a correctness
+// requirement, not a preference: refresh_tokens carries a self-
+// referencing rotated_to_id with NO ACTION, and a newest-first batch
+// breaks that constraint the moment the entry is promoted to swept.
+//
+// A Keep predicate is honored by negation, so a row matching Keep
+// survives past its grace. The table and column names come from the
+// registry, which is code in this package, never from a request.
+func (s *Sweeper) DeleteStatement(p Policy) string {
+	where := fmt.Sprintf("%s < $1", p.TTLColumn)
+	if p.Keep != "" {
+		where += fmt.Sprintf(" AND NOT (%s)", p.Keep)
+	}
+	return fmt.Sprintf(
+		"DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s WHERE %s ORDER BY %s ASC LIMIT $2)",
+		p.Table, p.Table, where, p.TTLColumn)
+}

--- a/internal/sso/store.go
+++ b/internal/sso/store.go
@@ -254,15 +254,11 @@ func (s *Service) link(ctx context.Context, providerID uuid.UUID, subject string
 	return nil
 }
 
-// PurgeExpiredStates deletes auth-state rows past their TTL. Called by a
-// periodic sweeper.
-func (s *Service) PurgeExpiredStates(ctx context.Context) (int64, error) {
-	ct, err := s.pool.Exec(ctx, `DELETE FROM sso_auth_states WHERE expires_at < now()`)
-	if err != nil {
-		return 0, fmt.Errorf("sso: purge states: %w", err)
-	}
-	return ct.RowsAffected(), nil
-}
+// PurgeExpiredStates used to live here. Its doc comment said "Called by
+// a periodic sweeper" and there was no periodic sweeper. sso_auth_states
+// is swept from internal/retention now. The single-use consume in
+// consumeAuthState is unaffected: it deletes the one row it matched, and
+// that is not retention.
 
 func encryptSecret(plain string) ([]byte, error) {
 	dek, err := secretkey.Active()

--- a/specs/system/daemon-orchestration.spec.yaml
+++ b/specs/system/daemon-orchestration.spec.yaml
@@ -1,7 +1,11 @@
 spec:
   id: system-daemon-orchestration
   title: openwatch serve daemon lifecycle and Slice B runtime wiring
-  version: "1.2.0"
+  # Version 1.3.0 (was 1.2.0). Minor: one added constraint and one added
+  # acceptance criterion for the retention sweeper's boot wiring. Nothing
+  # published here changed meaning, so a consumer written against 1.2.0 is
+  # still correct against this file.
+  version: "1.3.0"
   status: approved
   tier: 1
 
@@ -41,7 +45,15 @@ spec:
 
       audit.Emit is the only EmitFunc threaded through Slice B
       packages — none of them imports audit directly for emission.
+      v1.3.0 additions:
+        - Retention sweeper (retention.NewSweeper) started as a
+          long-lived tick. The registry of retention policies and the
+          sweep behavior belong to system-retention-sweeper; this spec
+          owns only the fact that serve starts it. A sweeper that is
+          built and tested but never started is the defect that spec
+          exists to close, and the boot path is where it closes.
     related_specs:
+      - system-retention-sweeper
       - system-liveness-loop
       - system-event-bus
       - system-alert-router
@@ -106,6 +118,20 @@ spec:
       type: technical
       enforcement: error
 
+    - id: C-10
+      description: >
+        v1.3.0 - openwatch serve MUST construct the retention sweeper
+        (retention.NewSweeper) and start it in cmdServe, after the pool
+        and audit are up and alongside the other scheduled services.
+        Retention is the one scheduled job whose absence is invisible:
+        nothing 503s, no page is blank, and the only symptom is a disk
+        that fills months later. Two purge functions already shipped
+        with a doc comment naming a caller that did not exist. Its
+        policies live in system-retention-sweeper; the guard that it
+        actually runs lives here. Source-inspection enforces (AC-12)
+      type: technical
+      enforcement: error
+
   acceptance_criteria:
     - id: AC-01
       description: openwatch serve binary builds cleanly with the Slice B imports — alertrouter, alertrouter/channels/stdout, eventbus, liveness — present in cmd/openwatch/main.go's import block.
@@ -151,3 +177,15 @@ spec:
       description: 'v1.2.0 - Source-inspection: enumerate every "func (s *Server) WithX" builder declared in internal/server/*.go (excluding _test files) and assert each WithX token appears in cmd/openwatch/main.go. Fails if any builder is unwired - the generic regression guard that the per-service AC-08/AC-09 checks specialize. Catches the alerts-service class of gap for every current and future builder'
       priority: critical
       references_constraints: [C-09]
+    - id: AC-12
+      description: >
+        v1.3.0 - Source-inspection: cmd/openwatch/main.go contains
+        retention.NewSweeper( inside cmdServe, and the constructed
+        sweeper is started with a Run call taking ctx, on the same
+        pattern as the exception and account-policy sweeps. Fails if the
+        sweeper is constructed and never started, or imported and never
+        constructed. system-retention-sweeper AC-10 asserts the other
+        half, that the sweeper walks the registry rather than a
+        hard-coded table list.
+      priority: critical
+      references_constraints: [C-10]

--- a/specs/system/retention-sweeper.spec.yaml
+++ b/specs/system/retention-sweeper.spec.yaml
@@ -1,0 +1,479 @@
+spec:
+  id: system-retention-sweeper
+  # Version 1.0.0. New spec. Nothing in the tree implements any of it today,
+  # so every acceptance criterion below is red on arrival. Tier 1, because a
+  # sweep deletes rows and a delete is not reversible, and because two of the
+  # three swept tables hold security state (SSO auth states and used OTPs).
+  version: "1.0.0"
+  status: approved
+  tier: 1
+
+  context:
+    system: openwatch
+    feature: Scheduled data retention
+    description: >
+      One registry of retention policies, one scheduler that walks it.
+      Each table in the schema carries exactly one entry saying what
+      happens to its old rows: swept, never, deferred, or undecided.
+      Every entry carries a reason. undecided is a real answer and the
+      most common one today, because 39 of the 46 tables have never had
+      a retention decision taken. Saying so in the registry is what
+      stops the next reader from mistaking silence for a decision.
+
+      Why this is a spec and not a function. OpenWatch already had two
+      purge functions and no sweeper. internal/sso/store.go
+      PurgeExpiredStates says "Called by a periodic sweeper" and had no
+      caller. internal/identity/mfa.go PurgeStaleOTPs says "Called by a
+      cron tick" and had no caller. Different authors, two months apart,
+      same outcome. Neither was caught, because the repo enforces "the
+      spec is implemented" and "the code compiles", and enforces nothing
+      about "the code runs in production". Both functions are exported,
+      and golangci-lint's unused check does not report an exported
+      identifier in a library package. See bugs/OW-013 in the Context
+      Plane.
+
+      So the criteria that matter here are not the ones that test a
+      delete. They are AC-02 (every table has an explicit entry),
+      AC-10 (the sweeper is reachable from main.go) and AC-11 (nobody
+      runs a second, private sweep). A unit test of a purge function
+      that production never calls is exactly today's state.
+
+      Retention is a security control on one table, not only a capacity
+      control. auth_mfa_otp_uses is the OTP replay ledger, and the
+      replay check is existence-based, so how long a row survives IS the
+      replay-rejection window. See C-10.
+    related_specs:
+      - system-daemon-orchestration
+      - system-idempotency
+      - system-auth-identity
+      - system-sso
+      - api-compliance-exceptions
+      - system-api-tokens
+
+  objective:
+    summary: >
+      Old rows leave the database on a schedule that an operator can
+      read off one list, and a table nobody thought about fails CI
+      rather than growing forever in silence.
+    scope:
+      includes:
+        - A retention registry in internal/retention, one entry per table in the schema
+        - "Three swept tables: idempotency_keys, sso_auth_states, auth_mfa_otp_uses"
+        - "Two never-swept tables recorded as never, with reasons: api_tokens, compliance_exceptions"
+        - "Two deferred tables recorded as deferred, with reasons: sessions, refresh_tokens"
+        - Thirty-nine remaining tables recorded as undecided, each with a reason pointing at bugs/OW-013
+        - One sweeper on one cron.Scheduler that walks the registry
+        - A completeness guard over every table the migrations create
+        - A wiring guard proving the sweeper is reached from cmd/openwatch/main.go
+        - Batched, oldest-first deletes under a per-tick deadline
+      excludes:
+        - Sweeping sessions or refresh_tokens (deferred, each needs its own migration and review)
+        - Any change to the compliance_exceptions expiry flip, which is a status transition and stays where it is
+        - Partitioning, archival to cold storage, or export before delete
+        - A size cap on idempotency_keys.response_body or a length cap on its key column (raised by OW-013, still open, not scoped here)
+        - Operator-facing configuration of grace values (the registry is code in this version)
+
+  constraints:
+    - id: C-01
+      description: >
+        A single registry in internal/retention MUST hold one entry per
+        table. Each entry carries Table, TTLColumn, Grace, State, Keep
+        and Reason. State is one of swept, never, deferred, undecided.
+        Reason MUST be non-empty for every entry in every one of the
+        four states, including swept ones: an entry with no reason is
+        invalid and fails AC-01. A swept or deferred entry MUST carry a
+        non-empty TTLColumn and a Grace greater than zero. A never or
+        undecided entry MUST carry neither. Keep is an optional SQL
+        predicate naming rows that MUST survive regardless of age.
+        undecided means no retention decision has been taken for this
+        table. It is not deferred: deferred names work that is designed
+        and blocked, and carries the parameters a promotion would use.
+        Recording zero Grace under the word deferred would make an empty
+        field the carrier of intent, which is the defect this registry
+        exists to remove.
+        A swept or deferred entry's TTLColumn MUST be a column the
+        migrations declare NOT NULL. The delete compares that column
+        against a past bound and a NULL satisfies no comparison, so a
+        nullable TTL column makes a table read as swept while silently
+        keeping every row whose column is NULL. All five entries naming
+        a column satisfy this today. The rule exists so the sixth is
+        caught by CI rather than by review.
+      type: technical
+      enforcement: error
+    - id: C-02
+      description: >
+        The registry MUST cover the schema in both directions. Every
+        table in the effective set MUST have exactly one entry, and
+        every entry MUST name a table in that set. The table set is the
+        schema the migrations actually produce, not the set of CREATE
+        TABLE statements. Apply the Up sections of
+        internal/db/migrations/*.sql in order: a CREATE TABLE adds a
+        name, an ALTER TABLE ... RENAME TO replaces it. Migration 0042
+        renames reports to report_snapshots and there is no CREATE TABLE
+        report_snapshots, so a parser that only collects CREATE TABLE
+        demands an entry for a table that no longer exists and rejects
+        the entry for the one that does. There is exactly one rename and
+        no DROP TABLE in any Up section today. The rule is stated in
+        terms of the effective set so a second rename needs no spec
+        change. Adding a table without adding an entry
+        MUST fail CI. The guard MUST NOT be keyed on a column name. An
+        earlier survey keyed on expires_at and missed auth_mfa_otp_uses
+        entirely, which keys on used_at. Enumerating tables and
+        demanding an explicit decision is the only version that cannot
+        miss one.
+      type: technical
+      enforcement: error
+    - id: C-03
+      description: >
+        The registry-driven sweeper MUST be the only scheduled deletion
+        path for any table in the registry. No other package may run its
+        own timed purge of a registry table. This is scoped to deletion
+        on a schedule. It does not touch a single-use consume (the SSO
+        callback deletes its own auth state), a user-initiated delete,
+        or a scheduled status transition such as the compliance
+        exception expiry flip at cmd/openwatch/main.go. There are five
+        cron.New call sites in this tree, each a package owning its own
+        scheduled work. That pattern produced two dead purge functions.
+        Retention does not repeat it.
+      type: technical
+      enforcement: error
+    - id: C-04
+      description: >
+        cmd/openwatch/main.go MUST construct the sweeper and start it in
+        cmdServe. A sweeper that exists, is tested, and is never started
+        is the defect this spec was written for, not a partial fix of
+        it. Source-inspection enforces (AC-10), on the pattern already
+        set by TestCmdServe_AllServerBuildersWired in
+        cmd/openwatch/source_test.go.
+      type: technical
+      enforcement: error
+    - id: C-05
+      description: >
+        Deletes MUST be batched, oldest-first, and bounded in time. Each
+        statement MUST carry ORDER BY the entry's TTLColumn ascending
+        and a LIMIT, and the sweeper MUST repeat until a batch comes
+        back short. Oldest-first is not a preference. refresh_tokens
+        carries a self-referencing rotated_to_id with NO ACTION, so a
+        newest-first batch violates the constraint the moment that entry
+        is promoted. Each tick MUST run under its own context deadline,
+        strictly shorter than the tick interval, so a slow sweep cannot
+        overlap the next tick. cron.Scheduler passes no deadline of its
+        own, so the sweeper MUST set one.
+      type: technical
+      enforcement: error
+    - id: C-06
+      description: >
+        The sweeper MUST delete from exactly the entries whose State is
+        swept. An entry in any state other than swept MUST NOT be
+        touched. The rule is written positively so it cannot rot when a
+        state is added: a filter that lists the states to skip goes
+        wrong the moment a fourth state exists. A Keep
+        predicate MUST be honored by negation in the WHERE clause, so a
+        row matching Keep survives past its grace.
+      type: security
+      enforcement: error
+    - id: C-07
+      description: >
+        The three swept entries in this version MUST be exactly these.
+        idempotency_keys, TTL column expires_at, grace 24h. Lookup
+        already filters on expires_at > now(), so a swept row was
+        already unreadable. sso_auth_states, TTL column expires_at,
+        grace 1h. A state is single-use and already rejected once
+        expired, so the sweep only reclaims abandoned logins.
+        auth_mfa_otp_uses, TTL column used_at, grace 24h. Note the
+        column: this table has no expires_at.
+      type: technical
+      enforcement: error
+    - id: C-08
+      description: >
+        Two tables MUST be recorded as never, in code, with reasons.
+        api_tokens, because the operator UI lists expired tokens on
+        purpose (internal/apitoken/apitoken.go filters neither
+        expires_at nor revoked_at), because expires_at is nullable so
+        NULL means permanent, and because the row is a forensic record
+        carrying created_by, last_used_at and revoked_at.
+        compliance_exceptions, because expiry there is already a status
+        transition rather than a deletion, and the table's partial
+        unique index depends on expired rows persisting. That table is
+        the model this spec follows, not a defect it corrects. Recording
+        never in the registry is what stops a future reader from
+        "fixing" either one.
+      type: technical
+      enforcement: error
+    - id: C-09
+      description: >
+        Two tables MUST be recorded as deferred, with reasons naming the
+        work each needs. Deferred is a state the registry expresses, not
+        silence. sessions needs a non-partial index, because the
+        existing idx_sessions_expires_at is WHERE revoked_at IS NULL,
+        and its predicate must use absolute_expires_at rather than
+        expires_at, which slides forward on every request.
+        refresh_tokens has no index on expires_at at all, so a sweep
+        today is a sequential scan; its deletion must be oldest-first
+        because of the rotated_to_id self-FK; and a row with
+        reuse_detected_at set is the only durable artifact of a detected
+        token theft, so the entry MUST carry Keep =
+        "reuse_detected_at IS NOT NULL". That predicate MUST sit on the
+        deferred entry now, not arrive with the promotion. Keep is a
+        promotion parameter exactly like TTLColumn and Grace, which C-01
+        already requires a deferred entry to carry. A safety predicate
+        added at promotion time depends on whoever promotes it
+        remembering; carried now, promotion is a one-word state change,
+        and AC-05 (the right Keep is present) composes with AC-09 (a
+        Keep predicate is honored) into the property. Neither table may
+        be promoted to swept without its migration. Deleting live
+        session history is not reversible.
+      type: security
+      enforcement: error
+    - id: C-10
+      description: >
+        For auth_mfa_otp_uses the registry Grace IS the replay-rejection
+        window, and MUST be treated as a security parameter. The replay
+        check inserts (user_id, otp) with ON CONFLICT DO NOTHING, so a
+        used OTP is rejected exactly as long as its row survives. Grace
+        MUST be greater than or equal to the TOTP acceptance window,
+        which is 90 seconds (period 30s, skew 1, so three steps). A
+        shorter grace reopens a replay hole silently. The registry is
+        the single source of truth: any constant or doc comment stating
+        a different window (today internal/identity/mfa.go
+        OTPReplayWindow = 180s, plus the comments at lines 33 to 36 and
+        88 to 93) MUST be reconciled to it. The 24h grace in C-07 is
+        longer than today's constant, so replay rejection gets stronger,
+        never weaker, and system-auth-identity AC-16 still holds.
+        Read the live state before changing any of this. PurgeStaleOTPs
+        deletes at 180 seconds and has no caller, so rows are kept
+        forever and replay rejection is accidentally unlimited today.
+        Wiring that function up as written would NARROW protection from
+        unlimited to 180 seconds. The obvious fix for OW-013, "just call
+        the purge function that already exists", is therefore a security
+        regression on this one table. Drive the delete from the registry
+        instead.
+      type: security
+      enforcement: error
+    - id: C-11
+      description: >
+        The two orphaned purge functions MUST be resolved, not left
+        beside the new sweeper. internal/sso/store.go PurgeExpiredStates
+        and internal/identity/mfa.go PurgeStaleOTPs MUST each be either
+        called by internal/retention or deleted from the tree. No doc
+        comment may assert a caller that does not exist. Both comments
+        do today, which is how each function read as live for months.
+      type: technical
+      enforcement: error
+    - id: C-12
+      description: >
+        Each tick MUST log one record per swept table naming the table
+        and the number of rows deleted, under the tick's cron-
+        correlation id. A failure on one table MUST NOT stop the
+        remaining tables; the sweeper collects the error, finishes the
+        pass, and returns an error naming the table that failed. The
+        sweeper MUST NOT emit an audit event for its own deletes.
+        audit_events is itself a growing table, so a per-delete or
+        per-tick audit event would trade one unbounded table for
+        another, and routine retention is not an actor's action.
+      type: technical
+      enforcement: error
+    - id: C-13
+      description: >
+        The undecided entries MUST be pinned by table name in the test,
+        not counted. Thirty-nine tables carry State undecided today. A
+        count-based guard lets a promotion pay for a new undecided
+        table and hold the total, so a new table can arrive undecided
+        forever without a reviewer seeing it. Pinning the names means
+        adding an undecided table edits a list under review, and
+        promoting one edits it too, which is a record rather than
+        friction. Each undecided entry carries a Reason naming the
+        state of the decision and pointing at bugs/OW-013.
+      type: technical
+      enforcement: error
+
+  acceptance_criteria:
+    - id: AC-01
+      description: >
+        Registry entries are well formed. Every entry has a non-empty
+        Table, a non-empty Reason, and a State in {swept, never,
+        deferred, undecided}. Every swept or deferred entry has a
+        non-empty TTLColumn and Grace > 0. Every never or undecided
+        entry has an empty TTLColumn and a zero Grace. No table name
+        appears twice. The test names the offending entry. For every
+        swept or deferred entry, assert the migrations declare its
+        TTLColumn NOT NULL. This reads the schema, not the registry, so
+        an entry naming a nullable column fails even though the entry
+        itself is well formed.
+      priority: critical
+      references_constraints: [C-01]
+    - id: AC-02
+      description: >
+        The registry covers the schema, both directions. Build the
+        effective table set: read the Up section of each
+        internal/db/migrations/*.sql in order (the text above the goose
+        Down marker, so the DROP TABLE statements in the Down sections
+        are ignored), where a CREATE TABLE adds a name and an ALTER
+        TABLE ... RENAME TO replaces it. The set is what the migrations
+        produce, not the CREATE TABLE statements: 0042 renames reports
+        to report_snapshots and never creates report_snapshots, so a
+        parser that collects only CREATE TABLE asserts against a dead
+        name and rejects the live one. Assert each name in the effective
+        set appears exactly once in the registry, and that every
+        registry entry names a table in that set. The test fails naming
+        the table that has no entry. No part of this check reads a
+        column name.
+      priority: critical
+      references_constraints: [C-02]
+    - id: AC-03
+      description: >
+        The three swept entries are exactly idempotency_keys
+        (expires_at, 24h), sso_auth_states (expires_at, 1h) and
+        auth_mfa_otp_uses (used_at, 24h). Asserted field by field, so a
+        silent edit of a grace or a TTL column fails. The
+        auth_mfa_otp_uses assertion pins used_at specifically, because
+        that table has no expires_at and a column-name assumption is
+        what missed it before.
+      priority: critical
+      references_constraints: [C-07]
+    - id: AC-04
+      description: >
+        Never-swept tables survive a sweep. api_tokens and
+        compliance_exceptions are State never with non-empty reasons.
+        Seed an api_tokens row whose expires_at is a year in the past
+        and a compliance_exceptions row whose expires_at is a year in
+        the past, run a full sweep, and assert both rows are still
+        present.
+      priority: critical
+      references_constraints: [C-06, C-08]
+    - id: AC-05
+      description: >
+        Deferred tables survive a sweep and say why. sessions and
+        refresh_tokens are State deferred, each with a non-empty reason.
+        Seed a session past its absolute_expires_at and a refresh token
+        past its expires_at, run a full sweep, and assert both rows are
+        still present. Assert the parameters a promotion would use, not
+        only the state: sessions' TTLColumn is absolute_expires_at, not
+        expires_at, which slides forward on every request; and
+        refresh_tokens carries Keep = "reuse_detected_at IS NOT NULL"
+        today, while it is still deferred. Both are stated in C-09 and
+        neither is checked anywhere else, so without this a wrong column
+        or a missing safety predicate stays green until the day someone
+        flips the state to swept.
+      priority: critical
+      references_constraints: [C-06, C-09]
+    - id: AC-06
+      description: >
+        A sweep deletes past the grace and nothing else. For each swept
+        entry, seed one row whose TTL column is inside the grace and one
+        whose TTL column is past it, run the sweep, and assert exactly
+        the past-grace row is gone. The seeding reads the TTL column
+        from the registry entry, so auth_mfa_otp_uses is exercised on
+        used_at without the test naming it.
+      priority: critical
+      references_constraints: [C-06, C-07]
+    - id: AC-07
+      description: >
+        Deletes are batched and oldest-first. With a batch size of N and
+        2N+1 eligible rows, a single sweep pass removes all 2N+1 and
+        issues more than one statement. The generated SQL contains
+        ORDER BY the entry's TTL column ASC and a LIMIT. Source or
+        generated-statement inspection covers the ORDER BY and LIMIT
+        shape; the row count covers the drain.
+      priority: critical
+      references_constraints: [C-05]
+    - id: AC-08
+      description: >
+        A tick cannot outrun its interval. The per-tick deadline the
+        sweeper sets is strictly less than the tick interval it is
+        constructed with, asserted directly. A sweep whose context is
+        already canceled returns promptly without panicking and leaves
+        the remaining rows in place.
+      priority: high
+      references_constraints: [C-05]
+    - id: AC-09
+      description: >
+        A Keep predicate is honored. Using a test registry entry that
+        carries a Keep predicate, seed two past-grace rows, one matching
+        Keep and one not. The sweep deletes only the non-matching row.
+        This is the criterion that makes the refresh_tokens promotion
+        safe later, so it is tested before that promotion, not with it.
+      priority: critical
+      references_constraints: [C-06, C-09]
+    - id: AC-10
+      description: >
+        Wiring guard. Source-inspection over cmd/openwatch/main.go
+        asserts cmdServe contains retention.NewSweeper( and starts it,
+        matching the house pattern of a Run call taking ctx. A second
+        assertion, over internal/retention, requires the sweep to range
+        over the registry rather than a hard-coded list of tables, so a
+        newly swept entry is executed without a code change at the call
+        site. Same shape as TestCmdServe_AllServerBuildersWired. This is
+        the criterion the two dead purge functions would have failed.
+      priority: critical
+      references_constraints: [C-03, C-04]
+    - id: AC-11
+      description: >
+        No second sweeper. Outside internal/retention and outside
+        _test.go files, no Go source in the tree contains an age-based
+        bulk DELETE from a swept table: a DELETE whose WHERE clause
+        compares that entry's TTL column against a past bound, the
+        "< now()" or "< now() - interval" shape. Enumerate the swept
+        entries from the registry, then scan the tree. Such a delete
+        anywhere else is a private retention policy the registry does
+        not know about, which is how the codebase reached two purge
+        functions and no sweeper. The shape matters, not the table name:
+        a delete keyed on an identifier does not match. The SSO
+        single-use consume (internal/sso/store.go consumeAuthState) is
+        the worked example. It deletes by state = $1 and checks expiry
+        in Go afterward, so it does not match, and it must keep
+        working.
+      priority: critical
+      references_constraints: [C-03, C-11]
+    - id: AC-12
+      description: >
+        The orphaned purges are resolved. For each of
+        internal/sso/store.go PurgeExpiredStates and
+        internal/identity/mfa.go PurgeStaleOTPs, assert the identifier
+        is either absent from the tree or referenced from
+        internal/retention. Also assert no doc comment in those two
+        files claims a periodic sweeper or a cron tick calls it unless
+        that caller is present.
+      priority: critical
+      references_constraints: [C-11]
+    - id: AC-13
+      description: >
+        The OTP replay window comes from the registry and never drops
+        below the TOTP acceptance window. Assert the auth_mfa_otp_uses
+        grace is at least 90 seconds. Assert that any surviving
+        OTPReplayWindow constant equals that grace. Functionally, verify
+        an OTP, run a full sweep, and verify the same OTP again within
+        the grace: the second attempt still returns ErrOTPReplayed. That
+        ties this spec to system-auth-identity AC-16 rather than
+        silently weakening it.
+      priority: critical
+      references_constraints: [C-10]
+    - id: AC-14
+      description: >
+        A tick reports what it did. After a pass that deletes rows, one
+        log record exists per swept table carrying the table name and
+        the deleted count, under the tick's cron- correlation id.
+        Asserted against a captured slog handler. The same test passes
+        an audit emit function that fails the test if it is called, so a
+        pass emits no audit event.
+      priority: high
+      references_constraints: [C-12]
+    - id: AC-15
+      description: >
+        One bad table does not end the pass. With a test registry whose
+        first swept entry names a table that does not exist, a pass
+        still deletes the eligible rows from the remaining swept tables
+        and returns an error naming the failing table.
+      priority: high
+      references_constraints: [C-12]
+    - id: AC-16
+      description: >
+        The undecided set is exactly the pinned list of thirty-nine
+        table names, asserted as a set so both a missing and an
+        unexpected name fail. Separately, seed a row in one undecided
+        table with a past timestamp, run a full sweep, and assert it
+        survives. AC-04 and AC-05 cannot catch this: a filter written
+        as "not never and not deferred" sweeps every undecided table
+        while both of them stay green.
+      priority: critical
+      references_constraints: [C-13, C-06]

--- a/specter.yaml
+++ b/specter.yaml
@@ -128,6 +128,7 @@ domains:
             - frontend-settings-scan-config
             - frontend-settings-exception-queue
             - frontend-settings-discovery-config
+            - system-retention-sweeper
 settings:
     specs_dir: specs
     # Honored by `specter coverage` (not by `specter sync` — CI passes


### PR DESCRIPTION
Nothing removed expired rows, so three tables grew for the life of an install.
`idempotency_keys` stores full response bodies, and `docs/guides/runbooks/DISK_FULL.md`
already listed it among the tables most likely to be large.

Closes `bugs/OW-013`.

## This sweeps one of the four tables the disk-full runbook names

Verified against the migrations, not assumed:

```
audit_events       undecided
transactions       undecided
idempotency_keys   swept, 24h   <- this change
job_queue          undecided
```

Say it plainly: "retention shipped" is not "disk growth solved." The runbook has
already nominated the next three promotions, which is what makes the undecided
list a work queue rather than abstract debt.

Deleting rows frees space for PostgreSQL to reuse but does not return it to the
filesystem. An operator who upgrades to reclaim disk needs `VACUUM FULL` or
`pg_repack` after the first sweep. The CHANGELOG says so.

## A registry, not a reaper

Every table the migrations produce carries one entry stating what happens to its
old rows: swept, never, deferred, or undecided, each with a reason. Adding a
table without an entry fails CI.

```
3 swept / 2 never / 2 deferred / 39 undecided = 46
```

The shape is the point. The survey that produced this bug keyed on a column name
and missed `auth_mfa_otp_uses`, which keys on `used_at` and has no `expires_at`.
Enumerating tables and demanding an explicit decision is the only version that
cannot miss one, and no part of the completeness check reads a column name.

`undecided` exists because the alternatives were both dishonest. Marking 39
tables `never` asserts a decision nobody took. Marking them `deferred` forces a
TTL column and a retention window on `users`, `hosts` and `credentials` that
nobody chose. `deferred` says "here is the policy, here is what blocks it";
`undecided` says "nobody has looked." Collapsing them would make an unreviewed
table read like a reviewed one.

The 39 are pinned **by name**, not counted. A count lets a promotion pay for a
new undecided table and hold the total, so a new table could arrive undecided
forever without a reviewer seeing it.

## The obvious fix was a security regression

`auth_mfa_otp_uses` is the one-time-code replay ledger. The check inserts
`(user_id, otp)` with `ON CONFLICT DO NOTHING`, so **retention is the
replay-rejection window**: a used code is rejected exactly as long as its row
survives.

`identity.PurgeStaleOTPs` deleted at 180 seconds and had no caller. Because
nothing swept the table, rejection was unbounded by accident. **Wiring up the
function that was already written would have narrowed protection from unlimited
to 180 seconds.** The registry drives the delete instead, at 24 hours, far above
the 90 second TOTP acceptance window. `OTPReplayWindow` is deleted rather than
kept beside it, because a constant next to a sweeper is a second source of truth
waiting to drift.

## Why a scheduler instead of calling the code that was already here

Two purge functions existed and neither had a caller. `sso.PurgeExpiredStates`
said "Called by a periodic sweeper." `identity.PurgeStaleOTPs` said "Called by a
cron tick." Different authors, two months apart, same outcome.

The repo enforces that a spec is implemented and that the code compiles, and
enforces nothing about whether the code runs. Both were exported, and the unused
check does not report an exported identifier in a library package.

So the criteria that matter here are not the ones that test a delete:

- **AC-02**, every table has an entry
- **AC-10**, the sweeper is reachable from `cmdServe`
- **AC-11**, nobody runs a second private sweep

A unit test of a purge function that production never calls is the state being
fixed, reproduced. Both orphaned purges are deleted rather than rewired, so the
registry is the only scheduled deletion path.

## Four assertions that looked healthy and were doing nothing

Worth recording, because three of them are in tests written for this change.

| Assertion | Why it could not fail |
|---|---|
| AC-10 registry half | satisfied by `Lookup`, so the sweep could have walked a hard-coded list forever |
| AC-13 functional half | verified and swept in the same instant, so any legal grace spared the row |
| AC-11 | matched one `*ast.BasicLit` at a time, so any SQL split across a `+` was invisible |
| a reviewer's `grep -c` | line-based, run on a value spanning three concatenation lines, reported absent |

Mutation found the first two. It could not find the third: every mutation written
for AC-11 was a single-line string, the same blind spot as the guard it tested. A
mutation is authored from the same mental model as the assertion, so a hole in the
model is a hole in both, and red confirms the model rather than the code.

AC-11 matters most of the four. It is the criterion that would have caught the two
dead purges, and it worked only because one of them happened to be a one-liner.
The fix folds `+` chains of string literals, stripping each fragment's delimiters
first so a statement split mid-token is still caught. A/B on the same two inputs:
**1 flagged before, 2 after.**

The tree is genuinely clean today. Both age-shaped bulk deletes are gone. This is
about the next one somebody writes.

## Deferred, and honest about it

`sessions` and `refresh_tokens` are decided but blocked. `sessions` needs a
non-partial index, and its predicate must use `absolute_expires_at`, because
`expires_at` slides forward on every request (`internal/identity/sessions.go:245`).
Pointed at `expires_at`, a promotion would delete the sessions of users who are
merely idle. `refresh_tokens` has no index on `expires_at` at all, and carries
`Keep = "reuse_detected_at IS NOT NULL"` **now** rather than at promotion, because
that row is the only durable record of a detected token theft.

Their 30 day grace is invented. The `Reason` field says so in the data, not only
in a comment, because anything rendering the registry reads `Grace` and a consumer
showing an invented number as a fact is the defect this registry removes.

## Verification

| Check | Result |
|---|---|
| `go test ./...` | 60 packages, 0 failures |
| `internal/retention` verbose | 36 pass, **0 skips** |
| `specter coverage --strictness annotation` | 119 specs, 100% |
| `go build`, `go vet`, `gofmt -l` | clean |
| `check-doc-style.py` | clean |

Zero skips is load-bearing: `dbtest.Pool` skips rather than fails without a DSN,
so all eight database criteria could have read green while running nothing.

No migration. All three swept tables already index their TTL column, which is
exactly the asymmetry that keeps `sessions` and `refresh_tokens` deferred.

## Filed rather than fixed here

- `bugs/OW-011`, the contract cannot show which routes are guarded
- `bugs/OW-014`, a replay drops every response header
- `bugs/OW-015`, `.sql` files sit outside the doc-style gate
- `bugs/OW-016`, five schema tests are contaminable by forward-only migrations

## Specs

`system-retention-sweeper` is new: 13 constraints, 16 criteria, at 1.0.0. It is
not bumped despite being amended during the work, because it had never been
committed and so has no published version to move from.
`system-daemon-orchestration` goes 1.2.0 to 1.3.0, which is tracked and did.
