### PR TITLE
docs(license): stop describing the deprecated slot as part of rotation

### DIFF
--- a/api/license.yaml
+++ b/api/license.yaml
@@ -118,11 +118,11 @@ components:
         support_contact: {type: string}
         warnings:
           type: array
-          description: Non-fatal observations (e.g., "deprecated key", "expiring soon")
+          description: Non-fatal observations (e.g., "expiring soon")
           items:
             type: object
             properties:
-              code: {type: string, examples: [license.using_deprecated_key, license.expiring_soon]}
+              code: {type: string, examples: [license.expiring_soon]}
               human_message: {type: string}
 
     FeatureCatalog:
@@ -237,8 +237,7 @@ paths:
             Warning:
               schema: {type: string}
               description: |
-                Set during grace period or when using a deprecated signing key.
-                RFC 7234 Warning header.
+                Set during the grace period. RFC 7234 Warning header.
           content:
             application/json:
               schema: {$ref: '#/components/schemas/License'}

--- a/internal/license/keys.go
+++ b/internal/license/keys.go
@@ -10,20 +10,29 @@ import (
 	"fmt"
 )
 
-// Embedded license-signing public keys. The current slot is required;
-// prev and deprecated slots are added when key rotation lands (post Stage 0).
+// Embedded license-signing public keys. Only the current slot is required.
 //
 //go:embed keys/*.pem
 var embeddedKeys embed.FS
 
-// publicKeys holds the parsed keys at package init. A token that matches no
-// slot fails validation. A token that matches the prev slot verifies and sets
-// the UsingPrevKey warning flag. The deprecated slot verifies only in dev mode
-// and sets no flag.
+// publicKeyRing holds the parsed keys at package init. A token matching no slot
+// fails validation. A token matching the prev slot verifies and sets the
+// UsingPrevKey warning flag.
+//
+// Rotation is two-stage: current, then prev, then retired. Hold prev for at
+// least the license term plus the grace period, about 13 months at the issuer's
+// typical 365-day term, and no license signed with that key can still be valid
+// when it is retired.
+//
+// The deprecated slot is reserved and is NOT a third rotation stage. Nothing
+// enables it: no production VerifyOptions sets AllowDeprecatedKey, dev mode
+// included. It is retained because it is the only policy gate in slot
+// selection, which is what the kid contract tests against
+// (system-license-validation AC-24: a kid naming this slot must not open it).
 type publicKeyRing struct {
 	current    ed25519.PublicKey
-	prev       ed25519.PublicKey // may be nil in Stage 0
-	deprecated ed25519.PublicKey // may be nil in Stage 0
+	prev       ed25519.PublicKey // nil unless a rotation has shipped one
+	deprecated ed25519.PublicKey // nil; reserved, see above
 }
 
 // loadEmbeddedKeys parses the PEM files baked into the binary. Called
@@ -37,9 +46,9 @@ func loadEmbeddedKeys() (*publicKeyRing, error) {
 	}
 	ring.current = cur
 
-	// Prev/deprecated are optional in Stage 0. When the rotation pattern
-	// arrives, drop license-pubkey-prev.pem / license-pubkey-deprecated.pem
-	// into internal/license/keys/ and they're picked up automatically.
+	// Both are optional. To rotate, drop license-pubkey-prev.pem into
+	// internal/license/keys/ and it is picked up automatically. The deprecated
+	// slot is reserved rather than part of rotation; see publicKeyRing.
 	if prev, err := parsePEMPublicKey("keys/license-pubkey-prev.pem"); err == nil {
 		ring.prev = prev
 	}

