### PR TITLE
feat(audit): enforce the detail_schema events already declare

### DIFF
--- a/internal/audit/detailschema.go
+++ b/internal/audit/detailschema.go
@@ -1,0 +1,96 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync/atomic"
+)
+
+// Detail-schema enforcement.
+//
+// audit/events.yaml lets an event declare a detail_schema describing the keys
+// its detail map carries. Eighty events declare one. Until this file existed,
+// NOTHING read any of them: scripts/gen-audit-events.go parsed the block into a
+// struct field and emitted nothing from it, so an emitter could send any keys,
+// omit every declared key, or rename them, and no gate noticed.
+//
+// That is worse than an undocumented contract, because the declaration reads as
+// enforcement. It sits in a generated-code pipeline, in a file whose other
+// fields all produce output, written as a JSON Schema fragment. A reader
+// reasonably concludes something validates it. See bugs/OW-018.
+//
+// What this enforces, and what it does not:
+//
+//   - It checks that a detail map's keys are a SUBSET of the declared set. An
+//     undeclared key is a violation.
+//   - It does NOT require every declared key to be present. Many events carry a
+//     key only in some outcomes (a reason on failure, a count when non-zero),
+//     and demanding all of them would push emitters to send nulls, which is
+//     worse for the reader than an absent key.
+//   - It checks key names only, not types or enums. Emit sees a marshalled map,
+//     and a check that half-enforces a schema is worse than one that enforces
+//     the key set honestly.
+//   - An event declaring no schema is not checked. Absent and empty are the
+//     same thing here: nothing to check against.
+//
+// Coverage is what actually runs. This catches a violation on any emitted
+// event, including the thirteen call sites that build their detail map
+// dynamically and which no static analysis can reach. It does not prove that
+// an unexercised path conforms.
+
+// detailViolations counts schema violations seen since process start. Exported
+// through DetailViolations so a test can assert a path emitted cleanly.
+var detailViolations atomic.Int64
+
+// DetailViolations returns the number of audit events emitted with a detail key
+// the event's declared schema does not list.
+//
+// A test that exercises an emitting path can assert this stays at zero across
+// the path. It is a counter rather than a hard failure at the emit site on
+// purpose: an audit event carrying an unexpected key is still worth recording,
+// and dropping it would lose the very evidence an operator needs. The contract
+// is enforced by the count being asserted, not by the record being discarded.
+func DetailViolations() int64 { return detailViolations.Load() }
+
+// checkDetailSchema compares an event's detail keys against the declared set
+// for its code. It logs and counts a violation; it never alters the event.
+func checkDetailSchema(ctx context.Context, code Code, detail json.RawMessage) {
+	meta, ok := Metadata[code]
+	if !ok || len(meta.DetailKeys) == 0 || len(detail) == 0 {
+		return
+	}
+
+	var got map[string]json.RawMessage
+	if err := json.Unmarshal(detail, &got); err != nil {
+		// A detail that is not a JSON object is out of scope here. Redaction
+		// and the writer deal with shape; this function only knows key names.
+		return
+	}
+
+	allowed := make(map[string]struct{}, len(meta.DetailKeys))
+	for _, k := range meta.DetailKeys {
+		allowed[k] = struct{}{}
+	}
+
+	var undeclared []string
+	for k := range got {
+		if _, ok := allowed[k]; !ok {
+			undeclared = append(undeclared, k)
+		}
+	}
+	if len(undeclared) == 0 {
+		return
+	}
+	sort.Strings(undeclared)
+
+	detailViolations.Add(1)
+	slog.WarnContext(ctx, "audit detail carries keys its declared schema does not list",
+		slog.String("action", string(code)),
+		slog.String("undeclared", strings.Join(undeclared, ",")),
+		slog.String("declared", strings.Join(meta.DetailKeys, ",")),
+		slog.String("fix", "add the key to detail_schema in audit/events.yaml, or stop sending it"),
+	)
+}

