### PR TITLE
fix(quality): make three gates catch what they claim

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -359,7 +359,7 @@
         "filename": "internal/db/db_gaps_test.go",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 32
       }
     ],
     "internal/dbbackup/dbbackup_test.go": [
@@ -759,5 +759,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T16:47:21Z"
+  "generated_at": "2026-08-13T17:37:23Z"
 }

--- a/internal/db/audit_queries_test.go
+++ b/internal/db/audit_queries_test.go
@@ -1,6 +1,7 @@
 // @spec system-db
 //
-// AC traceability (DB integration tests; skipped without OPENWATCH_TEST_DSN):
+// AC traceability (DB integration tests; dbtest skips them when
+// OPENWATCH_TEST_DSN is unset):
 // @ac AC-01  (TestInsertAndGetAuditEvent: pool + migrate idempotent)
 // @ac AC-07  (TestInsertAndGetAuditEvent: insert returns row, round-trip)
 // @ac AC-09  (TestListAuditEvents: newest-first ordering, cursor)
@@ -15,25 +16,21 @@ package db
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/Hanalyx/openwatch/internal/db/dbtest"
-	"github.com/Hanalyx/openwatch/internal/db/migrations"
 	"github.com/google/uuid"
 )
 
-// testDSN returns the integration-test DSN or skips the test. CI is
-// expected to set OPENWATCH_TEST_DSN; local dev runs without it.
-func testDSN(t *testing.T) string {
-	t.Helper()
-	dsn := os.Getenv("OPENWATCH_TEST_DSN")
-	if dsn == "" {
-		t.Skip("set OPENWATCH_TEST_DSN to run db integration tests")
-	}
-	return dsn
-}
+// There is deliberately no testDSN helper here. Handing a test the raw
+// OPENWATCH_TEST_DSN pointed it at the one shared database that every other
+// package also migrates and truncates, so a schema assertion could read a
+// column an earlier run had left behind rather than one this checkout's
+// migrations create. dbtest.Pool clones a template keyed on a hash of the
+// migration files, so a checkout without the migration gets a database
+// without the column. Use dbtest.Pool, or dbtest.DSN when the test must open
+// the connection itself.
 
 // @ac AC-01  (pool ping; migrate apply + idempotent re-run)
 // insert returns row, round-trip via GetAuditEventByID.
