### PR TITLE
feat(license): select the verification key by kid

### DIFF
--- a/internal/license/audit.go
+++ b/internal/license/audit.go
@@ -45,6 +45,15 @@ func emitInstalled(ctx context.Context, source string, lic *License) {
 		detail["features_count"] = len(lic.Features)
 		detail["using_prev_key"] = lic.UsingPrevKey
 		detail["in_grace_period"] = lic.InGracePeriod
+		// The kid the token presented, when it did not name the key that
+		// verified. Only set when there is something to report, so a normal
+		// load carries no extra field and the presence of the key is the
+		// signal. The consumer is Hanalyx, not the operator: a mislabel means
+		// the issuer stamped the wrong thumbprint, and says nothing about
+		// whether this deployment's license is good.
+		if lic.MismatchedKeyID != "" {
+			detail["mismatched_key_id"] = lic.MismatchedKeyID
+		}
 	}
 	if err := audit.EmitSync(ctx, audit.LicenseInstalled, audit.Event{
 		ActorType: "system",

--- a/internal/license/keys.go
+++ b/internal/license/keys.go
@@ -2,8 +2,10 @@ package license
 
 import (
 	"crypto/ed25519"
+	"crypto/sha256"
 	"crypto/x509"
 	"embed"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 )
@@ -14,9 +16,10 @@ import (
 //go:embed keys/*.pem
 var embeddedKeys embed.FS
 
-// publicKeys holds the parsed keys at package init. Mismatches against
-// every slot fail validation; matches against prev or deprecated emit
-// warnings (UsingPrevKey flag).
+// publicKeys holds the parsed keys at package init. A token that matches no
+// slot fails validation. A token that matches the prev slot verifies and sets
+// the UsingPrevKey warning flag. The deprecated slot verifies only in dev mode
+// and sets no flag.
 type publicKeyRing struct {
 	current    ed25519.PublicKey
 	prev       ed25519.PublicKey // may be nil in Stage 0
@@ -67,6 +70,32 @@ func parsePEMPublicKey(path string) (ed25519.PublicKey, error) {
 		return nil, fmt.Errorf("%s is not an Ed25519 public key", path)
 	}
 	return ed, nil
+}
+
+// KeyID returns the JWT `kid` value for a license-signing public key. It is the
+// SHA-256 of the key's SPKI DER encoding, in base64url with no padding.
+//
+// The value is a pure function of the key bytes. The issuer and the verifier
+// each derive it on their own, so no name-to-key registry has to be kept in
+// sync between them.
+//
+// A slot name such as "current" could not do that job. A license signed while a
+// key sat in the current slot would still carry the label "current" after
+// rotation moved that key to the prev slot. The label would then name the wrong
+// key, and the license would never be minted again to correct it.
+//
+// An input that is not a valid Ed25519 public key returns "". An empty key ID
+// matches no `kid` header, so it selects nothing.
+func KeyID(pub ed25519.PublicKey) string {
+	if len(pub) != ed25519.PublicKeySize {
+		return ""
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(der)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
 // SetVerificationKeyForTesting installs pub as the sole active license

--- a/internal/license/service_test.go
+++ b/internal/license/service_test.go
@@ -10,6 +10,7 @@ package license
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -34,15 +35,40 @@ func installTestKeyring(t *testing.T) {
 // can assert an emission without a database behind it. EmitSync writes straight
 // through to storage, which is what the license.* events use.
 type auditRecorder struct {
-	mu     sync.Mutex
-	events []audit.Code
+	mu      sync.Mutex
+	events  []audit.Code
+	details []json.RawMessage // parallel to events
 }
 
 func (r *auditRecorder) InsertEvent(_ audit.Ctx, ev *audit.Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.events = append(r.events, ev.Action)
+	r.details = append(r.details, ev.Detail)
 	return nil
+}
+
+// detailFor returns the decoded detail map of the first event with this code,
+// and whether such an event was recorded. Assertions read the emitted detail
+// rather than the License struct, so they measure what an auditor can see.
+func (r *auditRecorder) detailFor(t *testing.T, code audit.Code) (map[string]any, bool) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, c := range r.events {
+		if c != code {
+			continue
+		}
+		var m map[string]any
+		if len(r.details[i]) == 0 {
+			return nil, true
+		}
+		if err := json.Unmarshal(r.details[i], &m); err != nil {
+			t.Fatalf("decode %s detail %q: %v", code, r.details[i], err)
+		}
+		return m, true
+	}
+	return nil, false
 }
 
 func (r *auditRecorder) saw(code audit.Code) bool {

--- a/internal/license/types.go
+++ b/internal/license/types.go
@@ -63,6 +63,20 @@ type License struct {
 	UsingPrevKey    bool   // signed with the previous key (warning surface)
 	InGracePeriod   bool   // expired but within 30-day grace
 	UnknownFeatures []string
+	// MismatchedKeyID holds the `kid` the token presented when that kid did not
+	// name the key that verified it. Empty when the kid named the verifying key,
+	// and empty when the token carried no kid at all.
+	//
+	// The license is valid either way. A kid is inside the signed header, so an
+	// attacker cannot change one without breaking the signature, which makes a
+	// wrong kid an issuer mislabel rather than an attack. The verifier recovers
+	// by trying the rest of the ring, and this field is how that recovery stops
+	// being silent. An issuer stamping the wrong thumbprint on every license it
+	// mints is a defect somebody has to be able to see.
+	//
+	// Same treatment as UnknownFeatures: do not reject, do not ignore, record it
+	// for a consumer to read.
+	MismatchedKeyID string
 	// ClockRollbackDetected reports that this deployment's clock sits behind
 	// the recorded watermark by more than the tolerance. It is a WARNING, not
 	// a denial: the license still loads. See decision record 06.

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -1,6 +1,7 @@
 package license
 
 import (
+	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"strings"
@@ -61,15 +62,6 @@ func Verify(jwtBlob string, ring *publicKeyRing, opts VerifyOptions) (*License, 
 		opts.Now = time.Now
 	}
 
-	usingPrev := false
-	keyFunc := func(token *jwt.Token) (interface{}, error) {
-		// We accept only EdDSA. JWT v5 maps Ed25519 to EdDSA.
-		if _, ok := token.Method.(*jwt.SigningMethodEd25519); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-		return ring.current, nil
-	}
-
 	// WithoutClaimsValidation: we do exp/iat/nbf checks manually below so we
 	// can implement the 30-day grace period (jwt v5's default validator
 	// rejects expired tokens before our custom logic runs).
@@ -77,9 +69,48 @@ func Verify(jwtBlob string, ring *publicKeyRing, opts VerifyOptions) (*License, 
 		jwt.WithValidMethods([]string{"EdDSA"}),
 		jwt.WithoutClaimsValidation(),
 	)
-	parsed, err := parser.ParseWithClaims(jwtBlob, &claims{}, keyFunc)
-	if err != nil {
-		// Try the prev key if the signature failed against current.
+
+	// Which ring slots this call may verify against, in the order they are
+	// tried. Slot policy is applied here and nowhere else, so the `kid` header
+	// below cannot route around it.
+	candidates := trialKeys(ring, opts)
+
+	// `kid` reorders that list so the named slot is tried first. It never adds
+	// to the list.
+	//
+	// The header is matched against the allowed slots built above, not against
+	// the whole ring, so a header naming the deprecated key outside dev mode
+	// matches nothing. That is what separates this from a thumbprint-to-key
+	// map. A map hands back any ring member whose thumbprint matches, which
+	// would open the deprecated slot to anyone able to read a public key and
+	// stamp a header.
+	kid := keyIDFromJWT(jwtBlob)
+	if kid != "" {
+		candidates = preferKeyID(candidates, kid)
+	}
+
+	var (
+		parsed   *jwt.Token
+		err      error
+		verified keyCandidate
+	)
+	for _, cand := range candidates {
+		key := cand.key
+		parsed, err = parser.ParseWithClaims(jwtBlob, &claims{}, func(token *jwt.Token) (interface{}, error) {
+			// We accept only EdDSA. JWT v5 maps Ed25519 to EdDSA.
+			if _, ok := token.Method.(*jwt.SigningMethodEd25519); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			return key, nil
+		})
+		if err == nil {
+			// Keep the slot that verified, not the code path that ran. A kid
+			// header can put any allowed slot first, so anything inferred from
+			// the sequence of attempts would be wrong.
+			verified = cand
+			break
+		}
+		// Only a signature mismatch justifies reaching for another key.
 		//
 		// Match on ErrTokenSignatureInvalid, which is what jwt v5 wraps every
 		// verification failure in. Do NOT match ErrSignatureInvalid: that
@@ -88,23 +119,31 @@ func Verify(jwtBlob string, ring *publicKeyRing, opts VerifyOptions) (*License, 
 		// carries it. Matching it made this branch unreachable, which meant key
 		// rotation would have failed in the field the first release a prev key
 		// shipped, and only then.
-		if ring.prev != nil && errors.Is(err, jwt.ErrTokenSignatureInvalid) {
-			parsed, err = parser.ParseWithClaims(jwtBlob, &claims{}, func(*jwt.Token) (interface{}, error) {
-				return ring.prev, nil
-			})
-			if err == nil {
-				usingPrev = true
-			}
+		//
+		// Every other parse error is decided before the signature is checked,
+		// so it does not depend on which key is in hand. Stopping early on one
+		// costs nothing: another slot would return the same class of error.
+		if !errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+			break
 		}
-		// Try the deprecated key in dev mode.
-		if err != nil && opts.AllowDeprecatedKey && ring.deprecated != nil {
-			parsed, err = parser.ParseWithClaims(jwtBlob, &claims{}, func(*jwt.Token) (interface{}, error) {
-				return ring.deprecated, nil
-			})
-		}
-		if err != nil {
-			return nil, classifyParseError(err), err
-		}
+	}
+	if err != nil {
+		return nil, classifyParseError(err), err
+	}
+
+	// UsingPrevKey is read off the slot that verified. It is the one place the
+	// flag is set, so a candidate that loses its slot identity on the way here
+	// would leave using_prev_key reporting the opposite of the truth.
+	usingPrev := verified.isPrev
+
+	// Did the kid name the key that actually verified? Compare thumbprints
+	// rather than asking whether preferKeyID reordered anything. A kid like the
+	// literal string "current" names no slot, so it reorders nothing and the
+	// current key still verifies. That kid did not select the key either, and a
+	// reorder check would call it a match.
+	mismatchedKeyID := ""
+	if kid != "" && KeyID(verified.key) != kid {
+		mismatchedKeyID = kid
 	}
 
 	c, ok := parsed.Claims.(*claims)
@@ -194,9 +233,83 @@ func Verify(jwtBlob string, ring *publicKeyRing, opts VerifyOptions) (*License, 
 		Fingerprint:   c.Fingerprint,
 		UsingPrevKey:  usingPrev,
 		InGracePeriod: inGrace,
+		// A kid that did not name the verifying key. Empty is the normal case.
+		MismatchedKeyID: mismatchedKeyID,
 		// The caller audits these; the verifier only reports them.
 		UnknownFeatures: unknown,
 	}, VerifyValid, nil
+}
+
+// keyCandidate is one ring slot the verifier is allowed to try, paired with
+// what the caller has to be told about it.
+type keyCandidate struct {
+	key ed25519.PublicKey
+	// isPrev drives License.UsingPrevKey, which the API surfaces as
+	// using_prev_key. The deprecated slot deliberately leaves it false.
+	isPrev bool
+}
+
+// trialKeys returns the ring slots this call may verify against, in the order
+// they are tried.
+//
+// The deprecated slot is admitted only when the caller allows it, so the
+// dev-mode gate lives in this one place. The current slot is always listed,
+// even when it holds nothing, so the returned list is never empty and a ring
+// with no usable key still fails through the normal signature path.
+func trialKeys(ring *publicKeyRing, opts VerifyOptions) []keyCandidate {
+	cands := []keyCandidate{{key: ring.current}}
+	if ring.prev != nil {
+		cands = append(cands, keyCandidate{key: ring.prev, isPrev: true})
+	}
+	if opts.AllowDeprecatedKey && ring.deprecated != nil {
+		cands = append(cands, keyCandidate{key: ring.deprecated})
+	}
+	return cands
+}
+
+// preferKeyID moves the candidate whose key ID equals kid to the front, keeping
+// the rest in trial order. A kid that matches nothing leaves the order alone.
+//
+// The result is always a permutation of what came in. Nothing is dropped, so a
+// mislabeled token still reaches the key that signed it, and nothing is added,
+// so the slot policy the caller applied still holds.
+//
+// Dropping the other slots would be the tempting read of "select the key", and
+// it is wrong. The issuer stamps kid before any verifier reads it, so a stale
+// or mistyped kid is an issuer mislabel, not an attack: the signature still has
+// to verify against a key this build already trusts. Refusing to look further
+// would brick a paying install over a header no attacker can turn into a forged
+// license.
+func preferKeyID(cands []keyCandidate, kid string) []keyCandidate {
+	for i, c := range cands {
+		if KeyID(c.key) != kid {
+			continue
+		}
+		reordered := make([]keyCandidate, 0, len(cands))
+		reordered = append(reordered, c)
+		reordered = append(reordered, cands[:i]...)
+		reordered = append(reordered, cands[i+1:]...)
+		return reordered
+	}
+	return cands
+}
+
+// keyIDFromJWT reads the `kid` header out of an unverified token. It returns ""
+// when the header is absent, is not a string, or cannot be decoded at all.
+//
+// Nothing here is trusted. The value only picks which already-trusted key to
+// try, and a token that lies about its kid still has to pass the signature
+// check against that key. A "" result takes the plain trial order, which is the
+// path every license took before kid was read.
+func keyIDFromJWT(jwtBlob string) string {
+	// Errors are ignored on purpose. A token too broken to yield a header is
+	// also too broken to verify, and the parse below reports that properly.
+	token, _, _ := jwt.NewParser().ParseUnverified(jwtBlob, jwt.MapClaims{})
+	if token == nil {
+		return ""
+	}
+	kid, _ := token.Header["kid"].(string)
+	return kid
 }
 
 // classifyParseError maps jwt parser errors to typed VerifyResults so

--- a/internal/license/validator_kid_test.go
+++ b/internal/license/validator_kid_test.go
@@ -1,0 +1,644 @@
+// @spec system-license-validation
+//
+// AC traceability:
+// @ac AC-24  (TestVerify_KidDoesNotOpenDeprecatedSlot)
+// @ac AC-30  (TestVerify_KidSelectsCurrent)
+// @ac AC-25  (TestVerify_KidPrevSetsUsingPrevKey)
+// @ac AC-26  (TestVerify_NoKidUnchanged)
+// @ac AC-27  (TestVerify_UnusableKidFallsBack)
+// @ac AC-28  (TestKeyID_Derivation)
+// @ac AC-29  (TestKeyID_StableAndDistinct)
+// @ac AC-31  (TestVerify_MismatchedKidIsRecorded)
+// @ac AC-32  (TestLoadJWT_MismatchedKidReachesTheAuditTrail)
+
+package license
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// signJWTWithKid mints a license JWT signed with priv, carrying kid in the JWT
+// header when kid is not empty. The package's signJWT reads one fixed testdata
+// key and cannot set a header, so the kid tests need their own minter.
+func signJWTWithKid(t *testing.T, c claims, kid string, priv ed25519.PrivateKey) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodEdDSA, &c)
+	if kid != "" {
+		tok.Header["kid"] = kid
+	}
+	signed, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+// testKeyPrivate loads the testdata signing key, the private half of the key
+// installTestKeyring puts in the current slot. signJWT reads the same file but
+// keeps the key to itself, and the audit test has to sign with a kid header.
+func testKeyPrivate(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", "license-privkey-test.pem"))
+	if err != nil {
+		t.Fatalf("read test priv: %v", err)
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		t.Fatal("no PEM block in testdata/license-privkey-test.pem")
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse test priv: %v", err)
+	}
+	priv, ok := keyAny.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatalf("testdata key is %T, not ed25519", keyAny)
+	}
+	return priv
+}
+
+// newKeypair generates an Ed25519 keypair for a test ring slot. Key generation
+// for the shipped binary is offline and founder-owned, so the prev and
+// deprecated slots are built here rather than committed as PEM files under
+// keys/.
+func newKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate keypair: %v", err)
+	}
+	return pub, priv
+}
+
+// fullRing is a keyring with all three slots filled by distinct keys, plus the
+// private half of each so a test can sign as any slot. Every other test in this
+// package uses a ring whose prev and deprecated slots are nil, where "the
+// fallback still works" and "there was only ever one key" look identical.
+type fullRing struct {
+	ring           *publicKeyRing
+	currentPriv    ed25519.PrivateKey
+	prevPriv       ed25519.PrivateKey
+	deprecatedPriv ed25519.PrivateKey
+}
+
+func newFullRing(t *testing.T) fullRing {
+	t.Helper()
+	curPub, curPriv := newKeypair(t)
+	prevPub, prevPriv := newKeypair(t)
+	depPub, depPriv := newKeypair(t)
+	return fullRing{
+		ring: &publicKeyRing{
+			current:    curPub,
+			prev:       prevPub,
+			deprecated: depPub,
+		},
+		currentPriv:    curPriv,
+		prevPriv:       prevPriv,
+		deprecatedPriv: depPriv,
+	}
+}
+
+// ed25519SPKIPrefix is the fixed 12-byte DER header on an Ed25519
+// SubjectPublicKeyInfo: an outer SEQUENCE, an inner SEQUENCE holding OID
+// 1.3.101.112, then a BIT STRING with no unused bits. The 32 raw key bytes
+// follow it, for 44 bytes total.
+var ed25519SPKIPrefix = []byte{0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00}
+
+// independentKeyID computes the key id by a different route than KeyID takes.
+// KeyID calls x509.MarshalPKIXPublicKey; this builds the same DER from the
+// fixed prefix. Calling the same marshaller would only prove the
+// implementation equals itself, and a shared bug in that step would cancel out
+// on both sides. TestKeyID_Derivation checks the two routes agree.
+func independentKeyID(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	if len(pub) != ed25519.PublicKeySize {
+		t.Fatalf("public key is %d bytes, want %d", len(pub), ed25519.PublicKeySize)
+	}
+	der := make([]byte, 0, len(ed25519SPKIPrefix)+len(pub))
+	der = append(der, ed25519SPKIPrefix...)
+	der = append(der, pub...)
+	sum := sha256.Sum256(der)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// @ac AC-30
+// AC-30: a kid naming the current key verifies as Valid with UsingPrevKey
+// false. The ring holds three distinct keys, so this is the named slot being
+// used, not the only slot that existed.
+//
+// The AC pins the outcome rather than the selection, and deliberately. A kid
+// that misses falls back (C-17) and reaches the same outcome, so direct
+// selection is not observable from outside Verify. The outcome is what a caller
+// can see.
+func TestVerify_KidSelectsCurrent(t *testing.T) {
+	t.Run("system-license-validation/AC-30", func(t *testing.T) {
+		fr := newFullRing(t)
+		jwtBlob := signJWTWithKid(t, validClaims(), KeyID(fr.ring.current), fr.currentPriv)
+
+		lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+		if err != nil {
+			t.Fatalf("Verify (kid names current): %v", err)
+		}
+		if result != VerifyValid {
+			t.Fatalf("result = %s, want valid; a kid naming the current slot must verify", result)
+		}
+		if lic.UsingPrevKey {
+			t.Error("UsingPrevKey = true on a current-key license; using_prev_key would warn " +
+				"about a rotation that has not happened")
+		}
+	})
+}
+
+// @ac AC-25
+// AC-25: a prev-key license selected by kid still sets License.UsingPrevKey.
+// Before kid selection, that flag was set only by the failed-current-then-retry
+// sequence (AC-03), which direct selection never runs. The flag is surfaced as
+// using_prev_key, so losing it here means a declared field reports the opposite
+// of the truth: the deployment runs on a rotated-out key and the warning
+// surface stays dark.
+func TestVerify_KidPrevSetsUsingPrevKey(t *testing.T) {
+	t.Run("system-license-validation/AC-25", func(t *testing.T) {
+		fr := newFullRing(t)
+		jwtBlob := signJWTWithKid(t, validClaims(), KeyID(fr.ring.prev), fr.prevPriv)
+
+		lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+		if err != nil {
+			t.Fatalf("Verify (kid names prev): %v", err)
+		}
+		if result != VerifyValid {
+			t.Fatalf("result = %s, want valid; a kid naming the prev slot must verify", result)
+		}
+		if !lic.UsingPrevKey {
+			t.Error("UsingPrevKey = false, want true; kid selection reached the prev key, " +
+				"but using_prev_key reports the deployment is on the current key")
+		}
+	})
+}
+
+// @ac AC-24
+// AC-24: a kid naming the deprecated slot does not open that slot. Naming a key
+// is a request, not an authorization. A thumbprint-to-key map that hands back
+// any ring member on a match would turn the dev-only slot into a production
+// one, which is the whole security content of this change.
+func TestVerify_KidDoesNotOpenDeprecatedSlot(t *testing.T) {
+	t.Run("system-license-validation/AC-24", func(t *testing.T) {
+		fr := newFullRing(t)
+		jwtBlob := signJWTWithKid(t, validClaims(), KeyID(fr.ring.deprecated), fr.deprecatedPriv)
+
+		// Production: the flag is off, so naming the deprecated key does not
+		// reach it. Exactly signature_invalid, which is what the trial order
+		// gives. Accepting any non-valid result would also pass on a
+		// malformed_jwt, and that would mean the token was refused before the
+		// gate was ever consulted.
+		lic, result, _ := Verify(jwtBlob, fr.ring, VerifyOptions{})
+		if result != VerifySignatureInvalid {
+			t.Errorf("AllowDeprecatedKey false: result = %s, want signature_invalid; "+
+				"a kid naming the deprecated key must not unlock it", result)
+		}
+		if lic != nil {
+			t.Errorf("AllowDeprecatedKey false: license = %+v, want nil", lic)
+		}
+
+		// Dev mode: the same token, now permitted.
+		lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{AllowDeprecatedKey: true})
+		if err != nil {
+			t.Fatalf("AllowDeprecatedKey true: Verify: %v", err)
+		}
+		if result != VerifyValid {
+			t.Fatalf("AllowDeprecatedKey true: result = %s, want valid", result)
+		}
+		if lic.UsingPrevKey {
+			t.Error("AllowDeprecatedKey true: UsingPrevKey = true, want false; the " +
+				"deprecated slot is not the prev slot")
+		}
+	})
+}
+
+// @ac AC-27
+// AC-27: a kid the verifier cannot use falls back to the trial order. The
+// issuer stamps kid before any verifier reads it, so a header naming something
+// this binary does not hold must not cost the customer their license. Every key
+// in the ring is already a trusted anchor, so kid is a hint about which one,
+// not an extra trust decision.
+func TestVerify_UnusableKidFallsBack(t *testing.T) {
+	t.Run("system-license-validation/AC-27", func(t *testing.T) {
+		fr := newFullRing(t)
+		strangerPub, _ := newKeypair(t)
+
+		cases := []struct {
+			name string
+			kid  string
+		}{
+			// A kid no slot in this ring derives.
+			{"kid of a key the ring does not hold", KeyID(strangerPub)},
+			// A kid naming a real slot that did not sign this token. The
+			// verifier must still reach the key that did.
+			{"kid of the prev slot on a current-signed license", KeyID(fr.ring.prev)},
+			// A slot name is not a key id. KeyID derives from key bytes, so no
+			// key ever produces this string.
+			{"the literal slot name current", "current"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				jwtBlob := signJWTWithKid(t, validClaims(), tc.kid, fr.currentPriv)
+				lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+				if err != nil {
+					t.Fatalf("Verify (kid = %q): %v", tc.kid, err)
+				}
+				if result != VerifyValid {
+					t.Fatalf("result = %s, want valid; an unusable kid must fall back to "+
+						"the trial order, not refuse a license the ring can verify", result)
+				}
+				if lic.UsingPrevKey {
+					t.Error("UsingPrevKey = true; the current key signed this license, " +
+						"and the fallback must report the slot that verified")
+				}
+			})
+		}
+
+		// The fallback keeps reporting the slot that verified, not the slot the
+		// header named. Without this, a stale kid could make a rotated-out key
+		// look current.
+		t.Run("fallback to prev still sets UsingPrevKey", func(t *testing.T) {
+			jwtBlob := signJWTWithKid(t, validClaims(), KeyID(strangerPub), fr.prevPriv)
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid", result)
+			}
+			if !lic.UsingPrevKey {
+				t.Error("UsingPrevKey = false, want true; the prev key verified this license")
+			}
+		})
+	})
+}
+
+// @ac AC-31
+// AC-31: when the fallback rescues a token whose kid did not name the key that
+// verified it, the license says so at License.MismatchedKeyID.
+//
+// AC-27 makes that rescue succeed. Succeeding silently is the defect this
+// criterion exists to catch: an issuer that mislabels every license it mints
+// looks exactly like an issuer that labels them correctly.
+//
+// The two negative cases carry the criterion. A field hardcoded to the
+// presented kid passes every positive case on its own.
+func TestVerify_MismatchedKidIsRecorded(t *testing.T) {
+	t.Run("system-license-validation/AC-31", func(t *testing.T) {
+		fr := newFullRing(t)
+		strangerPub, _ := newKeypair(t)
+
+		// The three AC-27 shapes. Each is signed by the current key and stamped
+		// with a kid that did not name it, so each must carry that exact kid
+		// back out.
+		recorded := []struct {
+			name string
+			kid  string
+		}{
+			{"kid of a key the ring does not hold", KeyID(strangerPub)},
+			{"kid of the prev slot on a current-signed license", KeyID(fr.ring.prev)},
+			{"the literal slot name current", "current"},
+		}
+		for _, tc := range recorded {
+			t.Run(tc.name, func(t *testing.T) {
+				jwtBlob := signJWTWithKid(t, validClaims(), tc.kid, fr.currentPriv)
+				lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+				if err != nil {
+					t.Fatalf("Verify: %v", err)
+				}
+				if result != VerifyValid {
+					t.Fatalf("result = %s, want valid", result)
+				}
+				// The exact string the token presented, not a flag and not a
+				// description of it. A consumer has to be able to tell the
+				// issuer which label was wrong.
+				if lic.MismatchedKeyID != tc.kid {
+					t.Errorf("MismatchedKeyID = %q, want %q; the fallback rescued this "+
+						"license and reported nothing about the kid that missed",
+						lic.MismatchedKeyID, tc.kid)
+				}
+			})
+		}
+
+		// Both fields at once. The fallback lands on prev, so UsingPrevKey is
+		// true AND the mislabel is recorded. Neither field may swallow the
+		// other: an implementation that stopped recording once it had a
+		// rotation to report would pass every case above.
+		t.Run("a prev-key fallback records the mislabel and the rotation", func(t *testing.T) {
+			presented := KeyID(strangerPub)
+			jwtBlob := signJWTWithKid(t, validClaims(), presented, fr.prevPriv)
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid", result)
+			}
+			if lic.MismatchedKeyID != presented {
+				t.Errorf("MismatchedKeyID = %q, want %q", lic.MismatchedKeyID, presented)
+			}
+			if !lic.UsingPrevKey {
+				t.Error("UsingPrevKey = false, want true; the prev key verified this license")
+			}
+		})
+
+		// Negative one: the kid named the key that verified. Nothing was
+		// mislabeled, so there is nothing to report.
+		t.Run("empty when the kid named the verifying key", func(t *testing.T) {
+			jwtBlob := signJWTWithKid(t, validClaims(), KeyID(fr.ring.current), fr.currentPriv)
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid", result)
+			}
+			if lic.MismatchedKeyID != "" {
+				t.Errorf("MismatchedKeyID = %q, want empty; this kid named the key that "+
+					"verified, so reporting a mismatch accuses a correct issuer",
+					lic.MismatchedKeyID)
+			}
+		})
+
+		// Negative two: no kid at all. A license minted before the issuer
+		// stamped kid must not look mislabeled.
+		t.Run("empty when the token carries no kid", func(t *testing.T) {
+			jwtBlob := signJWTWithKid(t, validClaims(), "", fr.currentPriv)
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid", result)
+			}
+			if lic.MismatchedKeyID != "" {
+				t.Errorf("MismatchedKeyID = %q, want empty; the token presented no kid, "+
+					"so no kid can have missed", lic.MismatchedKeyID)
+			}
+		})
+	})
+}
+
+// @ac AC-32
+// AC-32: the mislabel reaches the audit trail, not just the License struct.
+//
+// This test reads the emitted license.installed detail map. AC-31 already
+// covers the struct field, and a value a Go caller can read but no auditor ever
+// sees leaves an issuer that mislabels every license it mints invisible (C-19).
+func TestLoadJWT_MismatchedKidReachesTheAuditTrail(t *testing.T) {
+	t.Run("system-license-validation/AC-32", func(t *testing.T) {
+		// The keyring holds the testdata key alone, which is the key signJWT
+		// signs with. Any kid other than that key's own is therefore a kid that
+		// did not select the key that verified.
+		verifying := testKeyPublic(t, "license-privkey-test.pem")
+
+		t.Run("present when the kid did not select the verifying key", func(t *testing.T) {
+			installTestKeyring(t)
+			rec := installAuditRecorder(t)
+			strangerPub, _ := newKeypair(t)
+			presented := KeyID(strangerPub)
+
+			jwtBlob := signJWTWithKid(t, validClaims(), presented, testKeyPrivate(t))
+			result, err := LoadJWT(jwtBlob, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("LoadJWT: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid; the fallback must still install the license", result)
+			}
+
+			// EmitLoadResult is what the boot and SIGHUP paths call once the
+			// load returns. LoadJWT itself emits nothing.
+			st := CurrentState()
+			if st == nil || st.License == nil {
+				t.Fatal("no license installed")
+			}
+			EmitLoadResult(context.Background(), "test", result, st.License, nil)
+
+			detail, ok := rec.detailFor(t, audit.LicenseInstalled)
+			if !ok {
+				t.Fatal("no license.installed event; a load that succeeded emitted nothing")
+			}
+			// The presented kid itself, not a boolean. Hanalyx has to be able to
+			// tell which thumbprint the issuer stamped wrongly.
+			if got := detail["mismatched_key_id"]; got != presented {
+				t.Errorf("mismatched_key_id = %v, want %q; the mislabel stayed on the "+
+					"License struct and never reached an auditor", got, presented)
+			}
+		})
+
+		t.Run("absent when the kid selected the verifying key", func(t *testing.T) {
+			installTestKeyring(t)
+			rec := installAuditRecorder(t)
+
+			jwtBlob := signJWTWithKid(t, validClaims(), KeyID(verifying), testKeyPrivate(t))
+			result, err := LoadJWT(jwtBlob, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("LoadJWT: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid", result)
+			}
+
+			st := CurrentState()
+			if st == nil || st.License == nil {
+				t.Fatal("no license installed")
+			}
+			EmitLoadResult(context.Background(), "test", result, st.License, nil)
+
+			detail, ok := rec.detailFor(t, audit.LicenseInstalled)
+			if !ok {
+				t.Fatal("no license.installed event")
+			}
+			// Absent or empty. Reporting a mislabel that did not happen would
+			// send Hanalyx after a correctly behaving issuer.
+			if got, present := detail["mismatched_key_id"]; present && got != "" {
+				t.Errorf("mismatched_key_id = %v, want absent or empty; this kid named "+
+					"the key that verified", got)
+			}
+			// The control: the event carries its usual detail, so the check
+			// above is reading a populated map rather than an empty one.
+			if _, present := detail["using_prev_key"]; !present {
+				t.Error("license.installed detail has no using_prev_key; the absence " +
+					"assertion above proves nothing against an empty detail map")
+			}
+		})
+	})
+}
+
+// @ac AC-26
+// AC-26: a license with no kid header behaves exactly as it did before kid
+// selection existed. This is a regression pin, not a smoke test, so the ring
+// holds three distinct keys. Run against a ring with nil prev and deprecated
+// slots, the fallback cases cannot fail.
+func TestVerify_NoKidUnchanged(t *testing.T) {
+	t.Run("system-license-validation/AC-26", func(t *testing.T) {
+		fr := newFullRing(t)
+
+		// The AC-01 case with a populated ring: the current key verifies first
+		// and claims nothing about rotation.
+		t.Run("current key verifies and does not claim prev", func(t *testing.T) {
+			jwtBlob := signJWTWithKid(t, validClaims(), "", fr.currentPriv)
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid", result)
+			}
+			if lic.UsingPrevKey {
+				t.Error("UsingPrevKey = true on a current-key license")
+			}
+		})
+
+		// The AC-03 case: current fails, prev catches it, and the flag is set.
+		// This is the path every license in the field takes after a rotation.
+		t.Run("prev key verifies and sets UsingPrevKey", func(t *testing.T) {
+			jwtBlob := signJWTWithKid(t, validClaims(), "", fr.prevPriv)
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("result = %s, want valid; the no-kid fallback to prev is the "+
+					"path a rotated deployment takes", result)
+			}
+			if !lic.UsingPrevKey {
+				t.Error("UsingPrevKey = false on a prev-key license")
+			}
+		})
+
+		// The deprecated slot stays behind the dev-mode flag on the no-kid path
+		// too. Adding kid selection must not have loosened it.
+		t.Run("deprecated key stays behind the dev-mode flag", func(t *testing.T) {
+			jwtBlob := signJWTWithKid(t, validClaims(), "", fr.deprecatedPriv)
+
+			lic, result, _ := Verify(jwtBlob, fr.ring, VerifyOptions{})
+			if result != VerifySignatureInvalid {
+				t.Errorf("AllowDeprecatedKey false: result = %s, want signature_invalid", result)
+			}
+			if lic != nil {
+				t.Errorf("AllowDeprecatedKey false: license = %+v, want nil", lic)
+			}
+
+			lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{AllowDeprecatedKey: true})
+			if err != nil {
+				t.Fatalf("AllowDeprecatedKey true: Verify: %v", err)
+			}
+			if result != VerifyValid {
+				t.Fatalf("AllowDeprecatedKey true: result = %s, want valid", result)
+			}
+			if lic.UsingPrevKey {
+				t.Error("AllowDeprecatedKey true: UsingPrevKey = true, want false")
+			}
+		})
+	})
+}
+
+// @ac AC-28
+// AC-28: KeyID is the base64url SHA-256 of the key's SPKI DER, with no padding.
+// The offline issuer stamps kid with its own implementation of this rule, so a
+// derivation that is merely stable and distinct can still disagree with every
+// license ever minted. Hex, retained padding, or hashing the raw 32 key bytes
+// instead of the 44-byte SPKI DER all pass a self-comparison and then fail in
+// the field.
+func TestKeyID_Derivation(t *testing.T) {
+	t.Run("system-license-validation/AC-28", func(t *testing.T) {
+		pubA, _ := newKeypair(t)
+		pubB, _ := newKeypair(t)
+
+		t.Run("matches an independently derived digest", func(t *testing.T) {
+			for _, pub := range []ed25519.PublicKey{pubA, pubB} {
+				want := independentKeyID(t, pub)
+				if got := KeyID(pub); got != want {
+					t.Errorf("KeyID = %q, want %q (base64url with no padding, over "+
+						"sha256 of the SPKI DER)", got, want)
+				}
+			}
+		})
+
+		// The hand-built DER is the independent route, so pin that it is the
+		// same DER the standard marshaller produces. If this ever fails, the
+		// check above is measuring against the wrong bytes.
+		t.Run("the hand-built SPKI DER is the standard one", func(t *testing.T) {
+			der, err := x509.MarshalPKIXPublicKey(pubA)
+			if err != nil {
+				t.Fatalf("marshal SPKI: %v", err)
+			}
+			hand := append(append([]byte{}, ed25519SPKIPrefix...), pubA...)
+			if string(der) != string(hand) {
+				t.Fatalf("hand-built DER %x does not match x509.MarshalPKIXPublicKey %x", hand, der)
+			}
+			if len(der) != 44 {
+				t.Errorf("SPKI DER is %d bytes, want 44", len(der))
+			}
+		})
+
+		// Hashing the raw key bytes rather than the SPKI DER is the likely
+		// wrong turn, and it produces a string of the same length and alphabet.
+		t.Run("hashes the SPKI DER, not the raw key bytes", func(t *testing.T) {
+			raw := sha256.Sum256(pubA)
+			if got := KeyID(pubA); got == base64.RawURLEncoding.EncodeToString(raw[:]) {
+				t.Error("KeyID hashes the raw 32 key bytes; the issuer hashes the 44-byte SPKI DER")
+			}
+		})
+
+		// 32 digest bytes encode to 43 base64 characters plus one pad. The pad
+		// must be absent and the alphabet must be the URL-safe one, or the
+		// value is not safe unescaped in a JWT header.
+		t.Run("base64url with no padding", func(t *testing.T) {
+			id := KeyID(pubA)
+			if len(id) != 43 {
+				t.Errorf("len(KeyID) = %d, want 43", len(id))
+			}
+			if strings.ContainsAny(id, "=+/") {
+				t.Errorf("KeyID = %q, want base64url with no padding (no '=', '+' or '/')", id)
+			}
+		})
+	})
+}
+
+// @ac AC-29
+// AC-29: KeyID is stable for a given key and distinct for different keys.
+func TestKeyID_StableAndDistinct(t *testing.T) {
+	t.Run("system-license-validation/AC-29", func(t *testing.T) {
+		pubA, _ := newKeypair(t)
+		pubB, _ := newKeypair(t)
+		idA := KeyID(pubA)
+
+		t.Run("stable across calls", func(t *testing.T) {
+			if again := KeyID(pubA); again != idA {
+				t.Errorf("KeyID is not stable: %q then %q", idA, again)
+			}
+			// A separate slice over the same bytes must give the same id.
+			// Anything keyed off the slice header rather than the contents
+			// passes the call-twice check and fails here.
+			copied := make(ed25519.PublicKey, len(pubA))
+			copy(copied, pubA)
+			if got := KeyID(copied); got != idA {
+				t.Errorf("KeyID over a copy of the same bytes = %q, want %q", got, idA)
+			}
+		})
+
+		t.Run("distinct between keys", func(t *testing.T) {
+			if idB := KeyID(pubB); idB == idA {
+				t.Errorf("two different keys share a key id: %q", idA)
+			}
+		})
+	})
+}

