### PR TITLE
fix(gitignore): re-include migrations after the app/ tree was promoted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -497,35 +497,18 @@ cache/
 *api_key*
 *private_key*
 
-# Exception: Allow alembic migration files (they describe schemas, not actual credentials)
-!backend/alembic/versions/*credential*.py
+# Exception: spec files that reference credentials or api_keys in their names
+# describe schemas, not secrets.
+!specs/**/*credential*.yaml
+!specs/**/*api_key*.yaml
 
-# Exception: Allow spec and test files that reference credentials/api_keys in their names
-!specs/api/admin/credentials.spec.yaml
-!tests/backend/unit/api/test_api_keys_spec.py
-!tests/backend/unit/api/test_credentials_spec.py
-!backend/app/routes/admin/credentials.py
-!backend/app/routes/auth/api_keys.py
-!backend/app/services/auth/credential_service.py
-!backend/app/services/auth/credential_handler.py
-
-# Exception: Go-rebuild source under app/ — the "safety net" patterns
-# above (*credential*, *secret*, *password*, *_credential*.sql, etc.)
-# were written for the legacy Python project's runtime files. The Go
-# rebuild has packages whose names legitimately include those words
-# (internal/credential, internal/secretkey, identity/password*,
-# migrations/*_credentials.sql) — they are source code, not secrets.
-# Re-include all files under app/ here; the app/.gitignore still
-# applies for genuine build artifacts (dist/, openapi_embed.yaml).
-!app/**
-
-# The Go tree was promoted from app/ to the repo root (2026-06-05), so the
-# !app/** negation above no longer reaches it. The safety-net name patterns
-# (*credential*, *secret*) wrongly catch these Go source package directories —
-# they are source code, not secrets. Genuine build artifacts under internal/
-# are ignored by their own explicit rules further down (internal/server/
-# openapi_embed.yaml, internal/server/spa/), so this negation does not expose
-# them.
+# The safety-net name patterns above (*credential*, *secret*, *password*,
+# *_credential*.sql) were written for the legacy Python project's runtime
+# files. The Go tree has package directories whose names legitimately match
+# them, and those are source code, not secrets. Genuine build artifacts under
+# internal/ are ignored by their own explicit rules further down
+# (internal/server/openapi_embed.yaml, internal/server/spa/), so these
+# negations do not expose them.
 !internal/credential/
 !internal/credential/**
 !internal/secretkey/
@@ -663,13 +646,11 @@ migrate_*.sql
 *_credential*.sql
 system_credentials_backup.sql
 
-# Temporary credential files
-create_test_credential.py
-
-# Exception (again, for the patterns above): re-include the Go
-# rebuild's migration files. The 0007_credentials.sql migration
-# describes the credentials table schema; it's source, not data.
-!app/internal/db/migrations/*.sql
+# Exception (again, for the patterns above): re-include the migration files.
+# 0007_credentials.sql describes the credentials table schema; it is source,
+# not data. Without this, a new migration whose name matches *credential*,
+# *secret* or *password* is silently refused by git add.
+!internal/db/migrations/*.sql
 
 # ======================================
 # VIRTUAL ENVIRONMENTS AND SCRIPTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   codes, and the `license.quota_exceeded` audit event. **If you match on those
   codes, they will not appear again.** OpenWatch does not cap hosts, scans,
   users, or retention.
-- The `license_gated` field from `GET /api/v1/rbac`. Entitlement is decided by
-  the route, not the permission, because per-host and fleet-scale use the same
-  permission. **If you read that field, drop it:** it was populated for one
-  permission that no route required, so it never affected a request.
+- The `license_gated` field from `GET /api/v1/auth/permissions:registry`.
+  Entitlement is decided by the route, not the permission, because per-host and
+  fleet-scale use the same permission. **If you read that field, drop it:** it
+  was populated for one permission that no route required, so it never affected
+  a request.
 
 ### Fixed
 


### PR DESCRIPTION
Removing two dead negations turned up a live defect underneath one of them.

## A new migration could not be committed

```
$ git add internal/db/migrations/0099_secret_probe.sql
The following paths are ignored by one of your .gitignore files
```

The safety-net patterns (`*credential*`, `*secret*`, `*password*`, `*_credential*.sql`) are re-included by negation. The negation covering migrations was `!app/internal/db/migrations/*.sql`. **The Go tree moved from `app/` to the repo root on 2026-06-05**, so that path stopped existing and the negation reached nothing.

`0007_credentials.sql` survives only because git keeps a file once it is tracked. Any *new* one was refused.

That is the same silent-drop trap the repo has hit twice before, with a new `.spec` file and a new `packaging/tests/*test*.sh`.

## Also removed

Eight more negations pointing into trees that no longer exist: `!app/**`, and seven `backend/` and `tests/backend/` paths left from the archived Python project.

**A negation whose target is gone reads as coverage that is not there.** That is exactly how this one hid: the line looked like it protected migrations, and had for months protected nothing.

The spec-file exception is rewritten as a pattern (`!specs/**/*credential*.yaml`) rather than three hardcoded paths, so it does not rot the same way.

## Scope

Left alone deliberately: forward-looking placeholders whose targets do not exist yet but reasonably might, such as `!.env.template`, `!.vscode/settings.json` and `!config/*.example.*`. Those are harmless and intentional.

Also left: `backend/*` **ignore** rules (not negations). They match nothing and do nothing, so removing them is cleanup for another day.

## Verification

| Check | Result |
|---|---|
| New `*secret*` migration stages | Yes, `A internal/db/migrations/0099_secret_probe.sql` |
| Previously tracked file newly ignored | None, checked across every tracked path |
| `app/` or `backend/` negations remaining | None |

Probe file removed after testing.