### PR TITLE
chore(gitignore): stop tracking the context-plane skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -741,6 +741,16 @@ docs/HOST_STATUS*.md
 # OpenWatch internal SDD documents (do not commit)
 internal/sdd/
 
+# The context-plane skill is a LOCAL ADAPTATION of a canonical document, not a
+# source of truth. CLAUDE.md says so plainly: the canonical copy lives in the
+# Context Plane at dev/skills/context-plane/SKILL, and when the two disagree the
+# CP copy wins and this one gets re-fetched. Tracking a mirror invites the
+# failure OW-015 already produced once, where a local restatement of a canonical
+# rule rotted and two readers took the copy as authority.
+#
+# .claude/skills/write-doc.md stays tracked. It has no canonical copy elsewhere.
+.claude/skills/context-plane/
+
 # OpenWatch internal documentation (do not commit)
 CLAUDE.md
 backend/CLAUDE.md


### PR DESCRIPTION
`.claude/skills/context-plane/` is a local adaptation of a canonical document,
not a source of truth. Its own header says so: the canonical copy lives in the
Context Plane at `dev/skills/context-plane/SKILL`, and when the two disagree the
CP copy wins and this one gets re-fetched.

Tracking a mirror invites the failure `bugs/OW-015` already produced. There, a
local restatement of a canonical style rule rotted, and two readers took the
copy as authority without checking the source it summarized. The canonical guide
had the right answer in a table the whole time.

Scoped to that one directory. **`.claude/skills/write-doc.md` stays tracked**: it
has no canonical copy elsewhere, so it is a source rather than a mirror.

Verified: `git check-ignore -v` resolves to the new rule, the directory no longer
appears in `git status`, `write-doc.md` is still tracked, and the repo-hygiene
test passes.