--- a/specs/system/license-validation.spec.yaml
+++ b/specs/system/license-validation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-license-validation
   title: License JWT validation
-  version: "2.0.0"
+  version: "2.1.0"
   status: approved
   tier: 1
 
@@ -14,7 +14,10 @@ spec:
       verifies signature against embedded keys (current/prev/deprecated),
       validates iss/aud/exp/iat/nbf, checks fingerprint binding, and
       detects clock rollback by comparing now against a persisted
-      last_known_good watermark.
+      last_known_good watermark. The JWT kid header, when present, picks
+      which slot of that ring to try. It is a thumbprint of the key
+      itself, so it only narrows the search the verifier would run
+      anyway.
 
   objective:
     summary: >
@@ -25,6 +28,7 @@ spec:
     scope:
       includes:
         - EdDSA signature verification
+        - kid-based key selection inside the embedded key ring
         - All standard JWT claim checks (iss, aud, exp, iat, nbf)
         - 30-day grace period
         - Fingerprint and clock-rollback detection
@@ -87,6 +91,26 @@ spec:
       enforcement: error
     - id: C-14
       description: A detected clock rollback MUST warn, not deny. The loader MUST still install the license, MUST mark it, and MUST emit license.clock_rollback_detected. The watermark row lives in the customer's own database and the adversary has root there, so denial is evadable by deleting the row while a false positive silently drops a paying deployment to free tier (decision record 06)
