### PR TITLE
fix(audit): make the policy events declare what they emit

### DIFF
--- a/audit/events.yaml
+++ b/audit/events.yaml
@@ -717,24 +717,48 @@ events:
   # =========================================================================
   - code: policy.loaded
     severity: info
+    # policy_version was declared here and never sent. The loader reports the
+    # move, not the destination: new_version and previous_version are the pair
+    # that says what changed. See CP bugs/OW-021.
     detail_schema:
       type: object
       properties:
         policy_type: {type: string}
-        policy_version: {type: string}
+        new_version: {type: string}
+        previous_version: {type: string}
+        warnings: {type: array, items: {type: string}}
 
   - code: policy.invalid
     severity: error
+    description: A policy load attempt was rejected and the prior state retained
+    # Declared nothing at all until OW-021, which left the emitted keys
+    # uncheckable rather than merely wrong: a nil schema is skipped, so this
+    # event was invisible to the detail-schema check.
+    detail_schema:
+      type: object
+      properties:
+        policy_type: {type: string}
+        attempted_version: {type: string}
+        errors: {type: array, items: {type: string}}
 
   - code: policy.applied
     severity: info
     description: Operation evaluated against a versioned policy
+    # decision was declared here and never sent; the emitter has always called
+    # it outcome. Renaming the declaration rather than the field keeps every
+    # stored row readable.
     detail_schema:
       type: object
       properties:
         policy_type: {type: string}
         policy_version: {type: string}
-        decision: {type: string, enum: [allow, deny, defer]}
+        # Evaluate is emitApplied's only caller and sets exactly these four.
+        # Outcome also has allow, deny and defer constants, which no code
+        # path assigns; they are not listed because this event cannot carry
+        # them.
+        outcome: {type: string, enum: [critical, high, medium, ok]}
+        reason: {type: string}
+        detail: {type: object}
 
   # =========================================================================
   # remediation — license-gated