@@ -106,17 +103,9 @@ func TestInsertAndGetAuditEvent(t *testing.T) {
 	// @ac AC-07
 	// AC-07: InsertAuditEvent returns the same row with occurred_at populated.
 	t.Run("system-db/AC-07", func(t *testing.T) {
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("Apply: %v", err)
-		}
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 
 		id := uuid.Must(uuid.NewV7())
@@ -142,19 +131,9 @@ func TestInsertAndGetAuditEvent(t *testing.T) {
 func TestListAuditEvents(t *testing.T) {
 	t.Run("system-db/AC-09", func(t *testing.T) {
 
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("migrations.Apply: %v", err)
-		}
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 
 		// Insert three events.
@@ -191,17 +170,9 @@ func TestListAuditEvents(t *testing.T) {
 // @ac AC-10  (Cursor returns only rows strictly older than Before.)
 func TestListAuditEvents_CursorWithBefore(t *testing.T) {
 	t.Run("system-db/AC-10", func(t *testing.T) {
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("Apply: %v", err)
-		}
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 
 		for i := 0; i < 3; i++ {
@@ -243,19 +214,9 @@ func TestListAuditEvents_CursorWithBefore(t *testing.T) {
 func TestCountAuditEvents(t *testing.T) {
 	t.Run("system-db/AC-11", func(t *testing.T) {
 
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("migrations.Apply: %v", err)
-		}
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 
 		n0, err := CountAuditEvents(ctx, pool)

--- a/internal/db/db_gaps_test.go
+++ b/internal/db/db_gaps_test.go
@@ -2,9 +2,12 @@
 //
 // Coverage closers for AC-02 (unreachable host), AC-03/04 (Apply runs +
 // idempotent), AC-05/06 (schema shape), AC-08 (round-trip JSON-equivalent),
-// AC-12 (data survives pool close/reopen). All require OPENWATCH_TEST_DSN
-// for the migrate+query path; AC-02 deliberately points at an unreachable
-// DSN and must NOT require a real DB.
+// AC-12 (data survives pool close/reopen).
+//
+// Every test that touches a database goes through dbtest, which skips when
+// OPENWATCH_TEST_DSN is unset and otherwise hands back this package's own
+// clone of a freshly-migrated template. AC-02 deliberately points at an
+// unreachable address and must NOT require a real DB.
 
 package db
 
@@ -68,14 +71,9 @@ func TestApply_RunsAllMigrations(t *testing.T) {
 // AC-04: Apply() against an already-migrated DB is a no-op and returns nil.
 func TestApply_IsIdempotent(t *testing.T) {
 	t.Run("system-db/AC-04", func(t *testing.T) {
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
 		if err := migrations.Apply(ctx, pool); err != nil {
 			t.Fatalf("first Apply: %v", err)
 		}
@@ -100,17 +98,9 @@ func TestApply_IsIdempotent(t *testing.T) {
 // NULL), actor_type (NOT NULL), action (NOT NULL), occurred_at.
 func TestSchema_AuditEvents(t *testing.T) {
 	t.Run("system-db/AC-05", func(t *testing.T) {
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("Apply: %v", err)
-		}
 
 		rows, err := pool.Query(ctx, `
 			SELECT column_name, is_nullable, data_type
@@ -250,17 +240,9 @@ func TestSchema_IdempotencyKeys(t *testing.T) {
 // (JSON-equal after JSONB normalization).
 func TestRoundTrip_DetailJSON(t *testing.T) {
 	t.Run("system-db/AC-08", func(t *testing.T) {
-		dsn := testDSN(t)
+		pool := dbtest.Pool(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		pool, err := NewPool(ctx, dsn, 5)
-		if err != nil {
-			t.Fatalf("NewPool: %v", err)
-		}
-		defer pool.Close()
-		if err := migrations.Apply(ctx, pool); err != nil {
-			t.Fatalf("Apply: %v", err)
-		}
 		_, _ = pool.Exec(ctx, "TRUNCATE TABLE audit_events")
 
 		id := uuid.Must(uuid.NewV7())
@@ -268,7 +250,7 @@ func TestRoundTrip_DetailJSON(t *testing.T) {
 			"nested": map[string]any{"k": "v", "n": 42},
 			"list":   []int{1, 2, 3},
 		})
-		_, err = InsertAuditEvent(ctx, pool, InsertAuditEventParams{
+		_, err := InsertAuditEvent(ctx, pool, InsertAuditEventParams{
 			ID:            id,
 			CorrelationID: "roundtrip-test",
 			ActorType:     "system",
@@ -298,7 +280,11 @@ func TestRoundTrip_DetailJSON(t *testing.T) {
 // Stage-0 acceptance walkthrough.
 func TestPersistsAcrossPoolReopen(t *testing.T) {
 	t.Run("system-db/AC-12", func(t *testing.T) {
-		dsn := testDSN(t)
+		// The one test here that opens its own connections: it closes a pool
+		// and reopens it, which is the restart this AC is about. dbtest.DSN
+		// gives it this package's isolated database rather than the shared
+		// one the base DSN points at.
+		dsn := dbtest.DSN(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 

--- a/internal/db/dbtest/dbtest.go
+++ b/internal/db/dbtest/dbtest.go
@@ -79,13 +79,42 @@ var (
 // per process.
 func Pool(t testing.TB) *pgxpool.Pool {
 	t.Helper()
+	pool, err := pgxpool.New(context.Background(), provisioned(t, 2))
+	if err != nil {
+		t.Fatalf("dbtest: connect isolated DB: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// DSN returns the connection string for this package's isolated database,
+// provisioned exactly as Pool provisions it.
+//
+// Use it only when a test must open the connection itself, which in practice
+// means a test that closes a pool and reopens it to stand in for a process
+// restart. Everywhere else, call Pool: a test that holds a DSN can reach the
+// server, and the point of this package is that it cannot reach another
+// package's data.
+//
+// Like Pool, it must be called DIRECTLY from the package's own test code.
+func DSN(t testing.TB) string {
+	t.Helper()
+	return provisioned(t, 2)
+}
+
+// provisioned skips when no base DSN is set, then returns this package's
+// isolated database DSN, provisioning it on the first call in the process.
+// skip is the runtime.Caller depth at which the package's own test file sits,
+// which is what names the database.
+func provisioned(t testing.TB, skip int) string {
+	t.Helper()
 	base := os.Getenv(EnvDSN)
 	if base == "" {
 		t.Skipf("set %s to run DB integration tests", EnvDSN)
 	}
 
 	// Derive the per-package database name from the caller's source dir.
-	_, file, _, ok := runtime.Caller(1)
+	_, file, _, ok := runtime.Caller(skip)
 	if !ok {
 		t.Fatal("dbtest: cannot resolve caller for per-package DB name")
 	}
@@ -95,13 +124,7 @@ func Pool(t testing.TB) *pgxpool.Pool {
 	if initErr != nil {
 		t.Fatalf("dbtest: provision %q: %v", dbName, initErr)
 	}
-
-	pool, err := pgxpool.New(context.Background(), pkgDSN)
-	if err != nil {
-		t.Fatalf("dbtest: connect isolated DB: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return pool
+	return pkgDSN
 }
 
 // databaseName builds a valid, stable, per-package PostgreSQL identifier:

--- a/internal/db/migrations/0009_role_permissions.sql
+++ b/internal/db/migrations/0009_role_permissions.sql
@@ -1,6 +1,6 @@
 -- Slice A — custom-role permission storage.
 --
--- Permission catalogue stays in code (auth.Permissions in
+-- Permission catalog stays in code (auth.Permissions in
 -- internal/auth/permissions.gen.go). Roles' grant lists live in the
 -- DB as TEXT[] so admins can mint custom roles at runtime.
 --

--- a/internal/db/migrations/0016_host_monitoring_multilayer.sql
+++ b/internal/db/migrations/0016_host_monitoring_multilayer.sql
@@ -20,7 +20,7 @@ ALTER TABLE host_liveness
     CHECK (monitoring_state IN
       ('online','degraded','critical','down','maintenance','unknown'));
 
--- Index lets the operator dashboard summarise band distribution.
+-- Index lets the operator dashboard summarize band distribution.
 CREATE INDEX idx_host_liveness_monitoring_state
   ON host_liveness (monitoring_state);
 

--- a/internal/db/migrations/0033_auth_policy.sql
+++ b/internal/db/migrations/0033_auth_policy.sql
@@ -10,7 +10,7 @@
 -- one row can ever exist. Reads and writes always target id = TRUE.
 --
 -- Defaults match the historical constants (15-minute idle, 12-hour
--- absolute) so promoting to data is behaviour-preserving until an admin
+-- absolute) so promoting to data is behavior-preserving until an admin
 -- changes it.
 
 -- +goose Up
@@ -36,7 +36,7 @@ CREATE TABLE auth_policy (
     updated_by                      UUID        REFERENCES users(id) ON DELETE SET NULL
 );
 
--- Seed the singleton row with the behaviour-preserving defaults.
+-- Seed the singleton row with the behavior-preserving defaults.
 INSERT INTO auth_policy (id) VALUES (TRUE);
 
 -- +goose Down

--- a/internal/idempotency/contract_test.go
+++ b/internal/idempotency/contract_test.go
@@ -1,0 +1,183 @@
+// @spec system-idempotency
+//
+// AC traceability:
+//   AC-15  TestIdempotency_NoCachedRouteDependsOnAResponseHeader
+//
+// This file reads api/openapi.yaml and nothing else. It needs no database
+// and no server, because the defect it guards against is declared in the
+// contract before any code runs.
+
+package idempotency
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// openAPIDoc is the slice of the contract this check reads: for every
+// operation, the parameters it declares and the headers its responses
+// declare. Everything else in the document is ignored.
+//
+// Responses carry a $ref as well as inline headers, because most 4xx bodies
+// here are shared components. A header added to one of those would otherwise
+// be invisible to this check while applying to every route that references
+// it, which is the wider blast radius of the two.
+type openAPIDoc struct {
+	Paths map[string]map[string]struct {
+		OperationID string `yaml:"operationId"`
+		Parameters  []struct {
+			Name string `yaml:"name"`
+			In   string `yaml:"in"`
+			Ref  string `yaml:"$ref"`
+		} `yaml:"parameters"`
+		Responses map[string]responseNode `yaml:"responses"`
+	} `yaml:"paths"`
+	Components struct {
+		Responses map[string]responseNode `yaml:"responses"`
+	} `yaml:"components"`
+}
+
+type responseNode struct {
+	Ref     string         `yaml:"$ref"`
+	Headers map[string]any `yaml:"headers"`
+}
+
+// headersOf returns the headers a response declares, following one level of
+// $ref into components/responses. OpenAPI allows a $ref to name another $ref;
+// this repo's contract does not, and the vacuity guard in the test above is
+// what would notice if that changed.
+func headersOf(doc openAPIDoc, r responseNode) map[string]any {
+	if r.Ref == "" {
+		return r.Headers
+	}
+	const prefix = "#/components/responses/"
+	if !strings.HasPrefix(r.Ref, prefix) {
+		return r.Headers
+	}
+	return doc.Components.Responses[strings.TrimPrefix(r.Ref, prefix)].Headers
+}
+
+// @ac AC-15
+// AC-15: a route that caches must not carry meaning in a response header.
+//
+// replayCached writes three things: Content-Type, the stored status and the
+// stored body. Every other header the handler set is gone on the second call.
+// A route that declares Idempotency-Key and also declares a response header is
+// therefore a route whose repeat call returns 2xx with the header missing,
+// which the client reads as a success it cannot act on. Login is the shape of
+// the problem: three Set-Cookie headers, a 200, and no session.
+//
+// No route does this today. The point of the check is the day someone adds
+// one, which is a contract edit rather than a code edit, so nothing else in
+// the suite would notice.
+func TestIdempotency_NoCachedRouteDependsOnAResponseHeader(t *testing.T) {
+	t.Run("system-idempotency/AC-15", func(t *testing.T) {
+		raw, err := os.ReadFile(filepath.Join("..", "..", "api", "openapi.yaml"))
+		if err != nil {
+			t.Fatalf("read openapi.yaml: %v", err)
+		}
+		var doc openAPIDoc
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("parse openapi.yaml: %v", err)
+		}
+
+		var cached []string
+		for path, item := range doc.Paths {
+			for method, op := range item {
+				switch method {
+				case "post", "put", "patch", "delete":
+				default:
+					// GET, HEAD and OPTIONS never reach the cache (C-02).
+					continue
+				}
+				declaresKey := false
+				for _, p := range op.Parameters {
+					// A $ref to the shared parameter counts the same as an
+					// inline declaration; matching the ref by name keeps this
+					// from missing a route that reuses the component.
+					if (p.In == "header" && p.Name == HeaderName) ||
+						strings.HasSuffix(p.Ref, "/"+HeaderName) {
+						declaresKey = true
+					}
+				}
+				if !declaresKey {
+					continue
+				}
+				cached = append(cached, method+" "+path)
+
+				for code, resp := range op.Responses {
+					for name := range headersOf(doc, resp) {
+						// Set-Cookie is wrong on any response of a cached
+						// route, not only a 2xx: it is never captured, so it
+						// can never be replayed.
+						if strings.EqualFold(name, "Set-Cookie") {
+							t.Errorf("%s %s declares Set-Cookie on %s; a replay never carries it",
+								method, path, code)
+							continue
+						}
+						if strings.HasPrefix(code, "2") {
+							t.Errorf("%s %s declares response header %q on %s; a replay writes only "+
+								"Content-Type, status and body, so the repeat call would omit it",
+								method, path, name, code)
+						}
+					}
+				}
+			}
+		}
+
+		// A check that finds no routes is a check that proves nothing. If the
+		// parameter is renamed or the parsing drifts, this is what says so.
+		if len(cached) == 0 {
+			t.Fatalf("no operation declares the %s parameter; either the contract changed "+
+				"or this check stopped reading it, and either way it is no longer guarding anything",
+				HeaderName)
+		}
+		sort.Strings(cached)
+		t.Logf("checked %d operations declaring %s:\n  %s",
+			len(cached), HeaderName, strings.Join(cached, "\n  "))
+	})
+}
+
+// @ac AC-15
+// AC-15: the replay path is the reason for the rule above, so assert it
+// directly rather than trusting the comment. If replayCached ever learns to
+// restore headers, this fails and the contract rule can be relaxed on
+// purpose instead of drifting out of date.
+func TestIdempotency_ReplayWritesOnlyContentTypeStatusAndBody(t *testing.T) {
+	t.Run("system-idempotency/AC-15", func(t *testing.T) {
+		src, err := os.ReadFile("middleware.go")
+		if err != nil {
+			t.Fatalf("read middleware.go: %v", err)
+		}
+		body := funcBody(string(src), "func replayCached(")
+		if body == "" {
+			t.Fatal("replayCached not found; this check no longer reads the replay path")
+		}
+		if n := strings.Count(body, "w.Header().Set("); n != 1 {
+			t.Errorf("replayCached sets %d headers, want exactly 1 (Content-Type). "+
+				"If it now restores captured headers, AC-15's contract rule needs revisiting.", n)
+		}
+		if !strings.Contains(body, `"Content-Type"`) {
+			t.Error("replayCached no longer sets Content-Type")
+		}
+	})
+}
+
+// funcBody returns the source between a function's opening marker and the
+// next top-level declaration, or "" when the marker is absent.
+func funcBody(src, marker string) string {
+	i := strings.Index(src, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := src[i+len(marker):]
+	if j := strings.Index(rest, "\nfunc "); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}

--- a/internal/idempotency/contract_test.go
+++ b/internal/idempotency/contract_test.go
@@ -29,22 +29,48 @@ import (
 // it, which is the wider blast radius of the two.
 type openAPIDoc struct {
 	Paths map[string]map[string]struct {
-		OperationID string `yaml:"operationId"`
-		Parameters  []struct {
-			Name string `yaml:"name"`
-			In   string `yaml:"in"`
-			Ref  string `yaml:"$ref"`
-		} `yaml:"parameters"`
-		Responses map[string]responseNode `yaml:"responses"`
+		OperationID string                  `yaml:"operationId"`
+		Parameters  []parameterNode         `yaml:"parameters"`
+		Responses   map[string]responseNode `yaml:"responses"`
 	} `yaml:"paths"`
 	Components struct {
-		Responses map[string]responseNode `yaml:"responses"`
+		Responses  map[string]responseNode  `yaml:"responses"`
+		Parameters map[string]parameterNode `yaml:"parameters"`
 	} `yaml:"components"`
+}
+
+type parameterNode struct {
+	Name string `yaml:"name"`
+	In   string `yaml:"in"`
+	Ref  string `yaml:"$ref"`
 }
 
 type responseNode struct {
 	Ref     string         `yaml:"$ref"`
 	Headers map[string]any `yaml:"headers"`
+}
+
+// declaresIdempotencyKey reports whether an operation takes the header,
+// following a $ref into components/parameters and reading the resolved
+// parameter's own name rather than the key it is filed under.
+//
+// Matching the ref string instead would tie this check to what the component
+// happens to be called. A shared parameter named IdempotencyKeyHeader would
+// then make every route using it invisible here, and the vacuity guard would
+// stay quiet because other routes still declare it inline. That is the same
+// defect this file exists to catch: a check that still runs, still passes, and
+// no longer covers what it names.
+func declaresIdempotencyKey(doc openAPIDoc, params []parameterNode) bool {
+	const prefix = "#/components/parameters/"
+	for _, p := range params {
+		if p.Ref != "" && strings.HasPrefix(p.Ref, prefix) {
+			p = doc.Components.Parameters[strings.TrimPrefix(p.Ref, prefix)]
+		}
+		if p.In == "header" && p.Name == HeaderName {
+			return true
+		}
+	}
+	return false
 }
 
 // headersOf returns the headers a response declares, following one level of
@@ -95,17 +121,7 @@ func TestIdempotency_NoCachedRouteDependsOnAResponseHeader(t *testing.T) {
 					// GET, HEAD and OPTIONS never reach the cache (C-02).
 					continue
 				}
-				declaresKey := false
-				for _, p := range op.Parameters {
-					// A $ref to the shared parameter counts the same as an
-					// inline declaration; matching the ref by name keeps this
-					// from missing a route that reuses the component.
-					if (p.In == "header" && p.Name == HeaderName) ||
-						strings.HasSuffix(p.Ref, "/"+HeaderName) {
-						declaresKey = true
-					}
-				}
-				if !declaresKey {
+				if !declaresIdempotencyKey(doc, op.Parameters) {
 					continue
 				}
 				cached = append(cached, method+" "+path)

--- a/packaging/tests/setup-container-test.sh
+++ b/packaging/tests/setup-container-test.sh
@@ -22,6 +22,24 @@ EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
+# See OW-019. Provisioning reaches the distribution mirrors, which fail
+# transiently, and a silenced package manager reports its own cleanup rather
+# than what it could not reach. Retry, and keep the output for the failure.
+retry_fetch() {
+    local what="$1"; shift
+    local attempt
+    for attempt in 1 2 3; do
+        if "$@" > /tmp/provision.log 2>&1; then
+            return 0
+        fi
+        echo "   $what failed, attempt $attempt of 3" >&2
+        sleep $(( attempt * 10 ))
+    done
+    echo "--- output of the last attempt ---" >&2
+    cat /tmp/provision.log >&2
+    fail "$what failed after 3 attempts"
+}
+
 echo ">> waiting for systemd to finish booting"
 for _ in $(seq 1 60); do
     state="$(systemctl is-system-running 2>/dev/null || true)"
@@ -40,8 +58,8 @@ systemctl is-system-running >/dev/null 2>&1 || \
 echo ">> installing packages"
 if [ "$PKG_KIND" = deb ]; then
     export DEBIAN_FRONTEND=noninteractive
-    apt-get update -qq
-    apt-get install -y -qq curl ca-certificates >/dev/null
+    retry_fetch "apt-get update" apt-get update
+    retry_fetch "curl install" apt-get install -y curl ca-certificates
     apt-get install -y "$PKG_DIR"/openwatch_*.deb "$PKG_DIR"/kensa-rules_*.deb
 else
     dnf install -y -q "$PKG_DIR"/openwatch-*.rpm "$PKG_DIR"/kensa-rules-*.rpm

--- a/packaging/tests/upgrade-container-test.sh
+++ b/packaging/tests/upgrade-container-test.sh
@@ -23,8 +23,28 @@ set -euo pipefail
 : "${HEAD_DOWN:?HEAD_DOWN must be passed in (head migration -- +goose Down SQL)}"
 PREV_VER=$((HEAD_VER - 1))
 
+# See OW-019. Provisioning reaches the distribution mirrors, which fail
+# transiently, and a silenced package manager reports its own cleanup rather
+# than what it could not reach. Retry, and keep the output for the failure.
+retry_fetch() {
+    local what="$1"; shift
+    local attempt
+    for attempt in 1 2 3; do
+        if "$@" > /tmp/provision.log 2>&1; then
+            return 0
+        fi
+        echo "   $what failed, attempt $attempt of 3" >&2
+        sleep $(( attempt * 10 ))
+    done
+    echo "--- output of the last attempt ---" >&2
+    cat /tmp/provision.log >&2
+    echo "FAIL: $what failed after 3 attempts" >&2
+    exit 1
+}
+
 echo "### prerequisites"
-dnf install -y -q postgresql-server postgresql openssl findutils >/dev/null
+retry_fetch "prerequisite install" \
+    dnf install -y postgresql-server postgresql openssl findutils
 
 echo "### start postgres (no systemd)"
 PGDATA=/var/lib/pgsql/data

--- a/packaging/tests/upgrade-from-ga-container-test.sh
+++ b/packaging/tests/upgrade-from-ga-container-test.sh
@@ -35,6 +35,30 @@ diagnose() {
 }
 fail() { echo "FAIL: $*" >&2; diagnose; exit 1; }
 
+# Provisioning reaches the distribution mirrors, and mirrors fail transiently.
+# With no retry, one bad minute upstream turns a PR red while every other gate
+# is green, and the failure looks like the branch under test.
+#
+# The output is captured and printed only when the last attempt fails, for the
+# same reason install_pkgs below is deliberately not quiet: when a silenced
+# package manager dies, the one line that survives describes its own cleanup
+# rather than what it could not reach. That is how this was filed as OW-019,
+# reading `[Errno 2] ... download_lock.pid` and nothing else.
+retry_fetch() {
+    local what="$1"; shift
+    local attempt
+    for attempt in 1 2 3; do
+        if "$@" > /tmp/provision.log 2>&1; then
+            return 0
+        fi
+        echo "   $what failed, attempt $attempt of 3" >&2
+        sleep $(( attempt * 10 ))
+    done
+    echo "--- output of the last attempt ---" >&2
+    cat /tmp/provision.log >&2
+    fail "$what failed after 3 attempts"
+}
+
 # curl exits non-zero when nothing is listening, and under set -e that kills
 # the script with curl's status before any assertion runs, which reads as a
 # harness crash rather than a product failure. Capture, then judge.
@@ -67,13 +91,14 @@ install_pkgs() {
 echo ">> installing PostgreSQL and the previous GA ($OLD_VER)"
 if [ "$PKG_KIND" = deb ]; then
     export DEBIAN_FRONTEND=noninteractive
-    apt-get update -qq
-    apt-get install -y -qq curl ca-certificates postgresql postgresql-contrib >/dev/null
+    retry_fetch "apt-get update" apt-get update
+    retry_fetch "postgresql install" \
+        apt-get install -y curl ca-certificates postgresql postgresql-contrib
 else
     # Not curl: the RHEL-family images ship curl-minimal, which provides the
     # binary and conflicts with the full package.
-    command -v curl >/dev/null || dnf install -y -q curl >/dev/null
-    dnf install -y -q postgresql-server postgresql-contrib >/dev/null
+    command -v curl >/dev/null || retry_fetch "curl install" dnf install -y curl
+    retry_fetch "postgresql install" dnf install -y postgresql-server postgresql-contrib
     [ -f /var/lib/pgsql/data/PG_VERSION ] || postgresql-setup --initdb >/dev/null
 fi
 systemctl enable --now postgresql >/dev/null 2>&1 || fail "postgresql did not start"

--- a/scripts/check-doc-style.py
+++ b/scripts/check-doc-style.py
@@ -297,9 +297,13 @@ EMOJI_EXT = (".md", ".yml", ".yaml", ".json")
 # .mjs and .cjs are the same JavaScript, only a different module system. Omitting them left the
 # comments in every ES-module script invisible to the check, including this repo's own sync
 # scripts. The same reasoning covers .mts and .cts on the TypeScript side.
-CODE_EXT = (".go", ".ts", ".tsx", ".mts", ".cts", ".py", ".js", ".jsx", ".mjs", ".cjs")
+# .sql carries prose too. A migration's header comment is where the reason for a schema change is
+# written, and those comments were invisible here until 2026-08-13: .sql was in neither tuple, so
+# every check returned without reading the file. Four US English defects had accumulated behind
+# that gap.
+CODE_EXT = (".go", ".ts", ".tsx", ".mts", ".cts", ".py", ".js", ".jsx", ".mjs", ".cjs", ".sql")
 GLOBS = ["*.md", "*.yml", "*.yaml", "*.json", "*.go", "*.ts", "*.tsx", "*.mts", "*.cts",
-         "*.py", "*.js", "*.jsx", "*.mjs", "*.cjs"]
+         "*.py", "*.js", "*.jsx", "*.mjs", "*.cjs", "*.sql"]
 
 # Comment extraction, deliberately conservative: only a WHOLE-LINE comment is scanned. A trailing
 # comment after code, or a marker inside a string literal, is skipped rather than guessed at. A
@@ -308,6 +312,7 @@ COMMENT_STARTS = {
     ".go": ("//",), ".ts": ("//",), ".tsx": ("//",), ".mts": ("//",), ".cts": ("//",),
     ".js": ("//",), ".jsx": ("//",), ".mjs": ("//",), ".cjs": ("//",),
     ".py": ("#",),
+    ".sql": ("--",),
 }
 # The C-family languages, for the block-comment continuation line ( * inside a doc comment).
 C_FAMILY = (".go", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
@@ -377,7 +382,13 @@ def line_findings(raw, is_prose, do_emoji, in_fence, is_comment=False, skip_form
         line = INLINE_CODE.sub("", raw)
         # Em dashes are a DOCUMENT rule, not a writing rule: the style guide prohibits them in
         # developer docs, and a code comment is not a doc. US English and AI speak do bind
-        # comments, so only this one check is skipped there. Matches openwatch's v3 scope.
+        # comments. Matches openwatch's v3 scope.
+        #
+        # Two checks are skipped in a comment, not one. This is the em dash; the emoji check is
+        # the other, and check_file skips it by passing do_emoji=False for every CODE_EXT file.
+        # Note that CLAUDE.md states the no-em-dash rule binds code comments, which is not what
+        # this line does. The scope question is open and belongs to the founder, so this comment
+        # records the disagreement rather than settling it.
         if not is_comment and not skip_formatting and EM_DASH.search(line):
             out.append(("em-dash", "—"))
         for _term, rx in WORD_RES + PHRASE_RES:
@@ -597,6 +608,7 @@ def selftest():
         (".js",  "// we organise the corpus", "organise"),
         (".py",  "#  we organise the corpus", "organise"),
         (".go",  " * we organise the corpus", "organise"),
+        (".sql", "-- we organise the corpus", "organise"),
     ):
         body = comment_text("a" + ext, line)
         if body is None or want not in body:

--- a/specs/system/idempotency.spec.yaml
+++ b/specs/system/idempotency.spec.yaml
@@ -7,7 +7,7 @@ spec:
   # covers method, path, query and body. AC-01 and AC-03 assert different
   # things than they did, and an anonymous caller no longer touches the cache
   # at all. A consumer written against 1.0.0 is wrong against this file.
-  version: "2.0.0"
+  version: "2.1.0"
   status: approved
   tier: 2
 
@@ -121,6 +121,15 @@ spec:
         response is written before any authorization runs.
       type: security
       enforcement: error
+    - id: C-11
+      description: >
+        A replay writes the stored status, Content-Type and body, and nothing
+        else. Every other response header the handler set is dropped. A route
+        that declares Idempotency-Key therefore MUST NOT carry meaning in a
+        response header, because the replayed call returns the success status
+        and body without it. Set-Cookie MUST never be captured or replayed.
+      type: security
+      enforcement: error
 
   acceptance_criteria:
     - id: AC-01
@@ -217,3 +226,13 @@ spec:
         overwrite or conflict with the other.
       priority: critical
       references_constraints: [C-09]
+    - id: AC-15
+      description: >
+        No operation that declares the Idempotency-Key parameter in
+        api/openapi.yaml declares a response header on a 2xx response, and
+        none declares Set-Cookie on any response. A replay returns the stored
+        status, Content-Type and body only, so such a route would answer a
+        repeat call with a success the client cannot use. No route does this
+        today, and the check fails the build on the day one is added.
+      priority: critical
+      references_constraints: [C-11]


### PR DESCRIPTION
Closes `bugs/OW-014`, `bugs/OW-015`, `bugs/OW-016`. Three checks that read as
guards and were not. Disjoint packages, so they travel together.

## OW-016: schema tests could not fail

Eight tests in `internal/db` took a pool from `testDSN`, which handed out the
one shared database every package migrates. goose is forward-only, so a column
stays once applied.

Shown rather than argued. With `0001` edited to make `correlation_id` nullable:

| path | result |
|---|---|
| shared base DB (what `testDSN` returned) | `is_nullable=NO`, goose at version 59, `0001` never re-runs, **test passes** |
| `dbtest` (this PR) | template hash rotates, fresh DB, **test fails**: `audit_events.correlation_id is_nullable = "YES", want "NO"` |

The bug named five tests in one file. Four were there, plus four more in
`audit_queries_test.go`, so all eight moved and **`testDSN` is deleted**, which
is what keeps this from coming back. `AC-12` closes and reopens a pool, so
`dbtest` gained `DSN()`.

Answering the bug's open question: no other package carries this. Every other DB
test already goes through `dbtest.Pool`. The one remaining raw-DSN reader,
`internal/server/api_helpers_test.go`, has its own `_test`-suffix safety gate and
never reads `information_schema`.

## OW-014: a replay drops every response header

`replayCached` writes `Content-Type`, the stored status and the stored body.
Every other header the handler set is gone on the second call.

No route declaring `Idempotency-Key` depends on one today, so this is a trap
rather than a repair. `AC-15` walks `api/openapi.yaml` and fails when a cached
route declares a response header on a 2xx, or `Set-Cookie` on any status. It
follows `$ref` into `components/responses`, because a header added to a shared
4xx would apply to every route referencing it and stay invisible otherwise. It
also fails when it matches no route at all, so a renamed parameter cannot
quietly empty it.

## OW-015: the style gate did not read SQL

`.sql` was in neither extension tuple, so `check-doc-style.py` opened no
migration and exited 0. Four US English defects had collected behind that gap
and are fixed.

Two claims in the bug the evidence did not support, and I would rather record
that than quietly ship around it:

- **No emoji in any migration.** The earlier count matched `U+2192`, which is
  below the checker's range.
- **No exemption ledger needed.** All 60 em dashes sit in comments or one string
  literal, both of which the code path already exempts.

## One thing left open, deliberately

`CLAUDE.md` says the no-em-dash rule binds code comments. The checker
deliberately exempts them. Classifying `.sql` as code adopts the checker's side
by default, and that scope question is the founder's to settle, so the comment
there records the disagreement instead of resolving it.

## Surfaced, not fixed here

`0006_user_roles.sql:29` seeds the role description
`'Day-to-day operations - hosts, scans, alerts'` with an em dash. It is
user-facing copy under the no-em-dash-in-UI rule, but it is seed **data**, not a
comment: editing the migration would fix only fresh installs, and existing
databases would need an UPDATE migration. Out of scope for a checker fix.

## Verification

- Full suite green: 60 packages, 0 failing.
- `make spec-check`: 119 specs, 119 passing. `system-idempotency` now 15/15.
- Five mutations, each red for its own reason: response header on a 2xx,
  `Set-Cookie` on a 403, `Set-Cookie` on the shared `BadRequest` component
  (proves `$ref` resolution), a renamed parameter (proves the check is not
  vacuous), and `replayCached` gaining a second header. Every file restored and
  verified by sha256.
- `system-idempotency` 2.0.0 to 2.1.0 (C-11, AC-15).


---

## Added after review: OW-019

`upgrade-from-ga rockylinux:9` failed this PR on a Rocky mirror problem, not on
anything here. The same job passed on this branch four minutes earlier with
every migration edit present, then failed after a commit touching one Go **test**
file; an unrelated branch hit the identical error three hours before.

Two defects in our CI made an upstream blip look like the branch:

- **No retry** on the provisioning install, under `set -e`.
- **`-q` plus `>/dev/null` discarded dnf's own error.** The surviving line
  described dnf cleaning up its lock. `install_pkgs` in the same file already
  argues against quiet mode for this exact reason.

`retry_fetch` retries three times with a growing pause and prints the captured
output only on final failure. Verified against real dnf in `rockylinux:9`: the
provisioning line installs `postgresql-server-13.23`, and an unresolvable
package fails after three attempts reporting `No match for argument`, which the
old form swallowed. Applied to all three container scripts that provision from a
mirror.

The package under test is deliberately not retried, since re-running a partly
applied install produces a second, different failure and that install is the
measurement rather than a prerequisite.

Filed and closed as CP `bugs/OW-019`.