+      type: security
+      enforcement: error
+    - id: C-15
+      description: A kid header MAY only narrow the key search. It MUST NOT widen it and it MUST NOT skip a policy gate. kid changes which slot of the ring is tried, and nothing else. It MUST NOT admit a key the trial order (C-02) would refuse, MUST NOT bypass AllowDeprecatedKey, and MUST NOT change what the result reports. License.UsingPrevKey MUST reflect the slot that verified, however that slot was reached
+      type: security
+      enforcement: error
+    - id: C-16
+      description: kid MUST be the base64url SHA-256 of the key's SPKI DER, with no padding. It MUST be a pure function of the key bytes, so the offline issuer and the verifier derive the same value with no shared registry. Slot names MUST NOT be used as kid values. A license signed while key A held the current slot would carry kid=current forever, and after rotation that label points at the wrong key
+      type: security
+      enforcement: error
+    - id: C-17
+      description: kid MUST be optional in both directions. A license with no kid MUST verify exactly as it does today, by walking current, then prev, then deprecated under AllowDeprecatedKey. A kid that matches no slot, or that matches a slot whose key does not verify the signature, MUST fall back to that same trial order instead of being refused. Every key in the ring is already a trusted anchor, so kid is a hint about which one, not an extra trust decision. Falling back still satisfies C-15, because the set of keys tried is the set the no-kid path would try
+      type: technical
+      enforcement: error
+    - id: C-18
+      description: The permissive direction is deliberate, and MUST NOT be hardened into a hard failure. kid sits in the JWS protected header, so it is inside the signed input. Re-encoding the header with a swapped kid breaks the signature. That was measured, and the result is signature_invalid with an ed25519 verification error. An attacker therefore cannot alter kid. A kid that disagrees with the key that verified is an issuer mislabel, minted with one key and stamped with another key's thumbprint. Failing hard would brick every affected install until the licenses are reissued. Falling back costs one extra parse and still accepts only tokens a ring key signed, under the same slot policy the no-kid path applies
+      type: security
+      enforcement: error
+    - id: C-19
+      description: A fallback MUST NOT be silent. When the token carries a kid that did not select the key that verified, Verify MUST record that kid on the returned License so the caller can audit the mislabel. It MUST NOT reject the token and it MUST NOT drop the value. This follows C-12, where an unknown feature id rides on License.UnknownFeatures instead of invalidating the license or vanishing. The struct field is not the destination, only the route to it. The mislabel MUST reach the audit trail, in the license.installed detail map that emitInstalled already builds, next to using_prev_key and in_grace_period. A field a Go caller can read but no auditor ever sees leaves an issuer that mislabels every license it mints invisible, which is the outcome this constraint exists to prevent. A value that exists and a value something reads are different claims, and only the second one is worth writing down
       type: security
       enforcement: error
 
