### PR TITLE
fix(security): move to Go 1.26.6 for the standard library advisories

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -94,7 +94,7 @@ jobs:
         if: steps.paths.outputs.go == 'true'
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
           cache-dependency-path: go.sum
 
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/go/bin/golangci-lint
-          key: golangci-bin-v1.64.8-go1.26.5-${{ runner.os }}
+          key: golangci-bin-v1.64.8-go1.26.6-${{ runner.os }}
 
       - name: Set up golangci-lint
         if: steps.paths.outputs.go == 'true' && steps.cache-golangci-bin.outputs.cache-hit != 'true'

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -219,7 +219,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Hanalyx/openwatch
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
**`make vuln` fails on `main` right now, and on every open PR.** Seven advisories
that govulncheck traces into code this repo actually calls, all in the Go
standard library, all fixed in 1.26.6:

| advisory | package |
|---|---|
| GO-2026-6218 | `net/url`, quadratic complexity in `resolvePath` |
| GO-2026-6091 | `html/template`, Javascript regexp context tracking |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-6089 | `net/http` |
| GO-2026-6088 | `encoding/xml` |
| GO-2026-5972 | |
| GO-2026-5026 | |

## Nothing in the tree caused it

Main's last Go CI run passed at 23:53. The advisories published after it, so the
first thing to fail was a PR that had done nothing but rebase onto main. Four
PRs failed the same gate at the same step within a minute of each other, which
is what pointed at the toolchain rather than at any branch. Confirmed by running
`make vuln` against a clean `main` checkout: it fails there too.

This blocks #821, #822, #823 and #826 from merging.

## What moves

Six pins: `go.mod`, the golangci-lint cache key, and the four `setup-go`
versions across `go-ci`, `package-smoke` and `release`. **The cache key carries
the Go version**, so leaving it would serve a lint binary built against the old
toolchain.

Three other mentions of `1.26.5` stay on purpose: `CHANGELOG.md` records the
1.26.4 to 1.26.5 move as history, and `version.go` plus the `api-version` spec
use it as an example of the string's shape, which the style guide asks to keep
generic rather than live.

## Verification

Run locally under `GOTOOLCHAIN=go1.26.6`:

- `go build ./...` clean
- `go vet ./...` clean
- full suite: 60 packages, 0 failing
- `make vuln`: **exit 0**

The two advisories it still reports are in modules this repo requires but does
not call, which is the state the gate already accepted before today.