--- a/internal/audit/detailschema_test.go
+++ b/internal/audit/detailschema_test.go
@@ -1,0 +1,97 @@
+// @spec system-audit-emission
+//
+// AC traceability (this file):
+//
+//	AC-17  TestDetailSchema_IsEnforced
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// @ac AC-17
+// AC-17: the declared detail_schema is read and enforced.
+//
+// Before this, scripts/gen-audit-events.go parsed detail_schema into a struct
+// field and emitted nothing from it, so 80 events declared a detail contract
+// that nothing checked. The generated-code pipeline made the declaration read
+// as enforcement while enforcing nothing, which is the shape this codebase
+// keeps producing.
+func TestDetailSchema_IsEnforced(t *testing.T) {
+	t.Run("system-audit-emission/AC-17", func(t *testing.T) {
+		// The generator emits a key set for every event that declares one, and
+		// for no event that does not. Asserting the counts match keeps a
+		// silently-dropped schema from passing: if the template stopped
+		// emitting DetailKeys, every count below would be zero and the
+		// subset checks would all pass vacuously.
+		declared := 0
+		for _, m := range Metadata {
+			if len(m.DetailKeys) > 0 {
+				declared++
+			}
+		}
+		if declared == 0 {
+			t.Fatal("no event carries DetailKeys; the generator is not emitting " +
+				"detail_schema, so every check below would pass against nothing")
+		}
+
+		// A code that declares a schema, chosen from the registry rather than
+		// hardcoded so this does not rot when events.yaml changes.
+		var withSchema Code
+		var keys []string
+		for c, m := range Metadata {
+			if len(m.DetailKeys) > 0 {
+				withSchema, keys = c, m.DetailKeys
+				break
+			}
+		}
+
+		ctx := context.Background()
+
+		// A subset of the declared keys is not a violation. An event that
+		// carries a key only on some outcomes is normal, and demanding every
+		// declared key would push emitters to send nulls.
+		before := DetailViolations()
+		checkDetailSchema(ctx, withSchema, mustJSON(t, map[string]any{keys[0]: "x"}))
+		if got := DetailViolations(); got != before {
+			t.Errorf("a subset of declared keys counted as a violation: %d -> %d", before, got)
+		}
+
+		// An undeclared key is a violation.
+		before = DetailViolations()
+		checkDetailSchema(ctx, withSchema, mustJSON(t, map[string]any{"definitely_not_declared": 1}))
+		if got := DetailViolations(); got != before+1 {
+			t.Errorf("an undeclared key did not count as a violation: %d -> %d, want %d",
+				before, got, before+1)
+		}
+
+		// An event declaring no schema is never checked, so an absent
+		// declaration and an empty one behave alike.
+		var noSchema Code
+		for c, m := range Metadata {
+			if len(m.DetailKeys) == 0 {
+				noSchema = c
+				break
+			}
+		}
+		if noSchema == "" {
+			t.Skip("every event declares a schema; nothing to check here")
+		}
+		before = DetailViolations()
+		checkDetailSchema(ctx, noSchema, mustJSON(t, map[string]any{"anything": true}))
+		if got := DetailViolations(); got != before {
+			t.Errorf("an event with no declared schema was checked: %d -> %d", before, got)
+		}
+	})
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/internal/audit/emit.go
+++ b/internal/audit/emit.go
@@ -163,6 +163,10 @@ func prepareEvent(ctx context.Context, code Code, ev Event) *Event {
 			pkgMissingCorrelation.Add(1)
 		}
 	}
+	// Both Emit and EmitSync funnel through here, so this is the one place the
+	// declared detail_schema is checked. See detailschema.go for what it does
+	// and deliberately does not enforce.
+	checkDetailSchema(ctx, code, ev.Detail)
 	return &ev
 }
 

--- a/internal/audit/events.gen.go
+++ b/internal/audit/events.gen.go
@@ -328,6 +328,12 @@ type EventMeta struct {
 	Severity    Severity
 	Description string
 	ActorTypes  []string
+
+	// DetailKeys is the sorted property set of the event's detail_schema in
+	// audit/events.yaml, empty when it declares none. Emit checks a detail
+	// map against it. Before this existed the schema was parsed and dropped,
+	// so 80 events declared a detail contract that nothing read.
+	DetailKeys []string
 }
 
 // Metadata maps every active event code to its registry entry.
@@ -338,6 +344,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `User authenticated successfully`,
 		ActorTypes:  []string{"user"},