@@ -180,3 +204,39 @@ spec:
       description: Reloading a license does not clear a rollback warning. The load ratchets against the watermark it was GIVEN, not only the one already in process, so a rollback load cannot store a time behind the persisted watermark. The conforming test loads with a wound-back clock against a watermark of T, then reloads with empty options the way SIGHUP does, and asserts ClockRollbackDetected is still true and the stored watermark is still T. Without this, reloading makes the alert go away with nothing fixed.
       priority: critical
       references_constraints: [C-13, C-14]
+    - id: AC-24
+      description: A kid naming the deprecated slot does not open that slot. The conforming test builds a ring whose deprecated slot holds a real key, signs a license with that key's private half, and stamps the matching kid. With AllowDeprecatedKey false the result is SignatureInvalid, the same result the trial order gives. With AllowDeprecatedKey true the license validates as Valid. A thumbprint-to-key map that returns any ring member on a kid match fails this criterion.
+      priority: critical
+      references_constraints: [C-15]
+    - id: AC-25
+      description: A prev-key license selected by kid still sets License.UsingPrevKey. The conforming test builds a ring whose current and prev slots hold different keys, signs with the prev private half, and stamps the prev kid. The result is Valid and UsingPrevKey is true. Today that flag is set only by the failed-current-then-retry sequence in AC-03, which direct selection never runs, so a kid path can leave the declared using_prev_key field reporting the opposite of the truth.
+      priority: critical
+      references_constraints: [C-15]
+    - id: AC-26
+      description: A license with no kid header behaves exactly as it does today. The conforming test re-runs the AC-01 and AC-03 cases with no kid header present and expects the same results, from the same trial order. The ring MUST hold three real, distinct keys, one per slot. A nil-slot ring cannot tell a working trial order apart from a ring that only ever had one key, and every test in this package today uses a nil-slot ring. This is the regression pin on the compatible direction.
+      priority: critical
+      references_constraints: [C-17]
+    - id: AC-27
+      description: A kid the verifier cannot use falls back to the trial order. The ring MUST hold three real, distinct keys. The conforming test covers three cases and expects Valid in each. First, a current-key-signed license stamped with a kid no slot derives. Second, a current-key-signed license stamped with the prev key's kid, which names a real slot that does not verify the signature. Third, a kid of the literal string current, which is a slot name and so derives from nothing. A verifier that hard-rejects any of these breaks the issuer's ability to stamp kid before any verifier reads it, and would brick installs over an issuer mislabel that no attacker can forge.
+      priority: high
+      references_constraints: [C-16, C-17, C-18]
+    - id: AC-28
+      description: KeyID derives the base64url SHA-256 of the key's SPKI DER, with no padding. The conforming test computes the expected string itself, with x509.MarshalPKIXPublicKey and crypto/sha256, and compares. Calling KeyID twice is not enough. A derivation can be stable and distinct and still be wrong, by using hex, by keeping the padding, or by hashing the raw key bytes instead of the SPKI DER. Each of those passes a self-comparison and then disagrees with the offline issuer.
+      priority: critical
+      references_constraints: [C-16]
+    - id: AC-29
+      description: KeyID is stable for a given key and distinct for different keys. The same public key gives the same string on every call, and two different keys give different strings.
+      priority: high
+      references_constraints: [C-16]
+    - id: AC-30
+      description: A kid naming the current key verifies as Valid with License.UsingPrevKey false. The ring MUST hold three real, distinct keys, so the result proves the named slot was used rather than the only slot that existed. Direct selection is not observable from outside Verify, because a miss falls back (C-17) and reaches the same outcome. This criterion pins the outcome, which is what a caller can see.
+      priority: high
+      references_constraints: [C-15]
+    - id: AC-31
+      description: A kid that did not select the verifying key is recorded on the returned License, at License.MismatchedKeyID. The conforming test asserts the field holds the kid the token presented, in all three AC-27 cases. It also asserts the field is empty in two negative cases. One is a kid that did select the verifying key (AC-30). The other is a token with no kid at all (AC-26). Without the negative cases a field hardcoded to the presented kid would pass. Silent recovery is the defect this criterion exists to catch.
+      priority: critical
+      references_constraints: [C-19]
+    - id: AC-32
+      description: The mismatched kid reaches the audit trail. A load whose token carries a kid that did not select the verifying key emits license.installed with mismatched_key_id in the detail map, holding the presented kid. The conforming test reads the emitted event, not the License struct, because AC-31 already covers the struct. It also asserts the key is absent or empty when the kid did select the verifying key, so the detail does not report a mislabel that did not happen. No new audit code is added. license.installed already means a license was loaded and here is what it was.
+      priority: critical
+      references_constraints: [C-19]