--- a/internal/audit/events.gen.go
+++ b/internal/audit/events.gen.go
@@ -231,7 +231,7 @@ const (
 	LicenseTampered Code = "license.tampered"
 	//
 	PolicyLoaded Code = "policy.loaded"
-	//
+	// A policy load attempt was rejected and the prior state retained
 	PolicyInvalid Code = "policy.invalid"
 	// Operation evaluated against a versioned policy
 	PolicyApplied Code = "policy.applied"
@@ -1168,15 +1168,15 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: ``,
 		ActorTypes:  nil,
-		DetailKeys:  []string{"policy_type", "policy_version"},
+		DetailKeys:  []string{"new_version", "policy_type", "previous_version", "warnings"},
 	},
 	PolicyInvalid: {
 		Code:        PolicyInvalid,
 		Category:    "policy",
 		Severity:    SeverityError,
-		Description: ``,
+		Description: `A policy load attempt was rejected and the prior state retained`,
 		ActorTypes:  nil,
-		DetailKeys:  nil,
+		DetailKeys:  []string{"attempted_version", "errors", "policy_type"},
 	},
 	PolicyApplied: {
 		Code:        PolicyApplied,
@@ -1184,7 +1184,7 @@ var Metadata = map[Code]EventMeta{
 		Severity:    SeverityInfo,
 		Description: `Operation evaluated against a versioned policy`,
 		ActorTypes:  nil,
-		DetailKeys:  []string{"decision", "policy_type", "policy_version"},
+		DetailKeys:  []string{"detail", "outcome", "policy_type", "policy_version", "reason"},
 	},
 	RemediationRequested: {
 		Code:        RemediationRequested,

--- a/internal/policy/audit_schema_test.go
+++ b/internal/policy/audit_schema_test.go
@@ -1,0 +1,68 @@
+// @spec system-policy
+//
+// AC traceability:
+//   AC-14  TestPolicyAuditDetailsMatchDeclaredSchema
+
+package policy
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Hanalyx/openwatch/internal/audit"
+)
+
+// @ac AC-14
+// AC-14: each policy event's declared detail_schema matches what its emitter
+// sends, in both directions.
+//
+// C-06, C-07 and C-08 name the keys each event must carry, and audit/events.yaml
+// disagreed with all three: policy.loaded declared policy_version and sent
+// new_version, policy.applied declared decision and sent outcome, and
+// policy.invalid declared nothing at all. See CP bugs/OW-021.
+//
+// The runtime check from bugs/OW-018 catches only one direction, emitted keys
+// that are not declared. It cannot see a declared key nothing sends, which is
+// the direction that produces consumers waiting for a field that never arrives.
+// Asserting the exact key set catches both.
+func TestPolicyAuditDetailsMatchDeclaredSchema(t *testing.T) {
+	t.Run("system-policy/AC-14", func(t *testing.T) {
+		// The expected sets come from the spec constraints, not from
+		// events.yaml, so this fails if the declaration drifts from the
+		// contract rather than agreeing with whatever it currently says.
+		want := map[audit.Code][]string{
+			audit.PolicyLoaded:  {"new_version", "policy_type", "previous_version", "warnings"},
+			audit.PolicyInvalid: {"attempted_version", "errors", "policy_type"},
+			audit.PolicyApplied: {"detail", "outcome", "policy_type", "policy_version", "reason"},
+		}
+		for code, keys := range want {
+			meta, ok := audit.Metadata[code]
+			if !ok {
+				t.Errorf("%s is not in the audit registry", code)
+				continue
+			}
+			if !reflect.DeepEqual(meta.DetailKeys, keys) {
+				t.Errorf("%s DetailKeys = %v, want %v", code, meta.DetailKeys, keys)
+			}
+		}
+
+		// And the emitters agree. Every policy event goes through the
+		// runtime check, so a violation here means the code and the
+		// declaration parted company even though the declaration still
+		// matches the spec.
+		before := audit.DetailViolations()
+		ctx := context.Background()
+		emitLoaded(ctx, TypeAlertThresholds, "1.1.0", "1.0.0", []string{"a warning"})
+		emitInvalid(ctx, TypeAlertThresholds, "0.9.0", []string{"an error"})
+		emitApplied(ctx, Decision{
+			PolicyType: TypeAlertThresholds, PolicyVersion: "1.1.0",
+			Outcome: OutcomeAlertOK, Reason: "within band",
+			Detail: map[string]any{"score": 91},
+		})
+		if got := audit.DetailViolations(); got != before {
+			t.Errorf("emitting the three policy events raised the violation count %d -> %d; "+
+				"an emitter sends a key its schema does not declare", before, got)
+		}
+	})
+}

--- a/specs/system/policy.spec.yaml
+++ b/specs/system/policy.spec.yaml
@@ -1,7 +1,7 @@
 spec:
   id: system-policy
   title: Policies-as-data framework
-  version: "1.1.0"
+  version: "1.2.0"
   status: approved
   tier: 1
 
@@ -133,3 +133,16 @@ spec:
       description: The embedded policy-pubkey-current.pem MUST NOT equal the public half of the testdata test key; a regression to the test trust anchor fails the build (SEC-H1 guard).
       priority: critical
       references_constraints: [C-10]
+    - id: AC-14
+      description: >
+        Each policy event's declared detail_schema in audit/events.yaml matches
+        the keys its emitter sends, in both directions: policy.loaded declares
+        exactly policy_type, new_version, previous_version and warnings;
+        policy.invalid declares policy_type, attempted_version and errors;
+        policy.applied declares policy_type, policy_version, outcome, reason and
+        detail. Emitting all three raises no detail-schema violation. The
+        expected sets are pinned to C-06, C-07 and C-08 rather than read back
+        from events.yaml, which disagreed with all three constraints until this
+        AC existed.
+      priority: high
+      references_constraints: [C-06, C-07, C-08]


### PR DESCRIPTION
Closes CP `bugs/OW-021`. Three policy events declared one thing and sent
another. The check from `bugs/OW-018` reported half of it; reading the emitters
gave the rest.

| event | sent | declared |
|---|---|---|
| `policy.loaded` | `policy_type`, `new_version`, `previous_version`, `warnings` | `policy_type`, **`policy_version`** |
| `policy.invalid` | `policy_type`, `attempted_version`, `errors` | **nothing at all** |
| `policy.applied` | `policy_type`, `policy_version`, `outcome`, `reason`, `detail` | **`decision`**, `policy_type`, `policy_version` |

Both directions of the same defect in one file. `policy_version` and `decision`
were declared and never sent, so a consumer built from `events.yaml` waits for
keys that have never appeared. The undeclared keys are the mirror: real data
under no contract, dropped by a consumer written from the declaration.

**`policy.invalid` was the worst and the check could not see it.** It declared no
`detail_schema`, and a nil schema is skipped rather than treated as "declares
nothing", so an event emitting three keys was silently exempt.

Declarations now match the emitters. Nothing about what gets written to
`audit_events` changes, so stored rows stay readable.

## Two things I checked instead of assuming, both wrong on the first guess

- `Decision.Detail` is a `map[string]any`, not a string. It is `type: object`.
- The `outcome` enum is `critical|high|medium|ok`. `Evaluate` is `emitApplied`'s
  only caller and sets exactly those four. `Outcome` also declares `allow`,
  `deny` and `defer`, which **no code path in the repo assigns**, so this event
  cannot carry them. I had written the enum as `allow|deny|defer` first, copying
  the stale `decision` declaration.

## Mutation-checked

Renamed `previous_version` to `prior_version` in the emitter. The check reports
`undeclared=prior_version` immediately, so the corrected schema still catches a
regression rather than merely agreeing with today's code.

## Ten more, filed not fixed

The same sweep found ten events in eight other packages with the same defect,
filed as CP `bugs/OW-022`. `remediation.executed` is the clearest: it declares
three counters and emits six identifiers, so everything saying **which** host had
**which** rule remediated is undeclared.

Two notes from that sweep are in the bug and worth repeating here: the warnings
are invisible without `go test -v`, because Go buffers log output for passing
tests, and a zero from this check is sample-dependent, which is how OW-018
shipped reporting zero.

## The spec was right the whole time

Worth stating plainly, because it changes what the fix means. `system-policy`
C-06, C-07 and C-08 already name the keys each event must carry, and they match
the **emitters**, not the schemas:

```
C-06  policy.loaded  MUST ... with policy_type, new_version, previous_version
C-07  policy.invalid MUST ... with policy_type, attempted_version, error list
C-08  policy.applied MUST ... recording outcome and policy_version
```

So `events.yaml` was not merely out of step with the code. It contradicted the
spec, and had since it was written.

`AC-14` now pins the exact key set for all three events, **and takes its expected
values from the constraints rather than from `events.yaml`**. A test written from
the file would have passed against the broken file. It also emits all three
events and asserts the violation counter does not move, so the emitters are
covered too.

Mutation-checked in both directions, because neither assertion catches the
other's case:

| mutation | caught by |
|---|---|
| declare a key nothing sends (`ghost_key`) | the `DetailKeys` assertion |
| emit a key nothing declares (`sneaky`) | the violation counter |

## Verification

Full suite 62 packages green, 120 specs passing, doc-style clean, and no
`policy.*` violation remains in the run.