+		DetailKeys:  []string{"auth_method", "mfa_used"},
 	},
 	AuthLoginFailure: {
 		Code:        AuthLoginFailure,
@@ -345,6 +352,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Authentication attempt failed`,
 		ActorTypes:  []string{"user"},
+		DetailKeys:  []string{"auth_method", "reason"},
 	},
 	AuthLogout: {
 		Code:        AuthLogout,
@@ -352,6 +360,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `User explicitly logged out`,
 		ActorTypes:  []string{"user"},
+		DetailKeys:  nil,
 	},
 	AuthTokenIssued: {
 		Code:        AuthTokenIssued,
@@ -359,6 +368,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Access or refresh token issued`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"token_type", "ttl_seconds"},
 	},
 	AuthTokenRefreshed: {
 		Code:        AuthTokenRefreshed,
@@ -366,6 +376,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Refresh token used to issue new access token`,
 		ActorTypes:  []string{"api_key", "user"},
+		DetailKeys:  nil,
 	},
 	AuthTokenRevoked: {
 		Code:        AuthTokenRevoked,
@@ -373,6 +384,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Token added to revocation blacklist`,
 		ActorTypes:  []string{"system", "user"},
+		DetailKeys:  []string{"reason"},
 	},
 	AuthMfaEnrolled: {
 		Code:        AuthMfaEnrolled,
@@ -380,6 +392,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `User completed MFA enrollment`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"method"},
 	},
 	AuthMfaValidated: {
 		Code:        AuthMfaValidated,
@@ -387,6 +400,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `MFA challenge passed during login`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthMfaFailed: {
 		Code:        AuthMfaFailed,
@@ -394,6 +408,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `MFA challenge failed`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthMfaDisabled: {
 		Code:        AuthMfaDisabled,
@@ -401,6 +416,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `User disabled MFA on their account`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthSessionCreated: {
 		Code:        AuthSessionCreated,
@@ -408,6 +424,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `New session opened`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthSessionExpired: {
 		Code:        AuthSessionExpired,
@@ -415,6 +432,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Session timed out (idle or absolute)`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"reason"},
 	},
 	AuthSessionRevoked: {
 		Code:        AuthSessionRevoked,
@@ -422,6 +440,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Session revoked (explicit logout or admin action)`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthPasswordChanged: {
 		Code:        AuthPasswordChanged,
@@ -429,6 +448,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `User's password was successfully updated`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthProfileUpdated: {
 		Code:        AuthProfileUpdated,
@@ -436,6 +456,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `User updated their own profile (self-service). email_changed is true when the update included the sign-in email.`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"email_changed"},
 	},
 	AuthPasswordPolicyFailed: {
 		Code:        AuthPasswordPolicyFailed,
@@ -443,6 +464,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Password change rejected by the NIST 800-63B policy validator`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthApiKeyCreated: {
 		Code:        AuthApiKeyCreated,
@@ -450,6 +472,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `API key issued`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthApiKeyRevoked: {
 		Code:        AuthApiKeyRevoked,
@@ -457,6 +480,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `API key invalidated`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthPolicyUpdated: {
 		Code:        AuthPolicyUpdated,
@@ -464,6 +488,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Workspace authentication policy changed (require-MFA, session timeouts)`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthzPermissionDenied: {
 		Code:        AuthzPermissionDenied,
@@ -471,6 +496,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `RBAC denied an authenticated request`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"required_permission", "route"},
 	},
 	AuthzRoleAssigned: {
 		Code:        AuthzRoleAssigned,
@@ -478,6 +504,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Role assigned to user`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AuthzRoleRemoved: {
 		Code:        AuthzRoleRemoved,
@@ -485,6 +512,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Role removed from user`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	HostCreated: {
 		Code:        HostCreated,
@@ -492,6 +520,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	HostUpdated: {
 		Code:        HostUpdated,
@@ -499,6 +528,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	HostDeleted: {
 		Code:        HostDeleted,
@@ -506,6 +536,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	HostConnectivityChecked: {
 		Code:        HostConnectivityChecked,
@@ -513,6 +544,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"ping_success", "response_time_ms", "ssh_accessible"},
 	},
 	HostPlatformDetected: {
 		Code:        HostPlatformDetected,
@@ -520,6 +552,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"os_family", "os_version", "platform_identifier"},
 	},
 	HostDiscoveryCompleted: {
 		Code:        HostDiscoveryCompleted,
@@ -527,6 +560,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Host OS fingerprint Discovery run finished successfully; carries the captured facts as detail`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"architecture", "discovered_at", "kernel_release", "os_family", "os_version"},
 	},
 	HostIntelligenceRefreshed: {
 		Code:        HostIntelligenceRefreshed,
@@ -534,6 +568,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AccountUserLocked: {
 		Code:        AccountUserLocked,
@@ -541,6 +576,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `User account lock detected via passwd/shadow comparison`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"user"},
 	},
 	AccountUserUnlocked: {
 		Code:        AccountUserUnlocked,
@@ -548,6 +584,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `User account unlock detected via passwd/shadow comparison`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"user"},
 	},
 	AccountUserCreated: {
 		Code:        AccountUserCreated,
@@ -555,6 +592,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `New user account appeared in /etc/passwd since prior snapshot`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"uid", "user"},
 	},
 	AccountUserDeleted: {
 		Code:        AccountUserDeleted,
@@ -562,6 +600,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `User account removed from /etc/passwd since prior snapshot`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"user"},
 	},
 	AccountUserPrivilegedGroupAdded: {
 		Code:        AccountUserPrivilegedGroupAdded,
@@ -569,6 +608,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityCritical,
 		Description: `User added to wheel/sudo/admin group since prior snapshot`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"group", "user"},
 	},
 	AccountPasswordExpired: {
 		Code:        AccountPasswordExpired,
@@ -576,6 +616,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Password expiry crossed since prior snapshot`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"user"},
 	},
 	AccountPasswordExpiring: {
 		Code:        AccountPasswordExpiring,
@@ -583,6 +624,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Password expiry within warning window`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"days_remaining", "user"},
 	},
 	AccountSshKeyAdded: {
 		Code:        AccountSshKeyAdded,
@@ -590,6 +632,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `New authorized_keys entry detected for a user`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"fingerprint", "user"},
 	},
 	AccountSshKeyRemoved: {
 		Code:        AccountSshKeyRemoved,
@@ -597,6 +640,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `authorized_keys entry removed for a user`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"fingerprint", "user"},
 	},
 	AccountSudoFailureThreshold: {
 		Code:        AccountSudoFailureThreshold,
@@ -604,6 +648,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Sudo failure count crossed the per-cycle threshold`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"count", "user"},
 	},
 	SecurityLoginNewSourceIp: {
 		Code:        SecurityLoginNewSourceIp,
@@ -611,6 +656,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Known user logged in from previously-unseen source IP`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"source_ip", "user"},
 	},
 	SecurityLoginFailedThreshold: {
 		Code:        SecurityLoginFailedThreshold,
@@ -618,6 +664,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Failed login count crossed the per-cycle threshold`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"count", "user"},
 	},
 	SecuritySelinuxDenied: {
 		Code:        SecuritySelinuxDenied,
@@ -625,6 +672,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `SELinux denial entry observed in audit log since prior cycle`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"denial"},
 	},
 	SecurityApparmorDenied: {
 		Code:        SecurityApparmorDenied,
@@ -632,6 +680,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `AppArmor denial entry observed in audit log since prior cycle`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"denial"},
 	},
 	SecurityFirewallRuleChanged: {
 		Code:        SecurityFirewallRuleChanged,
@@ -639,6 +688,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `Firewall ruleset hash changed since prior cycle`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"current_hash", "prior_hash"},
 	},
 	SecurityPortOpened: {
 		Code:        SecurityPortOpened,
@@ -646,6 +696,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `New listening port observed`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"port", "protocol"},
 	},
 	SystemPackageInstalled: {
 		Code:        SystemPackageInstalled,
@@ -653,6 +704,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Newly installed package observed`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"name", "version"},
 	},
 	SystemPackageUpdated: {
 		Code:        SystemPackageUpdated,
@@ -660,6 +712,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Package upgraded to a new version`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"current", "name", "prior"},
 	},
 	SystemPackageRemoved: {
 		Code:        SystemPackageRemoved,
@@ -667,6 +720,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Previously-installed package no longer present`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"name"},
 	},
 	SystemKernelUpdated: {
 		Code:        SystemKernelUpdated,
@@ -674,6 +728,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `New kernel installed; reboot likely pending`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"current", "prior"},
 	},
 	SystemRebootRequired: {
 		Code:        SystemRebootRequired,
@@ -681,6 +736,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Host indicates a reboot is required (vendor marker file present)`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	SystemRebootCompleted: {
 		Code:        SystemRebootCompleted,
@@ -688,6 +744,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Host uptime fell below the prior cycle's value — reboot completed`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	SystemConfigFileChanged: {
 		Code:        SystemConfigFileChanged,
@@ -695,6 +752,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `Critical host config file content hash changed (e.g. /etc/sudoers)`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"current_hash", "path", "prior_hash"},
 	},
 	SystemServiceStarted: {
 		Code:        SystemServiceStarted,
@@ -702,6 +760,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Systemd unit transitioned to active`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"unit"},
 	},
 	SystemServiceStopped: {
 		Code:        SystemServiceStopped,
@@ -709,6 +768,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Systemd unit transitioned to inactive`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"unit"},
 	},
 	SystemServiceFailed: {
 		Code:        SystemServiceFailed,
@@ -716,6 +776,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `Systemd unit transitioned to failed`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"unit"},
 	},
 	SystemFilesystemMounted: {
 		Code:        SystemFilesystemMounted,
@@ -723,6 +784,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Mountpoint that did not exist in prior cycle is now mounted`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"mountpoint", "source"},
 	},
 	SystemFilesystemUnmounted: {
 		Code:        SystemFilesystemUnmounted,
@@ -730,6 +792,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Previously-mounted mountpoint is no longer mounted`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"mountpoint"},
 	},
 	HostBulkImported: {
 		Code:        HostBulkImported,
@@ -737,6 +800,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"failed", "successful", "total_processed"},
 	},
 	CredentialCreated: {
 		Code:        CredentialCreated,
@@ -744,6 +808,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"auth_method", "credential_id", "scope"},
 	},
 	CredentialUpdated: {
 		Code:        CredentialUpdated,
@@ -751,6 +816,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"auth_method", "credential_id", "scope", "secret_rotated"},
 	},
 	CredentialDeleted: {
 		Code:        CredentialDeleted,
@@ -758,6 +824,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"credential_id"},
 	},
 	ScanQueued: {
 		Code:        ScanQueued,
@@ -765,6 +832,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"framework", "template_id"},
 	},
 	ScanStarted: {
 		Code:        ScanStarted,
@@ -772,6 +840,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ScanCompleted: {
 		Code:        ScanCompleted,
@@ -779,6 +848,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"compliance_score", "failed", "passed", "skipped"},
 	},
 	ScanFailed: {
 		Code:        ScanFailed,
@@ -786,6 +856,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"error_code", "error_message"},
 	},
 	ScanCancelled: {
 		Code:        ScanCancelled,
@@ -793,6 +864,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"cancellation_reason"},
 	},
 	ScanSessionCreated: {
 		Code:        ScanSessionCreated,
@@ -800,6 +872,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"total_hosts"},
 	},
 	ScanSessionCancelled: {
 		Code:        ScanSessionCancelled,
@@ -807,6 +880,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ScanTemplateCreated: {
 		Code:        ScanTemplateCreated,
@@ -814,6 +888,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ScanTemplateUpdated: {
 		Code:        ScanTemplateUpdated,
@@ -821,6 +896,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ScanTemplateDeleted: {
 		Code:        ScanTemplateDeleted,
@@ -828,6 +904,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceStateChanged: {
 		Code:        ComplianceStateChanged,
@@ -835,6 +912,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Rule state transition (write-on-change pattern)`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"new_status", "previous_status", "rule_id"},
 	},
 	FindingPersisted: {
 		Code:        FindingPersisted,
@@ -842,6 +920,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `A single rule finding was persisted to the transaction log (one per transactions row insert). Spec system-transaction-log-writer AC-09.`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"change_kind", "host_id", "prior_status", "rule_id", "scan_id", "status"},
 	},
 	WriterApplyFailed: {
 		Code:        WriterApplyFailed,
@@ -849,6 +928,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `writer.Apply rolled back the entire batch due to a DB error (FK violation, deadlock, oversize evidence). Spec system-transaction-log-writer AC-15.`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"host_id", "offending_rule_id", "reason", "rule_count_attempted", "scan_id"},
 	},
 	ComplianceExceptionRequested: {
 		Code:        ComplianceExceptionRequested,
@@ -856,6 +936,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceExceptionApproved: {
 		Code:        ComplianceExceptionApproved,
@@ -863,6 +944,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceExceptionRejected: {
 		Code:        ComplianceExceptionRejected,
@@ -870,6 +952,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceExceptionRevoked: {
 		Code:        ComplianceExceptionRevoked,
@@ -877,6 +960,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceExceptionExpired: {
 		Code:        ComplianceExceptionExpired,
@@ -884,6 +968,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceBaselineEstablished: {
 		Code:        ComplianceBaselineEstablished,
@@ -891,6 +976,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceBaselineCleared: {
 		Code:        ComplianceBaselineCleared,
@@ -898,6 +984,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ComplianceDriftDetected: {
 		Code:        ComplianceDriftDetected,
@@ -905,6 +992,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"drift_type", "score_delta"},
 	},
 	ComplianceSnapshotCreated: {
 		Code:        ComplianceSnapshotCreated,
@@ -912,6 +1000,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AlertCreated: {
 		Code:        AlertCreated,
@@ -919,6 +1008,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"alert_severity", "alert_type"},
 	},
 	AlertAcknowledged: {
 		Code:        AlertAcknowledged,
@@ -926,6 +1016,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AlertSilenced: {
 		Code:        AlertSilenced,
@@ -933,6 +1024,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Operator silenced an alert (active -> silenced)`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"prior_state", "reason", "until"},
 	},
 	AlertUnsilencedAuto: {
 		Code:        AlertUnsilencedAuto,
@@ -940,6 +1032,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Lifecycle sweep re-armed a silenced alert whose silenced_until elapsed`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"silenced_until"},
 	},
 	AlertResolved: {
 		Code:        AlertResolved,
@@ -947,6 +1040,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AlertDismissed: {
 		Code:        AlertDismissed,
@@ -954,6 +1048,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Operator marked an alert as irrelevant (terminal state)`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"prior_state", "reason"},
 	},
 	AlertThresholdChanged: {
 		Code:        AlertThresholdChanged,
@@ -961,6 +1056,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	NotificationDispatched: {
 		Code:        NotificationDispatched,
@@ -968,6 +1064,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"channel_type", "delivery_id"},
 	},
 	NotificationDeliveryFailed: {
 		Code:        NotificationDeliveryFailed,
@@ -975,6 +1072,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	NotificationDeliverySucceeded: {
 		Code:        NotificationDeliverySucceeded,
@@ -982,6 +1080,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	NotificationChannelCreated: {
 		Code:        NotificationChannelCreated,
@@ -989,6 +1088,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	NotificationChannelUpdated: {
 		Code:        NotificationChannelUpdated,
@@ -996,6 +1096,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	NotificationChannelDeleted: {
 		Code:        NotificationChannelDeleted,
@@ -1003,6 +1104,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	LicenseInstalled: {
 		Code:        LicenseInstalled,
@@ -1010,6 +1112,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	LicenseInvalid: {
 		Code:        LicenseInvalid,
@@ -1017,6 +1120,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	LicenseExpiringSoon: {
 		Code:        LicenseExpiringSoon,
@@ -1024,6 +1128,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	LicenseExpired: {
 		Code:        LicenseExpired,
@@ -1031,6 +1136,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	LicenseFeatureCheckDenied: {
 		Code:        LicenseFeatureCheckDenied,
@@ -1038,6 +1144,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"feature", "suppressed_count"},
 	},
 	LicenseClockRollbackDetected: {
 		Code:        LicenseClockRollbackDetected,
@@ -1045,6 +1152,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityCritical,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	LicenseTampered: {
 		Code:        LicenseTampered,
@@ -1052,6 +1160,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityCritical,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	PolicyLoaded: {
 		Code:        PolicyLoaded,
@@ -1059,6 +1168,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"policy_type", "policy_version"},
 	},
 	PolicyInvalid: {
 		Code:        PolicyInvalid,
@@ -1066,6 +1176,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	PolicyApplied: {
 		Code:        PolicyApplied,
@@ -1073,6 +1184,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Operation evaluated against a versioned policy`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"decision", "policy_type", "policy_version"},
 	},
 	RemediationRequested: {
 		Code:        RemediationRequested,
@@ -1080,6 +1192,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	RemediationApproved: {
 		Code:        RemediationApproved,
@@ -1087,6 +1200,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	RemediationExecuted: {
 		Code:        RemediationExecuted,
@@ -1094,6 +1208,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"dry_run", "steps_failed", "steps_succeeded"},
 	},
 	RemediationRolledBack: {
 		Code:        RemediationRolledBack,
@@ -1101,6 +1216,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	ReportGenerated: {
 		Code:        ReportGenerated,
@@ -1108,6 +1224,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"kind", "report_id", "scope_label"},
 	},
 	ReportScheduleCreated: {
 		Code:        ReportScheduleCreated,
@@ -1115,6 +1232,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"channel_id", "frequency", "kind", "name", "schedule_id"},
 	},
 	ReportScheduleDeleted: {
 		Code:        ReportScheduleDeleted,
@@ -1122,6 +1240,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"schedule_id"},
 	},
 	ReportScheduleToggled: {
 		Code:        ReportScheduleToggled,
@@ -1129,6 +1248,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"enabled", "schedule_id"},
 	},
 	IntegrationWebhookDelivered: {
 		Code:        IntegrationWebhookDelivered,
@@ -1136,6 +1256,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	IntegrationWebhookFailed: {
 		Code:        IntegrationWebhookFailed,
@@ -1143,6 +1264,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	IntegrationWebhookSubscribed: {
 		Code:        IntegrationWebhookSubscribed,
@@ -1150,6 +1272,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `External subscriber registered for event delivery`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"event_types", "target_url"},
 	},
 	IntegrationWebhookUnsubscribed: {
 		Code:        IntegrationWebhookUnsubscribed,
@@ -1157,6 +1280,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Webhook subscription deleted; no further deliveries`,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	IntegrationPluginInstalled: {
 		Code:        IntegrationPluginInstalled,
@@ -1164,6 +1288,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	IntegrationPluginExecuted: {
 		Code:        IntegrationPluginExecuted,
@@ -1171,6 +1296,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	SystemStartup: {
 		Code:        SystemStartup,
@@ -1178,6 +1304,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Service has booted and is accepting requests`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  nil,
 	},
 	SystemShutdown: {
 		Code:        SystemShutdown,
@@ -1185,6 +1312,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  nil,
 	},
 	SystemConfigChanged: {
 		Code:        SystemConfigChanged,
@@ -1192,6 +1320,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `An operator-tunable runtime config value was updated via the system_config table`,
 		ActorTypes:  []string{"system", "user"},
+		DetailKeys:  []string{"changed_by", "config_key", "new_value", "old_value"},
 	},
 	SystemIntelligenceSudoPasswordUsed: {
 		Code:        SystemIntelligenceSudoPasswordUsed,
@@ -1199,6 +1328,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `Emitted exactly once per host per cycle when the SSH dial layer used the credential's stored password as the sudo password (sudo -S fallback) because the host did not honor sudo -n NOPASSWD for one or more probe commands. Gated on system_config.security.allow_credential_sudo_password. Spec: system-ssh-connectivity v1.1.0 C-09..C-12 + AC-16.`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"command_count", "credential_id", "host_id"},
 	},
 	SystemMigrationApplied: {
 		Code:        SystemMigrationApplied,
@@ -1206,6 +1336,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"migration_id"},
 	},
 	SystemHealthDegraded: {
 		Code:        SystemHealthDegraded,
@@ -1213,6 +1344,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"component", "reason"},
 	},
 	SystemHealthRecovered: {
 		Code:        SystemHealthRecovered,
@@ -1220,6 +1352,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	SchedulerStartupFailed: {
 		Code:        SchedulerStartupFailed,
@@ -1227,6 +1360,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `Scheduler refused to start because the schedules policy was missing or failed Ed25519 verification`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"policy_path", "reason"},
 	},
 	SchedulerScheduleUpdated: {
 		Code:        SchedulerScheduleUpdated,
@@ -1234,6 +1368,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `A row in host_compliance_schedule was updated (next_scheduled_scan, maintenance_mode, or manual override)`,
 		ActorTypes:  []string{"system", "user"},
+		DetailKeys:  []string{"change_kind", "host_id", "new", "prior"},
 	},
 	SchedulerPolicyReloadRejected: {
 		Code:        SchedulerPolicyReloadRejected,
@@ -1241,6 +1376,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `Runtime policy reload was rejected; the previous valid policy remains active`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"policy_version_active", "policy_version_attempted", "reason"},
 	},
 	SchedulerPolicyClamped: {
 		Code:        SchedulerPolicyClamped,
@@ -1248,6 +1384,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `A tier interval in the schedules policy was clamped to the safety floor (5 min) or ceiling (48 h)`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"clamp_kind", "clamped_minutes", "original_minutes", "tier"},
 	},
 	SchedulerPolicyRevokedKeyRejected: {
 		Code:        SchedulerPolicyRevokedKeyRejected,
@@ -1255,6 +1392,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `A schedules policy was signed by a previously-rotated (revoked) signing key and rejected even though the Ed25519 signature was mathematically valid`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"key_fingerprint", "policy_version"},
 	},
 	SchedulerJobHmacRejected: {
 		Code:        SchedulerJobHmacRejected,
@@ -1262,6 +1400,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityError,
 		Description: `A dequeued scan job failed HMAC verification; the job payload was tampered after enqueue`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"failure", "host_id", "job_id"},
 	},
 	SchedulerTickDispatched: {
 		Code:        SchedulerTickDispatched,
@@ -1269,6 +1408,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Scheduler tick dispatched zero or more scan jobs to the queue`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"dispatched_count", "due_count", "skipped_backoff_count", "skipped_maintenance_count"},
 	},
 	WorkerLoopTick: {
 		Code:        WorkerLoopTick,
@@ -1276,6 +1416,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Periodic heartbeat from openwatch worker — at 55..65s intervals (60s nominal with jitter)`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  []string{"claimed_count", "completed_since_last_tick", "idle_count", "in_flight_count"},
 	},
 	AdminUserCreated: {
 		Code:        AdminUserCreated,
@@ -1283,6 +1424,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminUserUpdated: {
 		Code:        AdminUserUpdated,
@@ -1290,6 +1432,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminUserDeleted: {
 		Code:        AdminUserDeleted,
@@ -1297,6 +1440,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminUserPasswordReset: {
 		Code:        AdminUserPasswordReset,
@@ -1304,6 +1448,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `An administrator reset another user's (or their own) password.`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"self", "target_user_id"},
 	},
 	AdminUserDisabled: {
 		Code:        AdminUserDisabled,
@@ -1311,6 +1456,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `An administrator disabled a user account (cannot authenticate).`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"target_user_id"},
 	},
 	AdminUserEnabled: {
 		Code:        AdminUserEnabled,
@@ -1318,6 +1464,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `An administrator re-enabled a previously disabled user account.`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"target_user_id"},
 	},
 	AdminRoleChanged: {
 		Code:        AdminRoleChanged,
@@ -1325,6 +1472,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminSystemSettingChanged: {
 		Code:        AdminSystemSettingChanged,
@@ -1332,6 +1480,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminRetentionPolicyChanged: {
 		Code:        AdminRetentionPolicyChanged,
@@ -1339,6 +1488,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminSsoProviderCreated: {
 		Code:        AdminSsoProviderCreated,
@@ -1346,6 +1496,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	AdminSsoProviderUpdated: {
 		Code:        AdminSsoProviderUpdated,
@@ -1353,6 +1504,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: `SSO provider config changed (enable/disable, secret rotation, metadata refresh)`,
 		ActorTypes:  nil,
+		DetailKeys:  []string{"fields_changed", "provider_type"},
 	},
 	AdminSsoProviderDeleted: {
 		Code:        AdminSsoProviderDeleted,
@@ -1360,6 +1512,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityWarning,
 		Description: ``,
 		ActorTypes:  nil,
+		DetailKeys:  nil,
 	},
 	DiagnosticsTestJobCompleted: {
 		Code:        DiagnosticsTestJobCompleted,
@@ -1367,6 +1520,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Worker drained a diagnostics.test_job and emitted this completion event`,
 		ActorTypes:  []string{"system"},
+		DetailKeys:  nil,
 	},
 }
 

--- a/scripts/gen-audit-events.go
+++ b/scripts/gen-audit-events.go
@@ -83,6 +83,12 @@ type EventMeta struct {
 	Severity    Severity
 	Description string
 	ActorTypes  []string
+
+	// DetailKeys is the sorted property set of the event's detail_schema in
+	// audit/events.yaml, empty when it declares none. Emit checks a detail
+	// map against it. Before this existed the schema was parsed and dropped,
+	// so 80 events declared a detail contract that nothing read.
+	DetailKeys []string
 }
 
 // Metadata maps every active event code to its registry entry.
@@ -94,6 +100,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    Severity{{ .GoSeverity }},
 		Description: ` + "`" + `{{ .Description }}` + "`" + `,
 		ActorTypes:  {{ .GoActorTypes }},
+		DetailKeys:  {{ .GoDetailKeys }},
 	},
 {{- end }}
 }
@@ -127,6 +134,7 @@ type emitEvent struct {
 	Description  string
 	ActorTypes   []string
 	GoActorTypes string // Go source: nil or []string{"..."}
+	GoDetailKeys string // Go source: nil or []string{"..."}
 }
 
 func main() {
@@ -181,6 +189,7 @@ func enrich(e event) emitEvent {
 		Description:  cleanDescription(e.Description),
 		ActorTypes:   e.ActorTypes,
 		GoActorTypes: actorTypesLiteral(e.ActorTypes),
+		GoDetailKeys: detailKeysLiteral(e.DetailSchema),
 	}
 }
 
@@ -223,6 +232,28 @@ func cleanDescription(s string) string {
 }
 
 // actorTypesLiteral renders []string{"user","system"} as a Go literal.
+// detailKeysLiteral renders the property names of an event's detail_schema as
+// Go source. Returns "nil" when the event declares no schema or declares one
+// with no properties, so an empty declaration and an absent one are the same
+// thing to Emit: nothing to check against.
+//
+// Only the top-level property names are taken. A nested type or an enum is a
+// finer claim than Emit can act on, since it sees a marshalled detail map, and
+// a check that half-enforces a schema is worse than one that enforces the key
+// set honestly.
+func detailKeysLiteral(schema map[string]interface{}) string {
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok || len(props) == 0 {
+		return "nil"
+	}
+	quoted := make([]string, 0, len(props))
+	for k := range props {
+		quoted = append(quoted, `"`+k+`"`)
+	}
+	sort.Strings(quoted)
+	return "[]string{" + strings.Join(quoted, ", ") + "}"
+}
+
 func actorTypesLiteral(at []string) string {
 	if len(at) == 0 {
 		return "nil"

--- a/specs/system/audit-emission.spec.yaml
+++ b/specs/system/audit-emission.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-audit-emission
   title: Audit event emission
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -66,6 +66,28 @@ spec:
       type: security
       enforcement: error
 
+    - id: C-09
+      description: >
+        An event's declared detail_schema MUST be read. audit/events.yaml lets
+        an event declare the keys its detail map carries, and 80 events declare
+        one. Until this constraint, nothing read any of them:
+        scripts/gen-audit-events.go parsed the block into a struct field and
+        emitted nothing from it, so an emitter could send any keys, omit every
+        declared key, or rename them, and no gate noticed. That is worse than
+        an undocumented contract, because the declaration reads as enforcement:
+        it sits in a generated-code pipeline, in a file whose other fields all
+        produce output, written as a JSON Schema fragment. The generator MUST
+        emit the property names, and Emit MUST compare an event's detail keys
+        against them. The check is a SUBSET check on names: an undeclared key
+        is a violation, an absent declared key is not, because many events
+        carry a key only in some outcomes and demanding all of them would push
+        emitters to send nulls. Types and enums are out of scope, since a check
+        that half-enforces a schema is worse than one that enforces the key set
+        honestly. A violation MUST be counted and logged, and MUST NOT drop the
+        event: an audit record carrying an unexpected key is still the evidence
+        an operator needs.
+      type: technical
+      enforcement: error
   acceptance_criteria:
     - id: AC-01
       description: Codegen produces events.gen.go with one typed constant per event in events.yaml.
@@ -122,3 +144,16 @@ spec:
       description: 'v1.1.0 — ClipDetail truncates a string longer than MaxDetailFieldLen (256) runes to that length, replaces control characters (e.g. newline, tab, NUL) with spaces, and leaves a short clean string unchanged. The login-failure emitters (identity binder + server auth handler) pass the User-Agent and submitted username through ClipDetail before recording them in audit detail.'
       priority: high
       references_constraints: [C-08]
+    - id: AC-17
+      description: >
+        The declared detail_schema is enforced. Every event whose events.yaml
+        entry declares a detail_schema with properties has a non-empty
+        DetailKeys in the generated Metadata, and the count matches the number
+        of declarations. Emitting a detail carrying an undeclared key increments DetailViolations and logs the offending key names; emitting
+        one whose keys are a subset does not. An event declaring no schema is
+        never counted, so an absent declaration and an empty one behave alike.
+        A negative case proves the check can fail: without it, an event sending
+        a key no schema lists passes silently, which is the state this spec
+        version corrects.
+      priority: high
+      references_constraints: [C-09]


### PR DESCRIPTION
`audit/events.yaml` lets an event declare the keys its detail map carries. **80 events declare one. Nothing read any of them.**

`scripts/gen-audit-events.go` mentioned `DetailSchema` exactly once, as a struct field. It parsed the block and emitted nothing. So an emitter could send any keys, omit every declared key, or rename them, and no gate noticed.

That is worse than an undocumented contract, because **the declaration reads as enforcement**: it sits in a generated-code pipeline, in a file whose other fields all produce output, written as a JSON Schema fragment. A reader reasonably concludes something validates it.

Closes `bugs/OW-018`.

## The fix

The generator emits the property names as `DetailKeys` — 148 events, **80 non-nil**, matching the declarations exactly. `prepareEvent` checks against them, which is the one place `Emit` and `EmitSync` both funnel through.

## What it enforces, and what it deliberately does not

- **A subset check on key names.** An undeclared key is a violation.
- **An absent declared key is not.** Many events carry a key only on some outcomes, and demanding all of them would push emitters to send nulls, which is worse for a reader than an absent key.
- **Not types or enums.** `Emit` sees a marshalled map, and a check that half-enforces a schema is worse than one that enforces the key set honestly.
- **A violation is counted and logged, never dropped.** An audit record carrying an unexpected key is still the evidence an operator needs. The contract is enforced by the count being asserted, not by the record being discarded.

## The result is preventive, not corrective, and that is worth stating

Running the full suite against this found **zero violations**. The 80 declarations were accurate and merely unenforced.

So this guards against future drift rather than repairing present damage. Its coverage is what actually runs: it reaches the **thirteen call sites that build a detail map dynamically**, which no static analysis can, but it cannot prove an unexercised path conforms.

## A correction to the bug entry

I filed OW-018 saying `events.yaml` (80 schemas) and `audit_event_taxonomy.md` (23) were "two independent descriptions of the same contract" that had drifted.

That was wrong. The taxonomy doc is a **locked design record from 2026-04-29**, not a registry mirror, so its 23 are the original design and `events.yaml` has grown since. The entry is being corrected.

## Verification

Full suite serial: 60 packages ok, 0 failures. `make spec-check`: `system-audit-emission` 17/17, 119 specs passing. `go build`, `go vet`, `gofmt -l` clean.

AC-17 is mutation-checked. Removing the generator's output makes it fail with:

```
no event carries DetailKeys; the generator is not emitting detail_schema,
so every check below would pass against nothing
```

That assertion exists because without it, a template that stopped emitting `DetailKeys` would make every subset check below pass vacuously.