### PR DESCRIPTION
The verifier tried each key in the ring in turn: current, then previous, then
deprecated under the dev flag. It now reads the JWT `kid` header and tries the
named slot first.

Closes `features/OW-005-license-activation-has-no-install-path` item 2b. The
other half of item 2, the dead prev-key sentinel, landed in #811.

## Why a thumbprint and not a slot name

`kid` is the base64url SHA-256 of the key's SPKI DER, no padding. It has to be a
pure function of the key bytes, so the offline issuer and the verifier derive the
same value with no registry to keep in sync.

A slot name would be wrong. A license signed while key A sat in the `current`
slot would carry `kid: current` forever. After rotation A is the previous key,
and that label now points at a different key, silently, for every license
already in the field.

## kid may only narrow the key search

That is the whole security content, and it is structural rather than checked.
Slot policy is applied once, when the candidate list is built. `kid` only
**reorders** that list:

```go
candidates := trialKeys(ring, opts)
if kid := keyIDFromJWT(jwtBlob); kid != "" {
    candidates = preferKeyID(candidates, kid)
}
```

A permutation cannot add a member. So a header naming the deprecated key matches
nothing unless `AllowDeprecatedKey` already put that slot in the list.

The alternative to avoid is a thumbprint-to-key map. It hands back any ring
member whose thumbprint matches, which would open the deprecated slot to anyone
able to read a public key and stamp a header.

