### PR TITLE
docs(changelog): name the route the license_gated field was removed from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   codes, and the `license.quota_exceeded` audit event. **If you match on those
   codes, they will not appear again.** OpenWatch does not cap hosts, scans,
   users, or retention.
-- The `license_gated` field from `GET /api/v1/rbac`. Entitlement is decided by
-  the route, not the permission, because per-host and fleet-scale use the same
-  permission. **If you read that field, drop it:** it was populated for one
-  permission that no route required, so it never affected a request.
+- The `license_gated` field from `GET /api/v1/auth/permissions:registry`.
+  Entitlement is decided by the route, not the permission, because per-host and
+  fleet-scale use the same permission. **If you read that field, drop it:** it
+  was populated for one permission that no route required, so it never affected
+  a request.
 
 ### Fixed
 


### PR DESCRIPTION
The `[Unreleased]` entry for the removed `license_gated` field said it came from `GET /api/v1/rbac`. **No such route exists, or ever did.** The permission registry is `GET /api/v1/auth/permissions:registry`.

So an operator reading the changelog to find what changed had nothing to look at.

Found by an audit of the OW-005 record, which carried the same wrong route name. The underlying mistake was a search for the struct field `LicenseGated`, which finds its definition but not the generated accessor `LicenseGate(p)` that the middleware actually called. That produced a wrong belief about which code consumed the field, and the wrong route name travelled with it.

## Scope

One entry. The rest of the file was checked: every other `/api/v1/` path resolves against `api/openapi.yaml`, apart from six that name old paths deliberately, four in a rename table and two in entries explaining that the route does not exist.

Nothing else about the entry changed. The claim that the field never affected a request still holds, because no route required `audit:export`.

`check-doc-style.py` clean.