--- a/internal/license/validator.go
+++ b/internal/license/validator.go
@@ -42,8 +42,12 @@ type VerifyOptions struct {
 	// rolled-back clock does not move iat, so an iat comparison detects
 	// installing an older license instead, which is a different thing and
 	// not a threat here. See decision record 03.
-	LastKnownGood      time.Time
-	AllowDeprecatedKey bool // true only in OPENWATCH_DEV_MODE
+	LastKnownGood time.Time
+	// AllowDeprecatedKey admits the reserved deprecated slot. Nothing sets it
+	// outside tests, dev mode included, so the slot never enters the candidate
+	// list in production. It is the only policy gate in slot selection, which
+	// is what AC-24 tests: a kid naming that slot must not open it.
+	AllowDeprecatedKey bool
 }
 
 // clockRollbackTolerance is how far behind the watermark `now` may sit before
@@ -79,8 +83,9 @@ func Verify(jwtBlob string, ring *publicKeyRing, opts VerifyOptions) (*License, 
 	// to the list.
 	//
 	// The header is matched against the allowed slots built above, not against
-	// the whole ring, so a header naming the deprecated key outside dev mode
-	// matches nothing. That is what separates this from a thumbprint-to-key
+	// the whole ring, so a header naming the deprecated key matches nothing
+	// unless AllowDeprecatedKey put that slot in the list, which nothing in
+	// production does. That is what separates this from a thumbprint-to-key
 	// map. A map hands back any ring member whose thumbprint matches, which
 	// would open the deprecated slot to anyone able to read a public key and
 	// stamp a header.

--- a/internal/license/validator_kid_test.go
+++ b/internal/license/validator_kid_test.go
@@ -10,6 +10,7 @@
 // @ac AC-29  (TestKeyID_StableAndDistinct)
 // @ac AC-31  (TestVerify_MismatchedKidIsRecorded)
 // @ac AC-32  (TestLoadJWT_MismatchedKidReachesTheAuditTrail)
+// @ac AC-33  (TestNoProductionCodeOpensTheDeprecatedSlot)
 
 package license
 
@@ -23,6 +24,7 @@ import (
 	"encoding/pem"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -212,7 +214,9 @@ func TestVerify_KidDoesNotOpenDeprecatedSlot(t *testing.T) {
 			t.Errorf("AllowDeprecatedKey false: license = %+v, want nil", lic)
 		}
 
-		// Dev mode: the same token, now permitted.
+		// With the gate opened explicitly, the same token is permitted. Only a
+		// caller passing this option reaches the slot; nothing in production
+		// does, dev mode included.
 		lic, result, err := Verify(jwtBlob, fr.ring, VerifyOptions{AllowDeprecatedKey: true})
 		if err != nil {
 			t.Fatalf("AllowDeprecatedKey true: Verify: %v", err)
@@ -640,5 +644,55 @@ func TestKeyID_StableAndDistinct(t *testing.T) {
 				t.Errorf("two different keys share a key id: %q", idA)
 			}
 		})
+	})
+}
+
+// @ac AC-33
+// AC-33: no production code opens the deprecated slot.
+//
+// The option exists and the gate works; AC-24 proves that. What was never
+// guarded is the claim, repeated in four comments, that nothing in production
+// sets it. A comment asserting a property nothing checks is exactly how "still
+// validates but emits warning" survived for months against code that did
+// neither.
+func TestNoProductionCodeOpensTheDeprecatedSlot(t *testing.T) {
+	t.Run("system-license-validation/AC-33", func(t *testing.T) {
+		// Tests run from internal/license/, so the tree root is two up.
+		root, err := filepath.Abs(filepath.Join("..", ".."))
+		if err != nil {
+			t.Fatalf("resolve repo root: %v", err)
+		}
+		// Assignment in a composite literal or a plain assignment, set to true.
+		setter := regexp.MustCompile(`AllowDeprecatedKey\s*[:=]\s*true`)
+
+		walkErr := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				if name := info.Name(); name == ".git" || name == "node_modules" || name == "frontend" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			b, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			if setter.Match(b) {
+				rel, _ := filepath.Rel(root, path)
+				t.Errorf("%s sets AllowDeprecatedKey true. The deprecated slot is "+
+					"reserved, not a rotation step: nothing in production may open it. "+
+					"If this is deliberate, the comments in keys.go and validator.go "+
+					"and spec C-15 have to change with it", rel)
+			}
+			return nil
+		})
+		if walkErr != nil {
+			t.Fatalf("walk: %v", walkErr)
+		}
 	})
 }