## Two ways this could look right and be wrong

**`UsingPrevKey` now reads the slot that verified**, not the sequence of
attempts. Under `kid` selection the current slot is never tried first, so
anything inferred from that sequence reports the opposite of the truth on a
field surfaced as `using_prev_key`.

**A `kid` naming a slot whose key does not verify falls back** to the rest of
the list, and that direction must not be hardened later. C-18 records why.
`kid` sits in the JWS protected header, so it is inside the signed input.
Re-encoding the header with a swapped `kid`, leaving payload and signature
untouched, returns `signature_invalid`. So a `kid` that disagrees with its key
cannot be an attack. It is an issuer mislabel: minted with one key, stamped with
another key's thumbprint. Rejecting would brick every affected install until the
licenses were reissued. Falling back costs one signature check and still accepts
only tokens a trusted key signed.

The first implementation rejected. A test written against the spec caught it
before the ruling existed.

## The fallback is not silent

`License.MismatchedKeyID` records the presented `kid` when it did not name the
key that verified, and `emitInstalled` puts it on `license.installed` as
`mismatched_key_id`, set only when non-empty.

Deliberately **not** on `GET /api/v1/license`: that route is anonymous, and the
audience for a mislabel is the issuer rather than the operator. `using_prev_key`
is the closest analogue and is already gated rather than public.

Without the audit field the value would be readable only by a Go caller. A
recorded value nothing reads is the same defect as a surface carrying nothing,
one layer down, and it is the reason the recording requirement existed at all.
Both a reviewer and the tester reached that independently.

## Neither side has to go first, and both directions are measured

- A license with **no** `kid` takes exactly the old path. Pinned by a regression
  criterion, not assumed.
- A `kid` no verifier understands **already verifies** against released code:
  a token carrying `kid: "some-thumbprint-no-verifier-understands"` returns
  `result=valid` today.

So the issuer can stamp `kid` before any deployed verifier reads it, and a
verifier that reads it still accepts every license already minted. Filed as
`features/HP-OW-020` with the current key's id and both measurements.

## Verification

| Check | Result |
|---|---|
| `go test ./...` | 60 packages, 0 failures |
| `internal/license` under `-race` | 132 pass, **0 skips** |
| `make spec-check` | exit 0, 119 specs, 119 passing |
| `go build`, `go vet`, `gofmt -l` | clean |
| `check-doc-style.py` | clean |

**Six mutation checks, all killed, every failure naming its own assertion.** The
two that matter most:

- Matching `kid` against the whole ring instead of the policy-filtered list:
  `AllowDeprecatedKey false: result = valid, want signature_invalid`.