--- a/specs/system/license-validation.spec.yaml
+++ b/specs/system/license-validation.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-license-validation
   title: License JWT validation
-  version: "2.1.0"
+  version: "2.2.0"
   status: approved
   tier: 1
 
@@ -240,3 +240,15 @@ spec:
       description: The mismatched kid reaches the audit trail. A load whose token carries a kid that did not select the verifying key emits license.installed with mismatched_key_id in the detail map, holding the presented kid. The conforming test reads the emitted event, not the License struct, because AC-31 already covers the struct. It also asserts the key is absent or empty when the kid did select the verifying key, so the detail does not report a mislabel that did not happen. No new audit code is added. license.installed already means a license was loaded and here is what it was.
       priority: critical
       references_constraints: [C-19]
+    - id: AC-33
+      description: >
+        No production code opens the deprecated slot. Source inspection over
+        every non-test .go file in the tree asserts that none assigns
+        AllowDeprecatedKey a true value. The option exists, the gate works and
+        AC-24 proves it, but nothing guarded the claim that production never
+        opens it. That claim sits in four code comments, and a comment asserting
+        a property nothing checks is how the "still validates but emits warning"
+        line survived for months against code that did neither. The test names
+        the offending file.
+      priority: high
+      references_constraints: [C-15]


### PR DESCRIPTION
`licensing_foundation.md` §4.2 said the once-`prev` key becomes `deprecated` and "still validates but emits warning".

**Neither half is true, and never was.** Nothing sets `AllowDeprecatedKey` outside tests, dev mode included, and the deprecated slot deliberately leaves `UsingPrevKey` false. Four code comments repeated the claim.

## Not a wording defect

An unbuilt feature described in five places: `AllowDeprecatedKey` with no setter, no `UsingDeprecatedKey` flag, and `license.using_deprecated_key` referenced in the contract while **never declared in `audit/events.yaml`**, so nothing could emit it.

## Why the third key is unnecessary

The issuance guide sets terms at `iat + 365d` typical. With the 30-day grace, a license lives about 13 months. **Hold `prev` for term plus grace and no license signed with a key can still be valid when that key is retired.**

Reversal condition, recorded in OW-005: if Hanalyx ever issues multi-year terms, the arithmetic changes.

## Why the slot stays

My first recommendation was to delete it. Checking the coupling changed that.

The slot is named by **six elements of a spec that published at 2.1.0 in #817**: C-02, C-15, C-17, AC-24, and both AC-27 and AC-30, which each require "three real, distinct keys".

And **AC-24 is the only concrete instance of "kid must not skip a policy gate"**, one of the two traps #817 existed to close. A two-slot ring has no policy gate in slot selection, so the property goes vacuous and its guard disappears.

## AC-33: the guard the comments needed

The pre-push hook blocked this change for having no annotation delta, and it was right.

The new comments assert *no production code opens the slot*, and **nothing enforced that**. A comment asserting a property nothing checks is exactly how the line being removed here survived for months against code that did neither thing it claimed. So the assertion became a test rather than another comment.

It walks every non-test `.go` file and names the offender. Mutation-checked:

```
cmd/openwatch/main.go sets AllowDeprecatedKey true. The deprecated slot is
reserved, not a rotation step: nothing in production may open it.
```

Restored byte-identical after.

## Verification

| Check | Result |
|---|---|
| `make spec-check` | exit 0. `system-license-validation` **33/33**, 119 specs passing |
| `go build`, `go vet`, `gofmt -l` | clean |
| `go test ./internal/license/` | ok |
| `check-doc-style.py` | clean |

`system-license-validation` 2.1.0 to 2.2.0, additive. **No behavior change**; `api/license.yaml` is a design fragment not in the live contract.

`licensing_foundation.md` §4.2 and §10 are corrected separately, since that tree is gitignored and never reaches a PR.