- Dropping the mismatch from the audit detail while leaving it on the struct:
  red on the audit assertion while every struct assertion stayed green, which is
  the proof the two criteria measure different things rather than the same thing
  twice.

## No CHANGELOG entry, deliberately

No license in existence carries a `kid`, so every current license verifies by
exactly the path it did before. Nothing changes for someone deciding whether to
upgrade. `dev/GIT_AND_GITHUB_PRACTICES` excludes a change nobody can observe, and
the style guide excludes "registered but nothing consumes it yet" notes.

The entry becomes real when issuance starts stamping `kid`, which is `HP-OW-020`
and a Hanalyx-side change.

## Specs

`system-license-validation` 2.0.0 to 2.1.0. Minor: additive, no existing
criterion changed meaning. It is tracked and had a published version to move
from, unlike the retention spec in #816.

Adds C-15 through C-19 and AC-24 through AC-32.

## Found and not fixed here

- `licensing_foundation.md` §4.2 step 5 says the deprecated key "still validates
  but emits warning". Neither half is true: it validates only under
  `AllowDeprecatedKey`, and it sets no flag. Filing against OW-005.
- `license.installed` now carries six detail keys and
  `audit_event_taxonomy.md:366` declares no `detail_schema` for that event, so
  none of them has anything to be checked against.
